### PR TITLE
Add experimental session mode (cswap run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ cswap --switch-to user@example.com
 
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.
 
+### Run an account in one terminal (session mode) `[experimental]`
+
+Run two accounts at the same time: launch Claude Code as a specific account in the current terminal only, while every other terminal and the VS Code extension stay on your default account.
+
+```bash
+cswap run 2                     # launch Claude Code as account 2, here only
+cswap run user@example.com      # by email
+cswap run 2 -- --resume         # everything after '--' is forwarded to claude
+cswap run 2 --no-share          # don't share your ~/.claude customizations
+```
+
+Your `~/.claude` customizations (settings, keybindings, CLAUDE.md, skills, commands, agents) are shared into the session by default — use `--no-share` for a bare profile. Conversation history stays per-account. Note that session mode isolates the *account*, not your files: two Claude instances in the same repo still edit the same working tree.
+
 ### Refresh expired tokens
 
 If an account's token expires, log back into Claude Code with that account and re-run:
@@ -82,6 +95,7 @@ This will update the stored credentials without creating a duplicate.
 ### Other commands
 
 ```bash
+cswap run 2                     # Run an account in this terminal only (session mode)
 cswap --list                    # Show all accounts with 5h/7d usage and reset times
 cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
@@ -109,6 +123,8 @@ cswap --purge                   # Remove all claude-swap data
 | Windows | File-based (inside the backup directory, under `credentials/`) | `~/.claude-swap-backup/` |
 | macOS | macOS Keychain | `~/.claude-swap-backup/` |
 | Linux / WSL | File-based (inside the backup directory, under `credentials/`) | `${XDG_DATA_HOME:-~/.local/share}/claude-swap/` |
+
+Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`.
 
 On Linux/WSL, set `XDG_DATA_HOME` to override the default location. Data from older installs under `~/.claude-swap-backup/` is migrated automatically on first run.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-swap"
-version = "0.12.0"
+version = "0.13.0"
 description = "Multi-account switcher for Claude Code"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -12,8 +12,88 @@ from claude_swap.printer import dimmed, error, muted
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
+def _run_command(argv: list[str]) -> None:
+    """Handle `cswap run NUM|EMAIL [--no-share] [-- <claude args>]`.
+
+    Pre-dispatched before the main parser is built: a positional subcommand
+    can't coexist with main()'s required mutually-exclusive flag group, and
+    this keeps the existing parser untouched. Limitation: `run` must be the
+    first argument (`cswap --debug run 2` is not supported; use
+    `cswap run 2 --debug`).
+
+    On POSIX this execs claude and never returns; on Windows it exits with
+    claude's return code. Either way the post-dispatch update check in
+    main() is unreachable, which is intended.
+    """
+    # Everything after the first `--` is forwarded to claude verbatim.
+    if "--" in argv:
+        split = argv.index("--")
+        head, tail = argv[:split], argv[split + 1 :]
+    else:
+        head, tail = argv, []
+
+    parser = argparse.ArgumentParser(
+        prog="cswap run",
+        description=(
+            "[EXPERIMENTAL] Launch Claude Code as a stored account in this "
+            "terminal only (the default login and other terminals are "
+            "unaffected)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap run 2
+  cswap run user@example.com
+  cswap run 2 --no-share
+  cswap run 2 -- --resume
+        """,
+    )
+    parser.add_argument(
+        "account",
+        metavar="NUM|EMAIL",
+        help="Account to run (number or email)",
+    )
+    parser.add_argument(
+        "--no-share",
+        action="store_true",
+        help=(
+            "Don't share settings/keybindings/CLAUDE.md/skills/commands/agents "
+            "from ~/.claude into the session profile (and remove previously "
+            "shared items)"
+        ),
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args(head)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+
+        if sys.platform != "win32":
+            if os.geteuid() == 0 and not switcher._is_running_in_container():
+                error("Error: Do not run this script as root (unless running in a container)")
+                sys.exit(1)
+
+        from claude_swap.session import SessionManager
+
+        SessionManager(switcher).run(args.account, tail, share=not args.no_share)
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
 def main() -> None:
     """Main entry point for the CLI."""
+    if len(sys.argv) > 1 and sys.argv[1] == "run":
+        _run_command(sys.argv[2:])
+        return  # only reachable in tests where exec/exit is mocked
+
     parser = argparse.ArgumentParser(
         description="Multi-Account Switcher for Claude Code",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -28,6 +108,8 @@ Examples:
   %(prog)s --switch
   %(prog)s --switch-to 2
   %(prog)s --switch-to user@example.com
+  %(prog)s run 2                            # run account 2 in this terminal only
+  %(prog)s run 2 -- --resume                # forward args after '--' to claude
   %(prog)s --remove-account user@example.com
   %(prog)s --status
   %(prog)s --purge

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -37,6 +37,12 @@ class SwitchError(ClaudeSwitchError):
     pass
 
 
+class SessionError(ClaudeSwitchError):
+    """Error setting up or launching a session-mode profile."""
+
+    pass
+
+
 class LockError(ClaudeSwitchError):
     """Error acquiring lock."""
 

--- a/src/claude_swap/locking.py
+++ b/src/claude_swap/locking.py
@@ -19,20 +19,24 @@ from claude_swap.exceptions import LockError
 class FileLock:
     """Cross-process file lock using platform-specific APIs."""
 
-    def __init__(self, lock_path: Path):
+    def __init__(self, lock_path: Path, timeout: float = 10.0):
         self.lock_path = lock_path
+        self.timeout = timeout
         self._lock_file: IO | None = None
         self._locked = False
 
-    def acquire(self, timeout: float = 10.0) -> bool:
+    def acquire(self, timeout: float | None = None) -> bool:
         """Acquire exclusive lock with timeout.
 
         Args:
-            timeout: Maximum seconds to wait for lock.
+            timeout: Maximum seconds to wait for lock. Defaults to the
+                timeout given at construction.
 
         Returns:
             True if lock acquired, False if timeout.
         """
+        if timeout is None:
+            timeout = self.timeout
         self.lock_path.parent.mkdir(parents=True, exist_ok=True)
         self._lock_file = open(self.lock_path, "w")
 

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -1,0 +1,563 @@
+"""Session mode: run Claude Code as a stored account in one terminal.
+
+``cswap run NUM|EMAIL`` launches Claude Code with ``CLAUDE_CONFIG_DIR``
+pointing at a persistent per-account profile under
+``<backup_dir>/sessions/<num>-<email-slug>/``, leaving the default
+``~/.claude/`` login (and every other terminal, plus the VS Code extension)
+untouched. ``CLAUDE_CONFIG_DIR`` fully isolates Claude Code's config and
+credential lookup; on macOS, Claude hashes the (NFC-normalized) env var value
+into its keychain service name, so each profile gets its own keychain entry.
+
+Profiles are seeded with a plaintext ``.credentials.json`` — deliberate,
+including on macOS: the plaintext fallback is Claude's only credential
+mechanism on Linux (a stable contract), and Claude migrates it into its
+hashed keychain entry on first write. Writing that keychain entry ourselves
+would couple us to Claude's internal storage format and naming, where a
+mismatch is a hard "logged out" failure instead of a harmless stale entry.
+
+Sharing: by default the user's ``settings.json``, ``keybindings.json``,
+``CLAUDE.md``, ``skills/``, ``commands/``, and ``agents/`` follow them into
+the session profile — symlinks on macOS/Linux (Claude's settings writer
+detects symlinks and writes through to the target, so in-session ``/config``
+changes land in ``~/.claude``), copies re-synced on every launch on Windows.
+A manifest records what cswap created so removal never touches user data.
+
+This module must not import ``switcher`` (switcher imports us for the
+session-aware guards); it receives a ``ClaudeAccountSwitcher`` instance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unicodedata
+from pathlib import Path
+from typing import TYPE_CHECKING, NoReturn
+
+from claude_swap import macos_keychain
+from claude_swap.exceptions import SessionError
+from claude_swap.macos_keychain import KeychainError
+from claude_swap.locking import FileLock
+from claude_swap.models import Platform
+from claude_swap.oauth import refresh_oauth_credentials
+from claude_swap.printer import accent, dimmed, muted, warning
+from claude_swap.process_detection import ClaudeSession, list_sessions
+
+if TYPE_CHECKING:
+    from claude_swap.switcher import ClaudeAccountSwitcher
+
+# Items mirrored from ~/.claude into session profiles when sharing is on.
+# Deliberately excludes anything account- or instance-scoped: plugins/,
+# projects/ (per-account history is a feature), sessions/, ide/,
+# .claude.json, .credentials.json, statsig/ and other telemetry.
+SHARED_ITEMS = (
+    "settings.json",
+    "keybindings.json",
+    "CLAUDE.md",
+    "skills",
+    "commands",
+    "agents",
+)
+
+# Records which entries in a session profile cswap created (so --no-share and
+# re-syncs only ever remove cswap-managed links/copies, never user data).
+SHARE_MANIFEST = ".cswap-shared.json"
+
+# Deferred-invalidation marker: backup credentials changed while a session was
+# live (we never pull credentials out from under a running claude), so the
+# profile must be re-bootstrapped on the next non-live `cswap run` even if it
+# still passes the local reuse check.
+STALE_MARKER = ".cswap-stale-credentials"
+
+
+def mark_session_stale(session_dir: Path) -> None:
+    """Flag a live session profile for re-bootstrap once it exits."""
+    try:
+        (session_dir / STALE_MARKER).touch()
+    except OSError:
+        pass  # best-effort; worst case the old reuse behavior applies
+
+# Env vars that make claude bypass account OAuth entirely (verified against
+# claude 2.1.175). Dropped from the auth-status probe (they'd fake "logged in"
+# for the wrong reason) AND scrubbed from the session launch env with a
+# warning: `cswap run N` is an explicit request for account N, so letting an
+# exported API key silently hijack the session would defeat the command. The
+# same-account fast path (plain claude, untouched env) does not scrub.
+AUTH_OVERRIDE_ENV_VARS = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR",
+    "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
+)
+
+# `claude auth status` is a local check (no API call) but spawns the full CLI.
+_AUTH_STATUS_TIMEOUT = 10.0
+
+# Bootstrap holds the backup-dir lock across one token refresh (10s network
+# timeout) plus auth-status probes, so it needs more headroom than the
+# default 10s acquire used by the switch paths.
+_BOOTSTRAP_LOCK_TIMEOUT = 30.0
+
+
+def slugify_email(email: str) -> str:
+    """Filesystem-safe slug for an email address.
+
+    Uniqueness comes from the ``<num>-`` slot prefix on the session dir, so
+    this only needs to be safe (incl. Windows-forbidden chars), not injective.
+    """
+    normalized = unicodedata.normalize("NFC", email)
+    return "".join(
+        ch if (ch.isascii() and (ch.isalnum() or ch in "._-")) else "_"
+        for ch in normalized
+    )
+
+
+def session_dir_for(backup_dir: Path, account_num: str, email: str) -> Path:
+    """Session profile directory for an account.
+
+    Note: the profile itself contains Claude's own ``sessions/<pid>.json``
+    PID files, so full paths look like
+    ``<backup>/sessions/2-user_x.com/sessions/1234.json`` — intentional.
+    """
+    return backup_dir / "sessions" / f"{account_num}-{slugify_email(email)}"
+
+
+def keychain_service_name(session_dir: Path) -> str:
+    """Keychain service name Claude Code derives for this config dir.
+
+    Claude hashes the raw ``CLAUDE_CONFIG_DIR`` env var value, NFC-normalized
+    and unresolved (claude src ``envUtils.ts``/``macOsKeychainHelpers.ts``).
+    Hash exactly the string we export — never a resolved/realpath variant.
+    """
+    normalized = unicodedata.normalize("NFC", str(session_dir))
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:8]
+    return f"Claude Code-credentials-{digest}"
+
+
+def _keychain_account_name() -> str:
+    """Keychain account name, mirroring Claude's ``getUsername()``."""
+    user = os.environ.get("USER")
+    if user:
+        return user
+    try:
+        import pwd  # POSIX-only; matches the macOS-only call sites
+
+        return pwd.getpwuid(os.geteuid()).pw_name
+    except Exception:
+        return "claude-code-user"
+
+
+def delete_macos_keychain_entry(session_dir: Path) -> None:
+    """Best-effort delete of a session profile's hashed keychain entry.
+
+    No-op off macOS. Needed before seeding (Claude reads the keychain before
+    the plaintext file, so a stale entry would shadow a fresh seed) and on
+    profile removal (once the dir is gone the hashed name is unrecoverable).
+    """
+    if Platform.detect() != Platform.MACOS:
+        return
+    try:
+        macos_keychain.delete_password(
+            keychain_service_name(session_dir), _keychain_account_name()
+        )
+    except KeychainError:
+        pass  # best-effort; absent entry is already success (rc 44)
+
+
+def live_sessions_for(session_dir: Path) -> list[ClaudeSession]:
+    """Live Claude instances running against a session profile."""
+    if not session_dir.exists():
+        return []
+    return list_sessions(claude_dir=session_dir)
+
+
+def _probe_env(session_dir: Path) -> dict[str, str]:
+    """Env for the auth-status probe: session config dir, auth overrides dropped."""
+    env = {k: v for k, v in os.environ.items() if k not in AUTH_OVERRIDE_ENV_VARS}
+    env["CLAUDE_CONFIG_DIR"] = str(session_dir)
+    return env
+
+
+class SessionManager:
+    """Bootstraps per-account session profiles and launches Claude into them."""
+
+    def __init__(self, switcher: ClaudeAccountSwitcher):
+        self.switcher = switcher
+        self.sessions_dir = switcher.backup_dir / "sessions"
+        self._logger = switcher._logger
+
+    # -- launch ----------------------------------------------------------
+
+    def run(self, identifier: str, claude_args: list[str], share: bool = True) -> NoReturn:
+        """Launch Claude Code as the given account in the current terminal."""
+        claude_bin = shutil.which("claude")
+        if not claude_bin:
+            raise SessionError(
+                "'claude' was not found on PATH. Install Claude Code first."
+            )
+
+        account_num, email, org_uuid = self.switcher.resolve_account(identifier)
+
+        config_dir_preset = os.environ.get("CLAUDE_CONFIG_DIR")
+        if config_dir_preset:
+            # With CLAUDE_CONFIG_DIR set, "current default account" is
+            # meaningless (we may already be inside a session terminal), so
+            # the same-account fast path below must not trigger.
+            warning(
+                f"CLAUDE_CONFIG_DIR is already set ({config_dir_preset}); "
+                "overriding it for this launch."
+            )
+        else:
+            # Same-account fast path: never create a second credential copy
+            # for the account that is already the active default login —
+            # two copies of one account can drift if the server rotates the
+            # refresh token.
+            current = self.switcher._get_current_account()
+            if current is not None and current == (email, org_uuid):
+                print(
+                    dimmed(
+                        f"Account-{account_num} ({email}) is already the active "
+                        "default login — launching claude directly."
+                    )
+                )
+                self._exec(claude_bin, claude_args, env=dict(os.environ))
+
+        scrubbed = [v for v in AUTH_OVERRIDE_ENV_VARS if os.environ.get(v)]
+        if scrubbed:
+            warning(
+                f"Ignoring {', '.join(scrubbed)} for this session — it would "
+                f"override the selected account inside Claude Code."
+            )
+
+        session_dir, account_num, email = self.setup_session(identifier, share)
+
+        print(
+            f"{accent('Launching')} Account-{account_num} ({email}) "
+            f"{muted('[session mode]')}"
+        )
+        env = {
+            k: v for k, v in os.environ.items() if k not in AUTH_OVERRIDE_ENV_VARS
+        }
+        env["CLAUDE_CONFIG_DIR"] = str(session_dir)
+        self._exec(claude_bin, claude_args, env=env)
+
+    def _exec(self, claude_bin: str, claude_args: list[str], env: dict[str, str]) -> NoReturn:
+        """Hand the terminal over to claude. Never returns.
+
+        POSIX: ``execvpe`` replaces the cswap process entirely (the lock is
+        already released — an exec'd claude must never inherit a held flock).
+        Windows: ``os.exec*`` detaches from the console confusingly, so stay
+        resident as a thin wrapper and mirror claude's exit code.
+        """
+        argv = [claude_bin, *claude_args]
+        if sys.platform == "win32":
+            try:
+                rc = subprocess.run(argv, env=env).returncode
+            except KeyboardInterrupt:
+                rc = 130  # Ctrl+C went to claude; just mirror the exit
+            sys.exit(rc)
+        os.execvpe(claude_bin, argv, env)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    # -- bootstrap -------------------------------------------------------
+
+    def setup_session(self, identifier: str, share: bool) -> tuple[Path, str, str]:
+        """Ensure a valid session profile exists; returns (dir, num, email)."""
+        account_num, email, org_uuid = self.switcher.resolve_account(identifier)
+        session_dir = session_dir_for(self.switcher.backup_dir, account_num, email)
+
+        # Deferred invalidation: backup credentials changed while this profile
+        # was live, so its credentials are presumed stale even if they still
+        # pass the local reuse check. Honored only when no session is live —
+        # a second `cswap run` joining a live session must not invalidate
+        # under the running claude (the marker survives for later).
+        stale = (session_dir / STALE_MARKER).exists() and not live_sessions_for(
+            session_dir
+        )
+
+        # Cheap reuse check without the lock: most launches hit this.
+        if not stale and self._is_session_valid(session_dir, email, org_uuid):
+            self._sync_sharing(session_dir, share)
+            return session_dir, account_num, email
+
+        with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
+            # Re-evaluate the marker under the lock, then re-check validity:
+            # another `cswap run` may have bootstrapped while we waited.
+            if (session_dir / STALE_MARKER).exists() and not live_sessions_for(
+                session_dir
+            ):
+                self.switcher._invalidate_session_credentials(account_num, email)
+                (session_dir / STALE_MARKER).unlink(missing_ok=True)
+            if self._is_session_valid(session_dir, email, org_uuid):
+                self._sync_sharing(session_dir, share)
+                return session_dir, account_num, email
+
+            self._bootstrap(session_dir, account_num, email, org_uuid)
+            self._sync_sharing(session_dir, share)
+
+            if not self._is_session_valid(session_dir, email, org_uuid):
+                self._cleanup_failed_session(session_dir)
+                raise SessionError(
+                    f"Session profile for Account-{account_num} ({email}) failed "
+                    f"validation. Log in with that account and re-add it: "
+                    f"cswap --add-account --slot {account_num}"
+                )
+        # Lock released here, before any exec.
+
+        return session_dir, account_num, email
+
+    def _bootstrap(
+        self, session_dir: Path, account_num: str, email: str, org_uuid: str
+    ) -> None:
+        """Seed the session profile from backup storage. Caller holds the lock."""
+        # Claude reads the keychain before the plaintext file — a stale hashed
+        # entry from an earlier profile at this path would shadow the seed.
+        delete_macos_keychain_entry(session_dir)
+
+        creds = self.switcher.read_account_credentials(account_num, email)
+        if not creds:
+            raise SessionError(
+                f"Account-{account_num} has no stored credentials. "
+                f"Re-add with: cswap --add-account --slot {account_num}"
+            )
+
+        # One refresh so the profile starts with a fresh access token; persist
+        # a possibly-rotated refresh token back to backup so future switches
+        # and runs see the latest. Failure is non-fatal: the stored token may
+        # still be valid, and claude refreshes on its own at runtime.
+        # Setup-token accounts (--add-token) have no refresh token by design —
+        # skip silently instead of warning about a flow that can't happen.
+        if self._has_refresh_token(creds):
+            refreshed = refresh_oauth_credentials(creds)
+            if refreshed:
+                creds = refreshed
+                self.switcher.write_account_credentials(account_num, email, creds)
+            else:
+                warning(
+                    f"Could not refresh the token for Account-{account_num}; "
+                    "continuing with the stored credentials."
+                )
+
+        config_text = self.switcher.read_account_config(account_num, email)
+        try:
+            config_data = json.loads(config_text) if config_text else {}
+        except json.JSONDecodeError:
+            config_data = {}
+        oauth_account = config_data.get("oauthAccount")
+        if not oauth_account:
+            raise SessionError(
+                f"Account-{account_num} has no stored config backup. "
+                f"Re-add with: cswap --add-account --slot {account_num}"
+            )
+
+        session_dir.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(session_dir, 0o700)
+
+        creds_path = session_dir / ".credentials.json"
+        creds_path.write_text(creds, encoding="utf-8")
+        if sys.platform != "win32":
+            os.chmod(creds_path, 0o600)
+
+        # Merge the identity seed into any existing .claude.json so a
+        # re-bootstrap preserves the profile's own projects/history. The
+        # `theme` key is load-bearing: claude shows onboarding when
+        # `!config.theme || !config.hasCompletedOnboarding`.
+        config_path = session_dir / ".claude.json"
+        existing: dict = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text(encoding="utf-8")) or {}
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+        existing["oauthAccount"] = oauth_account
+        existing["hasCompletedOnboarding"] = True
+        existing.setdefault("theme", config_data.get("theme") or "dark")
+        config_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+        if sys.platform != "win32":
+            os.chmod(config_path, 0o600)
+
+        self._logger.info(
+            f"Bootstrapped session profile for account {account_num} at {session_dir}"
+        )
+
+    @staticmethod
+    def _has_refresh_token(creds: str) -> bool:
+        try:
+            return bool(json.loads(creds).get("claudeAiOauth", {}).get("refreshToken"))
+        except (json.JSONDecodeError, AttributeError):
+            return True  # unknown shape — let the refresh attempt decide
+
+    def _cleanup_failed_session(self, session_dir: Path) -> None:
+        # Keychain first: claude may have partially migrated the seed, and the
+        # hashed service name can't be recomputed once the dir is gone.
+        delete_macos_keychain_entry(session_dir)
+        shutil.rmtree(session_dir, ignore_errors=True)
+
+    # -- validation ------------------------------------------------------
+
+    def _is_session_valid(self, session_dir: Path, email: str, org_uuid: str) -> bool:
+        """Whether claude sees the profile as logged in with the right identity.
+
+        Local check only (`claude auth status` makes no API call): a revoked
+        but unexpired token still passes and fails on first real use.
+        """
+        if not session_dir.is_dir():
+            return False
+        try:
+            result = subprocess.run(
+                ["claude", "auth", "status", "--json"],
+                env=_probe_env(session_dir),
+                capture_output=True,
+                text=True,
+                timeout=_AUTH_STATUS_TIMEOUT,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        if result.returncode != 0:
+            return False
+        try:
+            status = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return False
+        if status.get("loggedIn") is not True:
+            return False
+        # Verified against claude 2.1.175; an env API key reports a different
+        # method, and the probe env already drops those vars anyway.
+        if status.get("authMethod") != "claude.ai":
+            return False
+        if status.get("email") != email:
+            return False
+        # Lenient org check: only when both sides have a value, so schema
+        # drift degrades to email-only validation instead of false negatives.
+        status_org = status.get("orgId")
+        if status_org and org_uuid and status_org != org_uuid:
+            return False
+        return True
+
+    # -- sharing ---------------------------------------------------------
+
+    def _sync_sharing(self, session_dir: Path, share: bool) -> None:
+        """Mirror SHARED_ITEMS from ~/.claude into the profile (or undo it).
+
+        Idempotent; runs on every launch. Deliberately sources from the
+        default ``~/.claude`` (not ``get_claude_config_home()``): sharing
+        always mirrors the default profile, even when ``CLAUDE_CONFIG_DIR``
+        is set in the invoking environment. Lock-free on the reuse path:
+        concurrent ``run`` vs ``run --no-share`` is last-writer-wins and
+        self-heals on the next launch.
+        """
+        if not session_dir.is_dir():
+            return
+        source_root = Path.home() / ".claude"
+        manifest_path = session_dir / SHARE_MANIFEST
+        managed = self._read_manifest(manifest_path)
+
+        if not share:
+            for name in managed:
+                self._remove_managed(session_dir / name)
+            manifest_path.unlink(missing_ok=True)
+            return
+
+        use_symlinks = self.switcher.platform != Platform.WINDOWS
+        new_managed: list[str] = []
+
+        for name in SHARED_ITEMS:
+            src = source_root / name
+            dest = session_dir / name
+
+            if not src.exists():
+                # Source vanished (or never existed): prune our own entry.
+                if name in managed:
+                    self._remove_managed(dest)
+                continue
+
+            if dest.is_symlink():
+                if name not in managed:
+                    managed = [*managed, name]  # adopt: only cswap links here
+                if use_symlinks:
+                    try:
+                        if dest.readlink() != src:
+                            dest.unlink()
+                            dest.symlink_to(src)
+                    except OSError:
+                        continue
+                    new_managed.append(name)
+                    continue
+                # Platform moved POSIX → Windows: replace link with a copy.
+                dest.unlink()
+            elif dest.exists() and name not in managed:
+                # Pre-existing user data in the profile — never touch it.
+                print(
+                    dimmed(
+                        f"Not sharing {name}: the session profile already has "
+                        "its own copy."
+                    )
+                )
+                continue
+
+            try:
+                if use_symlinks:
+                    if dest.exists():
+                        self._remove_managed(dest)
+                    dest.symlink_to(src)
+                else:
+                    if dest.exists():
+                        self._remove_managed(dest)
+                    if src.is_dir():
+                        shutil.copytree(src, dest)
+                    else:
+                        shutil.copy2(src, dest)
+            except OSError as e:
+                self._logger.warning(f"Failed to share {name} into session: {e}")
+                continue
+            new_managed.append(name)
+
+        # Anything we managed before but no longer created gets removed above;
+        # write the manifest atomically so a concurrent reader never sees a
+        # truncated file.
+        self._write_manifest(manifest_path, new_managed)
+
+    @staticmethod
+    def _read_manifest(manifest_path: Path) -> list[str]:
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+            items = data.get("items", [])
+            # Only ever act on names we could have created.
+            return [i for i in items if i in SHARED_ITEMS]
+        except (OSError, json.JSONDecodeError, AttributeError):
+            return []
+
+    def _write_manifest(self, manifest_path: Path, items: list[str]) -> None:
+        mode = "symlink" if self.switcher.platform != Platform.WINDOWS else "copy"
+        payload = json.dumps({"items": items, "mode": mode}, indent=2)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(manifest_path.parent), prefix=".cswap-shared-", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+            os.replace(tmp, manifest_path)
+        except OSError:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _remove_managed(dest: Path) -> None:
+        """Remove a cswap-created share entry (link or copy), never user data
+        beyond it — callers guarantee `dest` is manifest-listed or a symlink."""
+        try:
+            if dest.is_symlink() or dest.is_file():
+                dest.unlink(missing_ok=True)
+            elif dest.is_dir():
+                shutil.rmtree(dest, ignore_errors=True)
+        except OSError:
+            pass

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -19,6 +19,7 @@ from claude_swap.exceptions import (
     ConfigError,
     CredentialReadError,
     CredentialWriteError,
+    SessionError,
     SwitchError,
     ValidationError,
 )
@@ -375,6 +376,22 @@ class ClaudeAccountSwitcher:
             except Exception as e:
                 self._logger.warning(f"Failed to write credentials to Keychain: {e}")
                 raise
+        # Backup credentials changed (re-login via --add-account, --add-token,
+        # import, switch backing up, or a usage-refresh rotation): a session
+        # profile seeded from the old credentials may now hold a stale or
+        # rotated-out token that still passes the local reuse check. Drop the
+        # profile's credential material so the next `cswap run` re-bootstraps
+        # from this fresh backup (history is preserved). A LIVE session keeps
+        # its own copy untouched — claude manages it; pulling credentials out
+        # from under a running process would be worse than the drift caveat —
+        # but gets a stale marker so setup_session re-bootstraps it once it
+        # is no longer live, instead of trusting the local reuse check.
+        if self._live_session_pids(account_num, email):
+            from claude_swap.session import mark_session_stale
+
+            mark_session_stale(self._session_dir(account_num, email))
+        else:
+            self._invalidate_session_credentials(account_num, email)
 
     def _delete_account_credentials(self, account_num: str, email: str) -> None:
         """Delete account credentials from backup.
@@ -404,11 +421,23 @@ class ClaudeAccountSwitcher:
                     self._logger.warning(f"Failed to delete credentials from Keychain: {e}")
 
     def _delete_account_files(self, account_num: str, email: str) -> None:
-        """Delete all backup files for an account (credentials + config)."""
+        """Delete all backup files for an account (credentials + config).
+
+        Single chokepoint for every path that removes or displaces a slot
+        (remove_account, add_account/add_token slot overwrite & migration):
+        refuses while a session-mode claude is live against the slot, and
+        removes the slot's session profile alongside the backups so a stale
+        profile can never outlive its account.
+
+        Raises:
+            SessionError: a live session-mode instance is using this account.
+        """
+        self._ensure_no_live_session(account_num, email, "the operation")
         self._delete_account_credentials(account_num, email)
         config_file = self.configs_dir / f".claude-config-{account_num}-{email}.json"
         if config_file.exists():
             config_file.unlink()
+        self._delete_session_profile(account_num, email)
 
     def _read_account_config(self, account_num: str, email: str) -> str:
         """Read account config from backup."""
@@ -443,6 +472,115 @@ class ClaudeAccountSwitcher:
         config_file.write_text(config, encoding="utf-8")
         if sys.platform != "win32":
             os.chmod(config_file, 0o600)
+
+    # -- public accessors for session mode (claude_swap.session) ---------
+
+    def resolve_account(self, identifier: str) -> tuple[str, str, str]:
+        """Resolve NUM|EMAIL to (account_num, email, organizationUuid).
+
+        Unlike switch_to/remove_account, ambiguity is a hard error rather
+        than an interactive prompt: session mode ends in an exec, so callers
+        need a deterministic resolution.
+
+        Raises:
+            AccountNotFoundError: identifier doesn't match any account.
+            ConfigError: email matches multiple accounts.
+        """
+        self._get_sequence_data_migrated()
+        account_num = self._resolve_account_identifier(identifier)
+        if not account_num:
+            raise AccountNotFoundError(
+                f"No account found with identifier: {identifier}"
+            )
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(account_num)
+        if not record:
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+        return (
+            account_num,
+            record.get("email", ""),
+            record.get("organizationUuid", "") or "",
+        )
+
+    def read_account_credentials(self, account_num: str, email: str) -> str:
+        """Public wrapper for session bootstrap. Empty string when missing."""
+        return self._read_account_credentials(account_num, email)
+
+    def write_account_credentials(
+        self, account_num: str, email: str, credentials: str
+    ) -> None:
+        """Public wrapper for session bootstrap.
+
+        Takes NO lock: the caller is expected to hold ``self.lock_file``
+        already. Never combine with the locking persist callback in
+        list_accounts() — FileLock is not re-entrant across instances in one
+        process (see the v0.7.3 deadlock history).
+        """
+        self._write_account_credentials(account_num, email, credentials)
+
+    def read_account_config(self, account_num: str, email: str) -> str:
+        """Public wrapper for session bootstrap. Empty string when missing."""
+        return self._read_account_config(account_num, email)
+
+    # -- session profile lifecycle ----------------------------------------
+
+    def _session_dir(self, account_num: str, email: str) -> Path:
+        from claude_swap.session import session_dir_for
+
+        return session_dir_for(self.backup_dir, account_num, email)
+
+    def _live_session_pids(self, account_num: str, email: str) -> list[int]:
+        """PIDs of Claude instances running against an account's session profile."""
+        from claude_swap.session import live_sessions_for
+
+        return [s.pid for s in live_sessions_for(self._session_dir(account_num, email))]
+
+    def _ensure_no_live_session(self, account_num: str, email: str, action: str) -> None:
+        """Refuse a destructive operation while a session-mode claude is live."""
+        pids = self._live_session_pids(account_num, email)
+        if pids:
+            raise SessionError(
+                f"Account-{account_num} ({email}) has a live session-mode Claude "
+                f"instance (PID {', '.join(map(str, pids))}). "
+                f"Exit it first, then retry {action}."
+            )
+
+    def _invalidate_session_credentials(self, account_num: str, email: str) -> None:
+        """Drop a session profile's credential material, keeping its history.
+
+        The next `cswap run` fails the reuse check and re-bootstraps from
+        backup; the bootstrap merges .claude.json, so the profile's own
+        projects/history survive. Used when backup credentials change under
+        an existing profile (e.g. --import --force).
+        """
+        from claude_swap.session import STALE_MARKER, delete_macos_keychain_entry
+
+        session_dir = self._session_dir(account_num, email)
+        if not session_dir.exists():
+            return
+        delete_macos_keychain_entry(session_dir)
+        (session_dir / ".credentials.json").unlink(missing_ok=True)
+        (session_dir / STALE_MARKER).unlink(missing_ok=True)
+        self._logger.info(
+            f"Invalidated session credentials for account {account_num}"
+        )
+
+    def _delete_session_profile(self, account_num: str, email: str) -> None:
+        """Remove an account's session profile dir and its keychain entry.
+
+        Keychain first: the hashed service name is derived from the dir path
+        and can't be recomputed once the dir is gone.
+        """
+        from claude_swap.session import delete_macos_keychain_entry
+
+        session_dir = self._session_dir(account_num, email)
+        if not session_dir.exists():
+            return
+        delete_macos_keychain_entry(session_dir)
+        shutil.rmtree(session_dir, ignore_errors=True)
+        self._logger.info(
+            f"Removed session profile for account {account_num} at {session_dir}"
+        )
 
     def _init_sequence_file(self) -> None:
         """Initialize sequence.json if it doesn't exist."""
@@ -1023,6 +1161,10 @@ class ClaudeAccountSwitcher:
         email = account_info.get("email")
         active_account = data.get("activeAccountNumber")
 
+        # Check before the confirmation prompt (better UX); the chokepoint in
+        # _delete_account_files re-checks as a safety net for all paths.
+        self._ensure_no_live_session(account_num, email, "--remove-account")
+
         if str(active_account) == account_num:
             warning(f"Warning: Account-{account_num} ({email}) is currently active")
 
@@ -1095,9 +1237,17 @@ class ClaudeAccountSwitcher:
                 with FileLock(self.lock_file):
                     self._write_account_credentials(acct_num, acct_email, new_creds)
 
+            # An account running in session mode is "inactive" here but live
+            # in its own config dir, where claude manages the token. Treat it
+            # like the active account (no proactive refresh / 401-retry):
+            # refreshing the backup copy could rotate the refresh token out
+            # from under the live session. Worst case its usage shows as
+            # unavailable until the session exits.
+            has_live_session = bool(self._live_session_pids(str(num), email))
+
             return oauth.fetch_usage_for_account(
                 str(num), email, creds,
-                is_active=is_active,
+                is_active=is_active or has_live_session,
                 persist_credentials=persist,
             )
 
@@ -1397,6 +1547,26 @@ class ClaudeAccountSwitcher:
         The post-switch display runs after the lock releases so that persist
         callbacks inside list_accounts() can re-acquire it.
         """
+        # Session-mode drift warning (warn, never block): switching the
+        # default login to an account that also has a live session profile
+        # puts the same refresh token in two config dirs — if the server
+        # rotates it, one copy goes stale.
+        pre_data = self._get_sequence_data() or {}
+        pre_email = (
+            pre_data.get("accounts", {}).get(target_account, {}).get("email", "")
+        )
+        if pre_email:
+            pids = self._live_session_pids(target_account, pre_email)
+            if pids:
+                warning(
+                    f"Account-{target_account} ({pre_email}) has a live session-mode "
+                    f"Claude instance (PID {', '.join(map(str, pids))}). Running the "
+                    "same account as both the default login and a session can make "
+                    "one copy's token go stale if the server rotates it. If the "
+                    "session later fails to authenticate, exit it and re-run "
+                    f"'cswap run {target_account}'."
+                )
+
         with FileLock(self.lock_file):
             data = self._get_sequence_data()
             active_account = data.get("activeAccountNumber")
@@ -1641,6 +1811,31 @@ class ClaudeAccountSwitcher:
         legacy = get_legacy_backup_root()
         legacy_distinct = legacy != self.backup_dir
 
+        # Refuse while any session-mode claude is running: purging would pull
+        # its profile (and keychain entry) out from under a live process.
+        sessions_root = self.backup_dir / "sessions"
+        session_dirs = (
+            [d for d in sessions_root.iterdir() if d.is_dir()]
+            if sessions_root.is_dir()
+            else []
+        )
+        from claude_swap.session import live_sessions_for
+
+        live = {}
+        for d in session_dirs:
+            pids = [s.pid for s in live_sessions_for(d)]
+            if pids:
+                live[d.name] = pids
+        if live:
+            details = "; ".join(
+                f"{name} (PID {', '.join(map(str, pids))})"
+                for name, pids in live.items()
+            )
+            raise SessionError(
+                f"Live session-mode Claude instance(s) found: {details}. "
+                "Exit them first, then retry --purge."
+            )
+
         warning("This will remove ALL claude-swap data from your system:")
         print(f"  - Backup directory: {self.backup_dir}")
         if legacy_distinct and legacy.exists():
@@ -1649,6 +1844,8 @@ class ClaudeAccountSwitcher:
             print("  - All stored account credential files")
         else:
             print("  - All stored account credentials from the macOS Keychain")
+        if session_dirs:
+            print("  - All session profiles and their Keychain entries")
         print()
         print(dimmed("Note: This does NOT affect your current Claude Code login."))
         print()
@@ -1704,6 +1901,18 @@ class ClaudeAccountSwitcher:
                     # Best-effort cleanup of any pre-migration keyring entries left
                     # behind if the keyring → security migration never completed.
                     _sweep_legacy_keyring(usernames, removed_items)
+
+        # Session-profile keychain entries must go BEFORE the backup dir:
+        # the hashed service names are derived from the dir paths and can't
+        # be recomputed once the directories are deleted.
+        if session_dirs:
+            from claude_swap.session import delete_macos_keychain_entry
+
+            for d in session_dirs:
+                delete_macos_keychain_entry(d)
+            removed_items.append(
+                f"Session profiles: {', '.join(d.name for d in session_dirs)}"
+            )
 
         # Remove backup directory
         if self.backup_dir.exists():

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -389,6 +389,18 @@ def import_accounts(
                 continue
             target_num = existing_slot
             outcome = "overwrote"
+            # The credential write below invalidates the slot's non-live
+            # session profile (chokepoint in _write_account_credentials), so
+            # the next `cswap run` re-bootstraps from the imported creds. A
+            # live session keeps running on its own copy — warn about it.
+            live_pids = switcher._live_session_pids(target_num, entry["email"])
+            if live_pids:
+                _eprint(
+                    f"Warning: {entry['email']} (slot {target_num}) has a live "
+                    f"session-mode instance (PID {', '.join(map(str, live_pids))}); "
+                    "its session profile keeps the pre-import credentials until "
+                    "it is restarted via 'cswap run'."
+                )
         else:
             if entry["exported_num"] not in data.get("accounts", {}):
                 target_num = entry["exported_num"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -366,3 +366,97 @@ class TestCLICommands:
         )
         assert "--add-token" in result.stdout
         assert "--email" in result.stdout
+
+
+class TestRunCommand:
+    """`cswap run` pre-dispatch: parsing, forwarding, and dispatch."""
+
+    def _dispatch(self, argv: list[str]):
+        """Run cli.main() with a fake SessionManager; returns recorded calls."""
+        calls = []
+
+        class FakeSessionManager:
+            def __init__(self, switcher):
+                calls.append(("init", switcher))
+
+            def run(self, identifier, claude_args, share=True):
+                calls.append(("run", identifier, claude_args, share))
+
+        with patch("claude_swap.session.SessionManager", FakeSessionManager), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000), \
+             patch.object(sys, "argv", ["claude-swap", *argv]):
+            cli.main()
+        return calls
+
+    def test_run_dispatches_with_defaults(self):
+        calls = self._dispatch(["run", "2"])
+        assert ("run", "2", [], True) in calls
+
+    def test_run_by_email(self):
+        calls = self._dispatch(["run", "user@example.com"])
+        assert ("run", "user@example.com", [], True) in calls
+
+    def test_no_share_flag(self):
+        calls = self._dispatch(["run", "2", "--no-share"])
+        assert ("run", "2", [], False) in calls
+
+    def test_tail_forwarded_verbatim(self):
+        calls = self._dispatch(["run", "2", "--", "--resume", "--model", "x"])
+        assert ("run", "2", ["--resume", "--model", "x"], True) in calls
+
+    def test_tail_may_contain_run_flags(self):
+        """Args after `--` are NOT parsed by cswap, even if they look like ours."""
+        calls = self._dispatch(["run", "2", "--", "--no-share"])
+        assert ("run", "2", ["--no-share"], True) in calls
+
+    def test_run_without_account_errors(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "run"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+        assert "NUM|EMAIL" in capsys.readouterr().err
+
+    def test_run_unknown_flag_errors(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "run", "2", "--bogus"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+
+    def test_run_help(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "run", "--help"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 0
+        out = capsys.readouterr().out
+        assert "--no-share" in out
+        assert "this terminal only" in out
+
+    def test_main_help_mentions_run(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "run 2" in result.stdout
+
+    def test_session_error_exits_cleanly(self, capsys):
+        class FailingSessionManager:
+            def __init__(self, switcher):
+                pass
+
+            def run(self, identifier, claude_args, share=True):
+                from claude_swap.exceptions import SessionError
+
+                raise SessionError("boom")
+
+        with patch("claude_swap.session.SessionManager", FailingSessionManager), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000), \
+             patch.object(sys, "argv", ["claude-swap", "run", "2"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 1
+        assert "boom" in capsys.readouterr().err

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,898 @@
+"""Tests for session mode (claude_swap.session + the switcher guards)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import unicodedata
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from claude_swap import session as session_mod
+from claude_swap.exceptions import AccountNotFoundError, SessionError
+from claude_swap.models import Platform
+from claude_swap.session import (
+    SHARE_MANIFEST,
+    SHARED_ITEMS,
+    SessionManager,
+    _probe_env,
+    keychain_service_name,
+    live_sessions_for,
+    session_dir_for,
+    slugify_email,
+)
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+ACCOUNT_EMAIL = "account2@example.com"
+ACCOUNT_NUM = "2"
+ORG_UUID = "org-uuid-2"
+
+CREDS = json.dumps(
+    {
+        "claudeAiOauth": {
+            "accessToken": "stored-access",
+            "refreshToken": "stored-refresh",
+            "expiresAt": 1,
+        }
+    }
+)
+ROTATED_CREDS = json.dumps(
+    {
+        "claudeAiOauth": {
+            "accessToken": "fresh-access",
+            "refreshToken": "rotated-refresh",
+            "expiresAt": 9999999999999,
+        }
+    }
+)
+CONFIG = json.dumps(
+    {
+        "oauthAccount": {
+            "emailAddress": ACCOUNT_EMAIL,
+            "accountUuid": "uuid-2",
+            "organizationUuid": ORG_UUID,
+        },
+        "theme": "light",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def macos_platform(monkeypatch):
+    """Force Platform.detect() to MACOS so keychain paths run on any host."""
+    monkeypatch.setattr(Platform, "detect", classmethod(lambda cls: Platform.MACOS))
+
+
+@pytest.fixture
+def seeded_switcher(temp_home: Path, macos_platform) -> ClaudeAccountSwitcher:
+    """A switcher with account 2 fully backed up (creds + config + sequence)."""
+    switcher = ClaudeAccountSwitcher(debug=True)
+    switcher._setup_directories()
+    switcher._write_json(
+        switcher.sequence_file,
+        {
+            "activeAccountNumber": 1,
+            "lastUpdated": "2024-01-01T00:00:00Z",
+            "sequence": [1, 2],
+            "accounts": {
+                "1": {
+                    "email": "account1@example.com",
+                    "uuid": "uuid-1",
+                    "organizationUuid": "org-uuid-1",
+                    "organizationName": "Org One",
+                    "added": "2024-01-01T00:00:00Z",
+                },
+                ACCOUNT_NUM: {
+                    "email": ACCOUNT_EMAIL,
+                    "uuid": "uuid-2",
+                    "organizationUuid": ORG_UUID,
+                    "organizationName": "Org Two",
+                    "added": "2024-01-02T00:00:00Z",
+                },
+            },
+        },
+    )
+    switcher._write_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL, CREDS)
+    switcher._write_account_config(ACCOUNT_NUM, ACCOUNT_EMAIL, CONFIG)
+    return switcher
+
+
+@pytest.fixture
+def manager(seeded_switcher) -> SessionManager:
+    return SessionManager(seeded_switcher)
+
+
+@pytest.fixture
+def auth_status_tracks_seed(monkeypatch):
+    """Fake `claude auth status --json`: logged in iff the profile is seeded.
+
+    Reads CLAUDE_CONFIG_DIR from the probe env, so it also exercises that the
+    probe points at the right profile. Records every probe env for assertions.
+    """
+    probe_envs: list[dict] = []
+
+    def fake_run(cmd, env=None, **kwargs):
+        probe_envs.append(env)
+        config_dir = Path(env["CLAUDE_CONFIG_DIR"])
+        if (config_dir / ".credentials.json").exists():
+            payload = {
+                "loggedIn": True,
+                "authMethod": "claude.ai",
+                "email": ACCOUNT_EMAIL,
+                "orgId": ORG_UUID,
+            }
+        else:
+            payload = {"loggedIn": False, "authMethod": "none"}
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(session_mod.subprocess, "run", fake_run)
+    return probe_envs
+
+
+@pytest.fixture
+def refresh_rotates(monkeypatch):
+    calls: list[str] = []
+
+    def fake_refresh(creds: str) -> str:
+        calls.append(creds)
+        return ROTATED_CREDS
+
+    monkeypatch.setattr(session_mod, "refresh_oauth_credentials", fake_refresh)
+    return calls
+
+
+def make_live(session_dir: Path, pid: int | None = None) -> None:
+    """Simulate a live claude instance in a profile (own PID is always alive)."""
+    pid = pid or os.getpid()
+    pid_dir = session_dir / "sessions"
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    (pid_dir / f"{pid}.json").write_text(json.dumps({"pid": pid}))
+
+
+# ---------------------------------------------------------------------------
+# pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_slugify_plain(self):
+        assert slugify_email("user@example.com") == "user_example.com"
+
+    def test_slugify_plus_tag(self):
+        assert slugify_email("user+tag@example.com") == "user_tag_example.com"
+
+    def test_slugify_unicode(self):
+        slug = slugify_email("bø@x.com")
+        assert slug == "b__x.com"
+        assert slug.isascii()
+
+    def test_slugify_windows_illegal(self):
+        slug = slugify_email('a<>:"/\\|?*b@x.com')
+        assert not any(c in slug for c in '<>:"/\\|?*')
+
+    def test_session_dir_naming(self, tmp_path):
+        d = session_dir_for(tmp_path, "2", "user@example.com")
+        assert d == tmp_path / "sessions" / "2-user_example.com"
+
+    def test_keychain_service_name_known_vector(self, tmp_path):
+        d = tmp_path / "profile"
+        expected = hashlib.sha256(
+            unicodedata.normalize("NFC", str(d)).encode()
+        ).hexdigest()[:8]
+        assert keychain_service_name(d) == f"Claude Code-credentials-{expected}"
+
+    def test_keychain_service_name_nfc_nfd_equal(self):
+        nfc = Path(unicodedata.normalize("NFC", "/tmp/sé"))
+        nfd = Path(unicodedata.normalize("NFD", "/tmp/sé"))
+        assert str(nfc) != str(nfd)  # sanity: inputs genuinely differ
+        assert keychain_service_name(nfc) == keychain_service_name(nfd)
+
+    def test_probe_env_drops_auth_overrides(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-key")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-tok")
+        env = _probe_env(tmp_path)
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert env["CLAUDE_CONFIG_DIR"] == str(tmp_path)
+
+    def test_live_sessions_for_missing_dir(self, tmp_path):
+        assert live_sessions_for(tmp_path / "nope") == []
+
+    def test_live_sessions_for_dead_pid_ignored(self, tmp_path):
+        make_live(tmp_path, pid=2**22 + 12345)  # vanishingly unlikely to exist
+        assert live_sessions_for(tmp_path) == []
+
+    def test_live_sessions_for_own_pid(self, tmp_path):
+        make_live(tmp_path)
+        assert [s.pid for s in live_sessions_for(tmp_path)] == [os.getpid()]
+
+
+# ---------------------------------------------------------------------------
+# resolve_account accessor
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAccount:
+    def test_by_number(self, seeded_switcher):
+        assert seeded_switcher.resolve_account("2") == (
+            ACCOUNT_NUM,
+            ACCOUNT_EMAIL,
+            ORG_UUID,
+        )
+
+    def test_by_email(self, seeded_switcher):
+        num, email, org = seeded_switcher.resolve_account(ACCOUNT_EMAIL)
+        assert (num, email) == (ACCOUNT_NUM, ACCOUNT_EMAIL)
+
+    def test_unknown(self, seeded_switcher):
+        with pytest.raises(AccountNotFoundError):
+            seeded_switcher.resolve_account("9")
+
+    def test_unknown_email(self, seeded_switcher):
+        with pytest.raises(AccountNotFoundError):
+            seeded_switcher.resolve_account("nobody@example.com")
+
+
+# ---------------------------------------------------------------------------
+# bootstrap
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrap:
+    def test_happy_path(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        session_dir, num, email = manager.setup_session("2", share=False)
+
+        assert (num, email) == (ACCOUNT_NUM, ACCOUNT_EMAIL)
+        creds_path = session_dir / ".credentials.json"
+        assert creds_path.read_text() == ROTATED_CREDS
+
+        config = json.loads((session_dir / ".claude.json").read_text())
+        assert config["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
+        assert config["hasCompletedOnboarding"] is True
+        assert config["theme"] == "light"  # carried over from backup config
+
+        # Rotated refresh token persisted back to backup storage.
+        assert (
+            seeded_switcher.read_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
+            == ROTATED_CREDS
+        )
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions")
+    def test_profile_permissions(self, manager, auth_status_tracks_seed, refresh_rotates):
+        session_dir, _, _ = manager.setup_session("2", share=False)
+        assert (session_dir.stat().st_mode & 0o777) == 0o700
+        assert ((session_dir / ".credentials.json").stat().st_mode & 0o777) == 0o600
+        assert ((session_dir / ".claude.json").stat().st_mode & 0o777) == 0o600
+
+    def test_reuse_skips_refresh_and_writes(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        session_dir, _, _ = manager.setup_session("2", share=False)
+        first_creds = (session_dir / ".credentials.json").read_text()
+        refresh_calls_after_bootstrap = len(refresh_rotates)
+
+        session_dir2, _, _ = manager.setup_session("2", share=False)
+
+        assert session_dir2 == session_dir
+        assert len(refresh_rotates) == refresh_calls_after_bootstrap  # no new refresh
+        assert (session_dir / ".credentials.json").read_text() == first_creds
+
+    def test_refresh_failure_uses_stored_creds(
+        self, manager, auth_status_tracks_seed, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(session_mod, "refresh_oauth_credentials", lambda c: None)
+        session_dir, _, _ = manager.setup_session("2", share=False)
+        assert (session_dir / ".credentials.json").read_text() == CREDS
+        assert "Could not refresh" in capsys.readouterr().out
+
+    def test_setup_token_account_skips_refresh_silently(
+        self, manager, seeded_switcher, auth_status_tracks_seed, monkeypatch, capsys
+    ):
+        """--add-token accounts have no refresh token; no attempt, no warning."""
+        token_creds = json.dumps(
+            {"claudeAiOauth": {"accessToken": "sk-ant-oat01-x", "expiresAt": 0}}
+        )
+        seeded_switcher._write_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL, token_creds)
+        refresh_calls = []
+        monkeypatch.setattr(
+            session_mod,
+            "refresh_oauth_credentials",
+            lambda c: refresh_calls.append(c) or None,
+        )
+
+        session_dir, _, _ = manager.setup_session("2", share=False)
+
+        assert refresh_calls == []
+        assert "Could not refresh" not in capsys.readouterr().out
+        assert (session_dir / ".credentials.json").read_text() == token_creds
+
+    def test_missing_credentials(self, manager, seeded_switcher, auth_status_tracks_seed):
+        seeded_switcher._delete_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
+        with pytest.raises(SessionError, match="no stored credentials"):
+            manager.setup_session("2", share=False)
+
+    def test_missing_config(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        config_file = (
+            seeded_switcher.configs_dir
+            / f".claude-config-{ACCOUNT_NUM}-{ACCOUNT_EMAIL}.json"
+        )
+        config_file.unlink()
+        with pytest.raises(SessionError, match="no stored config backup"):
+            manager.setup_session("2", share=False)
+
+    def test_validation_failure_cleans_up(
+        self, manager, seeded_switcher, monkeypatch, refresh_rotates, block_real_keychain
+    ):
+        # Auth status never reports logged in → post-bootstrap validation fails.
+        def always_invalid(cmd, env=None, **kwargs):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"loggedIn": False, "authMethod": "none"}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(session_mod.subprocess, "run", always_invalid)
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        # A stale hashed-keychain entry from an earlier profile at this path.
+        service = keychain_service_name(session_dir)
+        account = session_mod._keychain_account_name()
+        block_real_keychain.set_password(service, account, "stale")
+
+        with pytest.raises(SessionError, match="failed\\s+validation"):
+            manager.setup_session("2", share=False)
+
+        assert not session_dir.exists()
+        assert block_real_keychain.get_password(service, account) is None
+
+    def test_stale_keychain_entry_deleted_before_seed(
+        self,
+        manager,
+        seeded_switcher,
+        auth_status_tracks_seed,
+        refresh_rotates,
+        block_real_keychain,
+    ):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        service = keychain_service_name(session_dir)
+        account = session_mod._keychain_account_name()
+        block_real_keychain.set_password(service, account, "stale")
+
+        manager.setup_session("2", share=False)
+
+        assert block_real_keychain.get_password(service, account) is None
+
+    def test_stale_marker_forces_rebootstrap_after_session_exits(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        """Backup creds updated while the session was live → after it exits,
+        the next run must re-bootstrap from the fresh backup even though the
+        stale profile would still pass the local reuse check."""
+        session_dir, _, _ = manager.setup_session("2", share=False)
+        (session_dir / ".credentials.json").write_text("stale lineage")
+        (session_dir / session_mod.STALE_MARKER).touch()
+        # No live PID files → the session has exited.
+
+        manager.setup_session("2", share=False)
+
+        # Re-bootstrapped: fresh (refreshed) creds, marker cleared.
+        assert (session_dir / ".credentials.json").read_text() == ROTATED_CREDS
+        assert not (session_dir / session_mod.STALE_MARKER).exists()
+
+    def test_stale_marker_preserved_while_session_still_live(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        """A second `cswap run` joining a live session must not invalidate
+        under the running claude; the marker survives for later."""
+        session_dir, _, _ = manager.setup_session("2", share=False)
+        (session_dir / ".credentials.json").write_text("live lineage")
+        (session_dir / session_mod.STALE_MARKER).touch()
+        make_live(session_dir)
+
+        manager.setup_session("2", share=False)
+
+        assert (session_dir / ".credentials.json").read_text() == "live lineage"
+        assert (session_dir / session_mod.STALE_MARKER).exists()
+
+    def test_rebootstrap_preserves_profile_history(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        session_dir, _, _ = manager.setup_session("2", share=False)
+        # Simulate claude having written its own state, then creds invalidated.
+        config = json.loads((session_dir / ".claude.json").read_text())
+        config["projects"] = {"/some/project": {"history": ["x"]}}
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+        (session_dir / ".credentials.json").unlink()
+
+        manager.setup_session("2", share=False)
+
+        merged = json.loads((session_dir / ".claude.json").read_text())
+        assert merged["projects"] == {"/some/project": {"history": ["x"]}}
+        assert merged["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
+
+
+# ---------------------------------------------------------------------------
+# validation strictness
+# ---------------------------------------------------------------------------
+
+
+class TestIsSessionValid:
+    @pytest.fixture
+    def valid_payload(self):
+        return {
+            "loggedIn": True,
+            "authMethod": "claude.ai",
+            "email": ACCOUNT_EMAIL,
+            "orgId": ORG_UUID,
+        }
+
+    def check(self, manager, tmp_path, monkeypatch, payload, rc=0) -> bool:
+        tmp_path.mkdir(exist_ok=True)
+        monkeypatch.setattr(
+            session_mod.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(
+                returncode=rc, stdout=json.dumps(payload), stderr=""
+            ),
+        )
+        return manager._is_session_valid(tmp_path, ACCOUNT_EMAIL, ORG_UUID)
+
+    def test_valid(self, manager, tmp_path, monkeypatch, valid_payload):
+        assert self.check(manager, tmp_path, monkeypatch, valid_payload)
+
+    def test_rejects_api_key_auth(self, manager, tmp_path, monkeypatch, valid_payload):
+        valid_payload["authMethod"] = "apiKey"
+        assert not self.check(manager, tmp_path, monkeypatch, valid_payload)
+
+    def test_rejects_wrong_email(self, manager, tmp_path, monkeypatch, valid_payload):
+        valid_payload["email"] = "other@example.com"
+        assert not self.check(manager, tmp_path, monkeypatch, valid_payload)
+
+    def test_rejects_wrong_org(self, manager, tmp_path, monkeypatch, valid_payload):
+        valid_payload["orgId"] = "different-org"
+        assert not self.check(manager, tmp_path, monkeypatch, valid_payload)
+
+    def test_lenient_when_org_absent(self, manager, tmp_path, monkeypatch, valid_payload):
+        del valid_payload["orgId"]
+        assert self.check(manager, tmp_path, monkeypatch, valid_payload)
+
+    def test_rejects_nonzero_exit(self, manager, tmp_path, monkeypatch, valid_payload):
+        assert not self.check(manager, tmp_path, monkeypatch, valid_payload, rc=1)
+
+    def test_rejects_missing_dir(self, manager, tmp_path, monkeypatch):
+        assert not manager._is_session_valid(
+            tmp_path / "missing", ACCOUNT_EMAIL, ORG_UUID
+        )
+
+
+# ---------------------------------------------------------------------------
+# sharing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def share_setup(temp_home: Path, seeded_switcher):
+    """Source items in ~/.claude and an existing (seeded-enough) session dir."""
+    source = temp_home / ".claude"
+    (source / "settings.json").write_text("{}")
+    (source / "CLAUDE.md").write_text("# memory")
+    (source / "skills").mkdir()
+    (source / "skills" / "a.md").write_text("skill")
+
+    session_dir = session_dir_for(seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL)
+    session_dir.mkdir(parents=True)
+    return source, session_dir, SessionManager(seeded_switcher)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink mode is POSIX-only")
+class TestSharingPosix:
+    def test_links_existing_sources_only(self, share_setup):
+        source, session_dir, mgr = share_setup
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / "settings.json").is_symlink()
+        assert (session_dir / "CLAUDE.md").is_symlink()
+        assert (session_dir / "skills").is_symlink()
+        assert not (session_dir / "keybindings.json").exists()  # no source
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert set(manifest["items"]) == {"settings.json", "CLAUDE.md", "skills"}
+        assert manifest["mode"] == "symlink"
+
+    def test_idempotent(self, share_setup):
+        source, session_dir, mgr = share_setup
+        mgr._sync_sharing(session_dir, share=True)
+        mgr._sync_sharing(session_dir, share=True)
+        assert (session_dir / "settings.json").readlink() == source / "settings.json"
+
+    def test_prunes_when_source_vanishes(self, share_setup):
+        source, session_dir, mgr = share_setup
+        mgr._sync_sharing(session_dir, share=True)
+        (source / "CLAUDE.md").unlink()
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert not (session_dir / "CLAUDE.md").is_symlink()
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "CLAUDE.md" not in manifest["items"]
+
+    def test_never_touches_user_data(self, share_setup, capsys):
+        source, session_dir, mgr = share_setup
+        (session_dir / "CLAUDE.md").write_text("session-private memory")
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert not (session_dir / "CLAUDE.md").is_symlink()
+        assert (session_dir / "CLAUDE.md").read_text() == "session-private memory"
+        assert "Not sharing CLAUDE.md" in capsys.readouterr().out
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "CLAUDE.md" not in manifest["items"]
+
+    def test_no_share_removes_only_managed(self, share_setup):
+        source, session_dir, mgr = share_setup
+        (session_dir / "private.txt").write_text("keep me")
+        mgr._sync_sharing(session_dir, share=True)
+
+        mgr._sync_sharing(session_dir, share=False)
+
+        assert not (session_dir / "settings.json").exists()
+        assert not (session_dir / "skills").exists()
+        assert (session_dir / "private.txt").read_text() == "keep me"
+        assert not (session_dir / SHARE_MANIFEST).exists()
+
+    def test_repoints_stale_link(self, share_setup, temp_home):
+        source, session_dir, mgr = share_setup
+        elsewhere = temp_home / "elsewhere.json"
+        elsewhere.write_text("{}")
+        (session_dir / "settings.json").symlink_to(elsewhere)
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / "settings.json").readlink() == source / "settings.json"
+
+
+class TestSharingWindowsMode:
+    """Copy mode, exercised by forcing the platform (runs on any host)."""
+
+    @pytest.fixture
+    def windows_mgr(self, share_setup):
+        source, session_dir, mgr = share_setup
+        mgr.switcher.platform = Platform.WINDOWS
+        return source, session_dir, mgr
+
+    def test_copies_instead_of_links(self, windows_mgr):
+        source, session_dir, mgr = windows_mgr
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / "settings.json").is_file()
+        assert not (session_dir / "settings.json").is_symlink()
+        assert (session_dir / "skills" / "a.md").read_text() == "skill"
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert manifest["mode"] == "copy"
+
+    def test_resync_overwrites_managed_copies(self, windows_mgr):
+        source, session_dir, mgr = windows_mgr
+        mgr._sync_sharing(session_dir, share=True)
+        (source / "settings.json").write_text('{"changed": true}')
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / "settings.json").read_text() == '{"changed": true}'
+
+    def test_no_share_removes_copies(self, windows_mgr):
+        source, session_dir, mgr = windows_mgr
+        mgr._sync_sharing(session_dir, share=True)
+        mgr._sync_sharing(session_dir, share=False)
+
+        assert not (session_dir / "settings.json").exists()
+        assert not (session_dir / "skills").exists()
+
+
+# ---------------------------------------------------------------------------
+# run() / exec handoff
+# ---------------------------------------------------------------------------
+
+
+class _ExecCalled(Exception):
+    def __init__(self, binary, argv, env):
+        self.binary, self.argv, self.env = binary, argv, env
+
+
+@pytest.fixture
+def capture_exec(monkeypatch):
+    def fake_execvpe(binary, argv, env):
+        raise _ExecCalled(binary, argv, env)
+
+    monkeypatch.setattr(session_mod.os, "execvpe", fake_execvpe)
+    monkeypatch.setattr(
+        session_mod.shutil, "which", lambda name: f"/fake/bin/{name}"
+    )
+
+
+class TestRun:
+    def test_claude_not_on_path(self, manager, monkeypatch):
+        monkeypatch.setattr(session_mod.shutil, "which", lambda name: None)
+        with pytest.raises(SessionError, match="not found on PATH"):
+            manager.run("2", [])
+
+    def test_exec_env_and_forwarded_args(
+        self, manager, capture_exec, auth_status_tracks_seed, refresh_rotates
+    ):
+        with pytest.raises(_ExecCalled) as exc:
+            manager.run("2", ["--resume", "--model", "x"])
+
+        call = exc.value
+        assert call.binary == "/fake/bin/claude"
+        assert call.argv == ["/fake/bin/claude", "--resume", "--model", "x"]
+        session_dir = session_dir_for(
+            manager.switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        assert call.env["CLAUDE_CONFIG_DIR"] == str(session_dir)
+
+    def test_fast_path_for_active_account(
+        self, manager, capture_exec, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(
+            manager.switcher,
+            "_get_current_account",
+            lambda: (ACCOUNT_EMAIL, ORG_UUID),
+        )
+        with pytest.raises(_ExecCalled) as exc:
+            manager.run("2", [])
+
+        assert "CLAUDE_CONFIG_DIR" not in exc.value.env
+        assert "already the active default login" in capsys.readouterr().out
+
+    def test_preset_config_dir_disables_fast_path(
+        self,
+        manager,
+        capture_exec,
+        monkeypatch,
+        auth_status_tracks_seed,
+        refresh_rotates,
+        capsys,
+    ):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/somewhere/else")
+        # Even a matching identity must NOT fast-path when the env var is set.
+        monkeypatch.setattr(
+            manager.switcher,
+            "_get_current_account",
+            lambda: (ACCOUNT_EMAIL, ORG_UUID),
+        )
+        with pytest.raises(_ExecCalled) as exc:
+            manager.run("2", [])
+
+        session_dir = session_dir_for(
+            manager.switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        assert exc.value.env["CLAUDE_CONFIG_DIR"] == str(session_dir)
+        assert "overriding it for this launch" in capsys.readouterr().out
+
+    def test_auth_override_vars_scrubbed_from_session_env(
+        self,
+        manager,
+        capture_exec,
+        monkeypatch,
+        auth_status_tracks_seed,
+        refresh_rotates,
+        capsys,
+    ):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-key")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok")
+        monkeypatch.setenv("UNRELATED_VAR", "kept")
+        with pytest.raises(_ExecCalled) as exc:
+            manager.run("2", [])
+
+        # Warned, and the overrides are scrubbed from the launched env —
+        # `cswap run 2` means account 2, not whatever the API key resolves to.
+        out = capsys.readouterr().out
+        assert "Ignoring ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN" in out
+        assert "ANTHROPIC_API_KEY" not in exc.value.env
+        assert "ANTHROPIC_AUTH_TOKEN" not in exc.value.env
+        assert exc.value.env["UNRELATED_VAR"] == "kept"
+
+    def test_fast_path_keeps_env_untouched(
+        self, manager, capture_exec, monkeypatch
+    ):
+        """Plain-claude fast path must NOT scrub: it's normal claude behavior."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-key")
+        monkeypatch.setattr(
+            manager.switcher,
+            "_get_current_account",
+            lambda: (ACCOUNT_EMAIL, ORG_UUID),
+        )
+        with pytest.raises(_ExecCalled) as exc:
+            manager.run("2", [])
+
+        assert exc.value.env["ANTHROPIC_API_KEY"] == "sk-ant-key"
+
+
+# ---------------------------------------------------------------------------
+# switcher guards
+# ---------------------------------------------------------------------------
+
+
+class TestGuards:
+    def test_remove_account_refused_while_live(self, seeded_switcher, monkeypatch):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        make_live(session_dir)
+        monkeypatch.setattr(
+            "builtins.input", lambda *a: pytest.fail("prompt must not be reached")
+        )
+        with pytest.raises(SessionError, match="live session-mode"):
+            seeded_switcher.remove_account(ACCOUNT_NUM)
+        # Account untouched.
+        assert seeded_switcher.read_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
+
+    def test_remove_account_cleans_session_profile(
+        self, seeded_switcher, monkeypatch, block_real_keychain
+    ):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        service = keychain_service_name(session_dir)
+        account = session_mod._keychain_account_name()
+        block_real_keychain.set_password(service, account, "creds")
+
+        monkeypatch.setattr("builtins.input", lambda *a: "y")
+        seeded_switcher.remove_account(ACCOUNT_NUM)
+
+        assert not session_dir.exists()
+        assert block_real_keychain.get_password(service, account) is None
+
+    def test_delete_account_files_chokepoint_refuses_live(self, seeded_switcher):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        make_live(session_dir)
+        with pytest.raises(SessionError, match="live session-mode"):
+            seeded_switcher._delete_account_files(ACCOUNT_NUM, ACCOUNT_EMAIL)
+
+    def test_purge_refused_while_live(self, seeded_switcher, monkeypatch):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        make_live(session_dir)
+        monkeypatch.setattr(
+            "builtins.input", lambda *a: pytest.fail("prompt must not be reached")
+        )
+        with pytest.raises(SessionError, match="Exit them first"):
+            seeded_switcher.purge()
+        assert seeded_switcher.backup_dir.exists()
+
+    def test_purge_sweeps_session_keychain_entries(
+        self, seeded_switcher, monkeypatch, block_real_keychain
+    ):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        service = keychain_service_name(session_dir)
+        account = session_mod._keychain_account_name()
+        block_real_keychain.set_password(service, account, "creds")
+
+        monkeypatch.setattr("builtins.input", lambda *a: "y")
+        seeded_switcher.purge()
+
+        assert block_real_keychain.get_password(service, account) is None
+        assert not seeded_switcher.backup_dir.exists()
+
+    def test_switch_warns_on_live_target_but_completes(
+        self, seeded_switcher, monkeypatch, capsys
+    ):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        make_live(session_dir)
+        # Direct-activation path (no live default identity) keeps this focused.
+        monkeypatch.setattr(seeded_switcher, "_get_current_account", lambda: None)
+        monkeypatch.setattr(seeded_switcher, "list_accounts", lambda **kw: None)
+
+        seeded_switcher._perform_switch(ACCOUNT_NUM)
+
+        out = capsys.readouterr().out
+        assert "live session-mode" in out
+        data = seeded_switcher._get_sequence_data()
+        assert data["activeAccountNumber"] == int(ACCOUNT_NUM)
+
+    def test_backup_credential_write_invalidates_stale_profile(
+        self, seeded_switcher, block_real_keychain
+    ):
+        """Re-login + --add-account (or any backup cred write) must force the
+        non-live session profile to re-bootstrap — otherwise the documented
+        recovery path leaves `cswap run` on stale credentials that still pass
+        the local reuse check."""
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        (session_dir / ".credentials.json").write_text("stale")
+        (session_dir / ".claude.json").write_text('{"projects": {}}')
+        service = keychain_service_name(session_dir)
+        account = session_mod._keychain_account_name()
+        block_real_keychain.set_password(service, account, "stale")
+
+        seeded_switcher._write_account_credentials(
+            ACCOUNT_NUM, ACCOUNT_EMAIL, ROTATED_CREDS
+        )
+
+        assert not (session_dir / ".credentials.json").exists()
+        assert (session_dir / ".claude.json").exists()  # history preserved
+        assert block_real_keychain.get_password(service, account) is None
+
+    def test_backup_credential_write_leaves_live_profile_alone_but_marks_stale(
+        self, seeded_switcher
+    ):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        make_live(session_dir)
+        (session_dir / ".credentials.json").write_text("live session creds")
+
+        seeded_switcher._write_account_credentials(
+            ACCOUNT_NUM, ACCOUNT_EMAIL, ROTATED_CREDS
+        )
+
+        # Live copy untouched, but flagged for re-bootstrap after exit.
+        assert (session_dir / ".credentials.json").read_text() == "live session creds"
+        assert (session_dir / session_mod.STALE_MARKER).exists()
+
+    def test_list_skips_refresh_for_live_session_accounts(
+        self, seeded_switcher, monkeypatch
+    ):
+        """cswap --list must not proactively refresh an account that is live in
+        a session — rotating the backup copy's token could invalidate the
+        session's copy."""
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        make_live(session_dir)
+        seen: dict[str, bool] = {}
+
+        def fake_fetch(num, email, creds, is_active=False, persist_credentials=None):
+            seen[num] = is_active
+            return None
+
+        monkeypatch.setattr(
+            "claude_swap.oauth.fetch_usage_for_account", fake_fetch
+        )
+        seeded_switcher.list_accounts()
+
+        assert seen[ACCOUNT_NUM] is True  # treated like active: no refresh
+        assert seen.get("1") in (None, False)  # account 1 has no live session
+
+    def test_invalidate_session_credentials_keeps_history(
+        self, seeded_switcher, block_real_keychain
+    ):
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        (session_dir / ".credentials.json").write_text("old creds")
+        (session_dir / ".claude.json").write_text('{"projects": {}}')
+        service = keychain_service_name(session_dir)
+        account = session_mod._keychain_account_name()
+        block_real_keychain.set_password(service, account, "creds")
+
+        seeded_switcher._invalidate_session_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
+
+        assert not (session_dir / ".credentials.json").exists()
+        assert (session_dir / ".claude.json").exists()
+        assert block_real_keychain.get_password(service, account) is None

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1138,3 +1138,67 @@ class TestExportSkipsBrokenSlots:
         assert [a["email"] for a in envelope["accounts"]] == ["bob@example.com"]
         # Warning is on stderr.
         assert "Skipping Account-1" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Session-mode interaction
+# ---------------------------------------------------------------------------
+
+
+class TestImportSessionInvalidation:
+    def _reexport_with_marker(self, s, temp_home: Path) -> Path:
+        out = temp_home / "alice.cswap"
+        export_accounts(s, str(out), account="1")
+        env = json.loads(out.read_text())
+        env["accounts"][0]["credentials"]["_marker"] = "NEW"
+        out.write_text(json.dumps(env))
+        return out
+
+    def test_force_overwrite_invalidates_session_credentials(
+        self, temp_home: Path, capsys
+    ):
+        from claude_swap.session import session_dir_for
+
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 1, "alice@example.com", "org-a")
+        out = self._reexport_with_marker(s, temp_home)
+
+        session_dir = session_dir_for(s.backup_dir, "1", "alice@example.com")
+        session_dir.mkdir(parents=True)
+        (session_dir / ".credentials.json").write_text("pre-import creds")
+        (session_dir / ".claude.json").write_text('{"projects": {}}')
+
+        import_accounts(s, str(out), force=True)
+
+        # Credential material dropped → next `cswap run` re-bootstraps from
+        # the imported backup; profile history (.claude.json) survives.
+        assert not (session_dir / ".credentials.json").exists()
+        assert (session_dir / ".claude.json").exists()
+
+    def test_force_overwrite_warns_but_keeps_live_session(
+        self, temp_home: Path, capsys
+    ):
+        import os as _os
+
+        from claude_swap.session import session_dir_for
+
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 1, "alice@example.com", "org-a")
+        out = self._reexport_with_marker(s, temp_home)
+
+        session_dir = session_dir_for(s.backup_dir, "1", "alice@example.com")
+        pid_dir = session_dir / "sessions"
+        pid_dir.mkdir(parents=True)
+        (pid_dir / f"{_os.getpid()}.json").write_text(
+            json.dumps({"pid": _os.getpid()})
+        )
+        (session_dir / ".credentials.json").write_text("pre-import creds")
+
+        import_accounts(s, str(out), force=True)
+
+        captured = capsys.readouterr()
+        assert "live" in captured.err
+        # Live session untouched; import itself still completed.
+        assert (session_dir / ".credentials.json").read_text() == "pre-import creds"
+        alice = s._read_account_credentials("1", "alice@example.com")
+        assert json.loads(alice)["_marker"] == "NEW"

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "claude-swap"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
Adds `cswap run NUM|EMAIL [--no-share] [-- <args>]`: launches Claude Code as a stored account in the current terminal only, via a persistent per-account profile and `CLAUDE_CONFIG_DIR`. The default login, other terminals, and the VS Code extension stay untouched — two accounts can work at the same time on one machine.

Related to #19 (covers the CLI side of that ask; per-VS-Code-window accounts remain open).

**What's included**

- Per-account session profiles under the backup dir, seeded from backup credentials with one token refresh (rotated refresh tokens persisted back). On macOS each profile gets its own isolated Keychain entry (Claude hashes the config dir into the service name).
- `~/.claude` customizations (settings, keybindings, CLAUDE.md, skills, commands, agents) shared into the session by default — symlinks on macOS/Linux (Claude writes through them), copy-on-launch on Windows; `--no-share` opts out. A manifest guarantees only cswap-created entries are ever removed.
- Guards: `cswap run` of the active account launches plain `claude` (no duplicate credential copy); `--switch` warns when the target has a live session; `--remove-account`/`--purge` refuse while one is live; every slot overwrite cleans or invalidates its session profile, deferred via a stale marker when the session is live; `--list` skips proactive token refresh for live-session accounts.
- Auth-override env vars (`ANTHROPIC_API_KEY` etc.) are scrubbed from the session launch so the selected account can't be hijacked.
- 71 new tests (474 total). Verified manually on macOS: two accounts running simultaneously, symlink write-through, liveness guards against a real session.

Bumps version to 0.13.0.