### PR TITLE
Show usage and reset info in cswap --list

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -310,8 +310,8 @@ class ClaudeAccountSwitcher:
         except (json.JSONDecodeError, AttributeError):
             return None
 
-    def _format_reset(self, resets_at: str) -> str:
-        """Format reset time as 'in Xh Ym (HH:MM)' in local time."""
+    def _format_reset(self, resets_at: str) -> tuple[str, str]:
+        """Return (countdown, clock) for a reset time in local time."""
         reset_utc = datetime.fromisoformat(resets_at)
         now = datetime.now(timezone.utc)
         remaining = reset_utc - now
@@ -335,9 +335,9 @@ class ClaudeAccountSwitcher:
             day = str(reset_local.day)
             time_str = reset_local.strftime(f"%b {day} %H:%M")
 
-        return f"in {countdown} ({time_str})"
+        return countdown, time_str
 
-    def _fetch_usage(self, access_token: str) -> str:
+    def _fetch_usage(self, access_token: str) -> dict | None:
         """Fetch 5-hour and 7-day utilization from the Anthropic usage API."""
         url = "https://api.anthropic.com/api/oauth/usage"
         headers = {
@@ -348,13 +348,14 @@ class ClaudeAccountSwitcher:
             req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=5) as resp:
                 data = json.loads(resp.read().decode())
-            h5 = data["five_hour"]["utilization"]
-            h5_reset = self._format_reset(data["five_hour"]["resets_at"])
-            d7 = data["seven_day"]["utilization"]
-            d7_reset = self._format_reset(data["seven_day"]["resets_at"])
-            return f"5h: {h5:.0f}% {h5_reset} | 7d: {d7:.0f}% {d7_reset}"
+            h5_countdown, h5_clock = self._format_reset(data["five_hour"]["resets_at"])
+            d7_countdown, d7_clock = self._format_reset(data["seven_day"]["resets_at"])
+            return {
+                "five_hour": {"pct": data["five_hour"]["utilization"], "countdown": h5_countdown, "clock": h5_clock},
+                "seven_day": {"pct": data["seven_day"]["utilization"], "countdown": d7_countdown, "clock": d7_clock},
+            }
         except Exception:
-            return "usage unavailable"
+            return None
 
     def _read_account_config(self, account_num: str, email: str) -> str:
         """Read account config from backup."""
@@ -574,16 +575,29 @@ class ClaudeAccountSwitcher:
             token = self._extract_access_token(creds)
             accounts_info.append((num, email, is_active, token))
 
-        def fetch(token: str | None) -> str:
-            return self._fetch_usage(token) if token else "no credentials"
+        def fetch(token: str | None) -> dict | str | None:
+            if not token:
+                return "no credentials"
+            return self._fetch_usage(token)
 
         with ThreadPoolExecutor() as executor:
             usages = list(executor.map(fetch, (t for _, _, _, t in accounts_info)))
 
         print("Accounts:")
-        for (num, email, is_active, _), usage in zip(accounts_info, usages):
+        for i, ((num, email, is_active, _), usage) in enumerate(zip(accounts_info, usages)):
             marker = " (active)" if is_active else ""
-            print(f"  {num}: {email}{marker} [{usage}]")
+            print(f"  {num}: {email}{marker}")
+            if isinstance(usage, str):
+                print(f"     {usage}")
+            elif usage is None:
+                print("     usage unavailable")
+            else:
+                h5 = usage["five_hour"]
+                d7 = usage["seven_day"]
+                print(f"     ├ 5h: {h5['pct']:>3.0f}%   resets {h5['clock']:<12}  in {h5['countdown']}")
+                print(f"     └ 7d: {d7['pct']:>3.0f}%   resets {d7['clock']:<12}  in {d7['countdown']}")
+            if i < len(accounts_info) - 1:
+                print()
 
     def status(self) -> None:
         """Display current account status."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -320,10 +320,10 @@ class TestFormatReset:
         with patch("claude_swap.switcher.datetime") as mock_dt:
             mock_dt.fromisoformat = datetime.fromisoformat
             mock_dt.now.return_value = fixed_now
-            result = switcher._format_reset(future.isoformat())
-        assert result.startswith("in 2h 15m")
-        # Time portion should be HH:MM only (no month/day since same day)
-        assert result.count(":") == 1
+            countdown, clock = switcher._format_reset(future.isoformat())
+        assert countdown == "2h 15m"
+        # Clock should be HH:MM only (no month/day since same day)
+        assert clock.count(":") == 1
 
     def test_different_day_shows_date(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
@@ -333,11 +333,10 @@ class TestFormatReset:
         with patch("claude_swap.switcher.datetime") as mock_dt:
             mock_dt.fromisoformat = datetime.fromisoformat
             mock_dt.now.return_value = fixed_now
-            result = switcher._format_reset(future.isoformat())
-        assert "in " in result
+            countdown, clock = switcher._format_reset(future.isoformat())
         import calendar
         months = list(calendar.month_abbr)[1:]
-        assert any(m in result for m in months)
+        assert any(m in clock for m in months)
 
     def test_minutes_only_when_under_one_hour(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
@@ -347,9 +346,9 @@ class TestFormatReset:
         with patch("claude_swap.switcher.datetime") as mock_dt:
             mock_dt.fromisoformat = datetime.fromisoformat
             mock_dt.now.return_value = fixed_now
-            result = switcher._format_reset(future.isoformat())
-        assert result.startswith("in 45m")
-        assert "h" not in result.split("(")[0]
+            countdown, clock = switcher._format_reset(future.isoformat())
+        assert countdown == "45m"
+        assert "h" not in countdown
 
 
 class TestFetchUsage:
@@ -375,15 +374,15 @@ class TestFetchUsage:
             mock_dt.now.return_value = fixed_now
             result = switcher._fetch_usage("sk-test-token")
 
-        assert "5h: 22%" in result
-        assert "7d: 61%" in result
-        assert "in 1h 0m" in result
+        assert result["five_hour"]["pct"] == 22.0
+        assert result["seven_day"]["pct"] == 61.0
+        assert result["five_hour"]["countdown"] == "1h 0m"
 
     def test_network_error(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
         with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
             result = switcher._fetch_usage("sk-test-token")
-        assert result == "usage unavailable"
+        assert result is None
 
     def test_bad_response(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
@@ -394,7 +393,7 @@ class TestFetchUsage:
 
         with patch("urllib.request.urlopen", return_value=mock_response):
             result = switcher._fetch_usage("sk-test-token")
-        assert result == "usage unavailable"
+        assert result is None
 
 
 class TestListAccountsUsage:
@@ -426,9 +425,12 @@ class TestListAccountsUsage:
             switcher.list_accounts()
 
         output = capsys.readouterr().out
-        assert "test@example.com (active) [5h: 10%" in output
-        assert "7d: 50%" in output
-        assert "account2@example.com [5h: 10%" in output
+        assert "test@example.com (active)" in output
+        assert "account2@example.com" in output
+        assert "├ 5h:" in output
+        assert "└ 7d:" in output
+        assert "10%" in output
+        assert "50%" in output
 
     def test_list_no_credentials(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
@@ -444,4 +446,4 @@ class TestListAccountsUsage:
             switcher.list_accounts()
 
         output = capsys.readouterr().out
-        assert "[no credentials]" in output
+        assert "no credentials" in output


### PR DESCRIPTION
Closes #4

## What changed

`cswap --list` now fetches and displays API utilization and reset timing for each account, so you can check limits across all accounts at a glance without switching between them.

**Before:**
```
Accounts:
  1: alice@example.com (active)
  2: bob@example.com
```

**After:**
```
Accounts:
  1: alice@example.com (active) [5h: 38% in 3h 18m (20:00) | 7d: 63% in 1d 7h (Mar 25 00:00)]
  2: bob@example.com [5h: 100% in 1h 18m (18:00) | 7d: 8% in 6d 20h (Mar 30 13:00)]
```

Reset times are converted from UTC to the local timezone of the machine running the CLI. Same-day resets show `HH:MM` only; future-day resets include the date (`Mar 25 00:00`). Countdown uses the most appropriate unit: minutes, `Xh Ym`, or `Xd Yh`.

## Implementation

All changes are in `src/claude_swap/switcher.py`:

- **`_extract_access_token(credentials)`** — parses the `accessToken` from the stored credentials JSON blob
- **`_fetch_usage(access_token)`** — calls the Anthropic OAuth usage endpoint (`/api/oauth/usage`) using the per-account token and returns a formatted string; returns `"usage unavailable"` on any error
- **`_format_reset(resets_at)`** — converts a UTC ISO timestamp to a human-readable countdown + local reset time
- **`list_accounts()`** — updated to read each account's credentials (active account via `_read_credentials`, backup accounts via `_read_account_credentials`) and append usage info to each line

New tests cover all three methods including success, network failure, malformed response, and edge cases (minutes-only countdown, same-day vs. future-day date formatting).