### PR TITLE
Fix Windows `cswap run` always failing session validation

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -410,9 +410,14 @@ class SessionManager:
         """
         if not session_dir.is_dir():
             return False
+        # On Windows `claude` is a `.cmd` shim, and a bare "claude" passed to
+        # subprocess won't resolve it (PATHEXT isn't applied) — it raises
+        # FileNotFoundError, which the handler below turns into a false
+        # "failed validation". shutil.which finds the shim.
+        claude_bin = shutil.which("claude") or "claude"
         try:
             result = subprocess.run(
-                ["claude", "auth", "status", "--json"],
+                [claude_bin, "auth", "status", "--json"],
                 env=_probe_env(session_dir),
                 capture_output=True,
                 text=True,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -480,6 +480,29 @@ class TestIsSessionValid:
             tmp_path / "missing", ACCOUNT_EMAIL, ORG_UUID
         )
 
+    def test_invokes_pathext_resolved_launcher(
+        self, manager, tmp_path, monkeypatch, valid_payload
+    ):
+        """The probe must call the resolved launcher, not bare "claude".
+
+        On Windows `claude` is a `.cmd` shim that a bare "claude" won't
+        resolve, so validation would always fail. Use shutil.which instead.
+        """
+        tmp_path.mkdir(exist_ok=True)
+        resolved = "/fake/bin/claude.CMD"
+        monkeypatch.setattr(session_mod.shutil, "which", lambda name: resolved)
+        seen_argv = {}
+
+        def capture_run(argv, *a, **k):
+            seen_argv["argv"] = argv
+            return SimpleNamespace(
+                returncode=0, stdout=json.dumps(valid_payload), stderr=""
+            )
+
+        monkeypatch.setattr(session_mod.subprocess, "run", capture_run)
+        assert manager._is_session_valid(tmp_path, ACCOUNT_EMAIL, ORG_UUID)
+        assert seen_argv["argv"][0] == resolved
+
 
 # ---------------------------------------------------------------------------
 # sharing


### PR DESCRIPTION
Hello, I tried running `cswap run` on my windows PC and it threw an error. After debugging (with the help of Claude), I am submitting this PR.

## Problem
On Windows, `cswap run <account>` always fails with "failed validation", no matter the account. This makes the session feature (#52) unusable on Windows. Relates to #19.

## Cause
`_is_session_valid` checks the profile by running `subprocess.run(["claude", "auth", "status", "--json"])`. On Windows, `claude` is a `.cmd` shim, and a bare `"claude"` doesn't resolve there (subprocess doesn't apply `PATHEXT`), so it raises `FileNotFoundError`. That error is caught and treated as "not valid", so cswap deletes the new profile and reports failure.

This is why `--switch` works (it never runs `claude`) and why `run` works on macOS/Linux (where `claude` resolves without an extension). `run()`'s own launch already used `shutil.which`; only this validation check used the bare name.

## Fix
Resolve `claude` with `shutil.which` (which applies `PATHEXT`) before running it.

## Testing
- Added a regression test checking the probe uses the resolved path.
- Verified on Windows: `cswap run` now passes validation and launches the correct account in session mode.
