### PR TITLE
fix: use file-based credential backup on Windows to avoid WCM size limit

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -14,6 +14,9 @@ from claude_swap.switcher import ClaudeAccountSwitcher
 
 def main() -> None:
     """Main entry point for the CLI."""
+    if sys.platform == "win32":
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
     parser = argparse.ArgumentParser(
         description="Multi-Account Switcher for Claude Code",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -258,10 +258,11 @@ class ClaudeAccountSwitcher:
     def _read_account_credentials(self, account_num: str, email: str) -> str:
         """Read account credentials from backup.
 
-        On Linux/WSL: Uses file-based storage to avoid keyring backend issues.
-        On macOS/Windows: Uses system keyring.
+        On Linux/WSL/Windows: Uses file-based storage (Claude Code stores creds in a file
+        on these platforms, so the credential blob can exceed WCM's 2560-byte limit).
+        On macOS: Uses system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self.platform in (Platform.LINUX, Platform.WSL, Platform.WINDOWS):
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             if cred_file.exists():
                 try:
@@ -272,7 +273,7 @@ class ClaudeAccountSwitcher:
                     return ""
             return ""
         else:
-            # Use keyring for macOS/Windows
+            # Use keyring for macOS
             username = f"account-{account_num}-{email}"
             try:
                 creds = keyring.get_password(KEYRING_SERVICE, username)
@@ -286,20 +287,22 @@ class ClaudeAccountSwitcher:
     ) -> None:
         """Write account credentials to backup.
 
-        On Linux/WSL: Uses file-based storage to avoid keyring backend issues.
-        On macOS/Windows: Uses system keyring.
+        On Linux/WSL/Windows: Uses file-based storage (Claude Code stores creds in a file
+        on these platforms, so the credential blob can exceed WCM's 2560-byte limit).
+        On macOS: Uses system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self.platform in (Platform.LINUX, Platform.WSL, Platform.WINDOWS):
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             try:
                 encoded = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
                 cred_file.write_text(encoded, encoding="utf-8")
-                os.chmod(cred_file, 0o600)
+                if self.platform != Platform.WINDOWS:
+                    os.chmod(cred_file, 0o600)
             except Exception as e:
                 self._logger.warning(f"Failed to write credentials file: {e}")
                 raise
         else:
-            # Use keyring for macOS/Windows
+            # Use keyring for macOS
             username = f"account-{account_num}-{email}"
             try:
                 keyring.set_password(KEYRING_SERVICE, username, credentials)
@@ -310,10 +313,10 @@ class ClaudeAccountSwitcher:
     def _delete_account_credentials(self, account_num: str, email: str) -> None:
         """Delete account credentials from backup.
 
-        On Linux/WSL: Deletes file-based credential storage.
-        On macOS/Windows: Removes from system keyring.
+        On Linux/WSL/Windows: Deletes file-based credential storage.
+        On macOS: Removes from system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self.platform in (Platform.LINUX, Platform.WSL, Platform.WINDOWS):
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             try:
                 if cred_file.exists():
@@ -321,7 +324,7 @@ class ClaudeAccountSwitcher:
             except Exception as e:
                 self._logger.warning(f"Failed to delete credentials file: {e}")
         else:
-            # Use keyring for macOS/Windows
+            # Use keyring for macOS
             username = f"account-{account_num}-{email}"
             try:
                 keyring.delete_password(KEYRING_SERVICE, username)


### PR DESCRIPTION
## Problem

Two bugs break `cswap` on Windows.

### Bug 1: `--add-account` fails with WinError 1783

```
win32ctypes.pywin32.pywintypes.error: (1783, 'CredWrite', 'The stub received bad data.')
```

`_write_account_credentials` routes Windows through the keyring backend (Windows Credential Manager), which has a **~2560-byte hard limit** on credential blobs. Claude Code on Windows stores credentials in `~/.claude/.credentials.json`, which regularly exceeds this limit.

### Bug 2: `--list` crashes with UnicodeEncodeError

```
UnicodeEncodeError: 'charmap' codec can't encode character '├' in position 5: character maps to <undefined>
```

Windows PowerShell defaults to cp1252 encoding. Box-drawing characters used in `--list` output (`├` `└`) cannot be encoded by cp1252.

## Fix

**Commit 1** (`switcher.py`): Route Windows through the same file-based backup path already used by Linux/WSL. macOS continues to use the system keyring (Keychain). Also skip `os.chmod` on Windows (no-op).

**Commit 2** (`cli.py`): Reconfigure stdout/stderr to UTF-8 at CLI startup on Windows before any output is written.

## Testing

Verified on Windows 10 with Python 3.14:
- `cswap --add-account` succeeds (previously crashed on CredWrite)
- `cswap --list` renders correctly with box-drawing chars