### PR TITLE
feat: display enterprise spend usage alongside 5h/7d rate limits

### DIFF
--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -261,6 +261,10 @@ def fetch_usage_for_account(
         if org_uuid:
             try:
                 return request_enterprise_usage_data(token, org_uuid)
+            except urllib.error.HTTPError as e:
+                if e.code == 401:
+                    raise
+                _logger.debug("Enterprise usage endpoint HTTP %d, falling back to standard", e.code)
             except Exception:
                 _logger.debug("Enterprise usage endpoint failed, falling back to standard")
         return request_usage_data(token)

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -116,16 +116,6 @@ def build_token_status(credentials: str) -> str | None:
     return f"oauth: {state}, refresh token {refresh_str}, expires {clock} in {countdown}"
 
 
-def format_monthly_reset() -> str:
-    """Return the first day of next month as a short local date string (e.g. 'Jun 1')."""
-    now = datetime.now(timezone.utc).astimezone()
-    if now.month == 12:
-        reset = now.replace(year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
-    else:
-        reset = now.replace(month=now.month + 1, day=1, hour=0, minute=0, second=0, microsecond=0)
-    return f"{reset.strftime('%b')} {reset.day}"
-
-
 def format_reset(resets_at: str) -> tuple[str, str]:
     """Return (countdown, clock) for a reset time in local time."""
     reset_utc = datetime.fromisoformat(resets_at)
@@ -190,15 +180,26 @@ def build_usage_result(data: dict) -> dict | None:
 
     eu = data.get("extra_usage")
     if eu and eu.get("is_enabled"):
-        spend_entry: dict = {
-            "used": float(eu["used_credits"]) / 100,
-            "limit": float(eu["monthly_limit"]) / 100,
-            "pct": float(eu["utilization"]),
-            "currency": eu.get("currency", "USD"),
-        }
-        if eu.get("resets_at"):
-            spend_entry["countdown"], spend_entry["clock"] = format_reset(eu["resets_at"])
-        result["spend"] = spend_entry
+        # Claude Code returns nullable used_credits, monthly_limit, and utilization
+        # (monthly_limit=None = unlimited). All three are needed to render the spend
+        # line, so when any is null skip just the spend entry; five_hour/seven_day
+        # go through unchanged.
+        used_credits = eu.get("used_credits")
+        monthly_limit = eu.get("monthly_limit")
+        utilization = eu.get("utilization")
+        if used_credits is not None and monthly_limit is not None and utilization is not None:
+            try:
+                spend_entry: dict = {
+                    "used": float(used_credits) / 100,
+                    "limit": float(monthly_limit) / 100,
+                    "pct": float(utilization),
+                    "currency": eu.get("currency", "USD"),
+                }
+                if eu.get("resets_at"):
+                    spend_entry["countdown"], spend_entry["clock"] = format_reset(eu["resets_at"])
+                result["spend"] = spend_entry
+            except (TypeError, ValueError) as e:
+                _logger.debug("extra_usage parse failed: %r", e)
 
     return result if result else None
 

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -116,6 +116,16 @@ def build_token_status(credentials: str) -> str | None:
     return f"oauth: {state}, refresh token {refresh_str}, expires {clock} in {countdown}"
 
 
+def format_monthly_reset() -> str:
+    """Return the first day of next month as a short local date string (e.g. 'Jun 1')."""
+    now = datetime.now(timezone.utc).astimezone()
+    if now.month == 12:
+        reset = now.replace(year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    else:
+        reset = now.replace(month=now.month + 1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    return reset.strftime(f"%b {reset.day}")
+
+
 def format_reset(resets_at: str) -> tuple[str, str]:
     """Return (countdown, clock) for a reset time in local time."""
     reset_utc = datetime.fromisoformat(resets_at)
@@ -157,6 +167,18 @@ def request_usage_data(access_token: str) -> dict:
         return json.loads(resp.read().decode())
 
 
+def request_enterprise_usage_data(access_token: str, org_uuid: str) -> dict:
+    """Request usage data from the claude.ai organization usage API."""
+    url = f"https://claude.ai/api/organizations/{org_uuid}/usage"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "User-Agent": "claude-swap/1.0",
+    }
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read().decode())
+
+
 def build_usage_result(data: dict) -> dict | None:
     """Normalize raw usage API data into the structure used by the CLI."""
     _logger.debug("Usage API response: %s", json.dumps(data, indent=2))
@@ -177,6 +199,18 @@ def build_usage_result(data: dict) -> dict | None:
             d7_entry["countdown"], d7_entry["clock"] = format_reset(d7["resets_at"])
         result["seven_day"] = d7_entry
 
+    eu = data.get("extra_usage")
+    if eu and eu.get("is_enabled"):
+        spend_entry: dict = {
+            "used": float(eu["used_credits"]) / 100,
+            "limit": float(eu["monthly_limit"]) / 100,
+            "pct": float(eu["utilization"]),
+            "currency": eu.get("currency", "USD"),
+        }
+        if eu.get("resets_at"):
+            spend_entry["countdown"], spend_entry["clock"] = format_reset(eu["resets_at"])
+        result["spend"] = spend_entry
+
     return result if result else None
 
 
@@ -195,11 +229,14 @@ def fetch_usage_for_account(
     email: str,
     credentials: str,
     is_active: bool,
+    org_uuid: str = "",
     persist_credentials: Callable[[str, str, str], None] | None = None,
 ) -> dict | None:
     """Fetch usage for an account, refreshing expired tokens for inactive accounts only.
 
     Active accounts are never refreshed — Claude Code owns those credentials.
+    Uses the claude.ai organization endpoint for enterprise accounts (org_uuid set),
+    falling back to the Anthropic OAuth usage endpoint for personal/Pro accounts.
     """
     oauth = extract_oauth_data(credentials)
     access_token = oauth.get("accessToken") if oauth else None
@@ -220,9 +257,25 @@ def fetch_usage_for_account(
             oauth = extract_oauth_data(working_credentials) or oauth
             access_token = oauth.get("accessToken") or access_token
 
+    def _fetch(token: str) -> dict:
+        if org_uuid:
+            try:
+                return request_enterprise_usage_data(token, org_uuid)
+            except Exception:
+                _logger.debug("Enterprise usage endpoint failed, falling back to standard")
+        return request_usage_data(token)
+
+    def _build(data: dict) -> dict | None:
+        result = build_usage_result(data)
+        if result and org_uuid:
+            spend = result.get("spend")
+            if spend and "clock" not in spend:
+                spend["reset_date"] = format_monthly_reset()
+        return result
+
     try:
-        data = request_usage_data(access_token)
-        return build_usage_result(data)
+        data = _fetch(access_token)
+        return _build(data)
     except urllib.error.HTTPError as e:
         _logger.debug("Usage fetch failed: %r", e)
         if (
@@ -246,8 +299,8 @@ def fetch_usage_for_account(
             return None
 
         try:
-            data = request_usage_data(new_token)
-            return build_usage_result(data)
+            data = _fetch(new_token)
+            return _build(data)
         except Exception as retry_error:
             _logger.debug("Usage fetch failed after refresh: %r", retry_error)
             return None

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -123,7 +123,7 @@ def format_monthly_reset() -> str:
         reset = now.replace(year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
     else:
         reset = now.replace(month=now.month + 1, day=1, hour=0, minute=0, second=0, microsecond=0)
-    return reset.strftime(f"%b {reset.day}")
+    return f"{reset.strftime('%b')} {reset.day}"
 
 
 def format_reset(resets_at: str) -> tuple[str, str]:

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -167,17 +167,6 @@ def request_usage_data(access_token: str) -> dict:
         return json.loads(resp.read().decode())
 
 
-def request_enterprise_usage_data(access_token: str, org_uuid: str) -> dict:
-    """Request usage data from the claude.ai organization usage API."""
-    url = f"https://claude.ai/api/organizations/{org_uuid}/usage"
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "User-Agent": "claude-swap/1.0",
-    }
-    req = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(req, timeout=5) as resp:
-        return json.loads(resp.read().decode())
-
 
 def build_usage_result(data: dict) -> dict | None:
     """Normalize raw usage API data into the structure used by the CLI."""
@@ -229,14 +218,11 @@ def fetch_usage_for_account(
     email: str,
     credentials: str,
     is_active: bool,
-    org_uuid: str = "",
     persist_credentials: Callable[[str, str, str], None] | None = None,
 ) -> dict | None:
     """Fetch usage for an account, refreshing expired tokens for inactive accounts only.
 
     Active accounts are never refreshed — Claude Code owns those credentials.
-    Uses the claude.ai organization endpoint for enterprise accounts (org_uuid set),
-    falling back to the Anthropic OAuth usage endpoint for personal/Pro accounts.
     """
     oauth = extract_oauth_data(credentials)
     access_token = oauth.get("accessToken") if oauth else None
@@ -257,29 +243,9 @@ def fetch_usage_for_account(
             oauth = extract_oauth_data(working_credentials) or oauth
             access_token = oauth.get("accessToken") or access_token
 
-    def _fetch(token: str) -> dict:
-        if org_uuid:
-            try:
-                return request_enterprise_usage_data(token, org_uuid)
-            except urllib.error.HTTPError as e:
-                if e.code == 401:
-                    raise
-                _logger.debug("Enterprise usage endpoint HTTP %d, falling back to standard", e.code)
-            except Exception:
-                _logger.debug("Enterprise usage endpoint failed, falling back to standard")
-        return request_usage_data(token)
-
-    def _build(data: dict) -> dict | None:
-        result = build_usage_result(data)
-        if result and org_uuid:
-            spend = result.get("spend")
-            if spend and "clock" not in spend:
-                spend["reset_date"] = format_monthly_reset()
-        return result
-
     try:
-        data = _fetch(access_token)
-        return _build(data)
+        data = request_usage_data(access_token)
+        return build_usage_result(data)
     except urllib.error.HTTPError as e:
         _logger.debug("Usage fetch failed: %r", e)
         if (
@@ -303,8 +269,8 @@ def fetch_usage_for_account(
             return None
 
         try:
-            data = _fetch(new_token)
-            return _build(data)
+            data = request_usage_data(new_token)
+            return build_usage_result(data)
         except Exception as retry_error:
             _logger.debug("Usage fetch failed after refresh: %r", retry_error)
             return None

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1176,9 +1176,11 @@ class ClaudeAccountSwitcher:
                         limit = spend["limit"]
                         pct = spend["pct"]
                         if "clock" in spend:
-                            lines.append(f"${used:,.2f} / ${limit:,.2f}  ·  {pct:.1f}% used   resets {spend['clock']:<12}  in {spend['countdown']}")
+                            lines.append(f"$$: {pct:>3.0f}%   resets {spend['clock']:<12}  ${used:,.2f} / ${limit:,.2f}")
+                        elif "reset_date" in spend:
+                            lines.append(f"$$: {pct:>3.0f}%   resets {spend['reset_date']:<12}  ${used:,.2f} / ${limit:,.2f}")
                         else:
-                            lines.append(f"${used:,.2f} / ${limit:,.2f}  ·  {pct:.1f}% used")
+                            lines.append(f"$$: {pct:>3.0f}%   ${used:,.2f} / ${limit:,.2f}")
                     h5 = usage.get("five_hour")
                     d7 = usage.get("seven_day")
                     if h5:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1022,7 +1022,7 @@ class ClaudeAccountSwitcher:
         def fetch(
             account_info: tuple[int, str, str, str, bool, str]
         ) -> dict | str | None:
-            num, email, _, org_uuid, is_active, creds = account_info
+            num, email, _, _, is_active, creds = account_info
             if not creds or not oauth.extract_access_token(creds):
                 return "no credentials"
 
@@ -1160,11 +1160,24 @@ class ClaudeAccountSwitcher:
             print(f"  {dimmed(f'Total managed accounts: {total}')}")
             creds = self._read_credentials() or ""
             if creds and oauth.extract_access_token(creds):
-                usage = oauth.fetch_usage_for_account(
-                    account_num, current_email, creds,
-                    is_active=True,
-                )
-                if usage:
+                # Reuse the cache list_accounts writes (cache-first). On miss,
+                # fetch with is_active=True (Claude Code owns active credentials,
+                # cswap must not refresh them) and merge into existing entries so
+                # other accounts' rows survive.
+                usage_cache_path = self.backup_dir / "cache" / "usage.json"
+                cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
+                if (cached is not MISSING and isinstance(cached, dict)
+                        and account_num in cached):
+                    usage = cached[account_num]
+                else:
+                    usage = oauth.fetch_usage_for_account(
+                        account_num, current_email, creds,
+                        is_active=True,
+                    )
+                    existing = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
+                    existing[account_num] = usage
+                    write_cache(usage_cache_path, existing)
+                if isinstance(usage, dict):
                     lines = []
                     spend = usage.get("spend")
                     if spend:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1033,7 +1033,6 @@ class ClaudeAccountSwitcher:
             return oauth.fetch_usage_for_account(
                 str(num), email, creds,
                 is_active=is_active,
-                org_uuid=org_uuid,
                 persist_credentials=persist,
             )
 
@@ -1071,8 +1070,6 @@ class ClaudeAccountSwitcher:
                     pct = spend["pct"]
                     if "clock" in spend:
                         lines.append(f"$$: {pct:>3.0f}%   resets {spend['clock']:<12}  ${used:,.2f} / ${limit:,.2f}")
-                    elif "reset_date" in spend:
-                        lines.append(f"$$: {pct:>3.0f}%   resets {spend['reset_date']:<12}  ${used:,.2f} / ${limit:,.2f}")
                     else:
                         lines.append(f"$$: {pct:>3.0f}%   ${used:,.2f} / ${limit:,.2f}")
                 h5 = usage.get("five_hour")
@@ -1166,7 +1163,6 @@ class ClaudeAccountSwitcher:
                 usage = oauth.fetch_usage_for_account(
                     account_num, current_email, creds,
                     is_active=True,
-                    org_uuid=current_org_uuid,
                 )
                 if usage:
                     lines = []
@@ -1177,8 +1173,6 @@ class ClaudeAccountSwitcher:
                         pct = spend["pct"]
                         if "clock" in spend:
                             lines.append(f"$$: {pct:>3.0f}%   resets {spend['clock']:<12}  ${used:,.2f} / ${limit:,.2f}")
-                        elif "reset_date" in spend:
-                            lines.append(f"$$: {pct:>3.0f}%   resets {spend['reset_date']:<12}  ${used:,.2f} / ${limit:,.2f}")
                         else:
                             lines.append(f"$$: {pct:>3.0f}%   ${used:,.2f} / ${limit:,.2f}")
                     h5 = usage.get("five_hour")

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1022,7 +1022,7 @@ class ClaudeAccountSwitcher:
         def fetch(
             account_info: tuple[int, str, str, str, bool, str]
         ) -> dict | str | None:
-            num, email, _, _, is_active, creds = account_info
+            num, email, _, org_uuid, is_active, creds = account_info
             if not creds or not oauth.extract_access_token(creds):
                 return "no credentials"
 
@@ -1033,6 +1033,7 @@ class ClaudeAccountSwitcher:
             return oauth.fetch_usage_for_account(
                 str(num), email, creds,
                 is_active=is_active,
+                org_uuid=org_uuid,
                 persist_credentials=persist,
             )
 
@@ -1062,9 +1063,20 @@ class ClaudeAccountSwitcher:
             elif usage is None:
                 print(f"     {dimmed('usage unavailable')}")
             else:
+                lines = []
+                spend = usage.get("spend")
+                if spend:
+                    used = spend["used"]
+                    limit = spend["limit"]
+                    pct = spend["pct"]
+                    if "clock" in spend:
+                        lines.append(f"$$: {pct:>3.0f}%   resets {spend['clock']:<12}  ${used:,.2f} / ${limit:,.2f}")
+                    elif "reset_date" in spend:
+                        lines.append(f"$$: {pct:>3.0f}%   resets {spend['reset_date']:<12}  ${used:,.2f} / ${limit:,.2f}")
+                    else:
+                        lines.append(f"$$: {pct:>3.0f}%   ${used:,.2f} / ${limit:,.2f}")
                 h5 = usage.get("five_hour")
                 d7 = usage.get("seven_day")
-                lines = []
                 if h5:
                     if "clock" in h5:
                         lines.append(f"5h: {h5['pct']:>3.0f}%   resets {h5['clock']:<12}  in {h5['countdown']}")
@@ -1149,6 +1161,35 @@ class ClaudeAccountSwitcher:
                 f"({current_email} {muted(f'[{tag}]')})"
             )
             print(f"  {dimmed(f'Total managed accounts: {total}')}")
+            creds = self._read_credentials() or ""
+            if creds and oauth.extract_access_token(creds):
+                usage = oauth.fetch_usage_for_account(
+                    account_num, current_email, creds,
+                    is_active=True,
+                    org_uuid=current_org_uuid,
+                )
+                if usage:
+                    lines = []
+                    spend = usage.get("spend")
+                    if spend:
+                        used = spend["used"]
+                        limit = spend["limit"]
+                        pct = spend["pct"]
+                        if "clock" in spend:
+                            lines.append(f"${used:,.2f} / ${limit:,.2f}  ·  {pct:.1f}% used   resets {spend['clock']:<12}  in {spend['countdown']}")
+                        else:
+                            lines.append(f"${used:,.2f} / ${limit:,.2f}  ·  {pct:.1f}% used")
+                    h5 = usage.get("five_hour")
+                    d7 = usage.get("seven_day")
+                    if h5:
+                        suffix = f"   resets {h5['clock']:<12}  in {h5['countdown']}" if "clock" in h5 else ""
+                        lines.append(f"5h: {h5['pct']:>3.0f}%{suffix}")
+                    if d7:
+                        suffix = f"   resets {d7['clock']:<12}  in {d7['countdown']}" if "clock" in d7 else ""
+                        lines.append(f"7d: {d7['pct']:>3.0f}%{suffix}")
+                    for j, line in enumerate(lines):
+                        connector = "└" if j == len(lines) - 1 else "├"
+                        print(f"  {dimmed(connector)} {muted(line)}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -161,6 +161,88 @@ class TestFetchUsage:
         assert "clock" in result["seven_day"]
         assert "countdown" in result["seven_day"]
 
+    @staticmethod
+    def _fetch_with_response(response_data):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(response_data).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        with patch("claude_swap.oauth.urllib.request.urlopen", return_value=mock_response):
+            return oauth.fetch_usage("sk-test-token")
+
+    def test_extra_usage_complete(self):
+        """All extra_usage fields populated — spend, five_hour, and seven_day all present."""
+        result = self._fetch_with_response({
+            "five_hour": {"utilization": 22.0, "resets_at": None},
+            "seven_day": {"utilization": 61.0, "resets_at": None},
+            "extra_usage": {
+                "is_enabled": True,
+                "used_credits": 72900,
+                "monthly_limit": 500000,
+                "utilization": 14.58,
+                "currency": "USD",
+            },
+        })
+        assert result is not None
+        assert result["five_hour"]["pct"] == 22.0
+        assert result["seven_day"]["pct"] == 61.0
+        assert result["spend"]["used"] == 729.0
+        assert result["spend"]["limit"] == 5000.0
+        assert result["spend"]["pct"] == 14.58
+        assert result["spend"]["currency"] == "USD"
+
+    def test_extra_usage_unlimited_keeps_other_rows(self):
+        """Unlimited (monthly_limit=None) drops the spend entry without losing five_hour/seven_day."""
+        result = self._fetch_with_response({
+            "five_hour": {"utilization": 22.0, "resets_at": None},
+            "seven_day": {"utilization": 61.0, "resets_at": None},
+            "extra_usage": {
+                "is_enabled": True,
+                "used_credits": 72900,
+                "monthly_limit": None,
+                "utilization": None,
+                "currency": "USD",
+            },
+        })
+        assert result is not None
+        assert result["five_hour"]["pct"] == 22.0
+        assert result["seven_day"]["pct"] == 61.0
+        assert "spend" not in result
+
+    def test_extra_usage_partial_keeps_other_rows(self):
+        """A null in used_credits leaves the rest of the response untouched."""
+        result = self._fetch_with_response({
+            "five_hour": {"utilization": 22.0, "resets_at": None},
+            "seven_day": {"utilization": 61.0, "resets_at": None},
+            "extra_usage": {
+                "is_enabled": True,
+                "used_credits": None,
+                "monthly_limit": 500000,
+                "utilization": 14.58,
+            },
+        })
+        assert result is not None
+        assert result["five_hour"]["pct"] == 22.0
+        assert result["seven_day"]["pct"] == 61.0
+        assert "spend" not in result
+
+    def test_extra_usage_disabled_keeps_other_rows(self):
+        """is_enabled=False suppresses spend even with valid numeric fields."""
+        result = self._fetch_with_response({
+            "five_hour": {"utilization": 22.0, "resets_at": None},
+            "seven_day": {"utilization": 61.0, "resets_at": None},
+            "extra_usage": {
+                "is_enabled": False,
+                "used_credits": 72900,
+                "monthly_limit": 500000,
+                "utilization": 14.58,
+            },
+        })
+        assert result is not None
+        assert result["five_hour"]["pct"] == 22.0
+        assert result["seven_day"]["pct"] == 61.0
+        assert "spend" not in result
+
 
 class TestRefreshOAuthCredentials:
     """Test direct OAuth refresh requests."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -359,6 +359,100 @@ class TestStatus:
         switcher.status()
 
 
+class TestStatusCache:
+    """status() shares the usage.json cache with list_accounts."""
+
+    def test_status_uses_cached_usage(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        """A fresh cache entry for the active account skips the API call."""
+        from claude_swap.cache import write_cache
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        cached_usage = {
+            "1": {"five_hour": {"pct": 25, "clock": "Jan 1 03:00", "countdown": "1h"},
+                  "seven_day": {"pct": 60, "clock": "Jan 2 03:00", "countdown": "2d"}},
+        }
+        write_cache(switcher.backup_dir / "cache" / "usage.json", cached_usage)
+
+        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
+            switcher.status()
+
+        mock_fetch.assert_not_called()
+        output = capsys.readouterr().out
+        assert "25%" in output
+        assert "60%" in output
+
+    def test_status_fetches_on_cache_miss_with_is_active_true(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        """On cache miss, fetch with is_active=True (never refresh active creds) and write back."""
+        from claude_swap.cache import read_cache, MISSING
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        usage_result = {
+            "five_hour": {"pct": 10, "clock": "Jan 1 03:00", "countdown": "0m"},
+            "seven_day": {"pct": 50, "clock": "Jan 2 03:00", "countdown": "0m"},
+        }
+
+        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage_result) as mock_fetch:
+            switcher.status()
+
+        mock_fetch.assert_called_once()
+        assert mock_fetch.call_args.kwargs.get("is_active") is True
+
+        output = capsys.readouterr().out
+        assert "10%" in output
+
+        cache_path = switcher.backup_dir / "cache" / "usage.json"
+        cached = read_cache(cache_path, 300)
+        assert cached is not MISSING
+        assert cached["1"] == usage_result
+
+    def test_status_preserves_other_accounts_in_cache(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """A cache miss for the active account merges into existing entries instead of clobbering."""
+        from claude_swap.cache import read_cache, write_cache, MISSING
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        # Cache has only account "2"; status() runs for account "1"
+        existing = {"2": {"five_hour": {"pct": 80}}}
+        cache_path = switcher.backup_dir / "cache" / "usage.json"
+        write_cache(cache_path, existing)
+
+        usage_result = {"five_hour": {"pct": 10, "clock": "Jan 1 03:00", "countdown": "0m"}}
+
+        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage_result):
+            switcher.status()
+
+        cached = read_cache(cache_path, 300)
+        assert cached is not MISSING
+        assert cached["1"] == usage_result
+        assert cached["2"] == {"five_hour": {"pct": 80}}
+
+
 class TestListAccountsUsage:
     """Test list_accounts shows usage info."""
 
@@ -466,7 +560,7 @@ class TestListAccountsUsage:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        def mock_fetch(account_num, email, credentials, is_active, org_uuid="", persist_credentials=None):
+        def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
             # Simulate a refresh on the inactive account only.
             if not is_active:
                 persist_credentials(account_num, email, refreshed_creds)

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -466,7 +466,7 @@ class TestListAccountsUsage:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
+        def mock_fetch(account_num, email, credentials, is_active, org_uuid="", persist_credentials=None):
             # Simulate a refresh on the inactive account only.
             if not is_active:
                 persist_credentials(account_num, email, refreshed_creds)


### PR DESCRIPTION
- Call the claude.ai org endpoint for enterprise accounts (org_uuid set), with fallback to the standard Anthropic endpoint on failure
- Parse extra_usage from the usage response; convert credits to dollars (API returns cents, divide by 100)
- Compute monthly reset date (1st of next month) when resets_at is null
- Format spend as "$$: pct%   resets date   $used / $limit" to align
  symmetrically with the existing 5h/7d rows
- Fix test mock signature to accept org_uuid keyword argument