### PR TITLE
move to file based storage on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ cswap --purge                   # Remove all claude-swap data
 
 | Platform | Credentials | Config backups |
 |----------|-------------|----------------|
-| Windows | Windows Credential Manager | `~/.claude-swap-backup/` |
+| Windows | File-based (inside the backup directory, under `credentials/`) | `~/.claude-swap-backup/` |
 | macOS | macOS Keychain | `~/.claude-swap-backup/` |
 | Linux / WSL | File-based (inside the backup directory, under `credentials/`) | `${XDG_DATA_HOME:-~/.local/share}/claude-swap/` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-swap"
-version = "0.10.3"
+version = "0.11.0b1"
 description = "Multi-account switcher for Claude Code"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -65,3 +65,15 @@ class MigrationError(ClaudeSwitchError):
     """Error migrating the backup directory between layouts (e.g. legacy → XDG)."""
 
     pass
+
+
+class MigrationIncomplete(ClaudeSwitchError):
+    """A one-time data migration could not finish for every record.
+
+    Raised by run-once migrations (see ``migrations.py``) when some entries
+    failed or the source backend was inaccessible. The migration runner treats
+    this as "not applied" so the migration is retried on the next run rather
+    than being recorded as done with records left behind.
+    """
+
+    pass

--- a/src/claude_swap/migrations.py
+++ b/src/claude_swap/migrations.py
@@ -1,0 +1,301 @@
+"""One-time, run-once data migrations for claude-swap.
+
+A small, boring home for compatibility migrations so they don't pollute the
+core switch/read/write flow in :mod:`claude_swap.switcher`. Each migration:
+
+- is **idempotent** and **self-guarded** (safe to run twice, safe even if the
+  state file is missing or corrupt),
+- returns ``True`` when it *completed* (runner records it as applied),
+- returns ``False`` when it was *skipped / not applicable* (runner records
+  nothing, so a later-restored backup can still trigger it),
+- raises :class:`~claude_swap.exceptions.MigrationIncomplete` (or any other
+  exception) when it *partially failed* — the runner logs it and leaves it
+  unmarked so the next run retries.
+
+Applied migrations are tracked in ``<backup_dir>/.migrations.json``:
+
+    {"version": 1, "applied": {"windows_keyring_to_files": "<iso-timestamp>"}}
+
+Run once at switcher construction (see ``ClaudeAccountSwitcher.__init__``);
+after the state file records a migration it short-circuits with a single tiny
+file read and never touches the source backend again.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+from claude_swap.exceptions import MigrationIncomplete
+from claude_swap.models import Platform, get_timestamp
+from claude_swap.switcher import KEYRING_SERVICE
+
+if TYPE_CHECKING:
+    from claude_swap.switcher import ClaudeAccountSwitcher
+
+STATE_FILENAME = ".migrations.json"
+STATE_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# State file
+# ---------------------------------------------------------------------------
+
+
+def _state_path(switcher: "ClaudeAccountSwitcher") -> Path:
+    return switcher.backup_dir / STATE_FILENAME
+
+
+def _load_applied(switcher: "ClaudeAccountSwitcher") -> dict:
+    """Return the ``{migration_id: timestamp}`` map; {} if missing or corrupt.
+
+    A missing or unparseable state file is treated as "nothing applied" so a
+    corrupt file can never permanently block a migration.
+    """
+    path = _state_path(switcher)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return {}
+    applied = data.get("applied") if isinstance(data, dict) else None
+    return applied if isinstance(applied, dict) else {}
+
+
+def _mark_applied(switcher: "ClaudeAccountSwitcher", migration_id: str) -> None:
+    """Record ``migration_id`` as applied, written atomically.
+
+    Preserves any previously-recorded migrations. Mirrors the mkstemp +
+    ``os.replace`` pattern used by ``ClaudeAccountSwitcher._write_credentials``.
+    The state file holds no secrets, but we ``chmod 0o600`` on non-Windows to
+    match the other local state files.
+    """
+    path = _state_path(switcher)
+    applied = _load_applied(switcher)
+    applied[migration_id] = get_timestamp()
+    content = json.dumps({"version": STATE_VERSION, "applied": applied}, indent=2)
+
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        os.write(fd, content.encode("utf-8"))
+        os.close(fd)
+        fd = -1
+        os.replace(tmp_path, str(path))
+        if sys.platform != "win32":
+            os.chmod(str(path), 0o600)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Migrations
+# ---------------------------------------------------------------------------
+
+
+def _delete_keyring_quietly(keyring, switcher, username: str) -> None:
+    """Best-effort delete of a keyring entry; never raises.
+
+    Used for cleanup *after* data has been safely relocated to a file, so a
+    failure here is cosmetic (the entry is no longer read, and ``purge`` mops
+    up any leftovers).
+    """
+    try:
+        keyring.delete_password(KEYRING_SERVICE, username)
+    except keyring.errors.PasswordDeleteError:
+        pass  # Entry doesn't exist — fine.
+    except Exception as e:  # noqa: BLE001 - best effort
+        switcher._logger.warning(
+            f"windows_keyring_to_files: best-effort delete of {username} failed: {e}"
+        )
+
+
+def migrate_windows_keyring_to_files(switcher: "ClaudeAccountSwitcher") -> bool:
+    """Copy Windows backup credentials from Credential Manager to files.
+
+    Windows now stores per-account backup credentials as base64 files (like
+    Linux/WSL) because the Credential Manager rejects entries over ~2,500 bytes
+    (#45). This relocates any pre-existing keyring entries so upgrading users
+    don't lose access, then cleans up the old entries best-effort.
+
+    Returns ``True`` (completed) on a Windows host once every account's creds
+    have been read successfully (including the benign "no legacy entries"
+    case); ``False`` (skip) on non-Windows or when there's no readable
+    sequence yet. Raises :class:`MigrationIncomplete` if the keyring backend is
+    inaccessible or any account could not be safely relocated, so the runner
+    retries on the next launch rather than marking it done.
+    """
+    if switcher.platform != Platform.WINDOWS:
+        return False
+    if not switcher.sequence_file.exists():
+        return False  # No managed accounts yet — let a later restore migrate.
+
+    data = switcher._get_sequence_data()
+    if data is None:
+        # sequence.json exists but is corrupt/unparseable. Never mark applied:
+        # a user who repairs or restores it must still get the migration.
+        return False
+
+    accounts = data.get("accounts", {})
+    if not accounts:
+        return True  # Readable sequence, nothing to migrate → done.
+
+    try:
+        import keyring  # noqa: PLC0415 - only needed on the migration path
+        # Touch the attribute we rely on so a broken backend surfaces here.
+        keyring.errors.PasswordDeleteError  # noqa: B018
+    except Exception as e:  # noqa: BLE001
+        # An inaccessible backend is NOT "nothing to migrate" — that would
+        # permanently skip real entries. Force a retry next run.
+        raise MigrationIncomplete(
+            f"keyring backend unavailable, deferring Windows migration: {e}"
+        ) from e
+
+    # Existing Windows keyring users may have sequence.json + configs but no
+    # credentials/ dir yet (it never held files before this change), and the
+    # file backend's write does a bare write_text. Ensure it exists up front —
+    # only reached on the real-work path (Windows + readable accounts).
+    switcher.credentials_dir.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "win32":
+        os.chmod(switcher.credentials_dir, 0o700)
+
+    # account-None-{email} can only be attributed to a slot when its email is
+    # unique; otherwise it's an ambiguous stale artifact (cleanup-only).
+    email_counts = Counter(info.get("email", "") for info in accounts.values())
+
+    migrated = 0
+    failed = 0
+
+    for account_num, info in accounts.items():
+        email = info.get("email", "")
+        canonical = f"account-{account_num}-{email}"
+        none_user = f"account-None-{email}"
+
+        # --- pick a source (canonical wins) -------------------------------
+        try:
+            creds = keyring.get_password(KEYRING_SERVICE, canonical)
+        except Exception as e:  # noqa: BLE001
+            switcher._logger.warning(
+                f"windows_keyring_to_files: read of {canonical} failed: {e}"
+            )
+            failed += 1
+            continue
+
+        source_username = canonical
+        if not creds and str(account_num) != "None" and email_counts[email] == 1:
+            # Canonical missing; fall back to account-None only when the email
+            # unambiguously maps to this one slot.
+            try:
+                creds = keyring.get_password(KEYRING_SERVICE, none_user)
+            except Exception as e:  # noqa: BLE001
+                switcher._logger.warning(
+                    f"windows_keyring_to_files: read of {none_user} failed: {e}"
+                )
+                failed += 1
+                continue
+            if creds:
+                source_username = none_user
+
+        if not creds:
+            # Nothing in the keyring for this slot (e.g. added on the new
+            # version, or an ambiguous account-None we won't touch). Benign —
+            # not a failure. Leave any account-None entry alone.
+            continue
+
+        # --- write + verify before deleting the only other copy -----------
+        try:
+            switcher._write_account_credentials(account_num, email, creds)
+            readback = switcher._read_account_credentials(account_num, email)
+        except Exception as e:  # noqa: BLE001
+            switcher._logger.warning(
+                f"windows_keyring_to_files: write/read-back for {canonical} failed: {e}"
+            )
+            # A partial/garbage file must not shadow the still-intact keyring
+            # entry (files are authoritative now). Drop it; retry rewrites it.
+            switcher._delete_account_credentials(account_num, email)
+            failed += 1
+            continue
+
+        if readback != creds:
+            switcher._logger.warning(
+                f"windows_keyring_to_files: read-back mismatch for {canonical}; "
+                "discarding the bad file and leaving the keyring entry in place"
+            )
+            switcher._delete_account_credentials(account_num, email)
+            failed += 1
+            continue
+
+        # Data is safely in the file now → files are authoritative. Remove the
+        # source entry, and the redundant account-None entry, best-effort.
+        _delete_keyring_quietly(keyring, switcher, source_username)
+        if str(account_num) != "None" and source_username != none_user:
+            _delete_keyring_quietly(keyring, switcher, none_user)
+        migrated += 1
+
+    if migrated:
+        print(
+            f"claude-swap: migrated {migrated} Windows credential(s) from "
+            "Credential Manager to files",
+            file=sys.stderr,
+        )
+
+    if failed:
+        raise MigrationIncomplete(
+            f"{failed} account(s) could not be migrated from Credential Manager; "
+            "will retry on next run"
+        )
+    return True
+
+
+# Registry of (id, fn). Order matters if migrations ever depend on each other.
+MIGRATIONS: list[tuple[str, Callable[["ClaudeAccountSwitcher"], bool]]] = [
+    ("windows_keyring_to_files", migrate_windows_keyring_to_files),
+]
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def run_migrations(switcher: "ClaudeAccountSwitcher") -> None:
+    """Run any not-yet-applied migrations. Never raises.
+
+    A no-op on fresh installs (backup dir not yet materialized — preserves the
+    lazy-dir invariant) and once the state file records every migration. A
+    failing migration is logged and left unmarked so it retries next run; it
+    must never abort switcher construction.
+    """
+    if not switcher.backup_dir.exists():
+        return
+
+    applied = _load_applied(switcher)
+    for migration_id, fn in MIGRATIONS:
+        if migration_id in applied:
+            continue
+        try:
+            completed = fn(switcher)
+        except Exception as e:  # noqa: BLE001 - migrations must never brick the tool
+            switcher._logger.warning(
+                f"Migration {migration_id} did not complete (will retry): {e}"
+            )
+            continue
+        if completed:
+            try:
+                _mark_applied(switcher, migration_id)
+            except Exception as e:  # noqa: BLE001
+                switcher._logger.warning(
+                    f"Migration {migration_id} ran but recording it failed "
+                    f"(will re-run next time): {e}"
+                )

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -117,6 +117,14 @@ class ClaudeAccountSwitcher:
         self.lock_file = self.backup_dir / ".lock"
         self._logger = setup_logging(self.backup_dir, debug=debug)
 
+        # Run any pending one-time data migrations (e.g. relocating Windows
+        # backup credentials out of Credential Manager into files). Imported
+        # lazily to avoid a circular import, and self-contained so it never
+        # aborts construction. No-op on fresh installs / once recorded.
+        from claude_swap.migrations import run_migrations
+
+        run_migrations(self)
+
     def _is_running_in_container(self) -> bool:
         """Check if running inside a container."""
         # Check environment variables (works on all platforms)
@@ -302,13 +310,23 @@ class ClaudeAccountSwitcher:
             except Exception as e:
                 raise CredentialWriteError(f"Failed to write credentials: {e}")
 
+    def _uses_file_backup_backend(self) -> bool:
+        """Whether per-account backup credentials live in files vs. the keyring.
+
+        Linux/WSL/Windows store them as base64 files under ``credentials_dir``;
+        macOS (and any UNKNOWN platform) use the system keyring. Windows moved
+        to files because the Windows Credential Manager rejects entries over
+        ~2,500 bytes, which Claude Code session credentials can exceed (#45).
+        """
+        return self.platform in (Platform.LINUX, Platform.WSL, Platform.WINDOWS)
+
     def _read_account_credentials(self, account_num: str, email: str) -> str:
         """Read account credentials from backup.
 
-        On Linux/WSL: Uses file-based storage to avoid keyring backend issues.
-        On macOS/Windows: Uses system keyring.
+        On Linux/WSL/Windows: Uses file-based storage (base64 files under
+        ``credentials_dir``). On macOS: Uses the system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self._uses_file_backup_backend():
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             if cred_file.exists():
                 try:
@@ -319,7 +337,7 @@ class ClaudeAccountSwitcher:
                     return ""
             return ""
         else:
-            # Use keyring for macOS/Windows
+            # Use keyring for macOS
             username = f"account-{account_num}-{email}"
             try:
                 creds = keyring.get_password(KEYRING_SERVICE, username)
@@ -333,20 +351,21 @@ class ClaudeAccountSwitcher:
     ) -> None:
         """Write account credentials to backup.
 
-        On Linux/WSL: Uses file-based storage to avoid keyring backend issues.
-        On macOS/Windows: Uses system keyring.
+        On Linux/WSL/Windows: Uses file-based storage (base64 files under
+        ``credentials_dir``). On macOS: Uses the system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self._uses_file_backup_backend():
             cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
             try:
                 encoded = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
                 cred_file.write_text(encoded, encoding="utf-8")
-                os.chmod(cred_file, 0o600)
+                if sys.platform != "win32":
+                    os.chmod(cred_file, 0o600)
             except Exception as e:
                 self._logger.warning(f"Failed to write credentials file: {e}")
                 raise
         else:
-            # Use keyring for macOS/Windows
+            # Use keyring for macOS
             username = f"account-{account_num}-{email}"
             try:
                 keyring.set_password(KEYRING_SERVICE, username, credentials)
@@ -357,10 +376,10 @@ class ClaudeAccountSwitcher:
     def _delete_account_credentials(self, account_num: str, email: str) -> None:
         """Delete account credentials from backup.
 
-        On Linux/WSL: Deletes file-based credential storage.
-        On macOS/Windows: Removes from system keyring.
+        On Linux/WSL/Windows: Deletes file-based credential storage.
+        On macOS: Removes from system keyring.
         """
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self._uses_file_backup_backend():
             cred_files = [self.credentials_dir / f".creds-{account_num}-{email}.enc"]
             if str(account_num) != "None":
                 cred_files.append(self.credentials_dir / f".creds-None-{email}.enc")
@@ -371,7 +390,7 @@ class ClaudeAccountSwitcher:
                 except Exception as e:
                     self._logger.warning(f"Failed to delete credentials file: {e}")
         else:
-            # Use keyring for macOS/Windows
+            # Use keyring for macOS
             usernames = [f"account-{account_num}-{email}"]
             if str(account_num) != "None":
                 usernames.append(f"account-None-{email}")
@@ -1611,7 +1630,9 @@ class ClaudeAccountSwitcher:
         """Remove all traces of claude-swap from the system.
 
         This removes:
-        - All stored account credentials (files on Linux, keyring on macOS/Windows)
+        - All stored account credentials (files on Linux/WSL/Windows, keyring on
+          macOS), plus a best-effort sweep of any pre-migration Windows
+          Credential Manager entries left behind
         - The active backup directory (XDG path on Linux/WSL, ~/.claude-swap-backup elsewhere)
         - Any stale legacy ~/.claude-swap-backup directory left around from
           before the XDG migration
@@ -1623,7 +1644,7 @@ class ClaudeAccountSwitcher:
         print(f"  - Backup directory: {self.backup_dir}")
         if legacy_distinct and legacy.exists():
             print(f"  - Legacy backup directory: {legacy}")
-        if self.platform in (Platform.LINUX, Platform.WSL):
+        if self._uses_file_backup_backend():
             print("  - All stored account credential files")
         else:
             print("  - All stored account credentials from the system keyring")
@@ -1643,8 +1664,8 @@ class ClaudeAccountSwitcher:
         if data:
             for account_num, account_info in data.get("accounts", {}).items():
                 email = account_info.get("email", "")
-                if self.platform in (Platform.LINUX, Platform.WSL):
-                    # Remove credential files on Linux
+                if self._uses_file_backup_backend():
+                    # Remove credential files (Linux/WSL/Windows)
                     cred_files = [
                         self.credentials_dir / f".creds-{account_num}-{email}.enc"
                     ]
@@ -1659,8 +1680,26 @@ class ClaudeAccountSwitcher:
                                 removed_items.append(f"Credential file: {cred_file.name}")
                         except Exception:
                             pass  # Ignore errors during purge
+                    if self.platform == Platform.WINDOWS:
+                        # Best-effort cleanup of any pre-migration Credential
+                        # Manager entries left behind if the keyring → file
+                        # migration never completed. Files are authoritative
+                        # now; these are just stale cruft.
+                        usernames = [f"account-{account_num}-{email}"]
+                        if str(account_num) != "None":
+                            usernames.append(f"account-None-{email}")
+                        for username in usernames:
+                            try:
+                                keyring.delete_password(KEYRING_SERVICE, username)
+                                removed_items.append(
+                                    f"Legacy keyring credential: {username}"
+                                )
+                            except keyring.errors.PasswordDeleteError:
+                                pass  # Entry doesn't exist
+                            except Exception:
+                                pass  # Ignore other errors during purge
                 else:
-                    # Remove from keyring on macOS/Windows
+                    # Remove from keyring on macOS
                     usernames = [f"account-{account_num}-{email}"]
                     if str(account_num) != "None":
                         usernames.append(f"account-None-{email}")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,409 @@
+"""Tests for one-time data migrations (claude_swap.migrations).
+
+The headline migration relocates Windows backup credentials from Credential
+Manager (keyring) to base64 files. Since ``migrations.py`` does ``import
+keyring`` locally, patching ``claude_swap.switcher.keyring`` would NOT affect
+it — these tests inject a fake ``keyring`` module via ``sys.modules`` so the
+migration's own import picks it up.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import migrations
+from claude_swap.exceptions import MigrationIncomplete
+from claude_swap.migrations import run_migrations
+from claude_swap.models import Platform
+from claude_swap.switcher import KEYRING_SERVICE, ClaudeAccountSwitcher
+
+
+# ---------------------------------------------------------------------------
+# Fakes / fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeKeyringErrors:
+    class PasswordDeleteError(Exception):
+        pass
+
+
+class FakeKeyring:
+    """Minimal stand-in for the ``keyring`` module backed by a dict."""
+
+    def __init__(self, store: dict | None = None):
+        # store maps (service, username) -> password
+        self.store: dict[tuple[str, str], str] = dict(store or {})
+        self.errors = _FakeKeyringErrors
+        self.get_calls: list[tuple[str, str]] = []
+        self.deleted: list[tuple[str, str]] = []
+        self.raise_get_for: set[str] = set()
+
+    def get_password(self, service, username):
+        self.get_calls.append((service, username))
+        if username in self.raise_get_for:
+            raise RuntimeError(f"boom reading {username}")
+        return self.store.get((service, username))
+
+    def set_password(self, service, username, password):
+        self.store[(service, username)] = password
+
+    def delete_password(self, service, username):
+        self.deleted.append((service, username))
+        if (service, username) in self.store:
+            del self.store[(service, username)]
+        else:
+            raise self.errors.PasswordDeleteError(username)
+
+
+def _make_windows_switcher(temp_home: Path) -> ClaudeAccountSwitcher:
+    """A switcher whose platform is forced to WINDOWS, with dirs created."""
+    switcher = ClaudeAccountSwitcher()
+    switcher.platform = Platform.WINDOWS
+    switcher._setup_directories()
+    return switcher
+
+
+def _seed_sequence(switcher: ClaudeAccountSwitcher, accounts: dict) -> None:
+    data = {
+        "activeAccountNumber": None,
+        "lastUpdated": "2024-01-01T00:00:00Z",
+        "sequence": [int(k) for k in accounts if k.isdigit()],
+        "accounts": accounts,
+    }
+    switcher._write_json(switcher.sequence_file, data)
+
+
+def _patch_keyring(fake: FakeKeyring):
+    return patch.dict(sys.modules, {"keyring": fake})
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsKeyringToFiles:
+    def test_migrates_entries_to_files_and_records_state(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(
+            switcher,
+            {
+                "1": {"email": "a@example.com"},
+                "2": {"email": "b@example.com"},
+            },
+        )
+        fake = FakeKeyring(
+            {
+                (KEYRING_SERVICE, "account-1-a@example.com"): "creds-A",
+                (KEYRING_SERVICE, "account-2-b@example.com"): "creds-B",
+            }
+        )
+
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+
+        # Files written with the right (decoded) content.
+        assert switcher._read_account_credentials("1", "a@example.com") == "creds-A"
+        assert switcher._read_account_credentials("2", "b@example.com") == "creds-B"
+        # Keyring entries cleaned up.
+        assert fake.store == {}
+        assert (KEYRING_SERVICE, "account-1-a@example.com") in fake.deleted
+        # State recorded.
+        state = json.loads((switcher.backup_dir / ".migrations.json").read_text())
+        assert "windows_keyring_to_files" in state["applied"]
+        assert state["version"] == 1
+
+    def test_idempotent_second_run_touches_no_keyring(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+        fake = FakeKeyring({(KEYRING_SERVICE, "account-1-a@example.com"): "creds-A"})
+
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+        first_calls = list(fake.get_calls)
+
+        # Second run: already applied → no keyring access at all.
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+
+        assert fake.get_calls == first_calls  # no new reads
+        assert switcher._read_account_credentials("1", "a@example.com") == "creds-A"
+
+    def test_creates_credentials_dir_if_missing(self, temp_home):
+        """Existing keyring users may have sequence.json but no credentials/
+        dir; the migration must create it rather than fail on write."""
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+        # Simulate the gap: remove the credentials dir created by setup.
+        import shutil as _shutil
+
+        _shutil.rmtree(switcher.credentials_dir)
+        assert not switcher.credentials_dir.exists()
+        fake = FakeKeyring({(KEYRING_SERVICE, "account-1-a@example.com"): "creds-A"})
+
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+
+        assert switcher.credentials_dir.exists()
+        assert switcher._read_account_credentials("1", "a@example.com") == "creds-A"
+        state = json.loads((switcher.backup_dir / ".migrations.json").read_text())
+        assert "windows_keyring_to_files" in state["applied"]
+
+    def test_completes_when_no_legacy_entries_present(self, temp_home):
+        """A new-version Windows install with accounts but no keyring entries
+        still marks the migration applied so we stop probing on every start."""
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+        # File already present (added on the new version); keyring empty.
+        switcher._write_account_credentials("1", "a@example.com", "file-creds")
+        fake = FakeKeyring()
+
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+
+        state = json.loads((switcher.backup_dir / ".migrations.json").read_text())
+        assert "windows_keyring_to_files" in state["applied"]
+        # The existing file is untouched.
+        assert switcher._read_account_credentials("1", "a@example.com") == "file-creds"
+
+
+# ---------------------------------------------------------------------------
+# Skips (return False → unmarked)
+# ---------------------------------------------------------------------------
+
+
+class TestSkips:
+    def test_non_windows_is_noop(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        switcher.platform = Platform.LINUX
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+        fake = FakeKeyring({(KEYRING_SERVICE, "account-1-a@example.com"): "x"})
+
+        with _patch_keyring(fake):
+            assert migrations.migrate_windows_keyring_to_files(switcher) is False
+        assert fake.get_calls == []
+        assert not (switcher.backup_dir / ".migrations.json").exists()
+
+    def test_no_sequence_file_skips_unmarked(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        # No sequence.json written.
+        fake = FakeKeyring()
+        with _patch_keyring(fake):
+            assert migrations.migrate_windows_keyring_to_files(switcher) is False
+        assert not (switcher.backup_dir / ".migrations.json").exists()
+
+    def test_corrupt_sequence_not_marked(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        switcher.sequence_file.write_text("{ not json", encoding="utf-8")
+        fake = FakeKeyring()
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+        # Unparseable sequence → never marked, so a later repair can migrate.
+        assert not (switcher.backup_dir / ".migrations.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# account-None disambiguation
+# ---------------------------------------------------------------------------
+
+
+class TestAccountNoneFallback:
+    def test_canonical_wins_over_none(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+        fake = FakeKeyring(
+            {
+                (KEYRING_SERVICE, "account-1-a@example.com"): "canonical",
+                (KEYRING_SERVICE, "account-None-a@example.com"): "stale-none",
+            }
+        )
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+
+        assert switcher._read_account_credentials("1", "a@example.com") == "canonical"
+        # The stale None entry is cleaned up, not migrated into the slot.
+        assert (KEYRING_SERVICE, "account-None-a@example.com") in fake.deleted
+        assert fake.store == {}
+
+    def test_none_used_as_fallback_when_email_unique(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "solo@example.com"}})
+        fake = FakeKeyring(
+            {(KEYRING_SERVICE, "account-None-solo@example.com"): "from-none"}
+        )
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+        assert (
+            switcher._read_account_credentials("1", "solo@example.com") == "from-none"
+        )
+
+    def test_none_not_used_for_duplicate_email(self, temp_home):
+        """Two org accounts share an email → account-None is ambiguous and must
+        not be migrated into any slot."""
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(
+            switcher,
+            {
+                "1": {"email": "dup@example.com", "organizationUuid": "org-1"},
+                "2": {"email": "dup@example.com", "organizationUuid": "org-2"},
+            },
+        )
+        fake = FakeKeyring(
+            {(KEYRING_SERVICE, "account-None-dup@example.com"): "ambiguous"}
+        )
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+
+        # Neither slot received the ambiguous value.
+        assert switcher._read_account_credentials("1", "dup@example.com") == ""
+        assert switcher._read_account_credentials("2", "dup@example.com") == ""
+        # The ambiguous account-None is left alone (not deleted), to avoid
+        # destroying possibly-only-copy data we can't attribute.
+        assert (KEYRING_SERVICE, "account-None-dup@example.com") in fake.store
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+class TestFailures:
+    def test_read_back_mismatch_keeps_keyring_and_unmarked(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+        fake = FakeKeyring({(KEYRING_SERVICE, "account-1-a@example.com"): "creds-A"})
+
+        # Force the verify step to disagree with the source.
+        with patch.object(
+            switcher, "_read_account_credentials", return_value="tampered"
+        ):
+            with _patch_keyring(fake):
+                run_migrations(switcher)
+
+        # Source entry preserved, migration not recorded → retried next run.
+        assert (KEYRING_SERVICE, "account-1-a@example.com") in fake.store
+        assert fake.deleted == []
+        assert not (switcher.backup_dir / ".migrations.json").exists()
+        # The bad/partial file must not shadow the intact keyring entry.
+        assert not (
+            switcher.credentials_dir / ".creds-1-a@example.com.enc"
+        ).exists()
+
+    def test_partial_failure_migrates_rest_and_stays_unmarked(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(
+            switcher,
+            {
+                "1": {"email": "ok@example.com"},
+                "2": {"email": "bad@example.com"},
+            },
+        )
+        fake = FakeKeyring(
+            {
+                (KEYRING_SERVICE, "account-1-ok@example.com"): "good",
+                (KEYRING_SERVICE, "account-2-bad@example.com"): "never-read",
+            }
+        )
+        fake.raise_get_for.add("account-2-bad@example.com")
+
+        with _patch_keyring(fake):
+            run_migrations(switcher)  # swallows MigrationIncomplete
+
+        # The healthy account migrated; the failed one is untouched + unmarked.
+        assert switcher._read_account_credentials("1", "ok@example.com") == "good"
+        assert (KEYRING_SERVICE, "account-2-bad@example.com") in fake.store
+        assert not (switcher.backup_dir / ".migrations.json").exists()
+
+    def test_partial_failure_raises_from_migration_fn(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "bad@example.com"}})
+        fake = FakeKeyring()
+        fake.raise_get_for.add("account-1-bad@example.com")
+        with _patch_keyring(fake):
+            with pytest.raises(MigrationIncomplete):
+                migrations.migrate_windows_keyring_to_files(switcher)
+
+    def test_inaccessible_backend_raises_incomplete(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+        # Make `import keyring` fail inside the migration.
+        with patch.dict(sys.modules, {"keyring": None}):
+            with pytest.raises(MigrationIncomplete):
+                migrations.migrate_windows_keyring_to_files(switcher)
+        # Runner swallows it and leaves it unmarked.
+        with patch.dict(sys.modules, {"keyring": None}):
+            run_migrations(switcher)
+        assert not (switcher.backup_dir / ".migrations.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Runner guards
+# ---------------------------------------------------------------------------
+
+
+class TestRunner:
+    def test_noop_when_backup_dir_absent(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.WINDOWS
+        # Do NOT create directories — fresh-install invariant.
+        if switcher.backup_dir.exists():
+            pytest.skip("host already materialized backup dir")
+        fake = FakeKeyring()
+        with _patch_keyring(fake):
+            run_migrations(switcher)
+        assert not switcher.backup_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Windows now uses the file backend (no keyring) for normal read/write/delete
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsFileBackend:
+    def test_round_trip_uses_files_not_keyring(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        assert switcher._uses_file_backup_backend() is True
+
+        with patch("claude_swap.switcher.keyring", create=True) as mock_keyring:
+            switcher._write_account_credentials("1", "a@example.com", "secret")
+            assert switcher._read_account_credentials("1", "a@example.com") == "secret"
+            switcher._delete_account_credentials("1", "a@example.com")
+            assert switcher._read_account_credentials("1", "a@example.com") == ""
+            mock_keyring.assert_not_called()
+            mock_keyring.get_password.assert_not_called()
+            mock_keyring.set_password.assert_not_called()
+
+        # The on-disk file lives under credentials/ as a base64 .enc file.
+        cred_file = switcher.credentials_dir / ".creds-1-a@example.com.enc"
+        assert not cred_file.exists()  # deleted above
+
+
+# ---------------------------------------------------------------------------
+# purge() best-effort legacy keyring cleanup on Windows
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeWindows:
+    def test_purge_removes_files_and_legacy_keyring(self, temp_home):
+        switcher = _make_windows_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+        switcher._write_account_credentials("1", "a@example.com", "secret")
+        cred_file = switcher.credentials_dir / ".creds-1-a@example.com.enc"
+        assert cred_file.exists()
+
+        with patch("claude_swap.switcher.keyring", create=True) as mock_keyring:
+            mock_keyring.errors.PasswordDeleteError = _FakeKeyringErrors.PasswordDeleteError
+            with patch("builtins.input", return_value="y"):
+                switcher.purge()
+
+        # File backend cleaned up.
+        assert not cred_file.exists()
+        # Best-effort legacy Credential Manager cleanup attempted.
+        called = [c.args for c in mock_keyring.delete_password.call_args_list]
+        assert (KEYRING_SERVICE, "account-1-a@example.com") in called

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "claude-swap"
-version = "0.10.3"
+version = "0.11.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## What & why

Windows now stores per-account backup credentials as **base64 files** (same as Linux/WSL) instead of the Windows Credential Manager. The Credential Manager rejects entries over ~2,500 bytes, which Claude Code session credentials can exceed — breaking add/switch (`WinError 1783`). macOS keeps using the Keychain.

Refs #45, #28.

## How

- **Backend switch** — Windows joins the file-based branch via a single `_uses_file_backup_backend()` helper used by read/write/delete and `purge()`. macOS (and UNKNOWN) stay on keyring.
- **Migration for existing users** — a small new `migrations.py` (run-once registry + atomic `.migrations.json` state) relocates any existing Credential Manager entries to files on first run:
  - canonical `account-{n}-{email}` wins; the ambiguous `account-None-*` is only used as a fallback for unique emails, otherwise left untouched,
  - **verify-before-delete**: write file → read back → compare, and only then best-effort delete the keyring entry (bad/partial files are discarded so they can't shadow the keyring),
  - partial failures / inaccessible backend → not marked applied, retried next run,
  - no-op on fresh installs (preserves the lazy backup-dir invariant) and once recorded.
- **purge()** also does a best-effort sweep of leftover Credential Manager entries on Windows.

## Tests

New `tests/test_migrations.py` (happy path, idempotency, skip/corrupt-sequence, `account-None` disambiguation, verify-before-delete, partial failure, inaccessible backend, missing `credentials/` dir, Windows file-backend round-trip, purge cleanup). Full suite: **378 passed, 2 skipped**.

> Note: the proper fix is this automatic migration — not the manual keyring-backend rename workaround posted on #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)