### PR TITLE
Add auto-switch at usage limit (Beta) to the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ cswap --switch-to user@example.com
 
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.
 
+### Auto-switch at usage limit (Beta)
+
+Launch the interactive menu and open **Auto-switch at limit (Beta)**:
+
+```bash
+cswap --tui
+```
+
+From there you can:
+
+- **Enable/Disable** automatic switching (the setting persists across runs).
+- **Set threshold** — the usage percentage that triggers a switch (default `95%`).
+- **Start monitor now** — runs a foreground watcher that polls the active
+  account's 5h/7d usage every 60 seconds. When usage reaches the threshold, it
+  rotates to the next managed account (same rotation as `cswap --switch`), then
+  keeps watching the new account. Press `s` to check immediately, or `q`/`Esc`
+  to stop.
+
+Because switching doesn't require a Claude Code restart (see the note above),
+the new account takes effect on your next message — on macOS once the Keychain
+cache expires. The monitor runs only while its screen is open in the TUI; there
+is no background daemon.
+
+> **Beta:** this feature is new and runs as a foreground watcher. The usage
+> percentages come from the same API as `cswap --list`. Please report any rough
+> edges via [Issues](https://github.com/realiti4/claude-swap/issues).
+
 ### Refresh expired tokens
 
 If an account's token expires, log back into Claude Code with that account and re-run:
@@ -86,7 +113,7 @@ cswap --list                    # Show all accounts with 5h/7d usage and reset t
 cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
 cswap --remove-account 2        # Remove an account
-cswap --tui                     # Launch the interactive arrow-key menu
+cswap --tui                     # Launch the interactive arrow-key menu (incl. auto-switch, Beta)
 cswap --upgrade                 # Upgrade claude-swap to the latest version
 cswap --purge                   # Remove all claude-swap data
 ```

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -63,6 +63,30 @@ SETUP_TOKEN_SCOPES = ("user:inference",)
 # Usage cache
 _USAGE_CACHE_TTL = 15  # seconds
 
+# Auto-switch (Beta): when the active account's 5h/7d usage reaches this
+# percentage, the TUI monitor rotates to the next managed account.
+DEFAULT_AUTO_SWITCH_THRESHOLD = 95
+
+
+def _max_usage_pct(usage: dict | None) -> float | None:
+    """Return the highest 5h/7d utilization percentage in a usage dict.
+
+    Only the rate-limit windows (``five_hour``/``seven_day``) are considered —
+    the dollar-denominated ``spend`` entry is intentionally ignored, since it is
+    not the limit that blocks Claude Code sessions. Returns ``None`` when no
+    usable percentage is present.
+    """
+    if not isinstance(usage, dict):
+        return None
+    pcts: list[float] = []
+    for key in ("five_hour", "seven_day"):
+        entry = usage.get(key)
+        if isinstance(entry, dict):
+            pct = entry.get("pct")
+            if isinstance(pct, (int, float)):
+                pcts.append(float(pct))
+    return max(pcts) if pcts else None
+
 
 def _format_usage_lines(usage: dict) -> list[str]:
     lines: list[str] = []
@@ -1226,6 +1250,110 @@ class ClaudeAccountSwitcher:
                         print(f"  {dimmed(connector)} {muted(line)}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
+
+    # ------------------------------------------------------------------ #
+    # Auto-switch (Beta)
+    # ------------------------------------------------------------------ #
+
+    def get_auto_switch_config(self) -> dict:
+        """Return the persisted auto-switch (Beta) settings.
+
+        Auto-switch is opt-in and stored in ``sequence.json`` under the
+        ``autoSwitch`` key. Defaults to disabled at
+        ``DEFAULT_AUTO_SWITCH_THRESHOLD``%.
+        """
+        data = self._get_sequence_data() or {}
+        cfg = data.get("autoSwitch") or {}
+        try:
+            threshold = int(cfg.get("threshold", DEFAULT_AUTO_SWITCH_THRESHOLD))
+        except (TypeError, ValueError):
+            threshold = DEFAULT_AUTO_SWITCH_THRESHOLD
+        return {
+            "enabled": bool(cfg.get("enabled", False)),
+            "threshold": threshold,
+        }
+
+    def set_auto_switch_config(
+        self, *, enabled: bool | None = None, threshold: int | None = None
+    ) -> dict:
+        """Persist auto-switch (Beta) settings, returning the merged config.
+
+        Only the provided fields are updated; the rest keep their stored (or
+        default) values.
+
+        Raises:
+            ValidationError: if ``threshold`` is outside the 1-100 range.
+        """
+        self._setup_directories()
+        self._init_sequence_file()
+        data = self._get_sequence_data() or {}
+        cfg = dict(data.get("autoSwitch") or {})
+        if enabled is not None:
+            cfg["enabled"] = bool(enabled)
+        if threshold is not None:
+            t = int(threshold)
+            if not 1 <= t <= 100:
+                raise ValidationError("Threshold must be between 1 and 100")
+            cfg["threshold"] = t
+        cfg.setdefault("enabled", False)
+        cfg.setdefault("threshold", DEFAULT_AUTO_SWITCH_THRESHOLD)
+        data["autoSwitch"] = cfg
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        return {"enabled": cfg["enabled"], "threshold": cfg["threshold"]}
+
+    def get_active_usage_pct(self) -> float | None:
+        """Return the highest 5h/7d utilization pct for the active account.
+
+        Used by the auto-switch monitor. Returns ``None`` when there is no
+        active login, no usable credentials, or the usage API is unreachable.
+
+        Reuses the same short-lived usage cache as ``list_accounts()`` /
+        ``status()`` so repeated polling stays cheap and consistent. The active
+        account is never refreshed (``is_active=True``) — Claude Code owns those
+        credentials.
+        """
+        identity = self._get_current_account()
+        if identity is None:
+            return None
+        current_email, current_org_uuid = identity
+
+        creds = self._read_credentials() or ""
+        if not creds or not oauth.extract_access_token(creds):
+            return None
+
+        # Resolve the active account number for cache keying (best-effort).
+        account_num = None
+        data = self._get_sequence_data() or {}
+        for num, account in data.get("accounts", {}).items():
+            if (account.get("email") == current_email and
+                    account.get("organizationUuid", "") == current_org_uuid):
+                account_num = num
+                break
+
+        usage_cache_path = self.backup_dir / "cache" / "usage.json"
+        usage = None
+        if account_num is not None:
+            cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
+            if (cached is not MISSING and isinstance(cached, dict)
+                    and account_num in cached):
+                usage = cached[account_num]
+
+        if usage is None:
+            usage = oauth.fetch_usage_for_account(
+                account_num or "active", current_email, creds, is_active=True,
+            )
+            if account_num is not None and isinstance(usage, dict):
+                existing = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
+                existing = (
+                    existing
+                    if (existing is not MISSING and isinstance(existing, dict))
+                    else {}
+                )
+                existing[account_num] = usage
+                write_cache(usage_cache_path, existing)
+
+        return _max_usage_pct(usage)
 
     def _first_run_setup(self) -> None:
         """First-run setup workflow."""

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import curses
 import sys
+import time
+from datetime import datetime
 from typing import Callable
 
 from claude_swap.exceptions import ClaudeSwitchError
@@ -26,6 +28,9 @@ from claude_swap.switcher import ClaudeAccountSwitcher
 # Minimum terminal size we render in. Below this, we bail to plain CLI advice.
 _MIN_ROWS = 12
 _MIN_COLS = 60
+
+# How often the auto-switch (Beta) monitor polls the active account's usage.
+_AUTO_POLL_SECONDS = 60
 
 
 def run(switcher: ClaudeAccountSwitcher) -> int:
@@ -66,6 +71,7 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
             ("Refresh credentials (current login, in-place)", "refresh"),
             ("List accounts (with usage)", "list"),
             ("Status", "status"),
+            ("Auto-switch at limit (Beta)", "auto"),
             ("Quit", "quit"),
         ]
         choice = _select_from(
@@ -90,6 +96,8 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
                 _shell_out(stdscr, lambda: switcher.list_accounts())
             elif choice == "status":
                 _shell_out(stdscr, switcher.status)
+            elif choice == "auto":
+                _do_auto_switch(stdscr, switcher)
         except ClaudeSwitchError as e:
             _show_message(stdscr, f"Error: {e}", is_error=True)
         except KeyboardInterrupt:
@@ -172,6 +180,174 @@ def _do_refresh(stdscr, switcher: ClaudeAccountSwitcher) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Auto-switch (Beta)
+# ---------------------------------------------------------------------------
+
+
+def _should_auto_switch(pct: float | None, threshold: int) -> bool:
+    """Whether the active account's usage warrants an automatic switch."""
+    return pct is not None and pct >= threshold
+
+
+def _do_auto_switch(stdscr, switcher: ClaudeAccountSwitcher) -> None:
+    """Settings + launcher for auto-switch (Beta).
+
+    Lets the user toggle automatic rotation to the next account when the active
+    account's 5h/7d usage reaches a threshold, tune that threshold, and start
+    the foreground monitor. Settings persist in ``sequence.json``.
+
+    No Claude Code restart is needed for the switch to take effect — on
+    Linux/Windows the new credentials are picked up on the next message, and on
+    macOS once the Keychain cache expires.
+    """
+    while True:
+        cfg = switcher.get_auto_switch_config()
+        state = "ON" if cfg["enabled"] else "OFF"
+        subtitle = (
+            f"Beta · currently {state} · threshold {cfg['threshold']}%  ·  "
+            "rotates to the next account at the limit"
+        )
+        items: list[tuple[str, str | None]] = [
+            ("Disable" if cfg["enabled"] else "Enable", "toggle"),
+            (f"Set threshold (now {cfg['threshold']}%)", "threshold"),
+            ("Start monitor now", "start"),
+            ("-- Back --", None),
+        ]
+        choice = _select_from(
+            stdscr,
+            "Auto-switch at limit (Beta)",
+            items=items,
+            subtitle=subtitle,
+        )
+        if choice is None:
+            return
+
+        if choice == "toggle":
+            switcher.set_auto_switch_config(enabled=not cfg["enabled"])
+        elif choice == "threshold":
+            raw = _prompt_text(stdscr, "Switch when usage reaches (%): ")
+            if raw:
+                try:
+                    switcher.set_auto_switch_config(threshold=int(raw))
+                except ValueError:
+                    _show_message(
+                        stdscr, "Threshold must be a whole number.", is_error=True
+                    )
+                except ClaudeSwitchError as e:
+                    _show_message(stdscr, f"Invalid threshold: {e}", is_error=True)
+        elif choice == "start":
+            cfg = switcher.get_auto_switch_config()
+            if not cfg["enabled"]:
+                # Starting the monitor implies enabling the feature.
+                cfg = switcher.set_auto_switch_config(enabled=True)
+            _run_auto_monitor(stdscr, switcher, cfg["threshold"])
+
+
+def _run_auto_monitor(
+    stdscr, switcher: ClaudeAccountSwitcher, threshold: int
+) -> None:
+    """Foreground watcher loop: poll active usage and switch at the threshold.
+
+    Polls every ``_AUTO_POLL_SECONDS`` (press ``s`` to check immediately,
+    ``q``/Esc to stop). When the active account reaches ``threshold``%, it
+    shells out to ``switcher.switch()`` to rotate to the next account, then
+    keeps watching the new active account.
+    """
+    curses.curs_set(0)
+    stdscr.timeout(1000)  # getch() returns -1 after ~1s, driving the countdown
+    last_pct: float | None = None
+    last_checked = "never"
+    message = "Monitoring started."
+    seconds_to_next = 0  # poll immediately on entry
+    try:
+        while True:
+            if seconds_to_next <= 0:
+                last_pct = switcher.get_active_usage_pct()
+                last_checked = datetime.now().strftime("%H:%M:%S")
+                seconds_to_next = _AUTO_POLL_SECONDS
+                if _should_auto_switch(last_pct, threshold):
+                    switched = _auto_perform_switch(stdscr, switcher)
+                    message = (
+                        f"Reached {last_pct:.0f}% — switched account."
+                        if switched
+                        else f"Reached {last_pct:.0f}% — switch failed (see above)."
+                    )
+                    # Re-read the new active account's usage on the next tick.
+                    last_pct = None
+                else:
+                    message = "Monitoring active account."
+
+            _draw_monitor(
+                stdscr, threshold, last_pct, last_checked, seconds_to_next, message
+            )
+            key = stdscr.getch()
+            if key in (27, ord("q"), ord("Q")):
+                return
+            if key in (ord("s"), ord("S")):
+                seconds_to_next = 0
+                continue
+            seconds_to_next -= 1
+    finally:
+        stdscr.timeout(-1)
+
+
+def _auto_perform_switch(stdscr, switcher: ClaudeAccountSwitcher) -> bool:
+    """Suspend curses, run ``switcher.switch()``, then resume. No Enter prompt."""
+    curses.def_prog_mode()
+    curses.endwin()
+    switched = True
+    try:
+        try:
+            switcher.switch()
+        except ClaudeSwitchError as e:
+            print(f"Auto-switch error: {e}")
+            switched = False
+        except KeyboardInterrupt:
+            print("\nOperation cancelled.")
+            switched = False
+        print()
+        time.sleep(2.5)  # brief pause so the output is readable
+    finally:
+        curses.reset_prog_mode()
+        stdscr.refresh()
+    return switched
+
+
+def _draw_monitor(
+    stdscr,
+    threshold: int,
+    pct: float | None,
+    last_checked: str,
+    seconds_to_next: int,
+    message: str,
+) -> None:
+    """Render the auto-switch monitor screen."""
+    stdscr.erase()
+    rows, cols = stdscr.getmaxyx()
+    _draw_header(
+        stdscr,
+        "Auto-switch monitor (Beta)",
+        f"threshold {threshold}%  ·  polling every {_AUTO_POLL_SECONDS}s",
+        cols,
+    )
+    pct_str = f"{pct:.0f}%" if pct is not None else "unavailable"
+    lines = [
+        f"Active account usage : {pct_str}",
+        f"Last checked         : {last_checked}",
+        f"Next check in        : {max(0, seconds_to_next)}s",
+        "",
+        message,
+    ]
+    for i, line in enumerate(lines):
+        if 4 + i >= rows - 2:
+            break
+        stdscr.addstr(4 + i, 2, line[: cols - 4])
+    footer = "[s] check now  [q/Esc] stop monitor"
+    stdscr.addstr(rows - 1, 2, footer[: cols - 4], curses.A_DIM)
+    stdscr.refresh()
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -187,7 +363,11 @@ def _status_line(switcher: ClaudeAccountSwitcher) -> str:
         email, org = identity
         tag = "personal" if not org else org[:8]
         active = f"{email} [{tag}]"
-    return f"Active: {active}  ·  {n} managed"
+    line = f"Active: {active}  ·  {n} managed"
+    cfg = switcher.get_auto_switch_config()
+    if cfg["enabled"]:
+        line += f"  ·  auto-switch ON ({cfg['threshold']}%)"
+    return line
 
 
 def _account_items(switcher: ClaudeAccountSwitcher) -> list[tuple[str, str]]:

--- a/tests/test_auto_switch.py
+++ b/tests/test_auto_switch.py
@@ -1,0 +1,227 @@
+"""Tests for the auto-switch (Beta) feature.
+
+Covers the switcher-side config/usage helpers and the TUI monitor logic.
+Curses primitives are mocked exactly as in ``test_tui.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_swap import tui
+from claude_swap.exceptions import ValidationError
+from claude_swap.switcher import (
+    DEFAULT_AUTO_SWITCH_THRESHOLD,
+    ClaudeAccountSwitcher,
+    _max_usage_pct,
+)
+
+
+def _stub_screen(rows: int = 30, cols: int = 100) -> MagicMock:
+    screen = MagicMock()
+    screen.getmaxyx.return_value = (rows, cols)
+    return screen
+
+
+def _login(temp_home: Path, email: str = "u@example.com") -> None:
+    config = {"oauthAccount": {"emailAddress": email}}
+    (temp_home / ".claude.json").write_text(json.dumps(config))
+
+
+# --------------------------------------------------------------------------- #
+# _max_usage_pct                                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestMaxUsagePct:
+    def test_none_when_no_usage(self):
+        assert _max_usage_pct(None) is None
+        assert _max_usage_pct({}) is None
+        assert _max_usage_pct("no credentials") is None
+
+    def test_returns_highest_of_5h_7d(self):
+        usage = {"five_hour": {"pct": 40}, "seven_day": {"pct": 95}}
+        assert _max_usage_pct(usage) == 95.0
+
+    def test_ignores_spend_entry(self):
+        usage = {"five_hour": {"pct": 10}, "spend": {"pct": 99}}
+        assert _max_usage_pct(usage) == 10.0
+
+    def test_handles_missing_pct(self):
+        assert _max_usage_pct({"five_hour": {}}) is None
+
+
+# --------------------------------------------------------------------------- #
+# Config persistence                                                          #
+# --------------------------------------------------------------------------- #
+
+
+class TestAutoSwitchConfig:
+    def test_default_is_disabled(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        cfg = switcher.get_auto_switch_config()
+        assert cfg == {
+            "enabled": False,
+            "threshold": DEFAULT_AUTO_SWITCH_THRESHOLD,
+        }
+
+    def test_enable_and_persist(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        switcher.set_auto_switch_config(enabled=True)
+        # A fresh instance reads the persisted value.
+        assert ClaudeAccountSwitcher().get_auto_switch_config()["enabled"] is True
+
+    def test_set_threshold(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        cfg = switcher.set_auto_switch_config(threshold=80)
+        assert cfg["threshold"] == 80
+        assert switcher.get_auto_switch_config()["threshold"] == 80
+
+    def test_partial_update_keeps_other_field(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        switcher.set_auto_switch_config(enabled=True, threshold=70)
+        switcher.set_auto_switch_config(threshold=60)
+        cfg = switcher.get_auto_switch_config()
+        assert cfg == {"enabled": True, "threshold": 60}
+
+    @pytest.mark.parametrize("bad", [0, -5, 101, 999])
+    def test_invalid_threshold_rejected(self, temp_home: Path, bad: int):
+        switcher = ClaudeAccountSwitcher()
+        with pytest.raises(ValidationError):
+            switcher.set_auto_switch_config(threshold=bad)
+
+    def test_does_not_clobber_accounts(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["1"] = {"email": "a@x.com"}
+        switcher._write_json(switcher.sequence_file, data)
+        switcher.set_auto_switch_config(enabled=True)
+        assert "1" in switcher._get_sequence_data()["accounts"]
+
+
+# --------------------------------------------------------------------------- #
+# get_active_usage_pct                                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestActiveUsagePct:
+    def test_none_without_login(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        assert switcher.get_active_usage_pct() is None
+
+    def test_none_without_credentials(self, temp_home: Path):
+        _login(temp_home)
+        switcher = ClaudeAccountSwitcher()
+        with patch.object(switcher, "_read_credentials", return_value=""):
+            assert switcher.get_active_usage_pct() is None
+
+    def test_returns_pct_from_usage_api(self, temp_home: Path):
+        _login(temp_home)
+        switcher = ClaudeAccountSwitcher()
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        usage = {"five_hour": {"pct": 96}, "seven_day": {"pct": 20}}
+        with patch.object(switcher, "_read_credentials", return_value=creds), \
+             patch(
+                 "claude_swap.oauth.fetch_usage_for_account",
+                 return_value=usage,
+             ):
+            assert switcher.get_active_usage_pct() == 96.0
+
+    def test_none_when_api_unavailable(self, temp_home: Path):
+        _login(temp_home)
+        switcher = ClaudeAccountSwitcher()
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        with patch.object(switcher, "_read_credentials", return_value=creds), \
+             patch(
+                 "claude_swap.oauth.fetch_usage_for_account",
+                 return_value=None,
+             ):
+            assert switcher.get_active_usage_pct() is None
+
+
+# --------------------------------------------------------------------------- #
+# TUI decision helper                                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestShouldAutoSwitch:
+    def test_below_threshold(self):
+        assert tui._should_auto_switch(94, 95) is False
+
+    def test_at_threshold(self):
+        assert tui._should_auto_switch(95, 95) is True
+
+    def test_above_threshold(self):
+        assert tui._should_auto_switch(99.5, 95) is True
+
+    def test_none_pct(self):
+        assert tui._should_auto_switch(None, 95) is False
+
+
+# --------------------------------------------------------------------------- #
+# TUI settings sub-flow                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestDoAutoSwitch:
+    def test_toggle_enables(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        # Enter on "Enable" (idx 0), then Esc to leave the settings screen.
+        screen.getch.side_effect = [10, 27]
+        tui._do_auto_switch(screen, switcher)
+        assert switcher.get_auto_switch_config()["enabled"] is True
+
+    def test_back_does_nothing(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        screen.getch.side_effect = [27]  # Esc immediately
+        tui._do_auto_switch(screen, switcher)
+        assert switcher.get_auto_switch_config()["enabled"] is False
+
+    def test_set_threshold_via_prompt(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        # Down to "Set threshold" (idx 1) + Enter, type "80" + Enter, then Esc.
+        keys = [tui.curses.KEY_DOWN, 10]
+        keys += [ord("8"), ord("0"), 10]
+        keys += [27]
+        screen.getch.side_effect = keys
+        with patch("claude_swap.tui.curses.curs_set"):
+            tui._do_auto_switch(screen, switcher)
+        assert switcher.get_auto_switch_config()["threshold"] == 80
+
+
+# --------------------------------------------------------------------------- #
+# TUI monitor loop                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestRunAutoMonitor:
+    def test_quits_without_switching_below_threshold(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        screen.getch.side_effect = [ord("q")]
+        with patch.object(switcher, "get_active_usage_pct", return_value=10.0), \
+             patch("claude_swap.tui._auto_perform_switch") as mock_switch, \
+             patch("claude_swap.tui.curses.curs_set"):
+            tui._run_auto_monitor(screen, switcher, threshold=95)
+        mock_switch.assert_not_called()
+
+    def test_switches_when_threshold_reached(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        screen.getch.side_effect = [ord("q")]
+        with patch.object(switcher, "get_active_usage_pct", return_value=96.0), \
+             patch(
+                 "claude_swap.tui._auto_perform_switch", return_value=True
+             ) as mock_switch, \
+             patch("claude_swap.tui.curses.curs_set"):
+            tui._run_auto_monitor(screen, switcher, threshold=95)
+        mock_switch.assert_called_once()


### PR DESCRIPTION
## What

Adds an opt-in **Auto-switch at limit (Beta)** entry to `cswap --tui`. When the active account's 5h/7d usage reaches a configurable threshold (default **95%**), a foreground monitor automatically rotates to the next managed account — using the existing `--switch` rotation logic, so no Claude Code restart is required.

The existing menu and behaviour are unchanged; this is purely an additional option.

## How it works

From `cswap --tui` → **Auto-switch at limit (Beta)**:

- **Enable / Disable** — persisted in `sequence.json` (`autoSwitch`), so the choice survives across runs.
- **Set threshold** — usage % that triggers a switch (1–100, default 95).
- **Start monitor now** — polls the active account's usage every 60s. On reaching the threshold it calls the same `switch()` rotation, then keeps watching the new active account. `s` checks immediately, `q`/`Esc` stops.

Because switching doesn't need a restart (Linux/Windows pick up the new credentials on the next message; macOS once the Keychain cache expires), the monitor works on a live session. It runs only while its TUI screen is open — there is **no background daemon**.

The status line shows `auto-switch ON (95%)` when enabled.

## Why Beta

It's a new foreground watcher and is labelled **(Beta)** throughout the UI and docs. Usage percentages come from the same API used by `cswap --list`.

## Implementation notes

- `switcher.py`
  - `get_auto_switch_config()` / `set_auto_switch_config(enabled=, threshold=)` — read/write settings in `sequence.json` (validates threshold 1–100; never clobbers accounts).
  - `get_active_usage_pct()` — highest 5h/7d utilization for the active account; reuses the existing short-lived usage cache; active account is never refreshed (`is_active=True`). The dollar-based `spend` entry is intentionally ignored.
  - `_max_usage_pct()` helper.
- `tui.py` — new settings/monitor sub-flow (`_do_auto_switch`, `_run_auto_monitor`, `_auto_perform_switch`, `_draw_monitor`), pure decision helper `_should_auto_switch`, and a status-line indicator.
- No new runtime dependencies (stdlib `curses`/`time` only).

## Tests

26 new tests in `tests/test_auto_switch.py` covering config persistence, usage-pct resolution, the decision helper, the settings sub-flow, and the monitor loop (switch / no-switch paths). Full suite: **407 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)