### PR TITLE
feat: store backups under $XDG_DATA_HOME on Linux/WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ cswap --purge                   # Remove all claude-swap data
 |----------|-------------|----------------|
 | Windows | Windows Credential Manager | `~/.claude-swap-backup/` |
 | macOS | macOS Keychain | `~/.claude-swap-backup/` |
-| Linux | File-based (`~/.claude-swap-backup/credentials/`) | `~/.claude-swap-backup/` |
+| Linux / WSL | File-based (inside the backup directory, under `credentials/`) | `${XDG_DATA_HOME:-~/.local/share}/claude-swap/` |
+
+On Linux/WSL the location follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). Set `XDG_DATA_HOME` to override; otherwise it defaults to `~/.local/share/claude-swap/`. Existing installs with data under `~/.claude-swap-backup/` are migrated automatically on the first run. If both the legacy and new paths exist, `cswap` refuses to start and asks you to remove the stale one manually.
 
 ## Backup and migration
 

--- a/src/claude_swap/cache.py
+++ b/src/claude_swap/cache.py
@@ -6,7 +6,9 @@ import json
 import time
 from pathlib import Path
 
-CACHE_DIR = Path.home() / ".claude-swap-backup" / "cache"
+from claude_swap.paths import get_backup_root
+
+CACHE_DIR = get_backup_root() / "cache"
 
 MISSING = object()
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -135,16 +135,19 @@ Examples:
     if args.full and not args.export:
         parser.error("--full can only be used with --export")
 
-    # Initialize switcher with debug mode
-    switcher = ClaudeAccountSwitcher(debug=args.debug)
-
-    # Check for root (unless in container) - POSIX only
-    if sys.platform != "win32":
-        if os.geteuid() == 0 and not switcher._is_running_in_container():
-            error("Error: Do not run this script as root (unless running in a container)")
-            sys.exit(1)
-
+    # Initialize switcher and dispatch under a single error handler so
+    # init-time failures (e.g. MigrationError on a backup-dir collision)
+    # are presented like every other ClaudeSwitchError: clean stderr line,
+    # exit 1, no traceback.
     try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+
+        # Check for root (unless in container) - POSIX only
+        if sys.platform != "win32":
+            if os.geteuid() == 0 and not switcher._is_running_in_container():
+                error("Error: Do not run this script as root (unless running in a container)")
+                sys.exit(1)
+
         if args.add_account:
             switcher.add_account(slot=args.slot)
         elif args.remove_account:

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -59,3 +59,9 @@ class TransferError(ClaudeSwitchError):
     """Error during account export or import."""
 
     pass
+
+
+class MigrationError(ClaudeSwitchError):
+    """Error migrating the backup directory between layouts (e.g. legacy → XDG)."""
+
+    pass

--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -9,15 +9,26 @@ claude-code does. Key rules (from claude-code source):
   ``.claude.json`` sits at homedir by default, not inside ``.claude/``.
 - Credentials: ``<config_home>/.credentials.json``.
 
+Also resolves the cswap backup root, which on Linux/WSL follows the XDG Base
+Directory Specification (``$XDG_DATA_HOME/claude-swap``) and falls back to the
+legacy ``~/.claude-swap-backup`` on macOS/Windows.
+
 References:
 - claude-code utils/env.ts getGlobalClaudeFile
 - claude-code utils/secureStorage/plainTextStorage.ts getStoragePath
+- XDG Base Directory Specification: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 """
 
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
+
+from claude_swap.exceptions import MigrationError
+from claude_swap.models import Platform
+
+LEGACY_BACKUP_DIRNAME = ".claude-swap-backup"
 
 
 def get_claude_config_home() -> Path:
@@ -45,3 +56,89 @@ def get_global_config_path() -> Path:
 def get_credentials_path() -> Path:
     """Return the path to the Claude credentials file."""
     return get_claude_config_home() / ".credentials.json"
+
+
+def get_legacy_backup_root() -> Path:
+    """Return the legacy (pre-XDG) backup root: ``~/.claude-swap-backup``."""
+    return Path.home() / LEGACY_BACKUP_DIRNAME
+
+
+def get_backup_root() -> Path:
+    """Return the cswap backup root for the current platform.
+
+    Linux/WSL: ``$XDG_DATA_HOME/claude-swap`` (default ``~/.local/share/claude-swap``).
+    macOS/Windows/unknown: ``~/.claude-swap-backup`` (legacy layout).
+
+    Per the XDG spec, ``$XDG_DATA_HOME`` is ignored when unset, empty, or
+    non-absolute. A leading ``~`` is expanded so values like ``~/data`` set
+    via systemd unit files or Dockerfiles (which don't get shell expansion)
+    still work.
+    """
+    if Platform.detect() in (Platform.LINUX, Platform.WSL):
+        xdg = os.environ.get("XDG_DATA_HOME", "")
+        if xdg:
+            xdg_path = Path(os.path.expanduser(xdg))
+            if xdg_path.is_absolute():
+                return xdg_path / "claude-swap"
+        return Path.home() / ".local" / "share" / "claude-swap"
+    return get_legacy_backup_root()
+
+
+def migrate_legacy_backup_dir(target: Path) -> bool:
+    """Move the legacy backup directory to ``target`` if needed.
+
+    Uses ``shutil.move`` (atomic ``rename`` on same FS; copy + unlink across
+    FS) guarded by a ``<target>.migrating`` flag file. Touching the flag
+    *before* the move and removing it *after* lets us tell an interrupted
+    migration apart from a foreign collision on the next run:
+
+    * Flag present, legacy still there → resume (discard any partial target
+      and retry).
+    * Flag present, legacy gone → previous run completed but didn't get to
+      clean the flag; just unlink it.
+    * No flag, both paths exist → genuine collision, refuse.
+
+    Returns:
+        True if the move ran in this call, False if it was a no-op.
+
+    Raises:
+        MigrationError: on a genuine collision, or when ``shutil.move`` fails.
+    """
+    legacy = get_legacy_backup_root()
+    try:
+        same_path = legacy.resolve() == target.resolve()
+    except OSError:
+        same_path = legacy == target
+    if same_path:
+        return False
+
+    flag = target.parent / f".{target.name}.migrating"
+
+    if not legacy.exists():
+        # Successful prior run that died before unlinking the flag.
+        flag.unlink(missing_ok=True)
+        return False
+
+    if flag.exists():
+        # Prior run was interrupted before completion. Discard any
+        # (potentially partial) target and retry the move from legacy.
+        if target.exists():
+            shutil.rmtree(target)
+    elif target.exists():
+        raise MigrationError(
+            f"Both legacy ({legacy}) and new ({target}) backup paths exist. "
+            f"Refusing to merge or overwrite — inspect both and remove the "
+            f"stale one manually before re-running."
+        )
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        flag.touch()
+        shutil.move(legacy, target)
+        flag.unlink()
+    except OSError as exc:
+        raise MigrationError(
+            f"Migration of {legacy} → {target} failed: {exc}"
+        ) from exc
+
+    return True

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -44,9 +44,12 @@ from claude_swap.printer import (
     warning,
 )
 from claude_swap.paths import (
+    get_backup_root,
     get_claude_config_home,
     get_credentials_path,
     get_global_config_path,
+    get_legacy_backup_root,
+    migrate_legacy_backup_dir,
 )
 from claude_swap.process_detection import get_running_instances
 
@@ -62,12 +65,25 @@ class ClaudeAccountSwitcher:
 
     def __init__(self, debug: bool = False):
         self.home = Path.home()
-        self.backup_dir = self.home / ".claude-swap-backup"
+        self.platform = Platform.detect()
+        self.backup_dir = get_backup_root()
+
+        # Migrate legacy ~/.claude-swap-backup to the new XDG path on Linux/WSL
+        # before any logger or directory setup writes to the new location.
+        # Migration is a no-op on macOS/Windows where backup_dir already
+        # equals the legacy path. MigrationError on a genuine collision
+        # propagates as a ClaudeSwitchError and is caught by the CLI.
+        if migrate_legacy_backup_dir(self.backup_dir):
+            legacy = get_legacy_backup_root()
+            print(
+                f"claude-swap: migrated data from {legacy} to {self.backup_dir}",
+                file=sys.stderr,
+            )
+
         self.sequence_file = self.backup_dir / "sequence.json"
         self.configs_dir = self.backup_dir / "configs"
         self.credentials_dir = self.backup_dir / "credentials"
         self.lock_file = self.backup_dir / ".lock"
-        self.platform = Platform.detect()
         self._logger = setup_logging(self.backup_dir, debug=debug)
 
     def _is_running_in_container(self) -> bool:
@@ -1230,10 +1246,17 @@ class ClaudeAccountSwitcher:
 
         This removes:
         - All stored account credentials (files on Linux, keyring on macOS/Windows)
-        - The ~/.claude-swap-backup directory and all its contents
+        - The active backup directory (XDG path on Linux/WSL, ~/.claude-swap-backup elsewhere)
+        - Any stale legacy ~/.claude-swap-backup directory left around from
+          before the XDG migration
         """
+        legacy = get_legacy_backup_root()
+        legacy_distinct = legacy != self.backup_dir
+
         warning("This will remove ALL claude-swap data from your system:")
         print(f"  - Backup directory: {self.backup_dir}")
+        if legacy_distinct and legacy.exists():
+            print(f"  - Legacy backup directory: {legacy}")
         if self.platform in (Platform.LINUX, Platform.WSL):
             print("  - All stored account credential files")
         else:
@@ -1285,6 +1308,15 @@ class ClaudeAccountSwitcher:
 
             shutil.rmtree(self.backup_dir)
             removed_items.append(f"Directory: {self.backup_dir}")
+
+        # Also clean a stale legacy directory if it somehow still exists
+        # (e.g. a partial pre-migration state, or files re-created after init).
+        if legacy_distinct and legacy.exists():
+            try:
+                shutil.rmtree(legacy)
+                removed_items.append(f"Legacy directory: {legacy}")
+            except OSError:
+                pass
 
         if removed_items:
             print(f"\n{accent('Removed:')}")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -13,10 +13,16 @@ from unittest.mock import patch
 
 import pytest
 
+from claude_swap.exceptions import MigrationError
+from claude_swap.models import Platform
 from claude_swap.paths import (
+    LEGACY_BACKUP_DIRNAME,
+    get_backup_root,
     get_claude_config_home,
     get_credentials_path,
     get_global_config_path,
+    get_legacy_backup_root,
+    migrate_legacy_backup_dir,
 )
 
 
@@ -84,3 +90,185 @@ class TestGetCredentialsPath:
         custom = tmp_path / "ccd"
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
         assert get_credentials_path() == custom / ".credentials.json"
+
+
+class TestGetBackupRoot:
+    """Linux/WSL: XDG-aware path. Other platforms: legacy ~/.claude-swap-backup."""
+
+    def test_linux_default_is_xdg_data_home(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.LINUX))
+        assert get_backup_root() == isolated_home / ".local" / "share" / "claude-swap"
+
+    def test_linux_respects_xdg_data_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        custom = tmp_path / "xdg"
+        monkeypatch.setenv("XDG_DATA_HOME", str(custom))
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.LINUX))
+        assert get_backup_root() == custom / "claude-swap"
+
+    def test_linux_ignores_empty_xdg_data_home(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("XDG_DATA_HOME", "")
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.LINUX))
+        assert get_backup_root() == isolated_home / ".local" / "share" / "claude-swap"
+
+    def test_linux_ignores_relative_xdg_data_home(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Per the XDG spec, relative paths must be ignored.
+        monkeypatch.setenv("XDG_DATA_HOME", "relative/path")
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.LINUX))
+        assert get_backup_root() == isolated_home / ".local" / "share" / "claude-swap"
+
+    def test_linux_expands_tilde_in_xdg_data_home(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # systemd unit files / Dockerfiles set env vars without shell
+        # expansion, so a literal ``~/foo`` must still resolve correctly.
+        monkeypatch.setenv("XDG_DATA_HOME", "~/custom-data")
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.LINUX))
+        assert get_backup_root() == isolated_home / "custom-data" / "claude-swap"
+
+    def test_wsl_uses_xdg_layout(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.WSL))
+        assert get_backup_root() == isolated_home / ".local" / "share" / "claude-swap"
+
+    def test_macos_uses_legacy_layout(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.MACOS))
+        assert get_backup_root() == isolated_home / LEGACY_BACKUP_DIRNAME
+
+    def test_windows_uses_legacy_layout(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.WINDOWS))
+        assert get_backup_root() == isolated_home / LEGACY_BACKUP_DIRNAME
+
+    def test_legacy_helper_returns_home_dot_claude_swap_backup(
+        self, isolated_home: Path
+    ):
+        assert get_legacy_backup_root() == isolated_home / LEGACY_BACKUP_DIRNAME
+
+
+class TestMigrateLegacyBackupDir:
+    def test_no_legacy_is_noop(self, isolated_home: Path):
+        target = isolated_home / ".local" / "share" / "claude-swap"
+        assert migrate_legacy_backup_dir(target) is False
+        assert not target.exists()
+
+    def test_target_equals_legacy_is_noop(self, isolated_home: Path):
+        # macOS/Windows: backup_root == legacy. Migration must not touch it.
+        legacy = isolated_home / LEGACY_BACKUP_DIRNAME
+        legacy.mkdir()
+        (legacy / "marker").write_text("keep me")
+        assert migrate_legacy_backup_dir(legacy) is False
+        assert (legacy / "marker").read_text() == "keep me"
+
+    def test_moves_legacy_to_target(self, isolated_home: Path):
+        legacy = isolated_home / LEGACY_BACKUP_DIRNAME
+        legacy.mkdir()
+        (legacy / "sequence.json").write_text('{"k": 1}')
+        nested = legacy / "configs"
+        nested.mkdir()
+        (nested / "x.json").write_text("{}")
+
+        target = isolated_home / ".local" / "share" / "claude-swap"
+        assert migrate_legacy_backup_dir(target) is True
+        assert not legacy.exists()
+        assert (target / "sequence.json").read_text() == '{"k": 1}'
+        assert (target / "configs" / "x.json").read_text() == "{}"
+
+    def test_collision_raises_migration_error(self, isolated_home: Path):
+        """Both paths exist → refuse to merge or overwrite."""
+        legacy = isolated_home / LEGACY_BACKUP_DIRNAME
+        legacy.mkdir()
+        (legacy / "sequence.json").write_text('{"src": "legacy"}')
+
+        target = isolated_home / ".local" / "share" / "claude-swap"
+        target.mkdir(parents=True)
+        (target / "sequence.json").write_text('{"src": "target"}')
+
+        with pytest.raises(MigrationError, match="Refusing to merge"):
+            migrate_legacy_backup_dir(target)
+        # Neither path is touched on collision.
+        assert (legacy / "sequence.json").read_text() == '{"src": "legacy"}'
+        assert (target / "sequence.json").read_text() == '{"src": "target"}'
+
+    def test_resumes_after_interrupted_move(self, isolated_home: Path):
+        """Flag present + legacy still there = previous run was interrupted.
+
+        Discard any partial target and retry the move.
+        """
+        legacy = isolated_home / LEGACY_BACKUP_DIRNAME
+        legacy.mkdir()
+        (legacy / "sequence.json").write_text('{"src": "legacy"}')
+
+        target = isolated_home / ".local" / "share" / "claude-swap"
+        target.mkdir(parents=True)
+        (target / "stale-partial.json").write_text("garbage")
+        flag = target.parent / f".{target.name}.migrating"
+        flag.touch()
+
+        assert migrate_legacy_backup_dir(target) is True
+        assert not legacy.exists()
+        assert not flag.exists()
+        assert not (target / "stale-partial.json").exists()
+        assert (target / "sequence.json").read_text() == '{"src": "legacy"}'
+
+    def test_cleans_stale_flag_after_completed_move(self, isolated_home: Path):
+        """Flag present + legacy gone = move completed but flag wasn't unlinked.
+
+        Just clean the flag; do NOT touch the (complete) target.
+        """
+        target = isolated_home / ".local" / "share" / "claude-swap"
+        target.mkdir(parents=True)
+        (target / "sequence.json").write_text('{"complete": true}')
+        flag = target.parent / f".{target.name}.migrating"
+        flag.touch()
+
+        assert migrate_legacy_backup_dir(target) is False
+        assert not flag.exists()
+        # Target is untouched.
+        assert (target / "sequence.json").read_text() == '{"complete": true}'
+
+    def test_oserror_is_wrapped(self, isolated_home, monkeypatch):
+        """Filesystem errors surface as MigrationError, not raw OSError."""
+        legacy = isolated_home / LEGACY_BACKUP_DIRNAME
+        legacy.mkdir()
+        (legacy / "sequence.json").write_text("{}")
+        target = isolated_home / ".local" / "share" / "claude-swap"
+
+        def exploding_move(*args, **kwargs):
+            raise PermissionError("simulated EACCES")
+
+        monkeypatch.setattr("claude_swap.paths.shutil.move", exploding_move)
+
+        with pytest.raises(MigrationError, match="failed"):
+            migrate_legacy_backup_dir(target)
+        # Legacy untouched (the real shutil.move was never called).
+        assert (legacy / "sequence.json").read_text() == "{}"
+
+    def test_preserves_file_modes(self, isolated_home: Path):
+        if os.name == "nt":
+            pytest.skip("POSIX file modes not meaningful on Windows")
+        legacy = isolated_home / LEGACY_BACKUP_DIRNAME
+        legacy.mkdir(mode=0o700)
+        cred = legacy / "credentials" / ".creds-1-user@example.com.enc"
+        cred.parent.mkdir(mode=0o700)
+        cred.write_text("data")
+        os.chmod(cred, 0o600)
+
+        target = isolated_home / ".local" / "share" / "claude-swap"
+        assert migrate_legacy_backup_dir(target) is True
+        moved = target / "credentials" / ".creds-1-user@example.com.enc"
+        assert moved.stat().st_mode & 0o777 == 0o600
+        assert (target / "credentials").stat().st_mode & 0o777 == 0o700

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -17,6 +17,7 @@ from claude_swap.exceptions import (
     ValidationError,
 )
 from claude_swap.models import Platform
+from claude_swap.paths import get_backup_root
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -870,8 +871,8 @@ class TestAccountExistsCompositeKey:
     def test_distinguishes_org_and_personal(self, temp_home, mock_credentials_file):
         """Accounts with same email but different organizationUuid should be treated as distinct."""
         from claude_swap.switcher import ClaudeAccountSwitcher
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir()
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps({
             "activeAccountNumber": 1,
             "lastUpdated": "2024-01-01T00:00:00Z",
@@ -950,7 +951,7 @@ class TestAddAccountOrgFields:
              patch.object(switcher, "_write_account_credentials"):
             switcher.add_account()
 
-        seq = json.loads((temp_home / ".claude-swap-backup" / "sequence.json").read_text())
+        seq = json.loads((get_backup_root() / "sequence.json").read_text())
         assert len(seq["accounts"]) == 2
         assert seq["accounts"]["1"]["organizationUuid"] == "org-uuid-A"
         assert seq["accounts"]["2"]["organizationUuid"] == ""
@@ -985,7 +986,7 @@ class TestAddAccountOrgFields:
             switcher.add_account()
         assert "Updated credentials" in f.getvalue()
 
-        seq = json.loads((temp_home / ".claude-swap-backup" / "sequence.json").read_text())
+        seq = json.loads((get_backup_root() / "sequence.json").read_text())
         assert len(seq["accounts"]) == 1
 
     def test_stores_org_name_in_sequence(self, temp_home):
@@ -1007,7 +1008,7 @@ class TestAddAccountOrgFields:
              patch.object(switcher, "_write_account_credentials"):
             switcher.add_account()
 
-        seq = json.loads((temp_home / ".claude-swap-backup" / "sequence.json").read_text())
+        seq = json.loads((get_backup_root() / "sequence.json").read_text())
         assert seq["accounts"]["1"]["organizationName"] == "My Org"
         assert seq["accounts"]["1"]["organizationUuid"] == "org-uuid"
 
@@ -1018,8 +1019,8 @@ class TestResolveIdentifierAmbiguity:
     def test_by_number_always_works(self, temp_home, sample_sequence_data_with_org):
         """Account number identifier should always resolve correctly."""
         from claude_swap.switcher import ClaudeAccountSwitcher
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir()
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data_with_org))
         switcher = ClaudeAccountSwitcher()
         assert switcher._resolve_account_identifier("1") == "1"
@@ -1029,8 +1030,8 @@ class TestResolveIdentifierAmbiguity:
         """Should raise ConfigError when email matches multiple accounts."""
         from claude_swap.switcher import ClaudeAccountSwitcher
         from claude_swap.exceptions import ConfigError
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir()
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data_with_org))
         switcher = ClaudeAccountSwitcher()
         with pytest.raises(ConfigError, match="ambiguous"):
@@ -1039,8 +1040,8 @@ class TestResolveIdentifierAmbiguity:
     def test_unique_email_still_works(self, temp_home, sample_sequence_data):
         """Unique email should still resolve to the correct account number."""
         from claude_swap.switcher import ClaudeAccountSwitcher
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir()
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data))
         switcher = ClaudeAccountSwitcher()
         assert switcher._resolve_account_identifier("account1@example.com") == "1"
@@ -1055,8 +1056,8 @@ class TestListAccountsOrgDisplay:
         from claude_swap.switcher import ClaudeAccountSwitcher
         from unittest.mock import patch
 
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir()
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data_with_org))
 
         config_path = temp_home / ".claude.json"
@@ -1084,8 +1085,8 @@ class TestListAccountsOrgDisplay:
         from claude_swap.switcher import ClaudeAccountSwitcher
         from unittest.mock import patch
 
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir()
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data_with_org))
 
         config_path = temp_home / ".claude.json"
@@ -1114,8 +1115,8 @@ class TestBackwardCompatibility:
         from claude_swap.switcher import ClaudeAccountSwitcher
         from unittest.mock import patch
 
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir()
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data))
 
         config_path = temp_home / ".claude.json"
@@ -1139,8 +1140,8 @@ class TestBackwardCompatibility:
         """status should display personal for old sequence.json entries."""
         from claude_swap.switcher import ClaudeAccountSwitcher
 
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir()
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data))
 
         config_path = temp_home / ".claude.json"
@@ -1164,8 +1165,8 @@ class TestUpgradeMigration:
 
     def _setup_pre_v06(self, temp_home, sequence_data, live_config):
         """Helper to set up pre-v0.6.0 state with a live config."""
-        backup_dir = temp_home / ".claude-swap-backup"
-        backup_dir.mkdir(exist_ok=True)
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
         (backup_dir / "sequence.json").write_text(json.dumps(sequence_data))
 
         config_path = temp_home / ".claude.json"
@@ -1293,7 +1294,7 @@ class TestUpgradeMigration:
         )
 
         switcher = ClaudeAccountSwitcher()
-        backup_dir = temp_home / ".claude-swap-backup"
+        backup_dir = get_backup_root()
         creds_dir = backup_dir / "credentials"
         creds_dir.mkdir(exist_ok=True)
         import base64
@@ -1509,3 +1510,85 @@ class TestAddAccountSlot:
 
         data = switcher._get_sequence_data()
         assert data["sequence"] == [2, 5]
+
+
+class TestPurgeLegacyCleanup:
+    """``purge`` must remove a stale legacy directory if it ever reappears.
+
+    Migration normally consumes the legacy path on init, but a partial
+    pre-migration state or external recreation could leave it behind.
+    Purge is the user's last-resort "remove everything" hammer, so it must
+    cover that case explicitly.
+    """
+
+    def _ensure_linux_layout(self, monkeypatch):
+        # Tests must observe the post-migration two-path world. On macOS in
+        # CI the backup root and the legacy root are the same directory, so
+        # there's nothing distinct to clean — pin to LINUX semantics.
+        monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.LINUX))
+
+    def _make_switcher_then_recreate_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[ClaudeAccountSwitcher, Path, Path]:
+        """Construct a switcher with no legacy present, then recreate it.
+
+        Mirrors the realistic state where migration completed (or never had
+        anything to migrate) and a stale legacy directory subsequently
+        reappeared — e.g. a user manually backing up to the old path, or a
+        third-party tool restoring a snapshot.
+        """
+        from claude_swap.paths import get_backup_root, get_legacy_backup_root
+
+        self._ensure_linux_layout(monkeypatch)
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
+
+        # Instantiate while legacy is absent → init succeeds.
+        switcher = ClaudeAccountSwitcher()
+
+        # Now legacy reappears after init.
+        legacy = get_legacy_backup_root()
+        legacy.mkdir(parents=True, exist_ok=True)
+        return switcher, backup_dir, legacy
+
+    def test_purge_removes_stale_legacy_directory(
+        self, temp_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        switcher, backup_dir, legacy = self._make_switcher_then_recreate_legacy(monkeypatch)
+        (legacy / "ghost.txt").write_text("should be removed")
+
+        with patch("builtins.input", return_value="y"):
+            switcher.purge()
+
+        assert not legacy.exists()
+        assert not backup_dir.exists()
+
+    def test_purge_prompt_lists_legacy_when_present(
+        self, temp_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ):
+        switcher, backup_dir, legacy = self._make_switcher_then_recreate_legacy(monkeypatch)
+
+        with patch("builtins.input", return_value="n"):
+            switcher.purge()
+
+        out = capsys.readouterr().out
+        assert str(backup_dir) in out
+        assert str(legacy) in out
+
+    def test_purge_prompt_omits_legacy_when_absent(
+        self, temp_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ):
+        from claude_swap.paths import get_backup_root, get_legacy_backup_root
+
+        self._ensure_linux_layout(monkeypatch)
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        legacy = get_legacy_backup_root()
+        assert not legacy.exists()
+
+        switcher = ClaudeAccountSwitcher()
+        with patch("builtins.input", return_value="n"):
+            switcher.purge()
+
+        out = capsys.readouterr().out
+        assert "Legacy backup directory" not in out


### PR DESCRIPTION
- Comply with the XDG Base Directory Spec on Linux/WSL; macOS/Windows keep the legacy ~/.claude-swap-backup/ layout because their file-vs- keyring split is already tied to it.
- Existing installs migrate automatically on first run, guarded by a <target>.migrating flag so an interrupted run resumes from a known state rather than re-copying from a possibly-partial source.
- When both legacy and new paths exist without a flag, refuse to act — better to surface a clear error than risk silently overwriting data the tool didn't create.
- Surface filesystem failures via a typed MigrationError so the CLI exits cleanly instead of dumping a traceback.
- cswap --purge also sweeps any stale legacy directory left behind.

Address #26 