### PR TITLE
feat: make --email optional for --add-token

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -20,9 +20,10 @@ def main() -> None:
         epilog="""
 Examples:
   %(prog)s --add-account
-  %(prog)s --add-token --email user@example.com
-  %(prog)s --add-token sk-ant-oat01-... --email user@example.com --slot 3
-  %(prog)s --add-token - --email user@example.com
+  %(prog)s --add-token sk-ant-oat01-...
+  %(prog)s --add-token sk-ant-oat01-... --slot 3
+  %(prog)s --add-token sk-ant-oat01-... --email me@example.com
+  %(prog)s --add-token - --slot 3
   %(prog)s --list
   %(prog)s --switch
   %(prog)s --switch-to 2
@@ -62,7 +63,11 @@ Examples:
     parser.add_argument(
         "--email",
         metavar="EMAIL",
-        help="Email address for the account (required with --add-token)",
+        help=(
+            "Email address for the account. Optional with --add-token; "
+            "defaults to setup-token-{slot}@token.local since setup-tokens "
+            "carry no real email metadata."
+        ),
     )
     parser.add_argument(
         "--account",
@@ -157,8 +162,8 @@ Examples:
     if args.slot is not None and not (args.add_account or args.add_token is not None):
         parser.error("--slot can only be used with --add-account or --add-token")
 
-    if args.add_token is not None and not args.email:
-        parser.error("--email is required with --add-token")
+    if args.email is not None and args.add_token is None:
+        parser.error("--email can only be used with --add-token")
 
     if args.account is not None and not args.export:
         parser.error("--account can only be used with --export")

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -725,18 +725,20 @@ class ClaudeAccountSwitcher:
         print(f"{accent('Added')} Account {account_num}: {current_email} {muted(f'[{tag}]')}")
 
     def add_account_from_token(
-        self, token: str, email: str, slot: int | None = None
+        self, token: str, email: str | None = None, slot: int | None = None
     ) -> None:
         """Register a raw OAuth setup-token as a new account.
 
         Useful for headless servers or when the token is received from another
         machine, without needing a prior Claude Code login on this machine.
-        No Anthropic API calls are made; ``email`` is taken as-is from the flag.
+        No Anthropic API calls are made.
 
         Args:
             token: Raw OAuth access token, or ``"-"`` to read one line from
                    stdin, or ``""`` to prompt securely via getpass.
-            email: Email address to associate with the account (required).
+            email: Email address to associate with the account. When omitted,
+                   defaults to ``setup-token-{slot}@token.local`` since
+                   setup-tokens carry no real email metadata.
             slot:  Slot number to use; auto-assigned when ``None``.
         """
         import getpass
@@ -750,12 +752,20 @@ class ClaudeAccountSwitcher:
         if not token:
             raise ValidationError("Token cannot be empty")
 
-        if not self._validate_email(email):
+        if email and not self._validate_email(email):
             raise ValidationError(f"Invalid email format: {email}")
 
         self._setup_directories()
         self._init_sequence_file()
         self._migrate_org_fields()
+
+        # Synthesize a placeholder email when one isn't provided. Setup-tokens
+        # have no real email metadata, so requiring users to invent one is
+        # noise; the slot number gives every default account a unique key.
+        if not email:
+            if slot is None:
+                slot = self._get_next_account_number()
+            email = f"setup-token-{slot}@token.local"
 
         # If the account already exists (same email, personal), refresh in place.
         if slot is None and self._account_exists(email, ""):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,13 +274,28 @@ class TestCLICommands:
         )
         assert "No accounts" in result.stdout or "managed" in result.stdout.lower()
 
-    def test_add_token_requires_email(self, capsys):
-        """--add-token without --email should exit with an error."""
-        with patch.object(sys, "argv", ["claude-swap", "--add-token", "sk-ant-oat01-abc"]):
+    def test_add_token_without_email_dispatches_with_none(self, temp_home: Path, capsys):
+        """--add-token without --email should dispatch with email=None (defaulted by switcher)."""
+        from claude_swap.switcher import ClaudeAccountSwitcher
+
+        with patch.object(
+            sys, "argv", ["claude-swap", "--add-token", "sk-ant-oat01-abc"],
+        ), patch.object(
+            ClaudeAccountSwitcher, "add_account_from_token"
+        ) as mock_add:
+            cli.main()
+
+        mock_add.assert_called_once_with(
+            token="sk-ant-oat01-abc", email=None, slot=None
+        )
+
+    def test_email_without_add_token_errors(self, capsys):
+        """--email without --add-token should exit with a clear error."""
+        with patch.object(sys, "argv", ["claude-swap", "--list", "--email", "u@x.com"]):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
         assert excinfo.value.code == 2
-        assert "--email is required with --add-token" in capsys.readouterr().err
+        assert "--email can only be used with --add-token" in capsys.readouterr().err
 
     def test_add_token_dispatches_to_switcher(self, temp_home: Path, capsys):
         """--add-token with --email should call add_account_from_token."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2052,6 +2052,71 @@ class TestAddAccountFromToken:
         data = switcher._get_sequence_data()
         assert data["sequence"] == [2, 5]
 
+    def test_default_email_when_omitted(self, temp_home, capsys):
+        """Omitting email should synthesize setup-token-{slot}@token.local."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok")
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["email"] == "setup-token-1@token.local"
+        out = capsys.readouterr().out
+        assert "setup-token-1@token.local" in out
+
+    def test_default_email_with_explicit_slot(self, temp_home):
+        """Default email should derive from explicit --slot when one is given."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok", slot=7)
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["7"]["email"] == "setup-token-7@token.local"
+
+    def test_default_email_writes_to_config_blob(self, temp_home):
+        """Defaulted email must propagate into the oauthAccount.emailAddress field."""
+        switcher = self._make_switcher(temp_home)
+        stored_config = None
+
+        def capture_config(num, email, cfg):
+            nonlocal stored_config
+            stored_config = cfg
+
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config", side_effect=capture_config):
+            switcher.add_account_from_token("tok", slot=3)
+
+        cfg = json.loads(stored_config)
+        assert cfg["oauthAccount"]["emailAddress"] == "setup-token-3@token.local"
+
+    def test_default_email_unique_per_slot(self, temp_home):
+        """Two default-email registrations to different slots must coexist."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok-a", slot=4)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok-b", slot=8)
+
+        data = switcher._get_sequence_data()
+        emails = {data["accounts"][n]["email"] for n in ("4", "8")}
+        assert emails == {
+            "setup-token-4@token.local",
+            "setup-token-8@token.local",
+        }
+
+    def test_explicit_email_not_overridden_by_default(self, temp_home):
+        """Explicit --email must win over the auto-default."""
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok", email="me@example.com", slot=2)
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["2"]["email"] == "me@example.com"
+
 
 class TestPurge:
     """Tests for purge cleanup."""


### PR DESCRIPTION
Follow-up to #29 per https://github.com/realiti4/claude-swap/pull/29#issuecomment-4358859871.

Setup-token registration via `cswap --add-token` carries no real email metadata — users obtain only the access-token string from `claude setup-token`. Requiring them to invent an email was noise.

## Changes
- `--email` is now optional. When omitted, the switcher synthesizes `setup-token-{slot}@token.local` (matches the existing `oauth-N@token.local` placeholder convention).
- Explicit `--email` still wins.
- Inverse guard: `--email` may now only be used with `--add-token`; using it on other commands surfaces a clear error.

## Examples
```
cswap --add-token sk-ant-oat01-...                  # → setup-token-1@token.local
cswap --add-token sk-ant-oat01-... --slot 3         # → setup-token-3@token.local
cswap --add-token sk-ant-oat01-... --email me@x.com # → me@x.com (explicit wins)
```

## Tests
- `test_add_token_without_email_dispatches_with_none`
- `test_email_without_add_token_errors`
- 5 new switcher tests for default-email derivation, blob propagation, slot uniqueness, and explicit override
- Full suite: 335 passed / 2 skipped