### PR TITLE
Fix Windows hang: Platform.detect() blocks on WMI query

### DIFF
--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import platform as platform_module
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -27,13 +26,17 @@ class Platform(Enum):
 
     @classmethod
     def detect(cls) -> Platform:
-        """Detect current platform."""
-        system = platform_module.system()
-        if system == "Darwin":
+        """Detect current platform.
+
+        Uses sys.platform rather than platform.system() because the latter
+        calls platform.uname() on Windows, which runs a WMI query that can
+        hang indefinitely when the WMI service is slow or unresponsive.
+        """
+        if sys.platform == "darwin":
             return cls.MACOS
-        elif system == "Windows":
+        elif sys.platform == "win32":
             return cls.WINDOWS
-        elif system == "Linux":
+        elif sys.platform.startswith("linux"):
             if os.environ.get("WSL_DISTRO_NAME"):
                 return cls.WSL
             return cls.LINUX

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -54,14 +54,13 @@ class TestEmailValidation:
 class TestPlatformDetection:
     """Test platform detection."""
 
-    @patch("platform.system", return_value="Darwin")
-    def test_macos_detection(self, mock_system, temp_home: Path):
+    @patch("sys.platform", "darwin")
+    def test_macos_detection(self, temp_home: Path):
         """Test macOS platform detection."""
         assert Platform.detect() == Platform.MACOS
 
-    @patch("platform.system", return_value="Linux")
-    @patch.dict(os.environ, {}, clear=False)
-    def test_linux_detection(self, mock_system, temp_home: Path):
+    @patch("sys.platform", "linux")
+    def test_linux_detection(self, temp_home: Path):
         """Test Linux platform detection."""
         # Ensure WSL_DISTRO_NAME is not set
         env = os.environ.copy()
@@ -69,19 +68,19 @@ class TestPlatformDetection:
         with patch.dict(os.environ, env, clear=True):
             assert Platform.detect() == Platform.LINUX
 
-    @patch("platform.system", return_value="Linux")
+    @patch("sys.platform", "linux")
     @patch.dict(os.environ, {"WSL_DISTRO_NAME": "Ubuntu"})
-    def test_wsl_detection(self, mock_system, temp_home: Path):
+    def test_wsl_detection(self, temp_home: Path):
         """Test WSL platform detection."""
         assert Platform.detect() == Platform.WSL
 
-    @patch("platform.system", return_value="Windows")
-    def test_windows_detection(self, mock_system, temp_home: Path):
+    @patch("sys.platform", "win32")
+    def test_windows_detection(self, temp_home: Path):
         """Test Windows platform detection."""
         assert Platform.detect() == Platform.WINDOWS
 
-    @patch("platform.system", return_value="FreeBSD")
-    def test_unknown_platform(self, mock_system, temp_home: Path):
+    @patch("sys.platform", "freebsd")
+    def test_unknown_platform(self, temp_home: Path):
         """Test unknown platform detection."""
         assert Platform.detect() == Platform.UNKNOWN
 


### PR DESCRIPTION
## Problem

On Windows, every `cswap` command hangs indefinitely (no output, no error). It never gets past startup.

## Root cause

`Platform.detect()` in `src/claude_swap/models.py` calls `platform.system()`. On Windows that resolves through `platform.uname()` → `win32_ver()` → `platform._wmi_query()`. On machines where the WMI service is slow or unresponsive, that query blocks forever.

`Platform.detect()` runs at import time (`cache.py` imports `get_backup_root()`, which calls it), so the hang affects **every** command, not just account switching.

Reproduced on Windows 11 with the uv-managed CPython 3.14 runtime. A bare `python -c "import platform; platform.system()"` never returns, while `sys.platform` returns instantly.

## Fix

Use `sys.platform` for detection instead of `platform.system()`. It never touches WMI, and it's already what the rest of the codebase uses for Windows checks (`locking.py`, `switcher.py`, etc.), so this also makes detection consistent.

- `darwin` → macOS
- `win32` → Windows
- `linux*` → Linux (or WSL when `WSL_DISTRO_NAME` is set)

The platform-detection tests are updated to patch `sys.platform` accordingly.

## Testing

- `cswap --status` (and other commands) now return immediately instead of hanging.
- `TestPlatformDetection` passes (5/5).
