### PR TITLE
fix: skip backup write when switching to the same account (cross-container reload)

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1127,6 +1127,48 @@ class ClaudeAccountSwitcher:
 
             current_email, _ = current_identity
 
+            # Same-account reload path: current and target are the same account
+            # (identified by slot number and email). This happens in multi-container
+            # setups where one container refreshes the shared backup via
+            # --add-account and another container wants to pull the update via
+            # --switch-to. The normal flow would overwrite the just-refreshed backup
+            # with the local container's stale credentials before reading it back,
+            # losing the update. Skip the backup write and reload directly.
+            if current_account == target_account and current_email == target_email:
+                target_creds = self._read_account_credentials(
+                    target_account, target_email
+                )
+                target_config = self._read_account_config(target_account, target_email)
+
+                if not target_creds or not target_config:
+                    raise SwitchError(
+                        f"Missing backup data for Account-{target_account}"
+                    )
+
+                self._write_credentials(target_creds)
+                try:
+                    target_config_data = json.loads(target_config)
+                except json.JSONDecodeError as exc:
+                    raise SwitchError(f"Invalid backup config: {exc}")
+                oauth_section = target_config_data.get("oauthAccount")
+                if not oauth_section:
+                    raise SwitchError("Invalid oauthAccount in backup")
+                current_config_data = self._read_json(config_path) or {}
+                current_config_data["oauthAccount"] = oauth_section
+                self._write_json(config_path, current_config_data)
+
+                data["activeAccountNumber"] = int(target_account)
+                data["lastUpdated"] = get_timestamp()
+                self._write_json(self.sequence_file, data)
+                self._logger.info(f"Reloaded account {target_account} from backup")
+                print(
+                    f"{accent('Reloaded')} Account-{target_account} ({target_email})"
+                )
+                print()
+                warning("Please restart Claude Code to use the new authentication.")
+                print()
+                return
+
             # Create transaction for rollback capability
             try:
                 original_creds = self._read_credentials()


### PR DESCRIPTION
## Problem

In multi-container setups where `~/.claude-swap-backup` is a shared volume, the following workflow silently fails:

1. **Container A**: `cswap --add-account` → refreshes account 1's tokens in the shared backup ✓
2. **Container B**: `cswap --switch-to 1` → Claude Code reports **not authenticated** ✗

### Root cause

`_perform_switch` always executes **Step 1: backup current account** before reading the target. The backup path is keyed only by `(account_num, email)`. When Container B's active account is the same slot/email as the target (common in multi-container setups), Step 1 overwrites the just-refreshed shared backup with Container B's stale local credentials. Step 2 then reads that overwritten data back, leaving Container B with an expired token.

\`\`\`
Container A: write fresh tokens → .creds-1-user@x.enc  ✓
Container B: --switch-to 1
  Step 1: write STALE local tokens → .creds-1-user@x.enc  ← clobbers Container A's work
  Step 2: read .creds-1-user@x.enc → gets stale tokens back
  Step 3: write stale tokens locally → not authenticated
\`\`\`

## Fix

When `current_account == target_account` and `current_email == target_email`, skip the backup write and reload directly from the shared backup. This mirrors the existing `current_identity is None` fresh-machine path already present in this function.

The user sees `Reloaded Account-N` instead of `Switched to Account-N` to signal the different code path.

## Testing

Shared-volume multi-container setup:
- `docker-compose.yml` mounts `~/.claude-swap-backup` as a shared volume across containers
- Container A: `cswap --add-account` (refreshes tokens)
- Container B: `cswap --switch-to 1` → now correctly loads Container A's fresh tokens