### PR TITLE
fix: use UTF-8 for JSON config I/O on Windows

### DIFF
--- a/src/claude_swap/cache.py
+++ b/src/claude_swap/cache.py
@@ -19,10 +19,16 @@ def read_cache(path: Path, ttl: float, default=MISSING):
     callers can distinguish "no cache" from a cached ``None`` value.
     """
     try:
-        raw = json.loads(path.read_text())
+        raw = json.loads(path.read_text(encoding="utf-8"))
         if time.time() - raw["timestamp"] < ttl:
             return raw["data"]
-    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+    except (
+        OSError,
+        json.JSONDecodeError,
+        UnicodeDecodeError,
+        KeyError,
+        TypeError,
+    ):
         pass
     return default
 
@@ -30,4 +36,7 @@ def read_cache(path: Path, ttl: float, default=MISSING):
 def write_cache(path: Path, data) -> None:
     """Write data to a cache file with a timestamp."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"timestamp": time.time(), "data": data}))
+    path.write_text(
+        json.dumps({"timestamp": time.time(), "data": data}),
+        encoding="utf-8",
+    )

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -112,7 +112,9 @@ class SwitchTransaction:
                 if step == "credentials_written":
                     switcher._write_credentials(self.original_credentials)
                 elif step == "config_written":
-                    self.config_path.write_text(self.original_config)
+                    self.config_path.write_text(
+                        self.original_config, encoding="utf-8"
+                    )
                     if sys.platform != "win32":
                         os.chmod(self.config_path, 0o600)
                 elif step == "sequence_updated":

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -106,10 +106,10 @@ class ClaudeAccountSwitcher:
         for path in [primary_config, fallback_config]:
             if path.exists():
                 try:
-                    data = json.loads(path.read_text())
+                    data = json.loads(path.read_text(encoding="utf-8"))
                     if "oauthAccount" in data:
                         candidates.append(path)
-                except (json.JSONDecodeError, OSError):
+                except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                     pass
 
         if not candidates:
@@ -136,8 +136,8 @@ class ClaudeAccountSwitcher:
         if not path.exists():
             return None
         try:
-            return json.loads(path.read_text())
-        except json.JSONDecodeError:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
             self._logger.warning(f"Invalid JSON in {path}")
             return None
 
@@ -147,11 +147,11 @@ class ClaudeAccountSwitcher:
 
         # Write to temp file first
         temp_path = path.with_suffix(f".{os.getpid()}.tmp")
-        temp_path.write_text(content)
+        temp_path.write_text(content, encoding="utf-8")
 
         # Validate written content
         try:
-            json.loads(temp_path.read_text())
+            json.loads(temp_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             temp_path.unlink()
             raise ConfigError("Generated invalid JSON")
@@ -198,7 +198,7 @@ class ClaudeAccountSwitcher:
             cred_file = self.home / ".claude" / ".credentials.json"
             if cred_file.exists():
                 try:
-                    return cred_file.read_text()
+                    return cred_file.read_text(encoding="utf-8")
                 except Exception as e:
                     self._logger.error(f"Failed to read credentials file: {e}")
                     return None
@@ -242,7 +242,7 @@ class ClaudeAccountSwitcher:
                 import tempfile
                 fd, tmp_path = tempfile.mkstemp(dir=str(cred_dir), suffix=".tmp")
                 try:
-                    os.write(fd, credentials.encode())
+                    os.write(fd, credentials.encode("utf-8"))
                     os.close(fd)
                     fd = -1
                     os.replace(tmp_path, str(cred_file))
@@ -269,7 +269,7 @@ class ClaudeAccountSwitcher:
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             if cred_file.exists():
                 try:
-                    encoded = cred_file.read_text()
+                    encoded = cred_file.read_text(encoding="utf-8")
                     return base64.b64decode(encoded).decode("utf-8")
                 except Exception as e:
                     self._logger.warning(f"Failed to read credentials file: {e}")
@@ -297,7 +297,7 @@ class ClaudeAccountSwitcher:
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             try:
                 encoded = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
-                cred_file.write_text(encoded)
+                cred_file.write_text(encoded, encoding="utf-8")
                 os.chmod(cred_file, 0o600)
             except Exception as e:
                 self._logger.warning(f"Failed to write credentials file: {e}")
@@ -336,7 +336,7 @@ class ClaudeAccountSwitcher:
         """Read account config from backup."""
         config_file = self.configs_dir / f".claude-config-{account_num}-{email}.json"
         if config_file.exists():
-            return config_file.read_text()
+            return config_file.read_text(encoding="utf-8")
         return ""
 
     def _write_account_config(
@@ -344,7 +344,7 @@ class ClaudeAccountSwitcher:
     ) -> None:
         """Write account config to backup."""
         config_file = self.configs_dir / f".claude-config-{account_num}-{email}.json"
-        config_file.write_text(config)
+        config_file.write_text(config, encoding="utf-8")
         if sys.platform != "win32":
             os.chmod(config_file, 0o600)
 
@@ -549,7 +549,7 @@ class ClaudeAccountSwitcher:
 
             config_path = self._get_claude_config_path()
             try:
-                current_config = config_path.read_text()
+                current_config = config_path.read_text(encoding="utf-8")
             except FileNotFoundError:
                 raise ConfigError("Claude config file not found")
             except PermissionError:
@@ -582,7 +582,7 @@ class ClaudeAccountSwitcher:
 
         config_path = self._get_claude_config_path()
         try:
-            current_config = config_path.read_text()
+            current_config = config_path.read_text(encoding="utf-8")
         except FileNotFoundError:
             raise ConfigError("Claude config file not found")
         except PermissionError:
@@ -977,7 +977,7 @@ class ClaudeAccountSwitcher:
                 original_creds = self._read_credentials()
                 if original_creds is None:
                     raise CredentialReadError("Failed to read current credentials")
-                original_config = config_path.read_text()
+                original_config = config_path.read_text(encoding="utf-8")
             except FileNotFoundError:
                 raise ConfigError("Claude config file not found")
             except PermissionError:

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -164,6 +164,26 @@ class TestGetCurrentAccount:
         assert switcher._get_current_account() is None
 
 
+class TestGetClaudeConfigPathUtf8:
+    """Regression: Windows default encoding must not break UTF-8 Claude configs."""
+
+    def test_fallback_config_with_unicode_punctuation(self, temp_home: Path):
+        """~/.claude.json with non-ASCII (e.g. smart quotes) must be readable."""
+        config = {
+            "oauthAccount": {
+                "emailAddress": "user@example.com",
+                "accountUuid": "uuid-1",
+                "displayName": "Name with \u201csmart\u201d quotes",
+            }
+        }
+        fallback = temp_home / ".claude.json"
+        fallback.write_text(json.dumps(config, ensure_ascii=False), encoding="utf-8")
+
+        switcher = ClaudeAccountSwitcher()
+        resolved = switcher._get_claude_config_path()
+        assert resolved == fallback
+
+
 class TestAccountExists:
     """Test account existence checking."""
 


### PR DESCRIPTION
## Summary

On Windows, `Path.read_text()` / `write_text()` default to the process encoding (typically cp1252). Claude Code stores JSON as UTF-8, so configs that contain real Unicode (smart quotes, display names, etc.) can raise `UnicodeDecodeError` before `json.loads` runs.

This is especially noticeable after https://github.com/realiti4/claude-swap/commit/92094c96afc477998ce98e15428d44cb9d7fe1b5, which reads both possible config locations inside `_get_claude_config_path`.

## Change

- Pass `encoding="utf-8"` for JSON/config-related reads and writes in `switcher.py`, `models.py`, and `cache.py`.
- Use `credentials.encode("utf-8")` when writing the credentials file.
- Catch `UnicodeDecodeError` in `_read_json` and `_get_claude_config_path` where JSON parse errors are already swallowed.
- Add a regression test: UTF-8 `~/.claude.json` with smart quotes in `oauthAccount`.

Closes #12

## Tests

- `uv run pytest tests/test_switcher.py::TestGetClaudeConfigPathUtf8 tests/test_cache.py -q`

(Full `pytest` on this machine: 126 passed, 2 skipped; 1 unrelated failure in `test_cli.py` on Windows/Python 3.14 due to `os.geteuid` not existing.)
