### PR TITLE
Make --upgrade safe on Windows and undetected installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ uv run cswap --help
 ### Updating
 
 ```bash
+cswap --upgrade        # uv/pipx installs on macOS/Linux: auto-detects and upgrades
+# or run your installer directly:
 uv tool upgrade claude-swap
-# or
 pipx upgrade claude-swap
 ```
 
@@ -86,6 +87,7 @@ cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
 cswap --remove-account 2        # Remove an account
 cswap --tui                     # Launch the interactive arrow-key menu
+cswap --upgrade                 # Upgrade claude-swap to the latest version
 cswap --purge                   # Remove all claude-swap data
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-swap"
-version = "0.11.0"
+version = "0.11.1"
 description = "Multi-account switcher for Claude Code"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_swap/update_check.py
+++ b/src/claude_swap/update_check.py
@@ -66,10 +66,20 @@ def check_for_update(current_version: str) -> str | None:
             write_cache(CACHE_PATH, latest_version)
 
         if latest_version and _parse_version(latest_version) > _parse_version(current_version):
-            hint = {
-                "uv": "Run `uv tool upgrade claude-swap` to update.",
-                "pipx": "Run `pipx upgrade claude-swap` to update.",
-            }.get(_detect_install_method() or "", "Consider upgrading!")
+            method = _detect_install_method()
+            direct = {
+                "uv": "uv tool upgrade claude-swap",
+                "pipx": "pipx upgrade claude-swap",
+            }.get(method or "")
+            if direct and sys.platform != "win32":
+                # cswap --upgrade actually performs the upgrade here.
+                hint = "Run `cswap --upgrade` to update."
+            elif direct:
+                # Windows: cswap --upgrade only prints, so point at the real command.
+                hint = f"Run `{direct}` to update."
+            else:
+                # Unknown install method: cswap --upgrade shows manual instructions.
+                hint = "Run `cswap --upgrade` for upgrade instructions."
             return (
                 f"A newer version of claude-swap is available ({latest_version}). "
                 f"You are using {current_version}. {hint}"

--- a/src/claude_swap/update_check.py
+++ b/src/claude_swap/update_check.py
@@ -105,6 +105,19 @@ def run_self_upgrade() -> int:
             "If you installed with `pip install -e .`, use `git pull` instead."
         )
         return 1
+
+    # Windows: the running cswap.exe launcher is locked, so an in-process
+    # uv/pipx upgrade fails when it tries to replace the executable even
+    # though the package itself updates. Tell the user to run it in a fresh
+    # shell instead of executing it ourselves.
+    if sys.platform == "win32":
+        error(
+            "claude-swap can't upgrade itself while running on Windows.\n"
+            "Close this process, then run in a new terminal:\n"
+            f"  {' '.join(cmd)}"
+        )
+        return 1
+
     try:
         result = subprocess.run(cmd, check=False)
         return result.returncode

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -165,8 +165,12 @@ class TestDetectInstallMethod:
 
 
 class TestCheckForUpdateMessage:
+    @patch("claude_swap.update_check.sys.platform", "linux")
     @patch("claude_swap.update_check.urllib.request.urlopen")
-    def test_uv_hint_appended(self, mock_urlopen, tmp_path, monkeypatch):
+    def test_detected_method_non_windows_suggests_cswap_upgrade(
+        self, mock_urlopen, tmp_path, monkeypatch
+    ):
+        # uv/pipx on macOS/Linux: cswap --upgrade actually upgrades, so advertise it.
         monkeypatch.setattr("claude_swap.update_check.CACHE_PATH", tmp_path / "cache.json")
         monkeypatch.setattr("claude_swap.update_check._detect_install_method", lambda: "uv")
         mock_urlopen.return_value = _make_pypi_response("0.4.0")
@@ -174,10 +178,15 @@ class TestCheckForUpdateMessage:
         result = check_for_update("0.3.2")
 
         assert result is not None
-        assert "uv tool upgrade claude-swap" in result
+        assert "cswap --upgrade" in result
+        assert "uv tool upgrade" not in result
 
+    @patch("claude_swap.update_check.sys.platform", "win32")
     @patch("claude_swap.update_check.urllib.request.urlopen")
-    def test_pipx_hint_appended(self, mock_urlopen, tmp_path, monkeypatch):
+    def test_detected_method_windows_suggests_direct_command(
+        self, mock_urlopen, tmp_path, monkeypatch
+    ):
+        # Windows: cswap --upgrade only prints, so point at the real command.
         monkeypatch.setattr("claude_swap.update_check.CACHE_PATH", tmp_path / "cache.json")
         monkeypatch.setattr("claude_swap.update_check._detect_install_method", lambda: "pipx")
         mock_urlopen.return_value = _make_pypi_response("0.4.0")
@@ -186,9 +195,13 @@ class TestCheckForUpdateMessage:
 
         assert result is not None
         assert "pipx upgrade claude-swap" in result
+        assert "cswap --upgrade" not in result
 
     @patch("claude_swap.update_check.urllib.request.urlopen")
-    def test_unknown_falls_back_to_generic(self, mock_urlopen, tmp_path, monkeypatch):
+    def test_unknown_method_suggests_cswap_instructions(
+        self, mock_urlopen, tmp_path, monkeypatch
+    ):
+        # Unknown install method: cswap --upgrade can only show instructions.
         monkeypatch.setattr("claude_swap.update_check.CACHE_PATH", tmp_path / "cache.json")
         monkeypatch.setattr("claude_swap.update_check._detect_install_method", lambda: None)
         mock_urlopen.return_value = _make_pypi_response("0.4.0")
@@ -196,7 +209,7 @@ class TestCheckForUpdateMessage:
         result = check_for_update("0.3.2")
 
         assert result is not None
-        assert "Consider upgrading" in result
+        assert "cswap --upgrade` for upgrade instructions" in result
         assert "uv tool upgrade" not in result
         assert "pipx upgrade" not in result
 

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -201,6 +201,7 @@ class TestCheckForUpdateMessage:
         assert "pipx upgrade" not in result
 
 
+@patch("claude_swap.update_check.sys.platform", "linux")
 class TestRunSelfUpgrade:
     @patch("claude_swap.update_check.subprocess.run")
     @patch("claude_swap.update_check._detect_install_method", return_value="uv")
@@ -249,3 +250,37 @@ class TestRunSelfUpgrade:
         assert run_self_upgrade() == 1
         err = capsys.readouterr().err
         assert "PATH" in err
+
+
+@patch("claude_swap.update_check.sys.platform", "win32")
+class TestRunSelfUpgradeWindows:
+    """On Windows the running .exe is locked, so we never upgrade in place --
+    we print the command for the user to run in a fresh shell and exit 1."""
+
+    @patch("claude_swap.update_check.subprocess.run")
+    @patch("claude_swap.update_check._detect_install_method", return_value="uv")
+    def test_uv_prints_command_and_does_not_run(self, mock_detect, mock_run, capsys):
+        assert run_self_upgrade() == 1
+        mock_run.assert_not_called()
+        err = capsys.readouterr().err
+        assert "uv tool upgrade claude-swap" in err
+        assert "Windows" in err
+
+    @patch("claude_swap.update_check.subprocess.run")
+    @patch("claude_swap.update_check._detect_install_method", return_value="pipx")
+    def test_pipx_prints_command_and_does_not_run(self, mock_detect, mock_run, capsys):
+        assert run_self_upgrade() == 1
+        mock_run.assert_not_called()
+        err = capsys.readouterr().err
+        assert "pipx upgrade claude-swap" in err
+        assert "Windows" in err
+
+    @patch("claude_swap.update_check.subprocess.run")
+    @patch("claude_swap.update_check._detect_install_method", return_value=None)
+    def test_unknown_method_hits_generic_fallback(self, mock_detect, mock_run, capsys):
+        assert run_self_upgrade() == 1
+        mock_run.assert_not_called()
+        err = capsys.readouterr().err
+        assert "uv tool upgrade claude-swap" in err
+        assert "pipx upgrade claude-swap" in err
+        assert "pip install --upgrade claude-swap" in err

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "claude-swap"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
On Windows the running `cswap.exe` is locked, so the in-process uv/pipx upgrade fails even though the package updates. `cswap --upgrade` now prints the upgrade command to run in a fresh shell (and returns 1) on Windows and for undetected installs, instead of attempting the in-place upgrade. macOS/Linux behaviour is unchanged. Bumps to 0.11.1 and documents `--upgrade` in the README.
