### PR TITLE
feat: add native account export and import functionality via zip archives

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -48,6 +48,16 @@ Examples:
         help="Add current account to managed accounts",
     )
     group.add_argument(
+        "--export-account",
+        metavar="NUM|EMAIL",
+        help="Export account to a zip archive",
+    )
+    group.add_argument(
+        "--import-account",
+        metavar="FILE",
+        help="Import account from a zip archive",
+    )
+    group.add_argument(
         "--remove-account",
         metavar="NUM|EMAIL",
         help="Remove account by number or email",
@@ -92,6 +102,10 @@ Examples:
     try:
         if args.add_account:
             switcher.add_account()
+        elif args.export_account:
+            switcher.export_account(args.export_account)
+        elif args.import_account:
+            switcher.import_account(args.import_account)
         elif args.remove_account:
             switcher.remove_account(args.remove_account)
         elif args.list:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -789,3 +789,105 @@ class ClaudeAccountSwitcher:
             print("\nNo claude-swap data found to remove.")
 
         print("\nPurge complete.")
+
+    def export_account(self, identifier: str, output_path: str | None = None) -> None:
+        """Export an account to a zip archive."""
+        import zipfile
+        from datetime import datetime
+
+        if not self.sequence_file.exists():
+            raise ConfigError("No accounts are managed yet")
+
+        # Resolve identifier
+        if not identifier.isdigit():
+            if not self._validate_email(identifier):
+                raise ValidationError(f"Invalid email format: {identifier}")
+
+        account_num = self._resolve_account_identifier(identifier)
+        if not account_num:
+            raise AccountNotFoundError(f"No account found with identifier: {identifier}")
+
+        data = self._get_sequence_data()
+        account_info = data.get("accounts", {}).get(account_num)
+        email = account_info.get("email")
+
+        # Sync active account to backup before export if it's currently active
+        active_account = str(data.get("activeAccountNumber"))
+        if active_account == account_num:
+            current_creds = self._read_credentials()
+            config_path = self._get_claude_config_path()
+            if current_creds and config_path.exists():
+                self._write_account_credentials(account_num, email, current_creds)
+                self._write_account_config(account_num, email, config_path.read_text())
+
+        creds = self._read_account_credentials(account_num, email)
+        config = self._read_account_config(account_num, email)
+
+        if not creds or not config:
+            raise SwitchError(f"Missing backup data for Account-{account_num}")
+
+        if not output_path:
+            date_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+            safe_email = email.replace('@', '_at_')
+            output_path = f"claude_account_{account_num}_{safe_email}_{date_str}.zip"
+
+        with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr('config.json', config)
+            zf.writestr('credentials.txt', creds)
+
+        self._logger.info(f"Exported account {account_num} to {output_path}")
+        print(f"Successfully exported Account-{account_num} ({email}) to {output_path}")
+
+    def import_account(self, archive_path: str) -> None:
+        """Import an account from a zip archive."""
+        import zipfile
+
+        archive = Path(archive_path)
+        if not archive.exists():
+            raise ValidationError(f"Archive not found: {archive_path}")
+
+        try:
+            with zipfile.ZipFile(archive, 'r') as zf:
+                config_str = zf.read('config.json').decode('utf-8')
+                creds_str = zf.read('credentials.txt').decode('utf-8')
+        except Exception as e:
+            raise ValidationError(f"Failed to read archive (must contain config.json and credentials.txt): {e}")
+
+        try:
+            config_data = json.loads(config_str)
+            email = config_data.get("oauthAccount", {}).get("emailAddress")
+            account_uuid = config_data.get("oauthAccount", {}).get("accountUuid", "")
+        except Exception:
+            raise ValidationError("Invalid config.json in archive")
+
+        if not email:
+            raise ValidationError("Could not find email address in imported config")
+
+        self._setup_directories()
+        self._init_sequence_file()
+
+        if self._account_exists(email):
+            print(f"Account {email} is already managed.")
+            return
+
+        account_num = str(self._get_next_account_number())
+
+        # Store backups
+        self._write_account_credentials(account_num, email, creds_str)
+        self._write_account_config(account_num, email, config_str)
+
+        # Update sequence.json
+        data = self._get_sequence_data()
+        data["accounts"][account_num] = {
+            "email": email,
+            "uuid": account_uuid,
+            "added": get_timestamp(),
+        }
+        data["sequence"].append(int(account_num))
+        
+        # If no active account, make this active? No, just add it.
+        data["lastUpdated"] = get_timestamp()
+
+        self._write_json(self.sequence_file, data)
+        self._logger.info(f"Imported account {account_num}: {email}")
+        print(f"Successfully imported Account-{account_num}: {email}")

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1,0 +1,144 @@
+"""Tests for import and export functionality."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+try:
+    import keyring
+except ImportError:
+    keyring = None
+
+from claude_swap.exceptions import ValidationError
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class TestImportExport:
+    """Test import and export functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup_keyring(self):
+        """Mock keyring for all tests to avoid keychain access on macOS."""
+        if sys.platform != "linux":
+            with patch("keyring.get_password", return_value='{"token": "test-token"}'), \
+                 patch("keyring.set_password"), \
+                 patch("keyring.delete_password"):
+                yield
+        else:
+            yield
+
+    def test_export_import_cycle(self, temp_home: Path, mock_claude_config: Path, mock_credentials_file: Path):
+        """Test a full export and import cycle."""
+        switcher = ClaudeAccountSwitcher()
+        
+        # 1. Add current account to managed accounts
+        with patch.object(switcher, "_read_credentials", return_value='{"token": "test-token"}'):
+            switcher.add_account()
+        
+        # Verify it was added
+        data = switcher._get_sequence_data()
+        assert "1" in data["accounts"]
+        email = data["accounts"]["1"]["email"]
+        
+        # 2. Export the account
+        export_path = temp_home / "export.zip"
+        switcher.export_account("1", str(export_path))
+        
+        assert export_path.exists()
+        
+        # Verify zip contents
+        with zipfile.ZipFile(export_path, 'r') as zf:
+            assert "config.json" in zf.namelist()
+            assert "credentials.txt" in zf.namelist()
+            
+        # 3. Remove the account
+        with patch("builtins.input", return_value="y"):
+            switcher.remove_account("1")
+            
+        data = switcher._get_sequence_data()
+        assert "1" not in data["accounts"]
+        
+        # 4. Import the account back
+        switcher.import_account(str(export_path))
+        
+        # 5. Verify restored
+        data = switcher._get_sequence_data()
+        # It might get a different number if sequence was cleared, but here it should likely be "1" or "2"
+        # Since we max() + 1, and we removed "1", it might be "1" again if sequence empty or next available
+        found = False
+        for acc in data["accounts"].values():
+            if acc["email"] == email:
+                found = True
+                break
+        assert found, f"Account {email} was not restored"
+
+    def test_import_missing_file(self, temp_home: Path):
+        """Test import from non-existent file."""
+        switcher = ClaudeAccountSwitcher()
+        with pytest.raises(ValidationError, match="Archive not found"):
+            switcher.import_account("nonexistent.zip")
+
+    def test_import_invalid_archive(self, temp_home: Path):
+        """Test import from archive missing required files."""
+        switcher = ClaudeAccountSwitcher()
+        invalid_zip = temp_home / "invalid.zip"
+        
+        with zipfile.ZipFile(invalid_zip, 'w') as zf:
+            zf.writestr("random.txt", "content")
+            
+        with pytest.raises(ValidationError, match="must contain config.json and credentials.txt"):
+            switcher.import_account(str(invalid_zip))
+
+    def test_import_invalid_json(self, temp_home: Path):
+        """Test import with malformed config.json."""
+        switcher = ClaudeAccountSwitcher()
+        invalid_zip = temp_home / "invalid_json.zip"
+        
+        with zipfile.ZipFile(invalid_zip, 'w') as zf:
+            zf.writestr("config.json", "{invalid json")
+            zf.writestr("credentials.txt", "creds")
+            
+        with pytest.raises(ValidationError, match="Invalid config.json"):
+            switcher.import_account(str(invalid_zip))
+
+    def test_import_missing_email(self, temp_home: Path):
+        """Test import with config.json missing email."""
+        switcher = ClaudeAccountSwitcher()
+        invalid_zip = temp_home / "no_email.zip"
+        
+        # Config without email
+        config = {"oauthAccount": {"accountUuid": "uuid"}}
+        
+        with zipfile.ZipFile(invalid_zip, 'w') as zf:
+            zf.writestr("config.json", json.dumps(config))
+            zf.writestr("credentials.txt", "creds")
+            
+        with pytest.raises(ValidationError, match="Could not find email address"):
+            switcher.import_account(str(invalid_zip))
+
+    def test_import_duplicate_account(self, temp_home: Path, mock_claude_config: Path, mock_credentials_file: Path):
+        """Test importing an account that already exists."""
+        switcher = ClaudeAccountSwitcher()
+        
+        # 1. Add current account
+        with patch.object(switcher, "_read_credentials", return_value='{"token": "test-token"}'):
+            switcher.add_account()
+            
+        # 2. Create an export of it
+        export_path = temp_home / "export.zip"
+        switcher.export_account("1", str(export_path))
+        
+        # 3. Try to import it again
+        with patch("builtins.print") as mock_print:
+            switcher.import_account(str(export_path))
+            mock_print.assert_any_call("Account test@example.com is already managed.")
+            
+        # Verify no new account was added
+        data = switcher._get_sequence_data()
+        assert len(data["accounts"]) == 1


### PR DESCRIPTION
This PR adds `--export-account` and `--import-account` flags to CLI. 

This enables native backup and seamless transfer of Claude Code accounts (configurations and credentials) between systems (such as Windows, macOS, and Linux) by bundling the data into a portable `.zip` archive.