### PR TITLE
Isolate tests from the developer's real home, config, and Keychain

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -55,7 +55,6 @@ from claude_swap.process_detection import get_running_instances
 
 # Service name for keyring storage
 KEYRING_SERVICE = "claude-code"
-KEYRING_ACTIVE_USERNAME = "active-credentials"
 
 # Setup-tokens are inference-only server-side; wider scopes trigger 403s
 # on profile endpoints. Matches Claude Code's CLAUDE_CODE_OAUTH_TOKEN path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,12 @@ def _isolate_real_home(request, tmp_path_factory, monkeypatch):
     ``security`` for the live login). Redirect ``$HOME`` to a throwaway dir unless
     the test already uses ``temp_home`` (which sets its own). Runs first (autouse).
 
+    Exempt the ``tmp_keychain`` fixture too: the macOS-CI integration tests that
+    use it drive the real ``security`` CLI (``default-keychain`` /
+    ``list-keychains``), which needs the real ``$HOME`` to locate
+    ``~/Library/Keychains``. An isolated ``$HOME`` makes those commands fail. The
+    fixture itself swaps the default keychain to a throwaway one and restores it.
+
     Always neutralize ``CLAUDE_CONFIG_DIR`` and ``XDG_DATA_HOME`` (even for
     ``temp_home`` tests): both bypass ``$HOME`` in path resolution
     (``paths.get_global_config_path``/``get_backup_root``), so a developer with
@@ -34,6 +40,8 @@ def _isolate_real_home(request, tmp_path_factory, monkeypatch):
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     if "temp_home" in request.fixturenames:
         return  # temp_home provides its own isolated home
+    if "tmp_keychain" in request.fixturenames:
+        return  # real-keychain integration tests need the real $HOME
     safe_home = tmp_path_factory.mktemp("isolated_home")
     (safe_home / ".claude").mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HOME", str(safe_home))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,35 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _isolate_real_home(request, tmp_path_factory, monkeypatch):
+    """Safety net: no test may read or write the developer's real ``$HOME``.
+
+    Some tests (CLI/TUI argument tests that call ``main()``, etc.) construct a real
+    ``ClaudeAccountSwitcher`` without the ``temp_home`` fixture. Without isolation
+    that switcher resolves to the real ``~/.claude-swap-backup`` — running data
+    migrations and reading the real account list (and on macOS, shelling out to
+    ``security`` for the live login). Redirect ``$HOME`` to a throwaway dir unless
+    the test already uses ``temp_home`` (which sets its own). Runs first (autouse).
+
+    Always neutralize ``CLAUDE_CONFIG_DIR`` and ``XDG_DATA_HOME`` (even for
+    ``temp_home`` tests): both bypass ``$HOME`` in path resolution
+    (``paths.get_global_config_path``/``get_backup_root``), so a developer with
+    either exported could otherwise have tests read/write real Claude config or
+    backup paths — and on macOS that leads back to the real Keychain. Tests that
+    exercise those vars set them explicitly, overriding this.
+    """
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    if "temp_home" in request.fixturenames:
+        return  # temp_home provides its own isolated home
+    safe_home = tmp_path_factory.mktemp("isolated_home")
+    (safe_home / ".claude").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(safe_home))
+    monkeypatch.setenv("USERPROFILE", str(safe_home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: safe_home)
+
+
 @pytest.fixture
 def temp_home(tmp_path: Path):
     """Create a temporary home directory for testing."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -16,11 +17,37 @@ from claude_swap import cli
 # src layout: ensure subprocess can find claude_swap
 _SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
 
+# A throwaway HOME for subprocesses. The in-process autouse HOME guard does NOT
+# reach child processes, so a spawned ``python -m claude_swap`` would otherwise
+# resolve to the developer's real ``~/.claude-swap-backup`` and run the data
+# migration against real accounts (touching the real Keychain on macOS). An empty,
+# isolated HOME has no ``sequence.json`` → the migration skips before any Keychain
+# access, and no ``.claude.json`` → no account to read.
+_ISOLATED_HOME = tempfile.mkdtemp(prefix="cswap-subproc-home-")
+
 
 def _subprocess_env(**extra: str) -> dict[str, str]:
-    """Build env dict with PYTHONPATH pointing at src/."""
+    """Build env dict with PYTHONPATH pointing at src/ and an isolated HOME.
+
+    HOME/USERPROFILE default to a throwaway dir so the spawned CLI never touches
+    the developer's real backup dir or Keychain; callers may still override HOME
+    explicitly (e.g. ``_subprocess_env(HOME=str(temp_home))``), in which case
+    USERPROFILE mirrors it unless the caller set USERPROFILE too.
+    """
     env = {**os.environ, **extra}
     env["PYTHONPATH"] = _SRC_DIR + os.pathsep + env.get("PYTHONPATH", "")
+    if "HOME" not in extra:
+        env["HOME"] = _ISOLATED_HOME
+        env["USERPROFILE"] = _ISOLATED_HOME
+    elif "USERPROFILE" not in extra:
+        env["USERPROFILE"] = extra["HOME"]
+    # CLAUDE_CONFIG_DIR / XDG_DATA_HOME bypass HOME in path resolution, so a
+    # developer with either exported would otherwise point the spawned CLI back
+    # at real config/backup paths (and on macOS, the real Keychain). Drop them
+    # unless a caller set them deliberately.
+    for var in ("CLAUDE_CONFIG_DIR", "XDG_DATA_HOME"):
+        if var not in extra:
+            env.pop(var, None)
     return env
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -299,7 +299,7 @@ class TestDoRemove:
 
 
 class TestCliIntegration:
-    def test_tui_in_help(self):
+    def test_tui_in_help(self, tmp_path):
         import os
         import subprocess
         import sys as _sys
@@ -310,6 +310,13 @@ class TestCliIntegration:
             + os.pathsep
             + env.get("PYTHONPATH", "")
         )
+        # Isolate the child from the developer's real home/config, consistent
+        # with test_cli._subprocess_env. ``--help`` exits in argparse before the
+        # switcher is built, so nothing is touched today — this just keeps the
+        # "no subprocess inherits the real HOME" invariant uniform.
+        env["HOME"] = env["USERPROFILE"] = str(tmp_path)
+        for _var in ("CLAUDE_CONFIG_DIR", "XDG_DATA_HOME"):
+            env.pop(_var, None)
         result = subprocess.run(
             [_sys.executable, "-m", "claude_swap", "--help"],
             capture_output=True, text=True, env=env,


### PR DESCRIPTION
Test-only safety change: stop `pytest` from reaching the developer's real `~/.claude-swap-backup`, Claude config, or macOS Keychain.

- Add an autouse `_isolate_real_home` fixture that redirects `HOME`/`USERPROFILE`/`Path.home` to a throwaway dir for tests not already using `temp_home`, and always neutralizes `CLAUDE_CONFIG_DIR`/`XDG_DATA_HOME`.
- Default spawned subprocesses to an isolated `HOME` (`test_cli._subprocess_env` and the `test_tui` help test), stripping the two config-dir env vars.
- Remove the unused `KEYRING_ACTIVE_USERNAME` constant.

No production behavior changes and no test assertions weakened. `378 passed, 2 skipped`.