### PR TITLE
fix: fall back to file-based credentials when keyring uses null backend

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -89,6 +89,36 @@ class ClaudeAccountSwitcher:
         self.credentials_dir = self.backup_dir / "credentials"
         self.lock_file = self.backup_dir / ".lock"
         self._logger = setup_logging(self.backup_dir, debug=debug)
+        self._use_file_credentials = self._should_use_file_credentials()
+
+    def _should_use_file_credentials(self) -> bool:
+        """Whether to use file-based credential storage instead of keyring.
+
+        Returns True on Linux/WSL (where file storage is always used) or
+        when the Python keyring resolves to a null/dummy backend that
+        silently discards writes (e.g. PYTHON_KEYRING_BACKEND is set to
+        keyring.backends.null.Keyring).
+        """
+        if self.platform in (Platform.LINUX, Platform.WSL):
+            return True
+        try:
+            from keyring.backends.null import Keyring as NullKeyring
+            backend = keyring.get_keyring()
+            if isinstance(backend, NullKeyring):
+                self._logger.warning(
+                    "Keyring resolved to null backend (PYTHON_KEYRING_BACKEND=%s); "
+                    "using file-based credential storage instead",
+                    os.environ.get("PYTHON_KEYRING_BACKEND", "<unset>"),
+                )
+                return True
+        except Exception:
+            self._logger.warning(
+                "Failed to detect keyring backend; "
+                "using file-based credential storage instead",
+                exc_info=True,
+            )
+            return True
+        return False
 
     def _is_running_in_container(self) -> bool:
         """Check if running inside a container."""
@@ -278,10 +308,10 @@ class ClaudeAccountSwitcher:
     def _read_account_credentials(self, account_num: str, email: str) -> str:
         """Read account credentials from backup.
 
-        On Linux/WSL: Uses file-based storage to avoid keyring backend issues.
-        On macOS/Windows: Uses system keyring.
+        Uses file-based storage on Linux/WSL or when the system keyring is
+        unavailable (e.g. null backend). Otherwise uses the system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self._use_file_credentials:
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             if cred_file.exists():
                 try:
@@ -306,10 +336,10 @@ class ClaudeAccountSwitcher:
     ) -> None:
         """Write account credentials to backup.
 
-        On Linux/WSL: Uses file-based storage to avoid keyring backend issues.
-        On macOS/Windows: Uses system keyring.
+        Uses file-based storage on Linux/WSL or when the system keyring is
+        unavailable (e.g. null backend). Otherwise uses the system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self._use_file_credentials:
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             try:
                 encoded = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
@@ -330,10 +360,10 @@ class ClaudeAccountSwitcher:
     def _delete_account_credentials(self, account_num: str, email: str) -> None:
         """Delete account credentials from backup.
 
-        On Linux/WSL: Deletes file-based credential storage.
-        On macOS/Windows: Removes from system keyring.
+        Uses file-based storage on Linux/WSL or when the system keyring is
+        unavailable (e.g. null backend). Otherwise uses the system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self._use_file_credentials:
             cred_files = [self.credentials_dir / f".creds-{account_num}-{email}.enc"]
             if str(account_num) != "None":
                 cred_files.append(self.credentials_dir / f".creds-None-{email}.enc")
@@ -1584,7 +1614,7 @@ class ClaudeAccountSwitcher:
         print(f"  - Backup directory: {self.backup_dir}")
         if legacy_distinct and legacy.exists():
             print(f"  - Legacy backup directory: {legacy}")
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self._use_file_credentials:
             print("  - All stored account credential files")
         else:
             print("  - All stored account credentials from the system keyring")
@@ -1604,8 +1634,8 @@ class ClaudeAccountSwitcher:
         if data:
             for account_num, account_info in data.get("accounts", {}).items():
                 email = account_info.get("email", "")
-                if self.platform in (Platform.LINUX, Platform.WSL):
-                    # Remove credential files on Linux
+                if self._use_file_credentials:
+                    # Remove credential files
                     cred_files = [
                         self.credentials_dir / f".creds-{account_num}-{email}.enc"
                     ]

--- a/tests/test_macos_keychain_contract.py
+++ b/tests/test_macos_keychain_contract.py
@@ -41,6 +41,7 @@ def macos_switcher(temp_home: Path) -> ClaudeAccountSwitcher:
     """Switcher with platform forced to MACOS regardless of host OS."""
     switcher = ClaudeAccountSwitcher()
     switcher.platform = Platform.MACOS
+    switcher._use_file_credentials = False
     return switcher
 
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -257,6 +257,60 @@ class TestDirectorySetup:
             assert stat.st_mode & 0o777 == 0o700
 
 
+class TestNullKeyringFallback:
+    """Test fallback to file-based credentials when keyring uses null backend."""
+
+    def test_null_backend_triggers_file_storage(self, temp_home: Path):
+        """When keyring resolves to null backend, _use_file_credentials should be True."""
+        from keyring.backends.null import Keyring as NullKeyring
+        null_backend = NullKeyring()
+        with patch("claude_swap.switcher.keyring.get_keyring", return_value=null_backend):
+            switcher = ClaudeAccountSwitcher()
+            assert switcher._use_file_credentials is True
+
+    def test_real_backend_uses_keyring(self, temp_home: Path):
+        """When keyring resolves to a real backend, _use_file_credentials should be False on macOS."""
+        from keyring.backends.macOS import Keyring as MacKeyring
+        real_backend = MacKeyring()
+        with patch.object(Platform, "detect", return_value=Platform.MACOS), \
+             patch("claude_swap.switcher.keyring.get_keyring", return_value=real_backend):
+            switcher = ClaudeAccountSwitcher()
+            assert switcher._use_file_credentials is False
+
+    def test_linux_always_uses_file_storage(self, temp_home: Path):
+        """Linux should always use file storage regardless of keyring backend."""
+        with patch.object(Platform, "detect", return_value=Platform.LINUX):
+            switcher = ClaudeAccountSwitcher()
+            assert switcher._use_file_credentials is True
+
+    def test_null_backend_credentials_roundtrip(self, temp_home: Path):
+        """Credentials written with null keyring fallback should be readable."""
+        from keyring.backends.null import Keyring as NullKeyring
+        null_backend = NullKeyring()
+        with patch("claude_swap.switcher.keyring.get_keyring", return_value=null_backend):
+            switcher = ClaudeAccountSwitcher()
+            switcher._setup_directories()
+
+            test_creds = json.dumps({"claudeAiOauth": {"accessToken": "test-token"}})
+            switcher._write_account_credentials("1", "test@example.com", test_creds)
+            read_back = switcher._read_account_credentials("1", "test@example.com")
+            assert read_back == test_creds
+
+    def test_null_backend_credentials_delete(self, temp_home: Path):
+        """Deleting credentials should work with null keyring fallback."""
+        from keyring.backends.null import Keyring as NullKeyring
+        null_backend = NullKeyring()
+        with patch("claude_swap.switcher.keyring.get_keyring", return_value=null_backend):
+            switcher = ClaudeAccountSwitcher()
+            switcher._setup_directories()
+
+            test_creds = json.dumps({"claudeAiOauth": {"accessToken": "test-token"}})
+            switcher._write_account_credentials("1", "test@example.com", test_creds)
+            switcher._delete_account_credentials("1", "test@example.com")
+            read_back = switcher._read_account_credentials("1", "test@example.com")
+            assert read_back == ""
+
+
 class TestAddAccountRefresh:
     """Test refreshing credentials for an existing account."""
 
@@ -2125,6 +2179,7 @@ class TestPurge:
         """Purge should clean account-None-* keyring entries from older buggy runs."""
         switcher = ClaudeAccountSwitcher()
         switcher.platform = Platform.MACOS
+        switcher._use_file_credentials = False
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, {
             "activeAccountNumber": 1,


### PR DESCRIPTION
## Summary

- When `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` is set (common for tools like DVC, poetry, etc.), the Python `keyring` library silently discards all writes and returns `None` on reads. This causes `cswap --add-account` to appear to succeed while credentials are never actually stored, making every subsequent `--switch` fail with "no stored credentials/config."
- This PR detects the null keyring backend at init time and automatically falls back to the same file-based credential storage already used on Linux/WSL.
- Adds 5 tests covering null backend detection, credential roundtrip, and deletion.
- Updates existing keyring contract tests to be compatible with the new fallback.

## Root cause

The null backend is typically activated via the `PYTHON_KEYRING_BACKEND` env var. Users may set this for unrelated Python tools (e.g. DVC, pip) without realizing it affects all `keyring` consumers, including `cswap`. The null backend has priority -1 and is specifically designed to be a no-op — it never raises errors, so the failure is completely silent.

## Related

Follow-up to #41 — the v0.10.2 fix made `--switch` skip broken slots gracefully, but the underlying credential loss was still happening for users with this env var set.

## Test plan

- [x] 5 new tests in `TestNullKeyringFallback` — all pass
- [x] Full test suite: zero new regressions (37 pre-existing failures unchanged)
- [x] Verified locally on macOS with `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` set