### PR TITLE
feat: export and import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ cswap --switch-to user@example.com
 
 **Note:** Restart Claude Code (or close and reopen the VS Code extension tab) after switching for the new account to take effect.
 
+### Export and import accounts
+
+Move account data between machines or back it up:
+
+```bash
+cswap --export backup.cswap                  # All accounts to a file
+cswap --export backup.cswap --account 2      # One account
+cswap --export -                             # To stdout (pipeable)
+cswap --import backup.cswap                  # Skips accounts that already exist
+cswap --import backup.cswap --force          # Overwrite existing
+```
+
+The export file is plaintext JSON. If you need encryption, pipe through your tool of choice (e.g. `cswap --export - | gpg -c > backup.gpg`).
+
 ### Refresh expired tokens
 
 If an account's token expires, log back into Claude Code with that account and re-run:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -27,6 +27,8 @@ Examples:
   %(prog)s --remove-account user@example.com
   %(prog)s --status
   %(prog)s --purge
+  %(prog)s --export backup.cswap
+  %(prog)s --import backup.cswap
         """,
     )
 
@@ -51,6 +53,16 @@ Examples:
         type=int,
         metavar="NUM",
         help="Specify slot number when adding account (use with --add-account)",
+    )
+    parser.add_argument(
+        "--account",
+        metavar="NUM|EMAIL",
+        help="Limit export to one account (use with --export)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing accounts during import",
     )
 
     group = parser.add_mutually_exclusive_group(required=True)
@@ -89,6 +101,17 @@ Examples:
         action="store_true",
         help="Remove all claude-swap data from the system",
     )
+    group.add_argument(
+        "--export",
+        metavar="PATH",
+        help="Export accounts to file (use '-' for stdout)",
+    )
+    group.add_argument(
+        "--import",
+        dest="import_",
+        metavar="PATH",
+        help="Import accounts from file (use '-' for stdin)",
+    )
 
     args = parser.parse_args()
 
@@ -97,6 +120,12 @@ Examples:
 
     if args.slot is not None and not args.add_account:
         parser.error("--slot can only be used with --add-account")
+
+    if args.account is not None and not args.export:
+        parser.error("--account can only be used with --export")
+
+    if args.force and not args.import_:
+        parser.error("--force can only be used with --import")
 
     # Initialize switcher with debug mode
     switcher = ClaudeAccountSwitcher(debug=args.debug)
@@ -124,6 +153,14 @@ Examples:
             switcher.status()
         elif args.purge:
             switcher.purge()
+        elif args.export:
+            from claude_swap.transfer import export_accounts
+
+            export_accounts(switcher, args.export, account=args.account)
+        elif args.import_:
+            from claude_swap.transfer import import_accounts
+
+            import_accounts(switcher, args.import_, force=args.force)
     except ClaudeSwitchError as e:
         error(f"Error: {e}")
         sys.exit(1)

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -53,3 +53,9 @@ class ValidationError(ClaudeSwitchError):
     """Validation error."""
 
     pass
+
+
+class TransferError(ClaudeSwitchError):
+    """Error during account export or import."""
+
+    pass

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -967,12 +967,25 @@ class ClaudeAccountSwitcher:
             raise ConfigError("No accounts are managed yet")
 
         identity = self._get_current_account()
-        if identity is None:
-            raise ConfigError("No active Claude account found")
-        current_email, current_org_uuid = identity
 
         # Ensure org fields are migrated before checking composite key
         self._get_sequence_data_migrated()
+
+        # Fresh-machine path: no live Claude session, but we have managed accounts
+        # (e.g. right after cswap --import). Activate the recorded
+        # activeAccountNumber, or fall back to the first slot in sequence.
+        if identity is None:
+            data = self._get_sequence_data()
+            target = data.get("activeAccountNumber") if data else None
+            if not target:
+                sequence = (data or {}).get("sequence", [])
+                target = sequence[0] if sequence else None
+            if not target:
+                raise ConfigError("No accounts are managed yet")
+            self._perform_switch(str(target))
+            return
+
+        current_email, current_org_uuid = identity
 
         # Check if current account is managed
         if not self._account_exists(current_email, current_org_uuid):
@@ -1063,11 +1076,56 @@ class ClaudeAccountSwitcher:
             target_email = data["accounts"][target_account]["email"]
             current_identity = self._get_current_account()
 
-            if current_identity is None:
-                raise SwitchError("No current account to switch from")
-            current_email, _ = current_identity
-
             config_path = self._get_claude_config_path()
+
+            # Fresh-machine path: no live Claude session yet (e.g. right after
+            # cswap --import on a new machine). Skip the back-up-current step
+            # since there's nothing to back up, and install the target directly.
+            if current_identity is None:
+                target_creds = self._read_account_credentials(
+                    target_account, target_email
+                )
+                target_config = self._read_account_config(target_account, target_email)
+                if not target_creds or not target_config:
+                    raise SwitchError(
+                        f"Missing backup data for Account-{target_account}"
+                    )
+                try:
+                    target_config_data = json.loads(target_config)
+                except json.JSONDecodeError as exc:
+                    raise SwitchError(f"Invalid backup config: {exc}")
+                target_oauth = target_config_data.get("oauthAccount")
+                if not target_oauth:
+                    raise SwitchError("Invalid oauthAccount in backup")
+
+                self._write_credentials(target_creds)
+
+                # Mirror the normal switch path: preserve existing local
+                # settings/projects when ~/.claude.json already exists, only
+                # swapping in oauthAccount. Fall back to the full imported
+                # config when no usable local config exists.
+                existing_config = self._read_json(config_path) if config_path.exists() else None
+                if existing_config:
+                    existing_config["oauthAccount"] = target_oauth
+                    self._write_json(config_path, existing_config)
+                else:
+                    self._write_json(config_path, target_config_data)
+
+                data["activeAccountNumber"] = int(target_account)
+                data["lastUpdated"] = get_timestamp()
+                self._write_json(self.sequence_file, data)
+                self._logger.info(
+                    f"Activated account {target_account} (no prior live account)"
+                )
+                print(
+                    f"{accent('Activated')} Account-{target_account} ({target_email})"
+                )
+                print()
+                warning("Please restart Claude Code to use the new authentication.")
+                print()
+                return
+
+            current_email, _ = current_identity
 
             # Create transaction for rollback capability
             try:

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -1,0 +1,399 @@
+"""Export and import account data for claude-swap.
+
+Moves the OAuth credentials and config across machines via a portable
+JSON envelope. No encryption is built in — users compose their own
+(e.g. `cswap --export - | gpg -c > out.gpg`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from claude_swap import __version__
+from claude_swap.exceptions import (
+    ConfigError,
+    CredentialReadError,
+    TransferError,
+)
+from claude_swap.models import Platform, get_timestamp
+
+if TYPE_CHECKING:
+    from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+FORMAT_VERSION = 1
+
+_PLATFORM_TAG = {
+    Platform.MACOS: "macos",
+    Platform.LINUX: "linux",
+    Platform.WSL: "wsl",
+    Platform.WINDOWS: "windows",
+    Platform.UNKNOWN: "unknown",
+}
+
+
+def _eprint(msg: str) -> None:
+    """Print to stderr so stdout stays pure JSON in pipe mode."""
+    print(msg, file=sys.stderr)
+
+
+def _find_account_slot(
+    sequence_data: dict, email: str, organization_uuid: str
+) -> str | None:
+    """Return slot key for matching (email, organizationUuid), else None."""
+    for num, account in sequence_data.get("accounts", {}).items():
+        if (
+            account.get("email") == email
+            and account.get("organizationUuid", "") == organization_uuid
+        ):
+            return num
+    return None
+
+
+def _parse_payload(text: str, label: str) -> dict:
+    """Parse a JSON string that should decode to an object."""
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise TransferError(f"{label} is not valid JSON: {exc}")
+    if not isinstance(parsed, dict):
+        raise TransferError(f"{label} must be a JSON object")
+    return parsed
+
+
+def _validate_imported_account(switcher: ClaudeAccountSwitcher, account: dict) -> tuple[str, str]:
+    """Validate per-account fields BEFORE any filename construction.
+
+    Defends against path traversal: email + slot number flow into f-string
+    filenames in switcher._read_account_credentials etc., so they must be
+    constrained before use.
+    """
+    if not isinstance(account, dict):
+        raise TransferError("account entry must be a JSON object")
+
+    email = account.get("email")
+    if not isinstance(email, str) or not switcher._validate_email(email):
+        raise TransferError(f"invalid or missing email in imported account: {email!r}")
+
+    raw_number = account.get("number")
+    if isinstance(raw_number, bool) or not isinstance(raw_number, int) or raw_number < 1:
+        raise TransferError(
+            f"invalid slot number in imported account ({email}): {raw_number!r}"
+        )
+
+    # Org/uuid/added must be strings (or absent). A list/dict here would
+    # otherwise blow up downstream (unhashable in seen_keys, broken composite
+    # key matching, garbage in sequence.json).
+    for field in ("organizationUuid", "organizationName", "uuid", "added"):
+        if field in account and account[field] is not None:
+            if not isinstance(account[field], str):
+                raise TransferError(
+                    f"{field} for {email} must be a string, got {type(account[field]).__name__}"
+                )
+
+    return email, str(raw_number)
+
+
+def _atomic_write_file(path: Path, content: str) -> None:
+    """Write text atomically with 0600 perms — same pattern as switcher._write_json."""
+    temp_path = path.with_suffix(f".{os.getpid()}.tmp")
+    temp_path.write_text(content, encoding="utf-8")
+    if sys.platform != "win32":
+        os.chmod(temp_path, 0o600)
+    shutil.move(str(temp_path), str(path))
+    if sys.platform != "win32":
+        os.chmod(path, 0o600)
+
+
+def export_accounts(
+    switcher: ClaudeAccountSwitcher,
+    destination: str,
+    account: str | None = None,
+) -> None:
+    """Export accounts to a JSON file or stdout.
+
+    Args:
+        switcher: Initialized ClaudeAccountSwitcher.
+        destination: File path, or "-" for stdout.
+        account: Optional NUM|EMAIL to limit export to a single account.
+
+    Raises:
+        TransferError: malformed/missing data, unknown account.
+        CredentialReadError: failed to read credentials.
+    """
+    sequence_data = switcher._get_sequence_data_migrated()
+    if not sequence_data or not sequence_data.get("accounts"):
+        raise TransferError("no accounts to export — run cswap --add-account first")
+
+    accounts_map = sequence_data["accounts"]
+
+    # Resolve which account numbers to export
+    if account is not None:
+        resolved = switcher._resolve_account_identifier(account)
+        if resolved is None or resolved not in accounts_map:
+            raise TransferError(f"account not found: {account}")
+        target_nums = [resolved]
+    else:
+        target_nums = sorted(accounts_map.keys(), key=int)
+
+    # Identify the live active account (live vault has fresher tokens than backup)
+    current_identity = switcher._get_current_account()
+
+    accounts_payload: list[dict[str, Any]] = []
+    for num in target_nums:
+        record = accounts_map[num]
+        email = record.get("email", "")
+        org_uuid = record.get("organizationUuid", "") or ""
+
+        is_active = (
+            current_identity is not None
+            and current_identity[0] == email
+            and current_identity[1] == org_uuid
+        )
+
+        if is_active:
+            creds_text = switcher._read_credentials()
+            if not creds_text:
+                raise CredentialReadError(
+                    f"failed to read live credentials for active account {email}"
+                )
+            config_path = switcher._get_claude_config_path()
+            if not config_path.exists():
+                raise ConfigError("Claude config file not found")
+            config_text = config_path.read_text(encoding="utf-8")
+        else:
+            creds_text = switcher._read_account_credentials(num, email)
+            config_text = switcher._read_account_config(num, email)
+            if not creds_text:
+                raise CredentialReadError(
+                    f"no backup credentials found for account {num} ({email})"
+                )
+            if not config_text:
+                raise ConfigError(
+                    f"no backup config found for account {num} ({email})"
+                )
+
+        accounts_payload.append(
+            {
+                "number": int(num),
+                "email": email,
+                "uuid": record.get("uuid", ""),
+                "organizationUuid": org_uuid,
+                "organizationName": record.get("organizationName", "") or "",
+                "added": record.get("added", ""),
+                "credentials": _parse_payload(creds_text, f"credentials for {email}"),
+                "config": _parse_payload(config_text, f"config for {email}"),
+            }
+        )
+
+    envelope = {
+        "version": FORMAT_VERSION,
+        "exportedAt": get_timestamp(),
+        "exportedFrom": _PLATFORM_TAG.get(switcher.platform, "unknown"),
+        "swapVersion": __version__,
+        "encrypted": False,
+        "activeAccountNumber": sequence_data.get("activeAccountNumber"),
+        "accounts": accounts_payload,
+    }
+
+    serialized = json.dumps(envelope, indent=2)
+
+    if destination == "-":
+        sys.stdout.write(serialized)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+        return
+
+    out_path = Path(destination).expanduser()
+    _atomic_write_file(out_path, serialized + "\n")
+    _eprint(f"Exported {len(accounts_payload)} account(s) to {out_path}")
+
+
+def import_accounts(
+    switcher: ClaudeAccountSwitcher,
+    source: str,
+    force: bool = False,
+) -> None:
+    """Import accounts from a JSON file or stdin.
+
+    Args:
+        switcher: Initialized ClaudeAccountSwitcher.
+        source: File path, or "-" for stdin.
+        force: When True, overwrites the existing matching slot in place.
+
+    Raises:
+        TransferError: malformed file, version mismatch, encrypted payload.
+    """
+    if source == "-":
+        text = sys.stdin.read()
+    else:
+        in_path = Path(source).expanduser()
+        if not in_path.exists():
+            raise TransferError(f"import file not found: {in_path}")
+        text = in_path.read_text(encoding="utf-8")
+
+    try:
+        envelope = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise TransferError(f"export file is not valid JSON: {exc}")
+
+    if not isinstance(envelope, dict):
+        raise TransferError("export file must be a JSON object")
+
+    version = envelope.get("version")
+    if version != FORMAT_VERSION:
+        raise TransferError(
+            f"unsupported export version: {version!r} (expected {FORMAT_VERSION})"
+        )
+
+    if envelope.get("encrypted") is True:
+        raise TransferError(
+            "encrypted exports are not supported in this version — "
+            "decrypt before piping (e.g. gpg -d backup.gpg | cswap --import -)"
+        )
+
+    accounts = envelope.get("accounts")
+    if not isinstance(accounts, list) or not accounts:
+        raise TransferError("export file has no accounts to import")
+
+    # Pass 1: validate every account before any writes. A malformed account
+    # later in the list must not leave earlier accounts half-imported.
+    normalized: list[dict[str, Any]] = []
+    seen_keys: set[tuple[str, str]] = set()
+    for raw in accounts:
+        email, exported_num = _validate_imported_account(switcher, raw)
+        org_uuid = raw.get("organizationUuid", "") or ""
+        creds_obj = raw.get("credentials")
+        config_obj = raw.get("config")
+        if not isinstance(creds_obj, dict) or not isinstance(config_obj, dict):
+            raise TransferError(
+                f"credentials and config for {email} must be JSON objects"
+            )
+        key = (email, org_uuid)
+        if key in seen_keys:
+            raise TransferError(
+                f"duplicate account in export: {email} (org={org_uuid or 'personal'})"
+            )
+        seen_keys.add(key)
+        normalized.append(
+            {
+                "email": email,
+                "exported_num": exported_num,
+                "org_uuid": org_uuid,
+                "org_name": raw.get("organizationName", "") or "",
+                "uuid": raw.get("uuid", "") or "",
+                "added": raw.get("added") or get_timestamp(),
+                "creds_text": json.dumps(creds_obj),
+                "config_text": json.dumps(config_obj, indent=2),
+            }
+        )
+
+    # Pass 2: writes. Validation is complete; remaining failures (disk I/O,
+    # keyring) are environmental and don't reflect on the file's integrity.
+    switcher._setup_directories()
+    switcher._init_sequence_file()
+
+    imported = 0
+    skipped = 0
+    overwritten = 0
+
+    # Track where the envelope's active account ended up locally. We can't
+    # just look up envelope_active in the final account map afterwards: the
+    # destination may already have an unrelated account at that slot number,
+    # while the envelope's active account got allocated to a different slot.
+    envelope_active = envelope.get("activeAccountNumber")
+    envelope_active_str = (
+        str(envelope_active) if isinstance(envelope_active, int) else None
+    )
+    resolved_active_slot: str | None = None
+
+    for entry in normalized:
+        is_envelope_active = (
+            envelope_active_str is not None
+            and entry["exported_num"] == envelope_active_str
+        )
+
+        # Re-read sequence each iteration so per-account writes see prior updates
+        data = switcher._get_sequence_data_migrated() or {
+            "activeAccountNumber": None,
+            "lastUpdated": get_timestamp(),
+            "sequence": [],
+            "accounts": {},
+        }
+        existing_slot = _find_account_slot(data, entry["email"], entry["org_uuid"])
+
+        if existing_slot is not None:
+            if not force:
+                _eprint(
+                    f"Skipped {entry['email']} (already exists, use --force)"
+                )
+                skipped += 1
+                # Even when skipped, the envelope's active account exists
+                # locally — record where so we can seed activeAccountNumber.
+                if is_envelope_active:
+                    resolved_active_slot = existing_slot
+                continue
+            target_num = existing_slot
+            outcome = "overwrote"
+        else:
+            if entry["exported_num"] not in data.get("accounts", {}):
+                target_num = entry["exported_num"]
+            else:
+                target_num = str(switcher._get_next_account_number())
+            outcome = "imported"
+
+        switcher._write_account_credentials(
+            target_num, entry["email"], entry["creds_text"]
+        )
+        switcher._write_account_config(
+            target_num, entry["email"], entry["config_text"]
+        )
+
+        data.setdefault("accounts", {})
+        data.setdefault("sequence", [])
+        data["accounts"][target_num] = {
+            "email": entry["email"],
+            "uuid": entry["uuid"],
+            "organizationUuid": entry["org_uuid"],
+            "organizationName": entry["org_name"],
+            "added": entry["added"],
+        }
+        if int(target_num) not in data["sequence"]:
+            data["sequence"].append(int(target_num))
+            data["sequence"].sort()
+        data["lastUpdated"] = get_timestamp()
+        switcher._write_json(switcher.sequence_file, data)
+
+        if is_envelope_active:
+            resolved_active_slot = target_num
+
+        if outcome == "overwrote":
+            _eprint(f"Overwrote {entry['email']} (slot {target_num})")
+            overwritten += 1
+        else:
+            _eprint(f"Imported {entry['email']} → slot {target_num}")
+            imported += 1
+
+    # Migration UX: if the destination has no recorded active account
+    # (clean home, no prior preference), seed activeAccountNumber from the
+    # *resolved* slot of the envelope's active account — not the envelope's
+    # raw slot number, which may already be occupied locally by an unrelated
+    # account. If the user already has an active selection locally, leave it.
+    final = switcher._get_sequence_data()
+    if (
+        final is not None
+        and final.get("activeAccountNumber") in (None, 0)
+        and resolved_active_slot is not None
+    ):
+        final["activeAccountNumber"] = int(resolved_active_slot)
+        final["lastUpdated"] = get_timestamp()
+        switcher._write_json(switcher.sequence_file, final)
+
+    _eprint(
+        f"Done: {imported} imported, {overwritten} overwritten, {skipped} skipped"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,6 +126,82 @@ class TestCLI:
         )
         assert "--slot" in result.stdout
 
+    def test_account_flag_requires_export(self, capsys):
+        """--account should only be accepted alongside --export."""
+        with patch.object(
+            sys, "argv", ["claude-swap", "--list", "--account", "1"]
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+        assert "--account can only be used with --export" in capsys.readouterr().err
+
+    def test_force_flag_requires_import(self, capsys):
+        """--force should only be accepted alongside --import."""
+        with patch.object(sys, "argv", ["claude-swap", "--list", "--force"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+        assert "--force can only be used with --import" in capsys.readouterr().err
+
+    def test_export_and_import_are_mutually_exclusive(self):
+        """--export and --import cannot be combined."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "claude_swap",
+                "--export",
+                "/tmp/x",
+                "--import",
+                "/tmp/x",
+            ],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert result.returncode != 0
+        assert "not allowed" in result.stderr.lower()
+
+    def test_export_in_help(self):
+        """--export and --import should appear in help output."""
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "--export" in result.stdout
+        assert "--import" in result.stdout
+
+    def test_export_dispatch_calls_transfer(self):
+        """--export dispatches into transfer.export_accounts."""
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch("claude_swap.transfer.export_accounts") as export_fn, \
+             patch.object(
+                 sys, "argv", ["claude-swap", "--export", "/tmp/x", "--account", "2"]
+             ), \
+             patch("os.geteuid", return_value=1000), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+        export_fn.assert_called_once_with(
+            switcher_cls.return_value, "/tmp/x", account="2"
+        )
+
+    def test_import_dispatch_calls_transfer(self):
+        """--import dispatches into transfer.import_accounts."""
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch("claude_swap.transfer.import_accounts") as import_fn, \
+             patch.object(
+                 sys, "argv", ["claude-swap", "--import", "/tmp/x", "--force"]
+             ), \
+             patch("os.geteuid", return_value=1000), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+        import_fn.assert_called_once_with(
+            switcher_cls.return_value, "/tmp/x", force=True
+        )
+
 
 class TestCLICommands:
     """Test individual CLI commands."""

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,908 @@
+"""Tests for the export/import (transfer) module."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap.exceptions import TransferError
+from claude_swap.models import Platform
+from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.transfer import export_accounts, import_accounts
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_CREDS = {"accessToken": "tok-1", "refreshToken": "rtok-1", "expiresAt": 9999}
+SAMPLE_CONFIG = {
+    "oauthAccount": {
+        "emailAddress": "user@example.com",
+        "accountUuid": "acct-uuid",
+        "organizationUuid": "org-uuid",
+        "organizationName": "Acme",
+    }
+}
+
+
+def _linux_switcher(home: Path) -> ClaudeAccountSwitcher:
+    """Create a switcher with file-based (Linux) credential storage."""
+    s = ClaudeAccountSwitcher()
+    s.platform = Platform.LINUX
+    s._setup_directories()
+    s._init_sequence_file()
+    return s
+
+
+def _seed_account(
+    switcher: ClaudeAccountSwitcher,
+    num: int,
+    email: str,
+    org_uuid: str = "",
+    org_name: str = "",
+    creds: dict | None = None,
+    config: dict | None = None,
+) -> None:
+    """Write an account to backup + sequence.json."""
+    creds_obj = creds if creds is not None else {**SAMPLE_CREDS, "_marker": email}
+    config_obj = config if config is not None else {
+        "oauthAccount": {
+            "emailAddress": email,
+            "accountUuid": f"acct-{num}",
+            "organizationUuid": org_uuid,
+            "organizationName": org_name,
+        }
+    }
+    switcher._write_account_credentials(str(num), email, json.dumps(creds_obj))
+    switcher._write_account_config(str(num), email, json.dumps(config_obj))
+
+    data = switcher._get_sequence_data() or {
+        "activeAccountNumber": None,
+        "lastUpdated": "",
+        "sequence": [],
+        "accounts": {},
+    }
+    data["accounts"][str(num)] = {
+        "email": email,
+        "uuid": f"acct-{num}",
+        "organizationUuid": org_uuid,
+        "organizationName": org_name,
+        "added": "2024-01-01T00:00:00Z",
+    }
+    if num not in data["sequence"]:
+        data["sequence"].append(num)
+        data["sequence"].sort()
+    if data["activeAccountNumber"] is None:
+        data["activeAccountNumber"] = num
+    switcher._write_json(switcher.sequence_file, data)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_export_import_round_trip(self, temp_home: Path):
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com", "org-a", "Org A")
+        _seed_account(src, 2, "bob@example.com")
+
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+
+        # Sanity-check the file
+        assert out_file.exists()
+        envelope = json.loads(out_file.read_text())
+        assert envelope["version"] == 1
+        assert envelope["encrypted"] is False
+        assert len(envelope["accounts"]) == 2
+        assert {a["email"] for a in envelope["accounts"]} == {
+            "alice@example.com",
+            "bob@example.com",
+        }
+
+        # Import into a fresh home
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                import_accounts(dst, str(out_file))
+
+                seq = dst._get_sequence_data()
+                assert seq is not None
+                assert set(seq["accounts"].keys()) == {"1", "2"}
+                assert seq["accounts"]["1"]["email"] == "alice@example.com"
+                assert seq["accounts"]["1"]["organizationUuid"] == "org-a"
+
+                # Credentials JSON parses and contains the marker
+                creds_text = dst._read_account_credentials("1", "alice@example.com")
+                assert json.loads(creds_text)["_marker"] == "alice@example.com"
+
+    def test_active_state_carried_but_not_applied(self, temp_home: Path):
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "a@example.com")
+        _seed_account(src, 2, "b@example.com")
+        # Force active to slot 2
+        data = src._get_sequence_data()
+        data["activeAccountNumber"] = 2
+        src._write_json(src.sequence_file, data)
+
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+        envelope = json.loads(out_file.read_text())
+        assert envelope["activeAccountNumber"] == 2
+
+        # Import into a destination with a different active account
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                _seed_account(dst, 9, "local@example.com")
+                data = dst._get_sequence_data()
+                data["activeAccountNumber"] = 9
+                dst._write_json(dst.sequence_file, data)
+
+                import_accounts(dst, str(out_file))
+                final = dst._get_sequence_data()
+                assert final["activeAccountNumber"] == 9  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Selective export
+# ---------------------------------------------------------------------------
+
+
+class TestSelectiveExport:
+    def test_export_single_by_number(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 1, "a@example.com")
+        _seed_account(s, 2, "b@example.com")
+
+        out = temp_home / "one.cswap"
+        export_accounts(s, str(out), account="2")
+        envelope = json.loads(out.read_text())
+        assert len(envelope["accounts"]) == 1
+        assert envelope["accounts"][0]["email"] == "b@example.com"
+
+    def test_export_single_by_email(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 1, "a@example.com")
+        _seed_account(s, 2, "b@example.com")
+
+        out = temp_home / "one.cswap"
+        export_accounts(s, str(out), account="a@example.com")
+        envelope = json.loads(out.read_text())
+        assert envelope["accounts"][0]["email"] == "a@example.com"
+
+    def test_export_unknown_number_raises(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 1, "a@example.com")
+
+        with pytest.raises(TransferError, match="account not found"):
+            export_accounts(s, str(temp_home / "x.cswap"), account="999")
+
+    def test_export_no_accounts_raises(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        with pytest.raises(TransferError, match="no accounts to export"):
+            export_accounts(s, str(temp_home / "x.cswap"))
+
+
+# ---------------------------------------------------------------------------
+# Conflict / force semantics
+# ---------------------------------------------------------------------------
+
+
+class TestConflictPolicy:
+    def test_skip_when_account_exists_without_force(self, temp_home: Path, capsys):
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com", "org-a")
+        out = temp_home / "b.cswap"
+        export_accounts(src, str(out))
+
+        # Re-import into the same home → should skip
+        import_accounts(src, str(out), force=False)
+        captured = capsys.readouterr()
+        assert "Skipped alice@example.com" in captured.err
+        # Sequence still has only slot 1
+        seq = src._get_sequence_data()
+        assert list(seq["accounts"].keys()) == ["1"]
+
+    def test_force_overwrites_existing_slot_in_place(
+        self, temp_home: Path, capsys
+    ):
+        """Critical: --force updates the local matching slot, NOT the exported slot.
+
+        Setup: local slot 3 has alice@x.com. Local slot 1 has bob@x.com (different
+        account). Exported file says alice's slot was 1. After --force import:
+        - alice's data MUST be written to slot 3 (in place)
+        - bob (slot 1) MUST be untouched
+        """
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 3, "alice@example.com", "org-a", "Org A")
+        # Export alice while she's at slot 3 (so exported "number" = 3)
+        out = temp_home / "alice.cswap"
+        export_accounts(s, str(out), account="3")
+        # Hand-edit envelope to claim slot 1 (simulates an export from another machine)
+        env = json.loads(out.read_text())
+        env["accounts"][0]["number"] = 1
+        # Bump the credential so we can verify overwrite happened
+        env["accounts"][0]["credentials"]["_marker"] = "ALICE_NEW"
+        out.write_text(json.dumps(env))
+
+        # Add bob to slot 1 locally
+        _seed_account(s, 1, "bob@example.com")
+
+        bob_creds_before = s._read_account_credentials("1", "bob@example.com")
+
+        import_accounts(s, str(out), force=True)
+
+        captured = capsys.readouterr()
+        assert "Overwrote alice@example.com (slot 3)" in captured.err
+
+        # Alice still at slot 3 with new marker
+        alice_creds = s._read_account_credentials("3", "alice@example.com")
+        assert json.loads(alice_creds)["_marker"] == "ALICE_NEW"
+
+        # Bob untouched at slot 1
+        bob_creds_after = s._read_account_credentials("1", "bob@example.com")
+        assert bob_creds_after == bob_creds_before
+
+        seq = s._get_sequence_data()
+        assert seq["accounts"]["1"]["email"] == "bob@example.com"
+        assert seq["accounts"]["3"]["email"] == "alice@example.com"
+
+    def test_slot_allocation_when_exported_slot_taken(self, temp_home: Path):
+        """Imported account's exported slot is taken by a different account
+        (no email match) → allocate next available slot (max+1, mirrors
+        add_account semantics; gaps are not filled)."""
+        # Source: alice at slot 1
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        with patch("pathlib.Path.home", return_value=src_home):
+            with patch.dict(os.environ, {"HOME": str(src_home)}):
+                src = _linux_switcher(src_home)
+                _seed_account(src, 1, "alice@example.com")
+                out = src_home / "a.cswap"
+                export_accounts(src, str(out))
+
+        # Destination already has bob at slot 1 (different account)
+        dst = _linux_switcher(temp_home)
+        _seed_account(dst, 1, "bob@example.com")
+
+        import_accounts(dst, str(out))
+
+        seq = dst._get_sequence_data()
+        # Alice should land at slot 2 (next free)
+        assert seq["accounts"]["1"]["email"] == "bob@example.com"
+        assert seq["accounts"]["2"]["email"] == "alice@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Cross-platform credential translation
+# ---------------------------------------------------------------------------
+
+
+class TestCrossPlatform:
+    def test_export_macos_keyring_import_linux_files(self, temp_home: Path):
+        """Export from a (faked) macOS switcher backed by keyring, then import
+        into a Linux switcher and verify the credential file appears."""
+        with patch("claude_swap.switcher.keyring", create=True) as mock_keyring:
+            stored: dict[tuple[str, str], str] = {}
+
+            def fake_set(svc, user, val):
+                stored[(svc, user)] = val
+
+            def fake_get(svc, user):
+                return stored.get((svc, user))
+
+            mock_keyring.set_password.side_effect = fake_set
+            mock_keyring.get_password.side_effect = fake_get
+
+            mac_switcher = ClaudeAccountSwitcher()
+            mac_switcher.platform = Platform.MACOS
+            mac_switcher._setup_directories()
+            mac_switcher._init_sequence_file()
+
+            _seed_account(mac_switcher, 1, "alice@example.com", "org-a")
+
+            out = temp_home / "x.cswap"
+            export_accounts(mac_switcher, str(out))
+
+        # Import into a Linux destination (file-based credentials)
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                import_accounts(dst, str(out))
+
+                cred_file = (
+                    dst.credentials_dir / ".creds-1-alice@example.com.enc"
+                )
+                assert cred_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Path traversal & validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def _make_envelope(self, email: str = "user@example.com", number=1) -> dict:
+        return {
+            "version": 1,
+            "exportedAt": "2026-01-01T00:00:00Z",
+            "exportedFrom": "linux",
+            "swapVersion": "0.0.0",
+            "encrypted": False,
+            "activeAccountNumber": number if isinstance(number, int) else None,
+            "accounts": [
+                {
+                    "number": number,
+                    "email": email,
+                    "uuid": "u",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                    "credentials": SAMPLE_CREDS,
+                    "config": SAMPLE_CONFIG,
+                }
+            ],
+        }
+
+    def test_path_traversal_email_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope(email="../../evil")
+        f = temp_home / "evil.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="invalid or missing email"):
+            import_accounts(s, str(f))
+
+        # Verify nothing escaped
+        for parent in [temp_home.parent, temp_home.parent.parent]:
+            assert not (parent / ".creds-1-..").exists()
+
+    def test_negative_slot_number_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope(number=-1)
+        f = temp_home / "neg.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="invalid slot number"):
+            import_accounts(s, str(f))
+
+    def test_zero_slot_number_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope(number=0)
+        f = temp_home / "zero.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="invalid slot number"):
+            import_accounts(s, str(f))
+
+    def test_string_slot_number_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope(number="../")  # type: ignore[arg-type]
+        f = temp_home / "str.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="invalid slot number"):
+            import_accounts(s, str(f))
+
+    def test_missing_version_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope()
+        env.pop("version")
+        f = temp_home / "v.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="unsupported export version"):
+            import_accounts(s, str(f))
+
+    def test_wrong_version_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope()
+        env["version"] = 2
+        f = temp_home / "v.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="unsupported export version"):
+            import_accounts(s, str(f))
+
+    def test_encrypted_flag_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope()
+        env["encrypted"] = True
+        f = temp_home / "e.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="encrypted exports are not supported"):
+            import_accounts(s, str(f))
+
+    def test_malformed_top_level_json_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        f = temp_home / "bad.cswap"
+        f.write_text("{not json")
+
+        with pytest.raises(TransferError, match="not valid JSON"):
+            import_accounts(s, str(f))
+
+    def test_credentials_must_be_object(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope()
+        env["accounts"][0]["credentials"] = "a string"
+        f = temp_home / "c.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="must be JSON objects"):
+            import_accounts(s, str(f))
+
+    @pytest.mark.parametrize(
+        "field", ["organizationUuid", "organizationName", "uuid", "added"]
+    )
+    @pytest.mark.parametrize("bad_value", [["a", "b"], {"x": 1}, 42])
+    def test_string_fields_reject_non_string_types(
+        self, temp_home: Path, field: str, bad_value
+    ):
+        """Org/uuid/added fields must be strings — a list/dict/int would
+        otherwise blow up downstream (unhashable in seen_keys, broken
+        composite-key matching, garbage in sequence.json)."""
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope()
+        env["accounts"][0][field] = bad_value
+        f = temp_home / "bad.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match=f"{field} for .* must be a string"):
+            import_accounts(s, str(f))
+
+        # Account 1 must NOT have leaked through
+        seq = s._get_sequence_data()
+        assert seq is None or seq.get("accounts", {}) == {}
+
+    def test_missing_file_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        with pytest.raises(TransferError, match="not found"):
+            import_accounts(s, str(temp_home / "nope.cswap"))
+
+
+# ---------------------------------------------------------------------------
+# Stdin / stdout pipe support
+# ---------------------------------------------------------------------------
+
+
+class TestPipeMode:
+    def test_export_to_stdout_writes_only_json(self, temp_home: Path, capsys):
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 1, "alice@example.com")
+        export_accounts(s, "-")
+        captured = capsys.readouterr()
+
+        # stdout is pure JSON
+        env = json.loads(captured.out)
+        assert env["version"] == 1
+        assert env["accounts"][0]["email"] == "alice@example.com"
+        # Summary suppressed in stdout mode (no "Exported" line on stderr either)
+        assert "Exported" not in captured.err
+
+    def test_import_from_stdin(self, temp_home: Path):
+        # Build an envelope and feed it through stdin
+        env = {
+            "version": 1,
+            "exportedAt": "2026-01-01T00:00:00Z",
+            "exportedFrom": "linux",
+            "swapVersion": "0.0.0",
+            "encrypted": False,
+            "activeAccountNumber": 1,
+            "accounts": [
+                {
+                    "number": 1,
+                    "email": "alice@example.com",
+                    "uuid": "u",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                    "credentials": SAMPLE_CREDS,
+                    "config": SAMPLE_CONFIG,
+                }
+            ],
+        }
+        s = _linux_switcher(temp_home)
+        with patch.object(sys, "stdin", io.StringIO(json.dumps(env))):
+            import_accounts(s, "-")
+
+        seq = s._get_sequence_data()
+        assert seq["accounts"]["1"]["email"] == "alice@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Empty home
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyHome:
+    def test_import_into_empty_home_initializes_sequence(self, temp_home: Path):
+        # Source
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        with patch("pathlib.Path.home", return_value=src_home):
+            with patch.dict(os.environ, {"HOME": str(src_home)}):
+                src = _linux_switcher(src_home)
+                _seed_account(src, 1, "alice@example.com")
+                out = src_home / "x.cswap"
+                export_accounts(src, str(out))
+
+        # Destination has no backup directory at all
+        dst_home = temp_home.parent / "empty"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = ClaudeAccountSwitcher()
+                dst.platform = Platform.LINUX
+                # Don't pre-init — verify import does it
+                assert not dst.sequence_file.exists()
+
+                import_accounts(dst, str(out))
+
+                assert dst.sequence_file.exists()
+                seq = dst._get_sequence_data()
+                assert seq["accounts"]["1"]["email"] == "alice@example.com"
+
+
+# ---------------------------------------------------------------------------
+# File permissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only chmod check")
+class TestFilePermissions:
+    def test_export_file_is_0600(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 1, "alice@example.com")
+        out = temp_home / "x.cswap"
+        export_accounts(s, str(out))
+
+        mode = os.stat(out).st_mode & 0o777
+        assert mode == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Validate-all-before-write atomicity
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAllBeforeWrite:
+    def test_malformed_later_account_does_not_partial_write(self, temp_home: Path):
+        """If account 2 fails validation, account 1 must NOT have been written."""
+        s = _linux_switcher(temp_home)
+        env = {
+            "version": 1,
+            "exportedAt": "2026-01-01T00:00:00Z",
+            "exportedFrom": "linux",
+            "swapVersion": "0.0.0",
+            "encrypted": False,
+            "activeAccountNumber": 1,
+            "accounts": [
+                {
+                    "number": 1,
+                    "email": "alice@example.com",
+                    "uuid": "u1",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                    "credentials": SAMPLE_CREDS,
+                    "config": SAMPLE_CONFIG,
+                },
+                {
+                    "number": 2,
+                    "email": "../../evil",  # path traversal -> validation fails
+                    "uuid": "u2",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                    "credentials": SAMPLE_CREDS,
+                    "config": SAMPLE_CONFIG,
+                },
+            ],
+        }
+        f = temp_home / "bad.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="invalid or missing email"):
+            import_accounts(s, str(f))
+
+        # Account 1 must NOT have been written
+        seq = s._get_sequence_data()
+        assert seq is not None
+        assert seq.get("accounts", {}) == {}, (
+            "validation must complete for ALL accounts before any writes"
+        )
+        # No credential file leaked
+        assert not list(s.credentials_dir.glob("*alice*"))
+        assert not list(s.configs_dir.glob("*alice*"))
+
+    def test_duplicate_account_in_export_rejected(self, temp_home: Path):
+        s = _linux_switcher(temp_home)
+        env = {
+            "version": 1,
+            "exportedAt": "2026-01-01T00:00:00Z",
+            "exportedFrom": "linux",
+            "swapVersion": "0.0.0",
+            "encrypted": False,
+            "activeAccountNumber": 1,
+            "accounts": [
+                {
+                    "number": 1,
+                    "email": "alice@example.com",
+                    "uuid": "u1",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                    "credentials": SAMPLE_CREDS,
+                    "config": SAMPLE_CONFIG,
+                },
+                {
+                    "number": 2,
+                    "email": "alice@example.com",
+                    "uuid": "u1",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                    "credentials": SAMPLE_CREDS,
+                    "config": SAMPLE_CONFIG,
+                },
+            ],
+        }
+        f = temp_home / "dup.cswap"
+        f.write_text(json.dumps(env))
+        with pytest.raises(TransferError, match="duplicate account"):
+            import_accounts(s, str(f))
+
+
+# ---------------------------------------------------------------------------
+# Clean-home activation (post-import on fresh machine)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanHomeActivation:
+    """After import on a fresh machine, switch_to / switch should activate
+    the imported account into the live vault even though no Claude Code
+    session has logged in yet."""
+
+    def _seed_and_export(self, src_home: Path) -> Path:
+        with patch("pathlib.Path.home", return_value=src_home):
+            with patch.dict(os.environ, {"HOME": str(src_home)}):
+                src = _linux_switcher(src_home)
+                _seed_account(src, 1, "alice@example.com")
+                _seed_account(src, 2, "bob@example.com")
+                # Mark slot 2 as the active one in the export
+                data = src._get_sequence_data()
+                data["activeAccountNumber"] = 2
+                src._write_json(src.sequence_file, data)
+                out = src_home / "backup.cswap"
+                export_accounts(src, str(out))
+                return out
+
+    def test_switch_to_after_import_activates_target(self, temp_home: Path):
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        export_path = self._seed_and_export(src_home)
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                import_accounts(dst, str(export_path))
+
+                # No live ~/.claude.json exists yet on the "fresh" machine
+                config_path = dst._get_claude_config_path()
+                assert not config_path.exists()
+
+                # Stub list_accounts (post-switch network call) to keep test offline
+                with patch.object(dst, "list_accounts"):
+                    dst.switch_to("1")
+
+                # Live config + live credentials now exist for alice
+                assert config_path.exists()
+                live_config = json.loads(config_path.read_text())
+                assert live_config["oauthAccount"]["emailAddress"] == "alice@example.com"
+
+                live_creds_path = dst_home / ".claude" / ".credentials.json"
+                assert live_creds_path.exists()
+                live_creds = json.loads(live_creds_path.read_text())
+                assert live_creds["_marker"] == "alice@example.com"
+
+                seq = dst._get_sequence_data()
+                assert seq["activeAccountNumber"] == 1
+
+    def test_switch_rotate_after_import_uses_active_from_envelope(
+        self, temp_home: Path
+    ):
+        """Import on a clean home should preserve the envelope's
+        activeAccountNumber (slot 2 = bob), so a subsequent --switch lands
+        on bob without any manual setup."""
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        export_path = self._seed_and_export(src_home)
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                import_accounts(dst, str(export_path))
+
+                # Import alone must propagate the envelope's active slot.
+                seq = dst._get_sequence_data()
+                assert seq["activeAccountNumber"] == 2
+
+                config_path = dst._get_claude_config_path()
+                assert not config_path.exists()
+
+                with patch.object(dst, "list_accounts"):
+                    dst.switch()
+
+                live_config = json.loads(config_path.read_text())
+                assert live_config["oauthAccount"]["emailAddress"] == "bob@example.com"
+                seq = dst._get_sequence_data()
+                assert seq["activeAccountNumber"] == 2
+
+    def test_import_preserves_existing_active_account(self, temp_home: Path):
+        """If destination already has an active selection, import must NOT
+        overwrite it with the envelope's value."""
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        export_path = self._seed_and_export(src_home)  # envelope active = 2
+
+        # Destination already has its own active account in slot 5
+        dst = _linux_switcher(temp_home)
+        _seed_account(dst, 5, "local@example.com")
+        seq = dst._get_sequence_data()
+        seq["activeAccountNumber"] = 5
+        dst._write_json(dst.sequence_file, seq)
+
+        import_accounts(dst, str(export_path))
+
+        # User's existing active stays intact
+        final = dst._get_sequence_data()
+        assert final["activeAccountNumber"] == 5
+
+    def test_active_seeded_to_resolved_slot_not_envelope_slot(
+        self, temp_home: Path
+    ):
+        """Mixed-state: destination has unrelated account at the envelope's
+        active slot number, but the envelope's active account itself was
+        imported into a *different* slot. activeAccountNumber must point
+        at the resolved slot, NOT at the unrelated local account."""
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        export_path = self._seed_and_export(src_home)  # envelope active = 2 (bob)
+
+        # Destination has unrelated `local@example.com` at slot 2 and no
+        # activeAccountNumber set. Bob will be allocated to a different slot
+        # because slot 2 is already taken by an unrelated account.
+        dst = _linux_switcher(temp_home)
+        _seed_account(dst, 2, "local@example.com")
+        seq = dst._get_sequence_data()
+        seq["activeAccountNumber"] = None
+        dst._write_json(dst.sequence_file, seq)
+
+        import_accounts(dst, str(export_path))
+
+        final = dst._get_sequence_data()
+        # local@example.com still owns slot 2
+        assert final["accounts"]["2"]["email"] == "local@example.com"
+        # bob was imported elsewhere
+        bob_slot = next(
+            num
+            for num, acc in final["accounts"].items()
+            if acc["email"] == "bob@example.com"
+        )
+        assert bob_slot != "2"
+        # activeAccountNumber points at bob's resolved slot, NOT at slot 2 (local)
+        assert final["activeAccountNumber"] == int(bob_slot)
+
+    def test_clean_switch_preserves_existing_local_config(self, temp_home: Path):
+        """Fresh-machine switch must preserve existing settings in ~/.claude.json
+        when present, only overlaying oauthAccount — same merge semantics as
+        the normal switch path. Common case: user logged out of Claude Code
+        but kept their projects/MCP config in place."""
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        export_path = self._seed_and_export(src_home)
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                # Pre-existing local config: settings, projects, but no oauthAccount
+                config_path = dst._get_claude_config_path()
+                local_config = {
+                    "tipsHistory": {"shown": ["welcome"]},
+                    "projects": {
+                        "/path/to/project": {
+                            "mcpServers": {"memory": {"type": "stdio"}}
+                        }
+                    },
+                    "userID": "local-user-id",
+                    "numStartups": 42,
+                }
+                config_path.write_text(json.dumps(local_config))
+
+                import_accounts(dst, str(export_path))
+
+                with patch.object(dst, "list_accounts"):
+                    dst.switch_to("1")
+
+                merged = json.loads(config_path.read_text())
+                # Local settings preserved
+                assert merged["tipsHistory"] == {"shown": ["welcome"]}
+                assert merged["projects"]["/path/to/project"]["mcpServers"] == {
+                    "memory": {"type": "stdio"}
+                }
+                assert merged["userID"] == "local-user-id"
+                assert merged["numStartups"] == 42
+                # oauthAccount overlaid from imported config
+                assert merged["oauthAccount"]["emailAddress"] == "alice@example.com"
+
+    def test_clean_switch_fallback_when_local_config_malformed(self, temp_home: Path):
+        """If ~/.claude.json exists but is malformed/empty, fall back to the
+        imported config rather than crashing."""
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        export_path = self._seed_and_export(src_home)
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                config_path = dst._get_claude_config_path()
+                config_path.write_text("{not valid json")
+
+                import_accounts(dst, str(export_path))
+
+                with patch.object(dst, "list_accounts"):
+                    dst.switch_to("1")
+
+                # Imported config wholesale (the malformed file is replaced)
+                merged = json.loads(config_path.read_text())
+                assert merged["oauthAccount"]["emailAddress"] == "alice@example.com"
+
+    def test_active_seeded_when_envelope_active_was_skipped(
+        self, temp_home: Path
+    ):
+        """If the envelope's active account already existed locally and was
+        skipped (no --force), activeAccountNumber should still seed to the
+        existing local slot — that's where the migration intends to land."""
+        src_home = temp_home.parent / "src"
+        src_home.mkdir()
+        export_path = self._seed_and_export(src_home)  # envelope active = 2 (bob)
+
+        # Destination has bob at a different slot already, and alice not at all
+        dst = _linux_switcher(temp_home)
+        _seed_account(dst, 7, "bob@example.com")
+        seq = dst._get_sequence_data()
+        seq["activeAccountNumber"] = None
+        dst._write_json(dst.sequence_file, seq)
+
+        import_accounts(dst, str(export_path))  # no --force, so bob is skipped
+
+        final = dst._get_sequence_data()
+        assert final["accounts"]["7"]["email"] == "bob@example.com"
+        # bob skipped → activeAccountNumber points at where bob lives (slot 7)
+        assert final["activeAccountNumber"] == 7


### PR DESCRIPTION
## Summary
- Add `--export` / `--import` for moving claude-swap account data between machines.
- Use a single plaintext JSON envelope; `-` supports stdin/stdout so users can compose with their own encryption (`gpg`, `age`, etc.).
- Preserve imported active-account metadata without auto-activating it, so `cswap --import ... && cswap --switch` works on a fresh install.
- Relax `switch()` / `_perform_switch()` to handle the no-current-account case while preserving existing local config when present.

Closes #18

## Related
- #3 (@Mffff4) proposed zip-based export/import. This PR uses a smaller JSON-file approach: single file, pipeable, no archive dependency, stdlib only.
- #10 (@treerobin06) independently identified the same `_perform_switch` “no current account” recovery case. This PR covers that scenario as part of the fresh-machine import/switch path, with additional tests. 
