### PR TITLE
fix: tolerate throwaway artifacts in legacy→XDG migration

### DIFF
--- a/src/claude_swap/logging_config.py
+++ b/src/claude_swap/logging_config.py
@@ -5,8 +5,26 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 
+class _LazyDirRotatingFileHandler(RotatingFileHandler):
+    """RotatingFileHandler that creates its parent dir on first emit.
+
+    Keeps the backup root from being materialized just because the switcher
+    was instantiated. Necessary so a no-op run (e.g. ``cswap --status`` with
+    no managed accounts) doesn't lay down ``cache/`` or log files inside the
+    XDG path, which would later trip the legacy → XDG migration collision
+    check if a legacy directory appeared between runs.
+    """
+
+    def _open(self):  # type: ignore[override]
+        Path(self.baseFilename).parent.mkdir(parents=True, exist_ok=True)
+        return super()._open()
+
+
 def setup_logging(log_dir: Path, debug: bool = False) -> logging.Logger:
     """Setup logging with file and optional console output.
+
+    The log directory is *not* created eagerly; it materializes on the first
+    log record actually written, via ``_LazyDirRotatingFileHandler``.
 
     Args:
         log_dir: Directory to store log files.
@@ -21,15 +39,14 @@ def setup_logging(log_dir: Path, debug: bool = False) -> logging.Logger:
     # Clear any existing handlers
     logger.handlers.clear()
 
-    # Ensure log directory exists
-    log_dir.mkdir(parents=True, exist_ok=True)
-
-    # File handler - always log to file
+    # File handler - opens lazily so the dir is only created when something
+    # is actually logged.
     log_file = log_dir / "claude-swap.log"
-    file_handler = RotatingFileHandler(
+    file_handler = _LazyDirRotatingFileHandler(
         log_file,
         maxBytes=1024 * 1024,  # 1MB
         backupCount=3,
+        delay=True,
     )
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(

--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -84,6 +84,43 @@ def get_backup_root() -> Path:
     return get_legacy_backup_root()
 
 
+# Names that any prior cswap run may have created in the backup root without
+# user data being present (logger output, update-check + usage cache). The
+# migration treats a target containing only these as effectively empty, since
+# wiping them loses no real state.
+_THROWAWAY_NAMES = {"cache"}
+_THROWAWAY_PREFIXES = ("claude-swap.log",)
+
+
+def _target_has_meaningful_data(target: Path) -> bool:
+    """Return True if target contains anything beyond throwaway artifacts."""
+    try:
+        entries = list(target.iterdir())
+    except (FileNotFoundError, NotADirectoryError):
+        return False
+    for entry in entries:
+        if entry.name in _THROWAWAY_NAMES:
+            continue
+        if any(entry.name.startswith(p) for p in _THROWAWAY_PREFIXES):
+            continue
+        return True
+    return False
+
+
+def _wipe_throwaway_artifacts(target: Path) -> None:
+    """Remove cache dir / log files so shutil.move can land on target."""
+    try:
+        entries = list(target.iterdir())
+    except (FileNotFoundError, NotADirectoryError):
+        return
+    for entry in entries:
+        if entry.is_dir() and not entry.is_symlink():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+    target.rmdir()
+
+
 def migrate_legacy_backup_dir(target: Path) -> bool:
     """Move the legacy backup directory to ``target`` if needed.
 
@@ -96,7 +133,11 @@ def migrate_legacy_backup_dir(target: Path) -> bool:
       and retry).
     * Flag present, legacy gone → previous run completed but didn't get to
       clean the flag; just unlink it.
-    * No flag, both paths exist → genuine collision, refuse.
+    * No flag, both paths exist → genuine collision, refuse — *unless* the
+      target only holds throwaway artifacts (cache/, log files) that any
+      prior cswap run may have laid down before legacy reappeared (e.g.
+      first run on a fresh box, then legacy synced in from another machine).
+      In that case wipe the artifacts and migrate normally.
 
     Returns:
         True if the move ran in this call, False if it was a no-op.
@@ -126,11 +167,13 @@ def migrate_legacy_backup_dir(target: Path) -> bool:
             if target.exists():
                 shutil.rmtree(target)
         elif target.exists():
-            raise MigrationError(
-                f"Both legacy ({legacy}) and new ({target}) backup paths exist. "
-                f"Refusing to merge or overwrite — inspect both and remove the "
-                f"stale one manually before re-running."
-            )
+            if _target_has_meaningful_data(target):
+                raise MigrationError(
+                    f"Both legacy ({legacy}) and new ({target}) backup paths exist. "
+                    f"Refusing to merge or overwrite — inspect both and remove the "
+                    f"stale one manually before re-running."
+                )
+            _wipe_throwaway_artifacts(target)
 
         target.parent.mkdir(parents=True, exist_ok=True)
         flag.touch()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,59 @@
+"""Tests for claude_swap.logging_config."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from claude_swap.logging_config import setup_logging
+
+
+def test_setup_does_not_create_dir(tmp_path: Path):
+    """Calling setup_logging must not materialize the log directory.
+
+    The log dir lives under the cswap backup root; pre-creating it laid down
+    cache/log artifacts that later tripped the legacy → XDG migration
+    collision check (see paths.migrate_legacy_backup_dir).
+    """
+    log_dir = tmp_path / "should-not-exist"
+    logger = setup_logging(log_dir)
+    try:
+        assert not log_dir.exists()
+        # File handler is registered but stays unopened until first emit.
+        assert logger.handlers
+    finally:
+        for handler in logger.handlers[:]:
+            handler.close()
+            logger.removeHandler(handler)
+
+
+def test_dir_is_created_on_first_log(tmp_path: Path):
+    log_dir = tmp_path / "lazy"
+    logger = setup_logging(log_dir)
+    try:
+        assert not log_dir.exists()
+        logger.warning("trigger")
+        for handler in logger.handlers:
+            handler.flush()
+        assert log_dir.is_dir()
+        assert (log_dir / "claude-swap.log").exists()
+    finally:
+        for handler in logger.handlers[:]:
+            handler.close()
+            logger.removeHandler(handler)
+
+
+def test_debug_adds_console_handler(tmp_path: Path):
+    log_dir = tmp_path / "dbg"
+    logger = setup_logging(log_dir, debug=True)
+    try:
+        assert logger.level == logging.DEBUG
+        assert any(
+            isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.FileHandler)
+            for h in logger.handlers
+        )
+    finally:
+        for handler in logger.handlers[:]:
+            handler.close()
+            logger.removeHandler(handler)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -203,6 +203,48 @@ class TestMigrateLegacyBackupDir:
         assert (legacy / "sequence.json").read_text() == '{"src": "legacy"}'
         assert (target / "sequence.json").read_text() == '{"src": "target"}'
 
+    def test_target_with_only_throwaway_artifacts_is_wiped(self, isolated_home: Path):
+        """Run-1 created cache/log in target; legacy appears later → migrate anyway.
+
+        Regression: pre-fix this raised "Both legacy and new exist" because
+        any prior cswap invocation laid down cache/ + claude-swap.log in the
+        XDG path even when no real data was present.
+        """
+        legacy = isolated_home / LEGACY_BACKUP_DIRNAME
+        legacy.mkdir()
+        (legacy / "sequence.json").write_text('{"src": "legacy"}')
+
+        target = isolated_home / ".local" / "share" / "claude-swap"
+        (target / "cache").mkdir(parents=True)
+        (target / "cache" / "update_check.json").write_text("{}")
+        (target / "claude-swap.log").write_text("noise")
+        (target / "claude-swap.log.1").write_text("rotated")
+
+        assert migrate_legacy_backup_dir(target) is True
+        assert not legacy.exists()
+        assert (target / "sequence.json").read_text() == '{"src": "legacy"}'
+        # Throwaway artifacts were replaced by legacy contents.
+        assert not (target / "cache").exists()
+        assert not (target / "claude-swap.log").exists()
+
+    def test_target_with_real_data_alongside_artifacts_still_collides(
+        self, isolated_home: Path
+    ):
+        """Cache/log next to real data → still a collision, must refuse."""
+        legacy = isolated_home / LEGACY_BACKUP_DIRNAME
+        legacy.mkdir()
+        (legacy / "sequence.json").write_text('{"src": "legacy"}')
+
+        target = isolated_home / ".local" / "share" / "claude-swap"
+        (target / "cache").mkdir(parents=True)
+        (target / "claude-swap.log").write_text("noise")
+        (target / "sequence.json").write_text('{"src": "target"}')
+
+        with pytest.raises(MigrationError, match="Refusing to merge"):
+            migrate_legacy_backup_dir(target)
+        assert (legacy / "sequence.json").read_text() == '{"src": "legacy"}'
+        assert (target / "sequence.json").read_text() == '{"src": "target"}'
+
     def test_resumes_after_interrupted_move(self, isolated_home: Path):
         """Flag present + legacy still there = previous run was interrupted.
 


### PR DESCRIPTION
## Summary

Two-part fix for a race where the legacy → XDG backup-dir migration aborted with `Both legacy and new ... Refusing to merge` after a prior no-op run laid down `cache/` + `claude-swap.log` in the XDG path and a legacy directory appeared between runs (e.g. synced or restored from another machine).

- **`paths.migrate_legacy_backup_dir`** — collision check now distinguishes real data from throwaway artifacts (`cache/`, `claude-swap.log*`). When the target only contains the latter, wipe and migrate normally. Self-heals already-affected installs.
- **`logging_config`** — new `_LazyDirRotatingFileHandler` defers parent-dir creation until the first log emit. Read-only flows (e.g. `cswap --status` on a fresh box with no managed accounts) no longer materialize the XDG path, preventing the trap from re-arming for users without legacy data.

## Test plan

- [x] `pytest tests/test_paths.py` — 27 pass, including two new tests:
  - `test_target_with_only_throwaway_artifacts_is_wiped` — regression for the user-reported scenario
  - `test_target_with_real_data_alongside_artifacts_still_collides` — strict collision check still fires when real data is present alongside artifacts
- [x] `pytest tests/test_logging_config.py` — 3 new tests covering lazy dir creation
- [x] Full suite: 340 passed, 2 skipped