### PR TITLE
feat: add --add-token for registering raw OAuth setup-tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ cswap --add-account
 
 This will update the stored credentials without creating a duplicate.
 
+### Add an account from a raw OAuth token
+
+If you only have a long-lived setup-token (e.g., produced by `claude setup-token`)
+and you don't want to log in via the browser flow first — useful on headless
+servers or when receiving a token from another machine — register it directly:
+
+```bash
+cswap --add-token sk-ant-oat01-... --email user@example.com
+cswap --add-token sk-ant-oat01-... --email user@example.com --slot 3
+cswap --add-token - --email user@example.com           # read token from stdin
+cswap --add-token --email user@example.com             # prompt securely (no echo)
+```
+
+`--email` is required so cswap's metadata stays aligned with the rest of the
+accounts. No Anthropic API calls are made.
+
 ### Other commands
 
 ```bash

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -20,6 +20,9 @@ def main() -> None:
         epilog="""
 Examples:
   %(prog)s --add-account
+  %(prog)s --add-token --email user@example.com
+  %(prog)s --add-token sk-ant-oat01-... --email user@example.com --slot 3
+  %(prog)s --add-token - --email user@example.com
   %(prog)s --list
   %(prog)s --switch
   %(prog)s --switch-to 2
@@ -52,7 +55,12 @@ Examples:
         "--slot",
         type=int,
         metavar="NUM",
-        help="Specify slot number when adding account (use with --add-account)",
+        help="Specify slot number when adding account (use with --add-account or --add-token)",
+    )
+    parser.add_argument(
+        "--email",
+        metavar="EMAIL",
+        help="Email address for the account (required with --add-token)",
     )
     parser.add_argument(
         "--account",
@@ -117,14 +125,28 @@ Examples:
         metavar="PATH",
         help="Import accounts from file (use '-' for stdin)",
     )
+    group.add_argument(
+        "--add-token",
+        metavar="TOKEN|-",
+        nargs="?",
+        const="",
+        help=(
+            "Register a raw OAuth setup-token as a new account. "
+            "Pass '-' to read from stdin or omit the value to be prompted securely. "
+            "Requires --email."
+        ),
+    )
 
     args = parser.parse_args()
 
     if args.token_status and not args.list:
         parser.error("--token-status can only be used with --list")
 
-    if args.slot is not None and not args.add_account:
-        parser.error("--slot can only be used with --add-account")
+    if args.slot is not None and not (args.add_account or args.add_token is not None):
+        parser.error("--slot can only be used with --add-account or --add-token")
+
+    if args.add_token is not None and not args.email:
+        parser.error("--email is required with --add-token")
 
     if args.account is not None and not args.export:
         parser.error("--account can only be used with --export")
@@ -147,6 +169,12 @@ Examples:
     try:
         if args.add_account:
             switcher.add_account(slot=args.slot)
+        elif args.add_token is not None:
+            switcher.add_account_from_token(
+                token=args.add_token,
+                email=args.email,
+                slot=args.slot,
+            )
         elif args.remove_account:
             switcher.remove_account(args.remove_account)
         elif args.list:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -698,6 +698,166 @@ class ClaudeAccountSwitcher:
         self._logger.info(f"Added account {account_num}: {current_email} (org: {organization_uuid or 'personal'})")
         print(f"{accent('Added')} Account {account_num}: {current_email} {muted(f'[{tag}]')}")
 
+    def add_account_from_token(
+        self, token: str, email: str, slot: int | None = None
+    ) -> None:
+        """Register a raw OAuth setup-token as a new account.
+
+        Useful for headless servers or when the token is received from another
+        machine, without needing a prior Claude Code login on this machine.
+        No Anthropic API calls are made; ``email`` is taken as-is from the flag.
+
+        Args:
+            token: Raw OAuth access token, or ``"-"`` to read one line from
+                   stdin, or ``""`` to prompt securely via getpass.
+            email: Email address to associate with the account (required).
+            slot:  Slot number to use; auto-assigned when ``None``.
+        """
+        import getpass
+
+        if token == "-":
+            token = sys.stdin.readline().rstrip("\n")
+        elif not token:
+            token = getpass.getpass("Setup token: ")
+
+        token = token.strip()
+        if not token:
+            raise ValidationError("Token cannot be empty")
+
+        if not self._validate_email(email):
+            raise ValidationError(f"Invalid email format: {email}")
+
+        self._setup_directories()
+        self._init_sequence_file()
+        self._migrate_org_fields()
+
+        # If the account already exists (same email, personal), refresh in place.
+        if slot is None and self._account_exists(email, ""):
+            seq = self._get_sequence_data()
+            account_num = next(
+                (num for num, acc in seq.get("accounts", {}).items()
+                 if acc.get("email") == email
+                 and acc.get("organizationUuid", "") == ""),
+                None,
+            )
+            credentials = json.dumps({"claudeAiOauth": {"accessToken": token}})
+            config = json.dumps({
+                "oauthAccount": {
+                    "emailAddress": email,
+                    "accountUuid": "",
+                    "organizationUuid": None,
+                    "organizationName": None,
+                }
+            })
+            self._write_account_credentials(account_num, email, credentials)
+            self._write_account_config(account_num, email, config)
+            seq["lastUpdated"] = get_timestamp()
+            self._write_json(self.sequence_file, seq)
+            self._logger.info(f"Updated token for account {account_num}: {email}")
+            print(
+                f"{accent('Updated token')} for Account {account_num} "
+                f"({email} {muted('[personal]')})."
+            )
+            return
+
+        displace_slot = None
+        migrate_from = None
+
+        if slot is not None:
+            if slot < 1:
+                raise ConfigError("Slot number must be >= 1")
+            account_num = str(slot)
+            data = self._get_sequence_data()
+
+            if self._account_exists(email, ""):
+                old_num = next(
+                    (num for num, acc in data.get("accounts", {}).items()
+                     if acc.get("email") == email
+                     and acc.get("organizationUuid", "") == ""),
+                    None,
+                )
+                if old_num and old_num != account_num:
+                    migrate_from = old_num
+
+            if account_num in data.get("accounts", {}):
+                existing = data["accounts"][account_num]
+                existing_email = existing.get("email", "unknown")
+                is_same = (
+                    existing_email == email
+                    and existing.get("organizationUuid", "") == ""
+                )
+                if not is_same:
+                    existing_tag = self._get_display_tag(
+                        existing_email,
+                        existing.get("organizationName", ""),
+                        existing.get("organizationUuid", ""),
+                    )
+                    warning(f"Slot {slot} already occupied")
+                    print(f"{existing_email} {muted(f'[{existing_tag}]')}")
+                    try:
+                        answer = input(f"Overwrite slot {slot}? [y/N] ").strip().lower()
+                    except (EOFError, KeyboardInterrupt):
+                        print(f"\n{dimmed('Cancelled')}")
+                        return
+                    if answer not in ("y", "yes"):
+                        print(dimmed("Cancelled"))
+                        return
+                    displace_slot = (account_num, existing_email)
+        else:
+            account_num = str(self._get_next_account_number())
+
+        credentials = json.dumps({"claudeAiOauth": {"accessToken": token}})
+        config = json.dumps({
+            "oauthAccount": {
+                "emailAddress": email,
+                "accountUuid": "",
+                "organizationUuid": None,
+                "organizationName": None,
+            }
+        })
+
+        if displace_slot:
+            d_num, d_email = displace_slot
+            self._delete_account_files(d_num, d_email)
+            data = self._get_sequence_data()
+            if int(d_num) in data["sequence"]:
+                data["sequence"].remove(int(d_num))
+            del data["accounts"][d_num]
+            self._write_json(self.sequence_file, data)
+
+        if migrate_from:
+            data = self._get_sequence_data()
+            old_email = data["accounts"][migrate_from].get("email", "")
+            self._delete_account_files(migrate_from, old_email)
+            if int(migrate_from) in data["sequence"]:
+                data["sequence"].remove(int(migrate_from))
+            del data["accounts"][migrate_from]
+            self._write_json(self.sequence_file, data)
+            print(f"{dimmed(f'Moved from slot {migrate_from} → {slot}')}")
+
+        self._write_account_credentials(account_num, email, credentials)
+        self._write_account_config(account_num, email, config)
+
+        data = self._get_sequence_data()
+        data["accounts"][account_num] = {
+            "email": email,
+            "uuid": "",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": get_timestamp(),
+        }
+        if int(account_num) not in data["sequence"]:
+            data["sequence"].append(int(account_num))
+            data["sequence"].sort()
+        data["lastUpdated"] = get_timestamp()
+
+        self._write_json(self.sequence_file, data)
+        self._logger.info(f"Added account {account_num} from token: {email}")
+        print(
+            f"{accent('Added')} Account {account_num}: {email} "
+            f"{muted('[personal]')} {muted('(from token)')}"
+        )
+
     def remove_account(self, identifier: str) -> None:
         """Remove account from managed accounts."""
         if not self.sequence_file.exists():

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -57,15 +57,9 @@ from claude_swap.process_detection import get_running_instances
 KEYRING_SERVICE = "claude-code"
 KEYRING_ACTIVE_USERNAME = "active-credentials"
 
-# Default OAuth scopes granted by Claude Code login. The refresh flow in
-# oauth.py overwrites this with whatever the server returns, so the value
-# is only used as a sensible default when seeding a credential blob from a
-# raw setup-token (which carries no scope metadata of its own).
-DEFAULT_OAUTH_SCOPES = (
-    "user:profile",
-    "user:inference",
-    "user:sessions:claude_code",
-)
+# Setup-tokens are inference-only server-side; wider scopes trigger 403s
+# on profile endpoints. Matches Claude Code's CLAUDE_CODE_OAUTH_TOKEN path.
+SETUP_TOKEN_SCOPES = ("user:inference",)
 
 # Usage cache
 _USAGE_CACHE_TTL = 15  # seconds
@@ -769,7 +763,7 @@ class ClaudeAccountSwitcher:
             credentials = json.dumps({
                 "claudeAiOauth": {
                     "accessToken": token,
-                    "scopes": list(DEFAULT_OAUTH_SCOPES),
+                    "scopes": list(SETUP_TOKEN_SCOPES),
                 }
             })
             config = json.dumps({
@@ -840,7 +834,7 @@ class ClaudeAccountSwitcher:
         credentials = json.dumps({
             "claudeAiOauth": {
                 "accessToken": token,
-                "scopes": list(DEFAULT_OAUTH_SCOPES),
+                "scopes": list(SETUP_TOKEN_SCOPES),
             }
         })
         config = json.dumps({

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -54,6 +54,16 @@ from claude_swap.process_detection import get_running_instances
 KEYRING_SERVICE = "claude-code"
 KEYRING_ACTIVE_USERNAME = "active-credentials"
 
+# Default OAuth scopes granted by Claude Code login. The refresh flow in
+# oauth.py overwrites this with whatever the server returns, so the value
+# is only used as a sensible default when seeding a credential blob from a
+# raw setup-token (which carries no scope metadata of its own).
+DEFAULT_OAUTH_SCOPES = (
+    "user:profile",
+    "user:inference",
+    "user:sessions:claude_code",
+)
+
 # Usage cache
 _USAGE_CACHE_TTL = 15  # seconds
 
@@ -740,7 +750,12 @@ class ClaudeAccountSwitcher:
                  and acc.get("organizationUuid", "") == ""),
                 None,
             )
-            credentials = json.dumps({"claudeAiOauth": {"accessToken": token}})
+            credentials = json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": token,
+                    "scopes": list(DEFAULT_OAUTH_SCOPES),
+                }
+            })
             config = json.dumps({
                 "oauthAccount": {
                     "emailAddress": email,
@@ -806,7 +821,12 @@ class ClaudeAccountSwitcher:
         else:
             account_num = str(self._get_next_account_number())
 
-        credentials = json.dumps({"claudeAiOauth": {"accessToken": token}})
+        credentials = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": token,
+                "scopes": list(DEFAULT_OAUTH_SCOPES),
+            }
+        })
         config = json.dumps({
             "oauthAccount": {
                 "emailAddress": email,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,13 +108,13 @@ class TestCLI:
         )
 
     def test_slot_flag_requires_add_account(self, capsys):
-        """--slot should only be accepted alongside --add-account."""
+        """--slot should only be accepted alongside --add-account or --add-token."""
         with patch.object(sys, "argv", ["claude-swap", "--list", "--slot", "3"]):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
 
         assert excinfo.value.code == 2
-        assert "--slot can only be used with --add-account" in capsys.readouterr().err
+        assert "--slot can only be used with --add-account or --add-token" in capsys.readouterr().err
 
     def test_slot_flag_in_help(self):
         """--slot should appear in help output."""
@@ -249,3 +249,54 @@ class TestCLICommands:
             env=_subprocess_env(HOME=str(temp_home)),
         )
         assert "No accounts" in result.stdout or "managed" in result.stdout.lower()
+
+    def test_add_token_requires_email(self, capsys):
+        """--add-token without --email should exit with an error."""
+        with patch.object(sys, "argv", ["claude-swap", "--add-token", "sk-ant-oat01-abc"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+        assert "--email is required with --add-token" in capsys.readouterr().err
+
+    def test_add_token_dispatches_to_switcher(self, temp_home: Path, capsys):
+        """--add-token with --email should call add_account_from_token."""
+        from claude_swap.switcher import ClaudeAccountSwitcher
+
+        with patch.object(
+            sys, "argv",
+            ["claude-swap", "--add-token", "mytoken", "--email", "u@example.com"],
+        ), patch.object(
+            ClaudeAccountSwitcher, "add_account_from_token"
+        ) as mock_add:
+            cli.main()
+
+        mock_add.assert_called_once_with(
+            token="mytoken", email="u@example.com", slot=None
+        )
+
+    def test_add_token_with_slot(self, temp_home: Path, capsys):
+        """--add-token --slot should forward slot to add_account_from_token."""
+        from claude_swap.switcher import ClaudeAccountSwitcher
+
+        with patch.object(
+            sys, "argv",
+            ["claude-swap", "--add-token", "tok", "--email", "u@example.com", "--slot", "3"],
+        ), patch.object(
+            ClaudeAccountSwitcher, "add_account_from_token"
+        ) as mock_add:
+            cli.main()
+
+        mock_add.assert_called_once_with(
+            token="tok", email="u@example.com", slot=3
+        )
+
+    def test_add_token_in_help(self):
+        """--add-token should appear in help output."""
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "--add-token" in result.stdout
+        assert "--email" in result.stdout

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -1509,3 +1509,131 @@ class TestAddAccountSlot:
 
         data = switcher._get_sequence_data()
         assert data["sequence"] == [2, 5]
+
+
+class TestAddAccountFromToken:
+    """Tests for add_account_from_token (--add-token flow)."""
+
+    def _make_switcher(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        return switcher
+
+    def test_basic_add_stores_account(self, temp_home, capsys):
+        """A valid token + email should store the account and print 'Added'."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials") as mock_creds, \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("sk-ant-oat01-abc", "user@example.com")
+
+        data = switcher._get_sequence_data()
+        assert "1" in data["accounts"]
+        assert data["accounts"]["1"]["email"] == "user@example.com"
+        assert 1 in data["sequence"]
+        out = capsys.readouterr().out
+        assert "Added" in out
+        assert "user@example.com" in out
+
+    def test_credentials_blob_format(self, temp_home):
+        """Stored credentials must wrap the token in claudeAiOauth.accessToken."""
+        switcher = self._make_switcher(temp_home)
+        stored_creds = None
+
+        def capture_creds(num, email, creds):
+            nonlocal stored_creds
+            stored_creds = creds
+
+        with patch.object(switcher, "_write_account_credentials", side_effect=capture_creds), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("mytoken", "user@example.com")
+
+        blob = json.loads(stored_creds)
+        assert blob["claudeAiOauth"]["accessToken"] == "mytoken"
+
+    def test_config_blob_contains_email(self, temp_home):
+        """Stored config must contain oauthAccount.emailAddress."""
+        switcher = self._make_switcher(temp_home)
+        stored_config = None
+
+        def capture_config(num, email, cfg):
+            nonlocal stored_config
+            stored_config = cfg
+
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config", side_effect=capture_config):
+            switcher.add_account_from_token("mytoken", "user@example.com")
+
+        cfg = json.loads(stored_config)
+        assert cfg["oauthAccount"]["emailAddress"] == "user@example.com"
+
+    def test_explicit_slot(self, temp_home):
+        """--slot should place the account in the specified slot."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok", "user@example.com", slot=7)
+
+        data = switcher._get_sequence_data()
+        assert "7" in data["accounts"]
+        assert "1" not in data["accounts"]
+        assert 7 in data["sequence"]
+
+    def test_update_in_place_same_email(self, temp_home, capsys):
+        """Calling add_account_from_token again for the same email refreshes in place."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("token-v1", "user@example.com")
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("token-v2", "user@example.com")
+
+        data = switcher._get_sequence_data()
+        assert len(data["accounts"]) == 1
+        out = capsys.readouterr().out
+        assert "Updated token" in out
+
+    def test_invalid_email_raises(self, temp_home):
+        """A malformed email should raise ValidationError."""
+        switcher = self._make_switcher(temp_home)
+        with pytest.raises(ValidationError, match="Invalid email"):
+            switcher.add_account_from_token("tok", "not-an-email")
+
+    def test_empty_token_raises(self, temp_home):
+        """An empty token string should raise ValidationError."""
+        switcher = self._make_switcher(temp_home)
+        with pytest.raises(ValidationError, match="empty"):
+            switcher.add_account_from_token("   ", "user@example.com")
+
+    def test_stdin_token(self, temp_home, capsys):
+        """Token='-' should read from stdin."""
+        switcher = self._make_switcher(temp_home)
+        import io
+        fake_stdin = io.StringIO("stdin-token\n")
+        with patch("sys.stdin", fake_stdin), \
+             patch.object(switcher, "_write_account_credentials") as mock_creds, \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("-", "user@example.com")
+
+        stored = mock_creds.call_args[0][2]
+        assert json.loads(stored)["claudeAiOauth"]["accessToken"] == "stdin-token"
+
+    def test_slot_zero_raises(self, temp_home):
+        """Slot 0 should raise ConfigError."""
+        switcher = self._make_switcher(temp_home)
+        with pytest.raises(ConfigError, match=">= 1"):
+            switcher.add_account_from_token("tok", "user@example.com", slot=0)
+
+    def test_sequence_sorted_after_add(self, temp_home):
+        """Sequence must remain sorted when using an explicit slot."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok", "a@example.com", slot=5)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok", "b@example.com", slot=2)
+
+        data = switcher._get_sequence_data()
+        assert data["sequence"] == [2, 5]

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -18,7 +18,7 @@ from claude_swap.exceptions import (
 )
 from claude_swap.models import Platform
 from claude_swap.paths import get_backup_root
-from claude_swap.switcher import ClaudeAccountSwitcher, DEFAULT_OAUTH_SCOPES
+from claude_swap.switcher import ClaudeAccountSwitcher, SETUP_TOKEN_SCOPES
 
 
 class TestEmailValidation:
@@ -1633,7 +1633,7 @@ class TestAddAccountFromToken:
 
         oauth_blob = json.loads(stored_creds)["claudeAiOauth"]
         assert oauth_blob["accessToken"] == "mytoken"
-        assert oauth_blob["scopes"] == list(DEFAULT_OAUTH_SCOPES)
+        assert oauth_blob["scopes"] == list(SETUP_TOKEN_SCOPES)
 
     def test_config_blob_contains_email(self, temp_home):
         """Stored config must contain oauthAccount.emailAddress."""
@@ -1697,7 +1697,7 @@ class TestAddAccountFromToken:
 
         oauth_blob = json.loads(stored_creds)["claudeAiOauth"]
         assert oauth_blob["accessToken"] == "token-v2"
-        assert oauth_blob["scopes"] == list(DEFAULT_OAUTH_SCOPES)
+        assert oauth_blob["scopes"] == list(SETUP_TOKEN_SCOPES)
 
     def test_invalid_email_raises(self, temp_home):
         """A malformed email should raise ValidationError."""
@@ -1724,7 +1724,7 @@ class TestAddAccountFromToken:
         stored = mock_creds.call_args[0][2]
         oauth_blob = json.loads(stored)["claudeAiOauth"]
         assert oauth_blob["accessToken"] == "stdin-token"
-        assert oauth_blob["scopes"] == list(DEFAULT_OAUTH_SCOPES)
+        assert oauth_blob["scopes"] == list(SETUP_TOKEN_SCOPES)
 
     def test_slot_zero_raises(self, temp_home):
         """Slot 0 should raise ConfigError."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -17,7 +17,7 @@ from claude_swap.exceptions import (
     ValidationError,
 )
 from claude_swap.models import Platform
-from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.switcher import ClaudeAccountSwitcher, DEFAULT_OAUTH_SCOPES
 
 
 class TestEmailValidation:
@@ -1536,7 +1536,7 @@ class TestAddAccountFromToken:
         assert "user@example.com" in out
 
     def test_credentials_blob_format(self, temp_home):
-        """Stored credentials must wrap the token in claudeAiOauth.accessToken."""
+        """Stored credentials must wrap the token in claudeAiOauth and seed default scopes."""
         switcher = self._make_switcher(temp_home)
         stored_creds = None
 
@@ -1548,8 +1548,9 @@ class TestAddAccountFromToken:
              patch.object(switcher, "_write_account_config"):
             switcher.add_account_from_token("mytoken", "user@example.com")
 
-        blob = json.loads(stored_creds)
-        assert blob["claudeAiOauth"]["accessToken"] == "mytoken"
+        oauth_blob = json.loads(stored_creds)["claudeAiOauth"]
+        assert oauth_blob["accessToken"] == "mytoken"
+        assert oauth_blob["scopes"] == list(DEFAULT_OAUTH_SCOPES)
 
     def test_config_blob_contains_email(self, temp_home):
         """Stored config must contain oauthAccount.emailAddress."""
@@ -1594,6 +1595,27 @@ class TestAddAccountFromToken:
         out = capsys.readouterr().out
         assert "Updated token" in out
 
+    def test_update_in_place_writes_scopes(self, temp_home):
+        """Refreshing an existing account in place must also seed default scopes."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("token-v1", "user@example.com")
+
+        stored_creds = None
+
+        def capture_creds(num, email, creds):
+            nonlocal stored_creds
+            stored_creds = creds
+
+        with patch.object(switcher, "_write_account_credentials", side_effect=capture_creds), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("token-v2", "user@example.com")
+
+        oauth_blob = json.loads(stored_creds)["claudeAiOauth"]
+        assert oauth_blob["accessToken"] == "token-v2"
+        assert oauth_blob["scopes"] == list(DEFAULT_OAUTH_SCOPES)
+
     def test_invalid_email_raises(self, temp_home):
         """A malformed email should raise ValidationError."""
         switcher = self._make_switcher(temp_home)
@@ -1617,7 +1639,9 @@ class TestAddAccountFromToken:
             switcher.add_account_from_token("-", "user@example.com")
 
         stored = mock_creds.call_args[0][2]
-        assert json.loads(stored)["claudeAiOauth"]["accessToken"] == "stdin-token"
+        oauth_blob = json.loads(stored)["claudeAiOauth"]
+        assert oauth_blob["accessToken"] == "stdin-token"
+        assert oauth_blob["scopes"] == list(DEFAULT_OAUTH_SCOPES)
 
     def test_slot_zero_raises(self, temp_home):
         """Slot 0 should raise ConfigError."""


### PR DESCRIPTION
## Summary

Closes #24. Adds `cswap --add-token` for registering an account from a raw long-lived OAuth setup-token (e.g. produced by `claude setup-token`) without requiring a prior Claude Code login on the current machine.

```bash
cswap --add-token sk-ant-oat01-... --email user@example.com
cswap --add-token sk-ant-oat01-... --email user@example.com --slot 3
cswap --add-token - --email user@example.com    # token from stdin
cswap --add-token --email user@example.com      # prompt securely (getpass, no echo)
```

Per the issue discussion, `--email` is required so cswap's metadata stays aligned with the rest of the accounts. No Anthropic API calls are made.

## Why

Today `--add-account` reads from the platform keychain / `~/.claude.json`, which means the account must already be logged in on the current machine. That's a problem on headless servers, or when receiving a setup-token from another machine. `--import` doesn't help because it only consumes cswap's own export schema.

## Implementation

- New `add_account_from_token(token, email, slot)` in `switcher.py`. Constructs the credential blob (`{"claudeAiOauth": {"accessToken": ...}}`) and a minimal config blob (`{"oauthAccount": {"emailAddress": ...}}`) instead of reading from `_read_credentials()`.
- Reuses `_write_account_credentials` / `_write_account_config` and the slot/sequence machinery — `--slot` works the same as with `--add-account`, and re-adding the same email without `--slot` refreshes credentials in place.
- Token sources: inline value, `-` for stdin, or empty for `getpass.getpass()` prompt.

## Test plan

- [x] 10 unit tests for `add_account_from_token` (basic add, blob format, slot handling, in-place refresh, validation, stdin, sequence ordering)
- [x] 4 CLI tests for `--add-token` (requires `--email`, dispatches to switcher, forwards `--slot`, appears in `--help`)
- [x] All 104 existing tests still pass

## Notes

- Token-added accounts are always treated as **personal** (`organizationUuid=""`). Org accounts would need an Anthropic API call to discover the UUID, which the issue explicitly ruled out.
- `accountUuid` is stored as `""` because we have no way to derive it from a raw token without an API call. This is consistent with what the rest of the code tolerates (e.g., `_get_display_tag` and migration code).