### PR TITLE
Add event-driven multi-account load balancer + cmux integration (supersedes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,32 +82,87 @@ cswap run 2 --no-share          # don't share your ~/.claude customizations
 
 Your `~/.claude` customizations (settings, keybindings, CLAUDE.md, skills, commands, agents) are shared into the session by default — use `--no-share` for a bare profile. Conversation history stays per-account.
 
-### Auto-switch at usage limit (Beta)
+### Load balancer (Beta)
 
-Launch the interactive menu and open **Auto-switch at limit (Beta)**:
+Run several Claude Code sessions across all your accounts and let cswap keep them
+fed. When a session's account nears its usage limit, cswap migrates that session
+to a higher-priority account that still has headroom — concentrating load on your
+top accounts and only spilling to the next tier when one fills up. Migrations are
+minimized (each one re-bills the context window), so a session only moves when its
+account is actually exhausted, never for a marginal gain.
+
+Only one subscription? There's nowhere to migrate, so cswap **pauses** the session
+instead and **auto-resumes** it (via `claude --resume`) the moment the limit
+window resets — your in-flight, dynamic workflow survives the limit instead of
+being thrown away.
+
+It's fully **event-driven**: the in-session statusline reports usage on each
+message, which is what triggers a rebalance. There's no polling loop and no
+background daemon. It's also credential-safe — each session's supervisor owns its
+own profile and only ever re-points its own credentials.
+
+#### Setup
 
 ```bash
-cswap --tui
+cswap --install                 # embed cswap into Claude Code (one-time, idempotent)
+cswap --status                  # shows load-balancer state + embed health
 ```
 
-From there you can:
+`--install` installs the statusline and QoL layer via a non-shared
+`settings.local.json` inside each managed profile, so plain `claude` and
+`cswap run` stay completely vanilla. It also runs automatically on upgrade.
 
-- **Enable/Disable** automatic switching (the setting persists across runs).
-- **Set threshold** — the usage percentage that triggers a switch (default `95%`).
-- **Start monitor now** — runs a foreground watcher that polls the active
-  account's 5h/7d usage every 60 seconds. When usage reaches the threshold, it
-  rotates to the next managed account (same rotation as `cswap --switch`), then
-  keeps watching the new account. Press `s` to check immediately, or `q`/`Esc`
-  to stop.
+#### Launch a managed session
 
-Because switching doesn't require a Claude Code restart (see the note above),
-the new account takes effect on your next message — on macOS once the Keychain
-cache expires. The monitor runs only while its screen is open in the TUI; there
-is no background daemon.
+```bash
+cswap launch                    # start a load-balanced session in this terminal
+cswap launch -- --resume        # everything after '--' is forwarded to claude
+cswap launch --no-share         # bare profile (don't share ~/.claude items)
+```
 
-> **Beta:** this feature is new and runs as a foreground watcher. The usage
-> percentages come from the same API as `cswap --list`. Please report any rough
-> edges via [Issues](https://github.com/realiti4/claude-swap/issues).
+`cswap launch` picks the best account (highest priority with headroom), then
+supervises claude until it exits — migrating or pausing/auto-resuming as limits
+are reached. Managed sessions get QoL defaults: the latest model,
+`--dangerously-skip-permissions`, and high effort (any flag you pass yourself
+wins). Plain `claude` and `cswap run` are unaffected.
+
+#### Priorities
+
+Higher priority = burned through first.
+
+```bash
+cswap --set-priority 2:5        # set Account-2's priority to 5
+```
+
+Priorities are also editable in the `cswap --balance` TUI.
+
+#### Dashboard
+
+```bash
+cswap --balance                 # settings + live dashboard (enable/disable, tune, priorities)
+```
+
+The dashboard shows which sessions are on which accounts, live, and is where you
+**enable** the balancer (it's opt-in/off by default), set the threshold/target/
+cooldown, and edit priorities.
+
+#### Statusline
+
+Each managed session renders a compact one-liner, updated on every message:
+
+```
+⇄ a2 ▕███▁▁▏88% · s2/5          # on Account-2, 88% used, session 2 of 5
+→a5 ▕███▁▁▏88% · s2/5           # migration to Account-5 pending
+⏸ a2 1h12m · s2/5               # paused, auto-resuming in 1h12m
+```
+
+It falls back to ASCII (`>a2 [###-----] 88% s2/5`) on terminals that can't render
+the box-drawing glyphs.
+
+> **Beta:** this is new. Migrations re-bill the context window, and the in-session
+> "ultracode" effort can't be persisted — the managed `xhigh` effort level is the
+> closest you can set outside a session. Please report rough edges via
+> [Issues](https://github.com/realiti4/claude-swap/issues).
 
 ### Refresh expired tokens
 
@@ -123,11 +178,15 @@ This will update the stored credentials without creating a duplicate.
 
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
+cswap launch                    # Start a load-balanced managed session (Beta)
 cswap --list                    # Show all accounts with 5h/7d usage and reset times
-cswap --status                  # Show current account
+cswap --status                  # Show current account + load-balancer/embed health
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
 cswap --remove-account 2        # Remove an account
-cswap --tui                     # Launch the interactive arrow-key menu (incl. auto-switch, Beta)
+cswap --install                 # Embed cswap into Claude Code for load balancing (Beta)
+cswap --balance                 # Load-balancer dashboard + settings (Beta)
+cswap --set-priority 2:5        # Set an account's balancing priority (Beta)
+cswap --tui                     # Launch the interactive arrow-key menu
 cswap --upgrade                 # Upgrade claude-swap to the latest version
 cswap --purge                   # Remove all claude-swap data
 ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,11 @@ cswap launch --no-share         # bare profile (don't share ~/.claude items)
 supervises claude until it exits — migrating or pausing/auto-resuming as limits
 are reached. Managed sessions get QoL defaults: the latest model,
 `--dangerously-skip-permissions`, and high effort (any flag you pass yourself
-wins). Plain `claude` and `cswap run` are unaffected.
+wins); these launch-flag defaults don't apply to plain `claude` or `cswap run`.
+Both `cswap launch` and `cswap run` pre-trust their launch directory in the
+session's isolated profile, so the spawned session skips Claude Code's "do you
+trust this folder?" prompt — managed sessions use a fresh profile per launch, so
+it would otherwise appear every time. Plain `claude` is unaffected.
 
 #### Priorities
 
@@ -156,6 +160,19 @@ cswap --balance                 # settings + live dashboard (enable/disable, tun
 The dashboard shows which sessions are on which accounts, live, and is where you
 **enable** the balancer (it's opt-in/off by default), set the threshold and target
 safety, and edit priorities.
+
+The live view lists **every** managed account — not just the ones currently in
+use — with, per account:
+
+- how many sessions are running on it,
+- its **5h** and **weekly (7d)** usage percentages and how long until each window
+  resets, and
+- when **Keep 5h sessions warm** is enabled, whether the account's 5h window is
+  `warm` (clock running) or `cold` (unstarted — a priming candidate).
+
+Idle-account usage is fetched in the background (and cached) so the numbers stay
+current without slowing the view. An account that's logged out or unreadable shows
+`usage unavailable`.
 
 #### Statusline
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cswap --status                  # shows load-balancer state + embed health
 ```
 
 `--install` installs the statusline and QoL layer via a non-shared
-`settings.local.json` inside each managed profile, so plain `claude` and
+`settings.json` inside each managed profile, so plain `claude` and
 `cswap run` stay completely vanilla. It also runs automatically on upgrade.
 
 #### Launch a managed session

--- a/README.md
+++ b/README.md
@@ -192,6 +192,17 @@ Managed sessions instead auto-fall-back to a secondary model via Claude's native
 cswap launch -- --fallback-model haiku   # your flag wins; cswap won't double-add
 ```
 
+**Transient/network errors** (a dropped socket, connection reset, timeout, a brief
+`502`/`503`/overload — e.g. "API Error: 401 The socket connection was closed
+unexpectedly") are handled separately from account problems. Managed sessions raise
+`CLAUDE_CODE_MAX_RETRIES` (default `20`, respecting your own override) so these get
+more in-turn retry-with-backoff and usually self-heal before the turn ever fails.
+The safety net deliberately **leaves them alone** — account migration is only for
+real rate limits, and credential refresh only for genuinely expired creds — so a
+connection glitch is never mistaken for bad credentials or an exhausted account.
+The one limitation: a turn that still fails after all retries can't be auto-re-run
+(a Claude Code limitation), so that single message is re-sent manually.
+
 #### cmux integration (Beta, macOS)
 
 If you use [cmux](https://cmux.com), wire the balancer into it:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ cswap --switch-to user@example.com
 
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.
 
+### Auto-switch at usage limit (Beta)
+
+Launch the interactive menu and open **Auto-switch at limit (Beta)**:
+
+```bash
+cswap --tui
+```
+
+From there you can:
+
+- **Enable/Disable** automatic switching (the setting persists across runs).
+- **Set threshold** — the usage percentage that triggers a switch (default `95%`).
+- **Start monitor now** — runs a foreground watcher that polls the active
+  account's 5h/7d usage every 60 seconds. When usage reaches the threshold, it
+  rotates to the next managed account (same rotation as `cswap --switch`), then
+  keeps watching the new account. Press `s` to check immediately, or `q`/`Esc`
+  to stop.
+
+Because switching doesn't require a Claude Code restart (see the note above),
+the new account takes effect on your next message — on macOS once the Keychain
+cache expires. The monitor runs only while its screen is open in the TUI; there
+is no background daemon.
+
+> **Beta:** this feature is new and runs as a foreground watcher. The usage
+> percentages come from the same API as `cswap --list`. Please report any rough
+> edges via [Issues](https://github.com/realiti4/claude-swap/issues).
+
 ### Refresh expired tokens
 
 If an account's token expires, log back into Claude Code with that account and re-run:
@@ -86,7 +113,7 @@ cswap --list                    # Show all accounts with 5h/7d usage and reset t
 cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
 cswap --remove-account 2        # Remove an account
-cswap --tui                     # Launch the interactive arrow-key menu
+cswap --tui                     # Launch the interactive arrow-key menu (incl. auto-switch, Beta)
 cswap --upgrade                 # Upgrade claude-swap to the latest version
 cswap --purge                   # Remove all claude-swap data
 ```

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ connection glitch is never mistaken for bad credentials or an exhausted account.
 The one limitation: a turn that still fails after all retries can't be auto-re-run
 (a Claude Code limitation), so that single message is re-sent manually.
 
-#### Idle-window priming (Beta, experimental — default OFF, opt-in)
+#### Keep 5h sessions warm (Beta, experimental — default OFF, opt-in)
 
 > **Unverified premise — opt-in only.** This feature assumes a Claude
 > subscription's 5-hour limit window is *fixed-from-first-use* (it starts counting
@@ -224,7 +224,7 @@ The one limitation: a turn that still fails after all retries can't be auto-re-r
 > priming is useless and should be removed. Because priming spends real credits,
 > it ships **disabled by default** behind a dedicated opt-in — independent of the
 > balancer's own enable — and must be turned on explicitly:
-> `Set up cswap` → `Auto-swap + multi-session load balancer (beta)` → `Prime idle 5h windows`.
+> `Set up cswap` → `Auto-swap + multi-session load balancer (beta)` → `Keep 5h sessions warm`.
 
 If the fixed-from-first-use premise holds, an account you haven't used yet this
 window has an *unstarted* clock that won't reset for a full 5 hours after you
@@ -238,6 +238,10 @@ It is conservative and credit-frugal:
 - Only accounts whose 5h window is genuinely **unstarted** (read via the usage
   API, which itself doesn't bill) are primed — never an account already running
   a window, already weekly-capped, in active use, or whose usage is unknown.
+- Only recognized Claude **subscription** accounts (Pro / Max / Team / Enterprise)
+  are ever primed. A pay-as-you-go **API / console** account is skipped entirely —
+  it has no 5h subscription window to warm, and priming it would spend real API
+  credits.
 - Each account is primed **at most once per window**; a per-account guard plus a
   shared once-per-interval sweep stamp mean that even with several managed
   sessions running, exactly one of them primes each account per interval (no
@@ -277,6 +281,30 @@ hook (the balancer's triggers) live in that profile and use events cmux
 doesn't touch, so both run side by side and your `CLAUDE_CONFIG_DIR` pin is
 preserved. With it **off**, cmux passes `claude` through untouched and cswap's
 profile settings drive everything. Nothing to configure either way.
+
+### Quick start (configurable default command)
+
+Tired of typing the same launch command? Turn on **Quick start** and a bare
+`cswap` becomes a configurable alias — it runs whatever command you set, with any
+extra args you pass appended to it:
+
+```bash
+cswap                       # runs your Quick-start command
+cswap -- --resume <id>      # ...with extra args appended (forwarded to claude)
+```
+
+Enable and edit it in `Set up cswap` → `Quick start`. It's **default OFF**, and
+the default command launches a load-balanced session with the QoL defaults baked
+in:
+
+```
+cswap launch -- --dangerously-skip-permissions --model claude-opus-4-8 --settings '{"ultracode": true}'
+```
+
+Quick start only fires when the first argument **isn't** a recognized cswap
+subcommand or flag — so `cswap --status`, `cswap run 2`, `cswap launch …`, and
+every other command keep working exactly as before. Only a bare/unrecognized
+invocation is treated as Quick-start input.
 
 ### Refresh expired tokens
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,29 @@ the box-drawing glyphs.
 > closest you can set outside a session. Please report rough edges via
 > [Issues](https://github.com/realiti4/claude-swap/issues).
 
+#### Rate-limit safety net
+
+The balancer migrates **proactively**, the moment the statusline reports an
+account crossing the threshold. If a turn still hits a hard **rate limit**
+(HTTP 429 — the "Retrying… attempt N/10" storm), a `StopFailure` safety net kicks
+in: when the turn fails after Claude exhausts its retries and the session's
+account is genuinely rate-limited, cswap auto-switches the session to a fresh
+account so the **next** turn recovers — no manual switching. The failed turn
+itself is lost (no hook can rescue an in-flight turn — a Claude Code limitation),
+so this is a backstop, not a substitute for the proactive migration.
+
+Want more margin? Lower the threshold in `cswap --balance` so the balancer
+migrates earlier and rarely reaches a hard limit.
+
+An **overload** (HTTP 529 "Overloaded") is different: it's server/model-side, so
+every account hits the same overloaded model — switching accounts wouldn't help.
+Managed sessions instead auto-fall-back to a secondary model via Claude's native
+`--fallback-model` (default `sonnet`). Override it per launch:
+
+```bash
+cswap launch -- --fallback-model haiku   # your flag wins; cswap won't double-add
+```
+
 #### cmux integration (Beta, macOS)
 
 If you use [cmux](https://cmux.com), wire the balancer into it:

--- a/README.md
+++ b/README.md
@@ -87,9 +87,20 @@ Your `~/.claude` customizations (settings, keybindings, CLAUDE.md, skills, comma
 Run several Claude Code sessions across all your accounts and let cswap keep them
 fed. When a session's account nears its usage limit, cswap migrates that session
 to a higher-priority account that still has headroom — concentrating load on your
-top accounts and only spilling to the next tier when one fills up. Migrations are
-minimized (each one re-bills the context window), so a session only moves when its
-account is actually exhausted, never for a marginal gain.
+top accounts and only spilling to the next tier when one fills up. Among accounts
+of the same priority, load spreads to the least-used one, so equal-priority
+accounts stay evenly used. Migrations are minimized (each one re-bills the context
+window), so a session only moves when its account is actually exhausted, never for
+a marginal gain.
+
+There's **no fixed cooldown timer** holding back a needed switch — a session
+stranded on a freshly-exhausted account moves immediately. Thrashing is instead
+prevented *algorithmically*: cswap acts only on the moment an account crosses the
+threshold (a rising edge, not every message), only picks a target that will stay
+under its safety ceiling after the move (so it can't immediately re-exhaust), and
+won't treat an exhausted account as a valid target again until it recovers past a
+hysteresis band. A concurrent online reservation keeps two sessions from landing
+on the same account at once.
 
 Only one subscription? There's nowhere to migrate, so cswap **pauses** the session
 instead and **auto-resumes** it (via `claude --resume`) the moment the limit
@@ -143,8 +154,8 @@ cswap --balance                 # settings + live dashboard (enable/disable, tun
 ```
 
 The dashboard shows which sessions are on which accounts, live, and is where you
-**enable** the balancer (it's opt-in/off by default), set the threshold/target/
-cooldown, and edit priorities.
+**enable** the balancer (it's opt-in/off by default), set the threshold and target
+safety, and edit priorities.
 
 #### Statusline
 
@@ -202,6 +213,41 @@ real rate limits, and credential refresh only for genuinely expired creds — so
 connection glitch is never mistaken for bad credentials or an exhausted account.
 The one limitation: a turn that still fails after all retries can't be auto-re-run
 (a Claude Code limitation), so that single message is re-sent manually.
+
+#### Idle-window priming (Beta, experimental — default OFF, opt-in)
+
+> **Unverified premise — opt-in only.** This feature assumes a Claude
+> subscription's 5-hour limit window is *fixed-from-first-use* (it starts counting
+> on the first credit-consuming request of a cycle and resets a fixed 5 hours
+> later), rather than a rolling trailing-5h window. That assumption has **not yet
+> been confirmed against a live account**. If the window turns out to be rolling,
+> priming is useless and should be removed. Because priming spends real credits,
+> it ships **disabled by default** behind a dedicated opt-in — independent of the
+> balancer's own enable — and must be turned on explicitly:
+> `Set up cswap` → `Load balancer (Beta)` → `Prime idle 5h windows`.
+
+If the fixed-from-first-use premise holds, an account you haven't used yet this
+window has an *unstarted* clock that won't reset for a full 5 hours after you
+first touch it. To keep fresh 5h capacity cycling online, when priming is enabled
+cswap sends one minimal, cheapest-model request (Haiku, a 1-token prompt,
+`max_tokens: 1`) to each idle managed account to start its clock, so windows stay
+staggered instead of all starting at once.
+
+It is conservative and credit-frugal:
+
+- Only accounts whose 5h window is genuinely **unstarted** (read via the usage
+  API, which itself doesn't bill) are primed — never an account already running
+  a window, already weekly-capped, in active use, or whose usage is unknown.
+- Each account is primed **at most once per window**; a per-account guard plus a
+  shared once-per-interval sweep stamp mean that even with several managed
+  sessions running, exactly one of them primes each account per interval (no
+  duplicate billable calls).
+- Priming rides the **resident session supervisor** — there is still no daemon and
+  no polling loop, and it never blocks the statusline render. The tiny prime
+  requests run in the background of an already-running managed session.
+
+Priming stages fresh **5-hour** capacity; it does not create weekly (7-day)
+capacity, so an account whose 7d cap is the binding limit is left alone.
 
 #### cmux integration (Beta, macOS)
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ instead and **auto-resumes** it (via `claude --resume`) the moment the limit
 window resets — your in-flight, dynamic workflow survives the limit instead of
 being thrown away.
 
+By default the balancer is **subscription-only**: it never spends tokens billed at
+pay-as-you-go API rates. When *every* subscription account is exhausted it pauses
+(as above) rather than spilling into extra-usage / an API account. If you'd rather
+keep working than wait for a reset, turn **Only use subscription tokens** off in
+`cswap --balance`: cswap then treats extra-usage–enabled and API/console accounts as
+a **last-resort tier** — consulted only after all subscription headroom is gone, and
+ordered by most monthly extra-usage budget remaining. A session already on an
+extra-usage account stays put (it spills into pay-as-you-go) instead of pausing. It's
+**off by default** so you never get a surprise API bill.
+
 It's fully **event-driven**: the in-session statusline reports usage on each
 message, which is what triggers a rebalance. There's no polling loop and no
 background daemon. It's also credential-safe — each session's supervisor owns its
@@ -159,7 +169,8 @@ cswap --balance                 # settings + live dashboard (enable/disable, tun
 
 The dashboard shows which sessions are on which accounts, live, and is where you
 **enable** the balancer (it's opt-in/off by default), set the threshold and target
-safety, and edit priorities.
+safety, edit priorities, and toggle **Only use subscription tokens** (default on —
+pause rather than bill at API rates).
 
 The live view lists **every** managed account — not just the ones currently in
 use — with, per account:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,26 @@ the box-drawing glyphs.
 > closest you can set outside a session. Please report rough edges via
 > [Issues](https://github.com/realiti4/claude-swap/issues).
 
+#### cmux integration (Beta, macOS)
+
+If you use [cmux](https://cmux.com), wire the balancer into it:
+
+```bash
+cswap cmux setup                # add a "Balanced Claude (cswap)" command to cmux
+cswap cmux 2                    # fan out 2 managed sessions, one per workspace
+cswap cmux 2 -- --resume        # forward args after '--' to each session's claude
+```
+
+`setup` backs up `~/.config/cmux/cmux.json` to a timestamped `.bak`, merges the
+surface idempotently (your other config is preserved), then validates and
+reloads. Afterwards you can spawn a load-balanced session from cmux's command
+palette / plus-button.
+
+`cswap cmux N` opens N cmux workspaces, each running `cswap launch`. The
+balancer's online reservation spreads them, so each pane **lands on a different
+account** — and each renders the same compact statusline as above. cswap pins
+every pane to its own profile, surviving cmux's `claude` wrapper.
+
 ### Refresh expired tokens
 
 If an account's token expires, log back into Claude Code with that account and re-run:
@@ -179,6 +199,8 @@ This will update the stored credentials without creating a duplicate.
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
 cswap launch                    # Start a load-balanced managed session (Beta)
+cswap cmux setup                # Add a balanced-Claude command to cmux (Beta, macOS)
+cswap cmux 2                    # Fan out 2 managed sessions across accounts in cmux
 cswap --list                    # Show all accounts with 5h/7d usage and reset times
 cswap --status                  # Show current account + load-balancer/embed health
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cswap run 2 --no-share          # don't share your ~/.claude customizations
 
 Your `~/.claude` customizations (settings, keybindings, CLAUDE.md, skills, commands, agents) are shared into the session by default — use `--no-share` for a bare profile. Conversation history stays per-account.
 
-### Load balancer (Beta)
+### Auto-swap + multi-session load balancer (beta)
 
 Run several Claude Code sessions across all your accounts and let cswap keep them
 fed. When a session's account nears its usage limit, cswap migrates that session
@@ -224,7 +224,7 @@ The one limitation: a turn that still fails after all retries can't be auto-re-r
 > priming is useless and should be removed. Because priming spends real credits,
 > it ships **disabled by default** behind a dedicated opt-in — independent of the
 > balancer's own enable — and must be turned on explicitly:
-> `Set up cswap` → `Load balancer (Beta)` → `Prime idle 5h windows`.
+> `Set up cswap` → `Auto-swap + multi-session load balancer (beta)` → `Prime idle 5h windows`.
 
 If the fixed-from-first-use premise holds, an account you haven't used yet this
 window has an *unstarted* clock that won't reset for a full 5 hours after you
@@ -268,6 +268,15 @@ palette / plus-button.
 balancer's online reservation spreads them, so each pane **lands on a different
 account** — and each renders the same compact statusline as above. cswap pins
 every pane to its own profile, surviving cmux's `claude` wrapper.
+
+cswap works alongside cmux's **Claude Code Integration** toggle in either
+setting. With it **on**, cmux injects its session-tracking/notification hooks
+via the `--settings` flag, which Claude Code merges *additively* with each
+managed profile's `settings.json`; cswap's `statusLine` and `StopFailure`
+hook (the balancer's triggers) live in that profile and use events cmux
+doesn't touch, so both run side by side and your `CLAUDE_CONFIG_DIR` pin is
+preserved. With it **off**, cmux passes `claude` through untouched and cswap's
+profile settings drive everything. Nothing to configure either way.
 
 ### Refresh expired tokens
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ account so the **next** turn recovers — no manual switching. The failed turn
 itself is lost (no hook can rescue an in-flight turn — a Claude Code limitation),
 so this is a backstop, not a substitute for the proactive migration.
 
+A **401 auth failure** (a "Please run /login · API Error: 401" turn) auto-recovers
+the same way: cswap refreshes the account's token and re-seeds the session, and if
+the account is logged out it migrates the session to a healthy account (re-login on
+one account if they're all dead) — so the **next** turn re-authenticates.
+
 Want more margin? Lower the threshold in `cswap --balance` so the balancer
 migrates earlier and rarely reaches a hard limit.
 

--- a/src/claude_swap/balancer.py
+++ b/src/claude_swap/balancer.py
@@ -137,14 +137,19 @@ class AccountView:
     # resets (the window equal to ``max_pct``); ``None`` if unknown.
     soonest_reset: int | None = None
     signal: str = "none"  # "live" (statusline) | "cache" (usage API) | "none"
-    # The 5h-window-specific utilization + reset, used ONLY by the idle-window
-    # priming detection (:func:`accounts_needing_prime`). ``five_hour_pct`` is the
-    # 5h utilization percent (distinct from ``max_pct``, which is max(5h, 7d));
-    # ``five_hour_reset`` is the 5h window's reset epoch when the clock is running
-    # (``None`` when the window is unstarted — the signal we prime on). Both are
-    # ``None`` when usage is unknown.
+    # The 5h-window-specific utilization + reset, used by the idle-window priming
+    # detection (:func:`accounts_needing_prime`) and surfaced in the dashboard.
+    # ``five_hour_pct`` is the 5h utilization percent (distinct from ``max_pct``,
+    # which is max(5h, 7d)); ``five_hour_reset`` is the 5h window's reset epoch when
+    # the clock is running (``None`` when the window is unstarted — the signal we
+    # prime on). Both are ``None`` when usage is unknown.
     five_hour_pct: float | None = None
     five_hour_reset: int | None = None
+    # The 7d-window-specific utilization + reset, for the dashboard's per-window
+    # breakdown. Carried separately from ``max_pct`` so the view can show the 5h
+    # and weekly caps independently. ``None`` when usage is unknown.
+    seven_day_pct: float | None = None
+    seven_day_reset: int | None = None
 
 
 @dataclass(frozen=True)
@@ -335,6 +340,23 @@ def _five_hour_unstarted(av: AccountView, cfg: BalancerConfig) -> bool:
     if av.five_hour_reset is not None:
         return False  # a concrete reset timestamp means the clock is already running
     return av.five_hour_pct <= PRIME_FIVE_HOUR_EPSILON
+
+
+def five_hour_warm(av: AccountView) -> bool | None:
+    """Tri-state: is the account's 5h window started (warm)? ``None`` if unknown.
+
+    The inverse of the priming clock-check (:func:`_five_hour_unstarted`): a window
+    with a concrete future reset, or pct above the epsilon, is already running
+    (warm); a ~0% window with no reset is cold (unstarted — exactly what the
+    idle-window priming targets). ``None`` when 5h usage is unknown (no signal), so
+    a view can show "?" rather than a misleading "cold". Used by the dashboard to
+    report whether each account's 5h window has been warmed.
+    """
+    if av.five_hour_pct is None:
+        return None
+    if av.five_hour_reset is not None:
+        return True
+    return av.five_hour_pct > PRIME_FIVE_HOUR_EPSILON
 
 
 def accounts_needing_prime(

--- a/src/claude_swap/balancer.py
+++ b/src/claude_swap/balancer.py
@@ -86,6 +86,13 @@ class BalancerConfig:
     target_safety: int = DEFAULT_TARGET_SAFETY
     hysteresis_band: int = DEFAULT_HYSTERESIS_BAND
     pause_fallback_s: int = DEFAULT_PAUSE_FALLBACK_S
+    # When True (the default), the balancer NEVER spends tokens billed at API
+    # rates: a session whose every *subscription* account is exhausted is paused
+    # until a window resets rather than spilling into pay-as-you-go extra-usage or
+    # an API/console account. When False, such accounts become a last-resort tier
+    # (used only after all subscription headroom is gone) so work continues instead
+    # of stopping. See :func:`_api_capable` / :func:`_rank_api_accounts`.
+    only_subscription: bool = True
 
 
 def config_from_dict(auto_balance: dict | None) -> BalancerConfig:
@@ -111,11 +118,15 @@ def config_from_dict(auto_balance: dict | None) -> BalancerConfig:
     if safety < 1:
         safety = 1
     band = max(0, _int("hysteresisBand", DEFAULT_HYSTERESIS_BAND))
+    # Default True: stay subscription-only (pause rather than bill at API rates)
+    # unless the user has explicitly opted into the API-rate last-resort tier.
+    only_subscription = bool(cfg.get("onlySubscriptionTokens", True))
     return BalancerConfig(
         exhaust_threshold=exhaust,
         target_safety=safety,
         hysteresis_band=band,
         pause_fallback_s=DEFAULT_PAUSE_FALLBACK_S,
+        only_subscription=only_subscription,
     )
 
 
@@ -150,6 +161,15 @@ class AccountView:
     # and weekly caps independently. ``None`` when usage is unknown.
     seven_day_pct: float | None = None
     seven_day_reset: int | None = None
+    # Pay-as-you-go capacity. ``extra_usage`` is True when the account can serve
+    # tokens past its subscription window at API rates (extra-usage / overflow
+    # billing enabled, or a pure API/console account). ``spend_pct`` is the monthly
+    # extra-usage budget utilization (0-100), used to skip an account that has
+    # maxed its monthly cap. Both feed the API-rate last-resort tier
+    # (:func:`_api_capable`), which is only ever consulted when
+    # ``cfg.only_subscription`` is False.
+    extra_usage: bool = False
+    spend_pct: float | None = None
 
 
 @dataclass(frozen=True)
@@ -272,6 +292,51 @@ def _fits(av: AccountView, projected: dict[str, float], cost: float, cfg: Balanc
 
 
 # --------------------------------------------------------------------------- #
+# API-rate last-resort tier (only consulted when ``cfg.only_subscription`` is
+# False) — accounts that can keep work going past their subscription window by
+# billing at pay-as-you-go / API rates.
+# --------------------------------------------------------------------------- #
+
+# Monthly extra-usage budget is a HARD cap (unlike the soft subscription
+# threshold): once spend hits 100% there is no pay-as-you-go capacity left.
+_SPEND_CAP_PCT = 100.0
+
+
+def _api_capable(av: AccountView | None, cfg: BalancerConfig) -> bool:
+    """Whether ``av`` can serve tokens at API rates right now (last resort).
+
+    True when the account has pay-as-you-go capacity — extra-usage / overflow
+    billing enabled (or a pure API/console account) — and its monthly extra-usage
+    budget is not maxed. Independent of the subscription window: an account with
+    subscription headroom is handled by the preferred tier (:func:`_rank_accounts`)
+    and only falls through to here once that window is exhausted. ``spend_pct``
+    unknown (``None``) is treated as having budget. Never True under
+    ``cfg.only_subscription`` callers (they don't consult this tier at all).
+    """
+    return (
+        av is not None
+        and av.extra_usage
+        and (av.spend_pct is None or av.spend_pct < _SPEND_CAP_PCT)
+    )
+
+
+def _rank_api_accounts(
+    acct_views: dict[str, AccountView], cfg: BalancerConfig
+) -> list[AccountView]:
+    """API-rate-capable accounts, best last-resort target first.
+
+    Ordering: least monthly extra-usage spent first (most pay-as-you-go budget
+    left, so we don't immediately hit a cap), then higher priority, then lowest
+    account number for a deterministic final tiebreak.
+    """
+    capable = [a for a in acct_views.values() if _api_capable(a, cfg)]
+    return sorted(
+        capable,
+        key=lambda a: (a.spend_pct if a.spend_pct is not None else 0.0, -a.priority, _num_key(a.num)),
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Decisions
 # --------------------------------------------------------------------------- #
 
@@ -297,6 +362,12 @@ def assign_new_session(
     for a in _rank_accounts(acct_views, projected, cfg):
         if _fits(a, projected, cost, cfg):
             return a.num
+    # No subscription account has headroom. Unless we're subscription-only, fall
+    # back to the API-rate tier (last resort) so the session starts working
+    # instead of starting paused.
+    if not cfg.only_subscription:
+        for a in _rank_api_accounts(acct_views, cfg):
+            return a.num
     return None
 
 
@@ -320,6 +391,18 @@ def choose_migration_target(
             continue
         if _fits(a, projected, cost, cfg):
             return a.num
+    if cfg.only_subscription:
+        return None
+    # No subscription headroom. If the session's CURRENT account can keep going at
+    # API rates (extra-usage), stay put — don't thrash between API-rate accounts;
+    # ``None`` here tells the caller to KEEP it. Otherwise migrate to the
+    # best-budget API-rate account so work continues instead of pausing.
+    if _api_capable(acct_views.get(s.account_num), cfg):
+        return None
+    for a in _rank_api_accounts(acct_views, cfg):
+        if a.num == s.account_num:
+            continue
+        return a.num
     return None
 
 
@@ -491,7 +574,14 @@ def rebalance(
     for s in stranded:
         tgt = choose_migration_target(s, acct_views, projected, cfg)
         if tgt is None:
-            actions.append(pause_decision(s, acct_views, now, cfg))
+            # No subscription target. When the API-rate tier is enabled and the
+            # current account can still serve at API rates (extra-usage), KEEP the
+            # session there (it spills into pay-as-you-go) rather than pausing —
+            # "do anything besides stopping work". Otherwise pause until reset.
+            if not cfg.only_subscription and _api_capable(acct_views.get(s.account_num), cfg):
+                actions.append(Action("KEEP", s.session_id, s.account_num, s.account_num))
+            else:
+                actions.append(pause_decision(s, acct_views, now, cfg))
         elif tgt == s.account_num:  # defensive; choose_migration_target excludes current
             actions.append(Action("KEEP", s.session_id, s.account_num, s.account_num))
         else:

--- a/src/claude_swap/balancer.py
+++ b/src/claude_swap/balancer.py
@@ -1,0 +1,370 @@
+"""Pure decision logic for the event-driven account load balancer (Beta).
+
+This module is deliberately **I/O-free and dependency-free** (no imports from
+:mod:`claude_swap.switcher`, :mod:`~.session`, :mod:`~.oauth`, the network, or
+the filesystem). It takes immutable snapshots of the world — the managed
+accounts and the live managed sessions — and returns a :class:`Plan` of
+:class:`Action` s. The caller (the statusline planner and the per-session
+supervisor) is responsible for all I/O: building the snapshot, persisting the
+plan's intents to the registry, and re-pointing credentials.
+
+Keeping the decision logic pure makes it exhaustively unit-testable with
+synthetic snapshots (see ``tests/test_balancer.py``) and keeps the hard part —
+*minimising churn while honouring priority* — separated from the credential
+plumbing.
+
+The model in one paragraph: new sessions are placed on the **highest-priority**
+account that has headroom, so load naturally *concentrates* on high-priority
+accounts and only spills to the next tier when one fills up (you "burn through"
+high-priority accounts first). A session is **migrated only when its current
+account is exhausted** — never for a marginal gain — and three independent
+brakes (a rising-edge trigger applied by the caller, a per-session cooldown, and
+a hysteresis band) stop a session from bouncing between accounts. When nothing
+has headroom, sessions are **paused** until the soonest rate-limit window
+resets, and resumed automatically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# --------------------------------------------------------------------------- #
+# Tunable constants (defaults; overridable per-install via sequence.json's
+# ``autoBalance`` block, see :func:`config_from_dict`).
+# --------------------------------------------------------------------------- #
+
+# An account is "exhausted" once max(5h, 7d) utilization reaches this percent.
+# Shares the default with the legacy auto-switch threshold.
+DEFAULT_EXHAUST_THRESHOLD = 95
+# A migration target's *projected* utilization (after placing the session) must
+# stay at or below this. The gap to the exhaust threshold absorbs the per-session
+# headroom reserve so a move never immediately re-exhausts the target.
+DEFAULT_TARGET_SAFETY = 90
+# An exhausted account only re-enters the usable pool once it drops this many
+# points below the exhaust threshold — absorbs the chunky, API-call-only jitter
+# of the statusline's ``used_percentage`` so accounts don't flap at the boundary.
+DEFAULT_HYSTERESIS_BAND = 3
+# Minimum seconds between migrations of the same session — the hard rate limit
+# that prevents A->B->A thrashing (each migration re-bills the context window).
+DEFAULT_MIGRATION_COOLDOWN = 600
+# Pause horizon when no reset time is known anywhere (defensive fallback).
+DEFAULT_PAUSE_FALLBACK_S = 3600
+
+# Per-session headroom reserve, in utilization points, debited from a target
+# when a session is (re)placed within a single balancing pass. A fixed base plus
+# a context-proportional nudge (bigger conversations cost more to migrate, so we
+# leave them more room). Bounded to BASE..BASE+CTX_MAX.
+BASE_RESERVE = 3.0
+CTX_RESERVE_MAX = 7.0
+CTX_RESERVE_DIVISOR = 50_000  # context tokens per extra reserve point
+
+# How recently a session must have been seen to count as "active" (used only to
+# order migrations: least-active sessions move first).
+_ACTIVE_RECENT_S = 120
+
+
+@dataclass(frozen=True)
+class BalancerConfig:
+    """Resolved balancer tunables for one decision pass."""
+
+    exhaust_threshold: int = DEFAULT_EXHAUST_THRESHOLD
+    target_safety: int = DEFAULT_TARGET_SAFETY
+    hysteresis_band: int = DEFAULT_HYSTERESIS_BAND
+    migration_cooldown: int = DEFAULT_MIGRATION_COOLDOWN
+    pause_fallback_s: int = DEFAULT_PAUSE_FALLBACK_S
+
+
+def config_from_dict(auto_balance: dict | None) -> BalancerConfig:
+    """Build a :class:`BalancerConfig` from a persisted ``autoBalance`` dict.
+
+    Missing or malformed fields fall back to the module defaults; the result is
+    clamped so the load-bearing invariant
+    ``exhaust_threshold - target_safety >= BASE_RESERVE`` always holds (otherwise
+    a freshly-migrated session could be judged exhausted on its next tick).
+    """
+    cfg = auto_balance or {}
+
+    def _int(key: str, default: int) -> int:
+        try:
+            return int(cfg.get(key, default))
+        except (TypeError, ValueError):
+            return default
+
+    exhaust = max(1, min(100, _int("threshold", DEFAULT_EXHAUST_THRESHOLD)))
+    safety = max(1, min(100, _int("targetSafety", DEFAULT_TARGET_SAFETY)))
+    # Keep at least BASE_RESERVE of margin between safety and exhaust.
+    safety = min(safety, exhaust - int(BASE_RESERVE))
+    if safety < 1:
+        safety = 1
+    band = max(0, _int("hysteresisBand", DEFAULT_HYSTERESIS_BAND))
+    cooldown = max(0, _int("cooldownSeconds", DEFAULT_MIGRATION_COOLDOWN))
+    return BalancerConfig(
+        exhaust_threshold=exhaust,
+        target_safety=safety,
+        hysteresis_band=band,
+        migration_cooldown=cooldown,
+        pause_fallback_s=DEFAULT_PAUSE_FALLBACK_S,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Immutable world snapshot
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class AccountView:
+    """A managed account's balancing-relevant state at one instant."""
+
+    num: str
+    priority: int = 0
+    # max(5h, 7d) utilization percent; ``None`` when usage is unknown (no signal)
+    # — an account with unknown usage has zero headroom and is never a target.
+    max_pct: float | None = None
+    # Epoch seconds when the window that is *currently capping* this account
+    # resets (the window equal to ``max_pct``); ``None`` if unknown.
+    soonest_reset: int | None = None
+    signal: str = "none"  # "live" (statusline) | "cache" (usage API) | "none"
+
+
+@dataclass(frozen=True)
+class SessionView:
+    """A managed session's balancing-relevant state at one instant."""
+
+    session_id: str
+    account_num: str
+    ctx_tokens: int = 0
+    last_seen: float = 0.0
+    paused_until: int | None = None
+    last_migrated_at: float = 0.0
+    pinned_account: str | None = None  # user hard-pin; never migrated/paused
+
+
+@dataclass(frozen=True)
+class Action:
+    """A single decision for one session."""
+
+    kind: str  # "MIGRATE" | "PAUSE" | "RESUME" | "KEEP"
+    session_id: str
+    from_account: str | None = None
+    to_account: str | None = None
+    resume_at: int | None = None  # PAUSE only: epoch seconds
+
+
+@dataclass(frozen=True)
+class Plan:
+    """The full set of decisions from one balancing pass (deterministic order)."""
+
+    actions: list[Action] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+
+def _pct_cost(ctx_tokens: int | None) -> float:
+    """Headroom (utilization points) one session is expected to consume.
+
+    A fixed base plus a context-proportional term: a session with a large
+    context window costs more to host (and more to migrate), so it is given a
+    wider safety reserve. Bounded to ``BASE_RESERVE .. BASE_RESERVE+CTX_RESERVE_MAX``.
+    """
+    extra = min(CTX_RESERVE_MAX, (ctx_tokens or 0) / CTX_RESERVE_DIVISOR)
+    return BASE_RESERVE + extra
+
+
+def _headroom(av: AccountView) -> float:
+    """Remaining utilization headroom; unknown usage counts as zero."""
+    return 100.0 - av.max_pct if av.max_pct is not None else 0.0
+
+
+def _exhausted(av: AccountView | None, cfg: BalancerConfig) -> bool:
+    return av is not None and av.max_pct is not None and av.max_pct >= cfg.exhaust_threshold
+
+
+def _usable(av: AccountView | None, cfg: BalancerConfig) -> bool:
+    """Whether an account is below the hysteresis-adjusted re-entry line."""
+    return (
+        av is not None
+        and av.max_pct is not None
+        and av.max_pct <= (cfg.exhaust_threshold - cfg.hysteresis_band)
+    )
+
+
+def _in_cooldown(s: SessionView, now: float, cfg: BalancerConfig) -> bool:
+    return (now - s.last_migrated_at) < cfg.migration_cooldown
+
+
+def _rank_accounts(
+    acct_views: dict[str, AccountView],
+    projected: dict[str, float],
+    cfg: BalancerConfig,
+) -> list[AccountView]:
+    """Usable accounts, best target first.
+
+    Ordered by: highest priority (burn high-priority first), then most
+    projected headroom within a priority tier, then lowest account number for
+    determinism.
+    """
+    usable = [a for a in acct_views.values() if _usable(a, cfg)]
+    return sorted(
+        usable,
+        key=lambda a: (
+            -a.priority,
+            -(100.0 - (a.max_pct + projected.get(a.num, 0.0))),
+            _num_key(a.num),
+        ),
+    )
+
+
+def _num_key(num: str) -> tuple[int, int | str]:
+    """Sort key that orders numeric account ids numerically, others lexically."""
+    return (0, int(num)) if str(num).isdigit() else (1, str(num))
+
+
+def _fits(av: AccountView, projected: dict[str, float], cost: float, cfg: BalancerConfig) -> bool:
+    return (av.max_pct + projected.get(av.num, 0.0) + cost) <= cfg.target_safety
+
+
+# --------------------------------------------------------------------------- #
+# Decisions
+# --------------------------------------------------------------------------- #
+
+
+def assign_new_session(
+    acct_views: dict[str, AccountView],
+    ctx_tokens: int,
+    now: float,
+    cfg: BalancerConfig,
+    projected: dict[str, float] | None = None,
+) -> str | None:
+    """Pick the account a brand-new managed session should launch on.
+
+    The highest-priority usable account whose projected utilization stays within
+    ``target_safety`` after placing this session. Returns the account number, or
+    ``None`` when nothing has room (the caller then starts the session paused).
+    """
+    projected = projected if projected is not None else {num: 0.0 for num in acct_views}
+    cost = _pct_cost(ctx_tokens)
+    for a in _rank_accounts(acct_views, projected, cfg):
+        if _fits(a, projected, cost, cfg):
+            return a.num
+    return None
+
+
+def choose_migration_target(
+    s: SessionView,
+    acct_views: dict[str, AccountView],
+    projected: dict[str, float],
+    cfg: BalancerConfig,
+) -> str | None:
+    """Best account to migrate ``s`` to, excluding its current account.
+
+    Highest priority first; only an account whose projected utilization stays
+    within ``target_safety`` qualifies (so a move never immediately re-exhausts
+    the target — the move-then-exhaust trap). ``None`` => the caller pauses.
+    """
+    cost = _pct_cost(s.ctx_tokens)
+    for a in _rank_accounts(acct_views, projected, cfg):
+        if a.num == s.account_num:
+            continue
+        if _fits(a, projected, cost, cfg):
+            return a.num
+    return None
+
+
+def pause_decision(
+    s: SessionView,
+    acct_views: dict[str, AccountView],
+    now: float,
+    cfg: BalancerConfig,
+) -> Action:
+    """Pause ``s`` until the soonest future reset across all accounts.
+
+    Uses the soonest *blocking-window* reset (each account's ``soonest_reset``
+    already tracks the window equal to its ``max_pct``), so a 5h reset that
+    leaves the 7d window capped does not resume the session prematurely.
+    """
+    resets = [
+        a.soonest_reset
+        for a in acct_views.values()
+        if a.soonest_reset and a.soonest_reset > now
+    ]
+    until = min(resets) if resets else int(now + cfg.pause_fallback_s)
+    return Action("PAUSE", s.session_id, from_account=s.account_num, resume_at=int(until))
+
+
+def rebalance(
+    acct_views: dict[str, AccountView],
+    sess_views: list[SessionView],
+    now: float,
+    cfg: BalancerConfig,
+) -> Plan:
+    """The core balancing pass — pure, deterministic, no I/O.
+
+    Phase A (resume): paused sessions whose timer elapsed *or* whose account
+    recovered below the hysteresis line.
+    Phase B (strand): non-pinned, non-paused, non-cooldown sessions whose
+    current account is exhausted.
+    Phase C (order): least-active / cheapest-context first, so a partial set of
+    moves stops early and the fewest expensive sessions are disturbed.
+    Phase D (place): greedily assign each stranded session a target with an
+    online headroom reservation (so two stranded sessions don't both land on the
+    same account and co-exhaust it); pause when nothing fits.
+    """
+    actions: list[Action] = []
+    projected: dict[str, float] = {num: 0.0 for num in acct_views}
+
+    # ---- Phase A: RESUME / collect expired pauses ---------------------------
+    # A paused session resumes only when its account has actually recovered
+    # below the hysteresis line. If the pause timer elapsed but the account is
+    # still capped, the session is "expired" and re-placed in Phase D (migrated
+    # to a usable account, or re-paused to the real reset) — never resumed into
+    # a still-capped account, and never both resumed and paused in one plan.
+    expired: list[SessionView] = []
+    for s in sorted(
+        (x for x in sess_views if x.paused_until is not None),
+        key=lambda x: x.session_id,
+    ):
+        cur = acct_views.get(s.account_num)
+        if _usable(cur, cfg):
+            actions.append(Action("RESUME", s.session_id, to_account=s.account_num))
+        elif now >= s.paused_until:
+            expired.append(s)
+        # else: still within the pause window and still capped -> leave paused.
+
+    # ---- Phase B: identify STRANDED ----------------------------------------
+    def is_stranded(s: SessionView) -> bool:
+        if s.pinned_account is not None:
+            return False
+        if s.paused_until is not None:  # paused sessions handled in Phase A
+            return False
+        if _in_cooldown(s, now, cfg):
+            return False
+        return _exhausted(acct_views.get(s.account_num), cfg)
+
+    stranded = [s for s in sess_views if is_stranded(s)]
+    stranded += [s for s in expired if s.pinned_account is None]
+
+    # ---- Phase C: order moves (least-active, cheapest first) ----------------
+    stranded.sort(
+        key=lambda s: (
+            (now - s.last_seen) < _ACTIVE_RECENT_S,  # active-recent sorts last
+            s.ctx_tokens,
+            s.session_id,
+        )
+    )
+
+    # ---- Phase D: place each, reserving headroom online ---------------------
+    for s in stranded:
+        tgt = choose_migration_target(s, acct_views, projected, cfg)
+        if tgt is None:
+            actions.append(pause_decision(s, acct_views, now, cfg))
+        elif tgt == s.account_num:  # defensive; choose_migration_target excludes current
+            actions.append(Action("KEEP", s.session_id, s.account_num, s.account_num))
+        else:
+            actions.append(Action("MIGRATE", s.session_id, s.account_num, tgt))
+            projected[tgt] = projected.get(tgt, 0.0) + _pct_cost(s.ctx_tokens)
+
+    return Plan(actions)

--- a/src/claude_swap/balancer.py
+++ b/src/claude_swap/balancer.py
@@ -56,6 +56,23 @@ DEFAULT_HYSTERESIS_BAND = 3
 # Pause horizon when no reset time is known anywhere (defensive fallback).
 DEFAULT_PAUSE_FALLBACK_S = 3600
 
+# The synthesized utilization assigned to an account a messages-API headroom
+# probe confirmed runnable RIGHT NOW (``signal="probe"``; see
+# ``registry.build_world`` / ``oauth.probe_messages_headroom``). A 2xx probe proves
+# only that "a turn works now", NOT an exact percentage, so we assume the account
+# is conservatively ~this full. The value is chosen against the default tunables:
+#   * < exhaust_threshold - hysteresis_band (90-3=87) so a probe-confirmed account
+#     is ``_usable`` => a stranded session CAN resume/migrate onto it (the point —
+#     beating an hour-long pause);
+#   * leaves room under target_safety (85) for exactly ONE zero-ctx session
+#     (80 + BASE_RESERVE=3 = 83 <= 85 fits) but NOT a second (after the first lands,
+#     the online reservation makes the second see 80+3+3=86 > 85 => does not fit),
+#     so two stranded sessions don't co-exhaust the same probe-confirmed account;
+#   * deliberately pessimistic so a probe (a guess) ranks BELOW any account with
+#     KNOWN real headroom below 80% — ``_rank_accounts`` sorts on projected headroom,
+#     and most genuinely-usable real accounts sit well under 80%.
+PROBE_CONFIRMED_PCT = 80.0
+
 # A 5h window is treated as UNSTARTED (a priming candidate) when its utilization
 # is at or below this many points. The Claude subscription 5h window is anchored
 # to the first credit-consuming call of a cycle: an account that has sent nothing
@@ -147,7 +164,10 @@ class AccountView:
     # Epoch seconds when the window that is *currently capping* this account
     # resets (the window equal to ``max_pct``); ``None`` if unknown.
     soonest_reset: int | None = None
-    signal: str = "none"  # "live" (statusline) | "cache" (usage API) | "none"
+    # "live" (statusline) | "cache" (usage API) | "probe" (messages-API headroom
+    # fallback — a 2xx confirmed runnable-now; max_pct is the synthesized
+    # PROBE_CONFIRMED_PCT, all per-window fields None) | "none" (unknown usage).
+    signal: str = "none"
     # The 5h-window-specific utilization + reset, used by the idle-window priming
     # detection (:func:`accounts_needing_prime`) and surfaced in the dashboard.
     # ``five_hour_pct`` is the 5h utilization percent (distinct from ``max_pct``,

--- a/src/claude_swap/balancer.py
+++ b/src/claude_swap/balancer.py
@@ -56,19 +56,29 @@ DEFAULT_HYSTERESIS_BAND = 3
 # Pause horizon when no reset time is known anywhere (defensive fallback).
 DEFAULT_PAUSE_FALLBACK_S = 3600
 
-# The synthesized utilization assigned to an account a messages-API headroom
-# probe confirmed runnable RIGHT NOW (``signal="probe"``; see
-# ``registry.build_world`` / ``oauth.probe_messages_headroom``). A 2xx probe proves
-# only that "a turn works now", NOT an exact percentage, so we assume the account
-# is conservatively ~this full. The value is chosen against the default tunables:
+# The CONSERVATIVE DEFAULT utilization assigned to an account a messages-API
+# headroom probe confirmed runnable RIGHT NOW (``signal="probe"``; see
+# ``registry.build_world`` / ``oauth.probe_messages_headroom``) when NO real reading
+# is available. A 2xx probe proves only that "a turn works now", NOT an exact
+# percentage, so absent any other signal we assume the account is conservatively
+# ~this full. NOTE: when the probe-confirmed account still carries a fresh last-known
+# REAL reading (a 429 marker threads it forward), ``registry._probe_view`` uses
+# ``min(PROBE_CONFIRMED_PCT, real)`` instead — a near-idle account (e.g. 27%) is not
+# pinned at 80, so a large-context session actually fits and migrates rather than
+# pausing for hours. The value is chosen against the default tunables:
 #   * < exhaust_threshold - hysteresis_band (90-3=87) so a probe-confirmed account
 #     is ``_usable`` => a stranded session CAN resume/migrate onto it (the point —
 #     beating an hour-long pause);
 #   * leaves room under target_safety (85) for exactly ONE zero-ctx session
-#     (80 + BASE_RESERVE=3 = 83 <= 85 fits) but NOT a second (after the first lands,
-#     the online reservation makes the second see 80+3+3=86 > 85 => does not fit),
-#     so two stranded sessions don't co-exhaust the same probe-confirmed account;
-#   * deliberately pessimistic so a probe (a guess) ranks BELOW any account with
+#     (80 + BASE_RESERVE=3 = 83 <= 85 fits) but NOT a second when 80 is the base
+#     (after the first lands, the online reservation makes the second see
+#     80+3+3=86 > 85 => does not fit). Co-exhaust protection does NOT rely on the 80
+#     itself: it is the ONLINE RESERVATION (``registry._reserve_load_by_account`` +
+#     the in-pass ``projected`` debit, both folded through ``_with_reserve``) that
+#     stacks a second session's cost on top of whatever base pct applies — so even
+#     when a real low reading lowers the base, a second session still can't co-land
+#     unless the account genuinely has room for both;
+#   * deliberately pessimistic so a bare probe (a guess) ranks BELOW any account with
 #     KNOWN real headroom below 80% — ``_rank_accounts`` sorts on projected headroom,
 #     and most genuinely-usable real accounts sit well under 80%.
 PROBE_CONFIRMED_PCT = 80.0

--- a/src/claude_swap/balancer.py
+++ b/src/claude_swap/balancer.py
@@ -16,12 +16,21 @@ plumbing.
 The model in one paragraph: new sessions are placed on the **highest-priority**
 account that has headroom, so load naturally *concentrates* on high-priority
 accounts and only spills to the next tier when one fills up (you "burn through"
-high-priority accounts first). A session is **migrated only when its current
-account is exhausted** — never for a marginal gain — and three independent
-brakes (a rising-edge trigger applied by the caller, a per-session cooldown, and
-a hysteresis band) stop a session from bouncing between accounts. When nothing
+high-priority accounts first). Among accounts of the *same* priority, placement
+prefers the **least-used** (most projected headroom) so equal-priority accounts
+stay evenly used over time. A session is **migrated only when its current
+account is exhausted** — never for a marginal gain — and three independent,
+*algorithmic* brakes (no timers) stop a session from bouncing between accounts:
+a rising-edge trigger applied by the caller (act only on the not-exhausted ->
+exhausted transition), the ``target_safety`` ceiling (a target's projected usage
+after placement must leave headroom, so a move never immediately re-exhausts it),
+and a hysteresis band (an exhausted account isn't a valid target until it
+recovers below ``threshold - band``). An online headroom reservation keeps two
+concurrently-stranded sessions from co-exhausting the same target. When nothing
 has headroom, sessions are **paused** until the soonest rate-limit window
-resets, and resumed automatically.
+resets, and resumed automatically. There is deliberately **no fixed time
+cooldown** — a genuinely-needed switch (a session stranded on a freshly-exhausted
+account) is never blocked by a timer.
 """
 
 from __future__ import annotations
@@ -44,11 +53,17 @@ DEFAULT_TARGET_SAFETY = 90
 # points below the exhaust threshold — absorbs the chunky, API-call-only jitter
 # of the statusline's ``used_percentage`` so accounts don't flap at the boundary.
 DEFAULT_HYSTERESIS_BAND = 3
-# Minimum seconds between migrations of the same session — the hard rate limit
-# that prevents A->B->A thrashing (each migration re-bills the context window).
-DEFAULT_MIGRATION_COOLDOWN = 600
 # Pause horizon when no reset time is known anywhere (defensive fallback).
 DEFAULT_PAUSE_FALLBACK_S = 3600
+
+# A 5h window is treated as UNSTARTED (a priming candidate) when its utilization
+# is at or below this many points. The Claude subscription 5h window is anchored
+# to the first credit-consuming call of a cycle: an account that has sent nothing
+# this window reports ~0% with no concrete reset timestamp. The small epsilon
+# absorbs the chunky, API-rounded ``utilization`` so a genuinely-idle window isn't
+# missed (and a started one — pct above this, or a real future reset — is left
+# alone so we never burn a credit re-priming an already-running clock).
+PRIME_FIVE_HOUR_EPSILON = 0.5
 
 # Per-session headroom reserve, in utilization points, debited from a target
 # when a session is (re)placed within a single balancing pass. A fixed base plus
@@ -70,7 +85,6 @@ class BalancerConfig:
     exhaust_threshold: int = DEFAULT_EXHAUST_THRESHOLD
     target_safety: int = DEFAULT_TARGET_SAFETY
     hysteresis_band: int = DEFAULT_HYSTERESIS_BAND
-    migration_cooldown: int = DEFAULT_MIGRATION_COOLDOWN
     pause_fallback_s: int = DEFAULT_PAUSE_FALLBACK_S
 
 
@@ -97,12 +111,10 @@ def config_from_dict(auto_balance: dict | None) -> BalancerConfig:
     if safety < 1:
         safety = 1
     band = max(0, _int("hysteresisBand", DEFAULT_HYSTERESIS_BAND))
-    cooldown = max(0, _int("cooldownSeconds", DEFAULT_MIGRATION_COOLDOWN))
     return BalancerConfig(
         exhaust_threshold=exhaust,
         target_safety=safety,
         hysteresis_band=band,
-        migration_cooldown=cooldown,
         pause_fallback_s=DEFAULT_PAUSE_FALLBACK_S,
     )
 
@@ -125,6 +137,14 @@ class AccountView:
     # resets (the window equal to ``max_pct``); ``None`` if unknown.
     soonest_reset: int | None = None
     signal: str = "none"  # "live" (statusline) | "cache" (usage API) | "none"
+    # The 5h-window-specific utilization + reset, used ONLY by the idle-window
+    # priming detection (:func:`accounts_needing_prime`). ``five_hour_pct`` is the
+    # 5h utilization percent (distinct from ``max_pct``, which is max(5h, 7d));
+    # ``five_hour_reset`` is the 5h window's reset epoch when the clock is running
+    # (``None`` when the window is unstarted — the signal we prime on). Both are
+    # ``None`` when usage is unknown.
+    five_hour_pct: float | None = None
+    five_hour_reset: int | None = None
 
 
 @dataclass(frozen=True)
@@ -136,6 +156,9 @@ class SessionView:
     ctx_tokens: int = 0
     last_seen: float = 0.0
     paused_until: int | None = None
+    # Telemetry only (timestamp of the last migration). NOTHING in the balancer
+    # gates on this — anti-thrash is purely algorithmic (rising-edge + target
+    # safety + hysteresis + online reservation), never a time cooldown.
     last_migrated_at: float = 0.0
     pinned_account: str | None = None  # user hard-pin; never migrated/paused
 
@@ -192,8 +215,15 @@ def _usable(av: AccountView | None, cfg: BalancerConfig) -> bool:
     )
 
 
-def _in_cooldown(s: SessionView, now: float, cfg: BalancerConfig) -> bool:
-    return (now - s.last_migrated_at) < cfg.migration_cooldown
+def _projected_headroom(av: AccountView, projected: dict[str, float]) -> float:
+    """Headroom remaining after the in-pass online reservation is debited.
+
+    ``100 - (current usage + reserved load)``. Higher = less-used = a better
+    target for an equal-priority tiebreak (keeps same-priority accounts evenly
+    used over time). Unknown-usage accounts never reach here (``_usable`` filters
+    them out), so ``max_pct`` is always a number.
+    """
+    return 100.0 - (av.max_pct + projected.get(av.num, 0.0))
 
 
 def _rank_accounts(
@@ -203,16 +233,25 @@ def _rank_accounts(
 ) -> list[AccountView]:
     """Usable accounts, best target first.
 
-    Ordered by: highest priority (burn high-priority first), then most
-    projected headroom within a priority tier, then lowest account number for
-    determinism.
+    Ordering (a single deterministic sort key):
+
+    1. **highest priority first** — load concentrates on / burns through
+       high-priority accounts before spilling to the next tier;
+    2. **least-used first within a priority tier** — most projected headroom
+       (current usage plus the in-pass online reservation) wins, so accounts of
+       *equal* priority are filled evenly rather than always hammering the same
+       one (EQUAL-PRIORITY EVEN USAGE). This governs *where* a session lands; the
+       only-switch-when-exhausted rule still governs *whether* it switches at all;
+    3. **lowest account number** — a deterministic final tiebreak so two
+       equal-priority, equal-headroom accounts always order the same way
+       regardless of dict iteration order.
     """
     usable = [a for a in acct_views.values() if _usable(a, cfg)]
     return sorted(
         usable,
         key=lambda a: (
             -a.priority,
-            -(100.0 - (a.max_pct + projected.get(a.num, 0.0))),
+            -_projected_headroom(a, projected),
             _num_key(a.num),
         ),
     )
@@ -242,8 +281,11 @@ def assign_new_session(
     """Pick the account a brand-new managed session should launch on.
 
     The highest-priority usable account whose projected utilization stays within
-    ``target_safety`` after placing this session. Returns the account number, or
-    ``None`` when nothing has room (the caller then starts the session paused).
+    ``target_safety`` after placing this session. Among accounts of the *same*
+    priority the **least-used** (most projected headroom) is chosen, so repeated
+    placements spread evenly across equal-priority accounts instead of stacking
+    on one (see :func:`_rank_accounts`). Returns the account number, or ``None``
+    when nothing has room (the caller then starts the session paused).
     """
     projected = projected if projected is not None else {num: 0.0 for num in acct_views}
     cost = _pct_cost(ctx_tokens)
@@ -261,9 +303,11 @@ def choose_migration_target(
 ) -> str | None:
     """Best account to migrate ``s`` to, excluding its current account.
 
-    Highest priority first; only an account whose projected utilization stays
-    within ``target_safety`` qualifies (so a move never immediately re-exhausts
-    the target — the move-then-exhaust trap). ``None`` => the caller pauses.
+    Highest priority first, then the **least-used** account within that priority
+    tier (most projected headroom — keeps equal-priority accounts evenly used);
+    only an account whose projected utilization stays within ``target_safety``
+    qualifies (so a move never immediately re-exhausts the target — the
+    move-then-exhaust trap). ``None`` => the caller pauses.
     """
     cost = _pct_cost(s.ctx_tokens)
     for a in _rank_accounts(acct_views, projected, cfg):
@@ -272,6 +316,67 @@ def choose_migration_target(
         if _fits(a, projected, cost, cfg):
             return a.num
     return None
+
+
+def _five_hour_unstarted(av: AccountView, cfg: BalancerConfig) -> bool:
+    """Whether ``av``'s 5h window has not started this cycle (an idle clock).
+
+    The Claude subscription 5h window only begins counting on the first
+    credit-consuming call of a cycle. An unstarted window reports ~0% utilization
+    with no concrete reset timestamp; a *running* window reports pct above the
+    epsilon and/or a real future reset. Defensive against all three observed
+    zero-state shapes (5h omitted, pct:0 with no reset, pct:0 with a reset): a
+    real future ``five_hour_reset`` always means started, regardless of pct.
+    """
+    if av.five_hour_pct is None:
+        return False  # unknown 5h usage -> not a confirmed-idle candidate
+    if av.five_hour_pct > cfg.exhaust_threshold:  # paranoia; a full window is "started"
+        return False
+    if av.five_hour_reset is not None:
+        return False  # a concrete reset timestamp means the clock is already running
+    return av.five_hour_pct <= PRIME_FIVE_HOUR_EPSILON
+
+
+def accounts_needing_prime(
+    acct_views: dict[str, AccountView],
+    cfg: BalancerConfig,
+) -> list[str]:
+    """Managed accounts whose 5h window is UNSTARTED and should be primed.
+
+    Pure and I/O-free (table-testable): the caller (the supervisor) performs the
+    actual network prime OUTSIDE the registry lock. An account is a candidate
+    when ALL hold:
+
+    * its usage signal is ``"cache"`` — a real idle-account usage read. ``"live"``
+      means it already hosts an in-use session (its clock is started), and
+      ``"none"`` means usage is unknown (skip rather than blind-prime a possibly
+      logged-out account);
+    * its 5h window is unstarted (:func:`_five_hour_unstarted`); and
+    * it is not already exhausted on its *other* (7d) window — priming a fresh 5h
+      window can't help an account whose weekly cap is the binding constraint, so
+      don't waste a credit on it.
+
+    Returned in deterministic account-number order so concurrent supervisors that
+    happen to prime in the same pass agree on ordering.
+    """
+    candidates = [
+        a.num
+        for a in acct_views.values()
+        if a.signal == "cache"
+        and _five_hour_unstarted(a, cfg)
+        and not _seven_day_exhausted(a, cfg)
+    ]
+    return sorted(candidates, key=_num_key)
+
+
+def _seven_day_exhausted(av: AccountView, cfg: BalancerConfig) -> bool:
+    """Whether the account's *non-5h* cap (its 7d window) is already exhausting it.
+
+    ``max_pct`` is max(5h, 7d). When the 5h window is unstarted (~0%), an exhausted
+    ``max_pct`` can only come from the 7d window, so ``max_pct >= threshold`` here
+    means the weekly cap is binding — priming a fresh 5h window wouldn't help.
+    """
+    return av.max_pct is not None and av.max_pct >= cfg.exhaust_threshold
 
 
 def pause_decision(
@@ -305,8 +410,10 @@ def rebalance(
 
     Phase A (resume): paused sessions whose timer elapsed *or* whose account
     recovered below the hysteresis line.
-    Phase B (strand): non-pinned, non-paused, non-cooldown sessions whose
-    current account is exhausted.
+    Phase B (strand): non-pinned, non-paused sessions whose current account is
+    exhausted. There is no time cooldown — a session stranded on a freshly
+    exhausted account is always eligible to move; rapid re-migration is prevented
+    by the caller's rising-edge gate plus target-safety + hysteresis, not a timer.
     Phase C (order): least-active / cheapest-context first, so a partial set of
     moves stops early and the fewest expensive sessions are disturbed.
     Phase D (place): greedily assign each stranded session a target with an
@@ -340,8 +447,10 @@ def rebalance(
             return False
         if s.paused_until is not None:  # paused sessions handled in Phase A
             return False
-        if _in_cooldown(s, now, cfg):
-            return False
+        # No time cooldown: a session whose account is exhausted is always
+        # eligible to move. Anti-thrash is algorithmic (the caller's rising-edge
+        # gate + target_safety + hysteresis + the online reservation), so a
+        # genuinely-needed switch is never blocked by a timer.
         return _exhausted(acct_views.get(s.account_num), cfg)
 
     stranded = [s for s in sess_views if is_stranded(s)]

--- a/src/claude_swap/balancer.py
+++ b/src/claude_swap/balancer.py
@@ -44,11 +44,11 @@ from dataclasses import dataclass, field
 
 # An account is "exhausted" once max(5h, 7d) utilization reaches this percent.
 # Shares the default with the legacy auto-switch threshold.
-DEFAULT_EXHAUST_THRESHOLD = 95
+DEFAULT_EXHAUST_THRESHOLD = 90
 # A migration target's *projected* utilization (after placing the session) must
 # stay at or below this. The gap to the exhaust threshold absorbs the per-session
 # headroom reserve so a move never immediately re-exhausts the target.
-DEFAULT_TARGET_SAFETY = 90
+DEFAULT_TARGET_SAFETY = 85
 # An exhausted account only re-enters the usable pool once it drops this many
 # points below the exhaust threshold — absorbs the chunky, API-call-only jitter
 # of the statusline's ``used_percentage`` so accounts don't flap at the boundary.

--- a/src/claude_swap/cache.py
+++ b/src/claude_swap/cache.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 import time
 from pathlib import Path
 
@@ -36,9 +38,24 @@ def read_cache(path: Path, ttl: float, default=MISSING):
 
 
 def write_cache(path: Path, data) -> None:
-    """Write data to a cache file with a timestamp."""
+    """Write data to a cache file with a timestamp.
+
+    Commits via a temp file + ``os.replace`` (atomic rename) so a concurrent
+    reader — another cswap process, a statusline, or the dashboard's idle-usage
+    refresher thread — never observes a half-written file (it sees the old
+    contents or the new ones, whole).
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps({"timestamp": time.time(), "data": data}),
-        encoding="utf-8",
-    )
+    payload = json.dumps({"timestamp": time.time(), "data": data})
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        os.replace(tmp, path)
+    except OSError:
+        # Best-effort cache: clean up the temp file and move on rather than
+        # raising into the caller (usage rendering, balancing, etc.).
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass

--- a/src/claude_swap/cache.py
+++ b/src/claude_swap/cache.py
@@ -25,6 +25,13 @@ MISSING = object()
 # a confirmed account is rediscovered quickly while still capping the billable rate.
 PROBE_VERDICT_TTL_S = 120
 
+# How old a last-known-good usage reading may be and still back an optimistic
+# ``signal="stale"`` view (see ``merge_last_known`` / ``last_known_usage``).
+# Comfortably exceeds the 1h max usage-endpoint backoff so a reading taken when a
+# 429 first hit stays usable for the whole window; an idle account's usage drifts
+# over hours, not minutes, so a reading this fresh is a sound optimistic estimate.
+STALE_USAGE_MAX_AGE_S = 2 * 3600
+
 
 def usage_backoff_active(entry, now: float | None = None) -> bool:
     """Whether a cached usage entry is a still-active 429 backoff marker.
@@ -70,6 +77,65 @@ def probe_ok(entry) -> bool:
     (real usage, no-signal/429 markers, non-dicts).
     """
     return isinstance(entry, dict) and entry.get("_probe_ok") is True
+
+
+def is_real_usage(entry) -> bool:
+    """Whether a cached entry holds REAL usage windows (not a failure/probe marker).
+
+    Real usage is a dict carrying the usage-API result; a failure marker carries
+    ``_unavailable`` and a probe verdict carries ``_probe_ok``. Used to decide when a
+    failure marker should snapshot the prior reading as last-known-good.
+    """
+    return (
+        isinstance(entry, dict)
+        and not entry.get("_unavailable")
+        and not entry.get("_probe_ok")
+    )
+
+
+def merge_last_known(marker: dict, prev, now: float | None = None) -> dict:
+    """Carry a last-known-good usage snapshot onto a failure ``marker``.
+
+    Optimistic-headroom support: a failure/backoff marker remembers the most recent
+    REAL usage reading so :func:`registry.build_world` can keep an idle account that
+    was healthy-when-last-seen as a (no-credit) migration target through the backoff
+    window, instead of treating its unknown usage as zero headroom. If ``prev`` is
+    itself real usage, snapshot it now; if ``prev`` is an earlier marker already
+    carrying ``_last_known`` (a chain of markers across the window), inherit it.
+    Returns ``marker`` (mutated in place).
+    """
+    if not isinstance(marker, dict):
+        return marker
+    if is_real_usage(prev):
+        marker["_last_known"] = prev
+        marker["_last_known_at"] = now if now is not None else time.time()
+    elif isinstance(prev, dict) and isinstance(prev.get("_last_known"), dict):
+        marker["_last_known"] = prev["_last_known"]
+        at = prev.get("_last_known_at")
+        if isinstance(at, (int, float)):
+            marker["_last_known_at"] = at
+    return marker
+
+
+def last_known_usage(entry, max_age: float, now: float | None = None):
+    """A still-recent last-known-good usage snapshot carried on a failure marker.
+
+    Returns the snapshotted usage dict when ``entry`` carries ``_last_known`` and its
+    ``_last_known_at`` is within ``max_age`` seconds; otherwise ``None``. Lets
+    :func:`registry.build_world` synthesize an optimistic ``signal="stale"`` view for
+    an account whose usage endpoint is 429-backed-off but which was below the safety
+    line when last read — so a stranded session can migrate onto it without spending
+    a probe credit, accepting that it may turn out capped (then it recovers again).
+    """
+    if not isinstance(entry, dict):
+        return None
+    lk = entry.get("_last_known")
+    at = entry.get("_last_known_at")
+    if not (isinstance(lk, dict) and isinstance(at, (int, float))):
+        return None
+    if (now if now is not None else time.time()) - at >= max_age:
+        return None
+    return lk
 
 
 def read_cache(path: Path, ttl: float, default=MISSING):

--- a/src/claude_swap/cache.py
+++ b/src/claude_swap/cache.py
@@ -14,6 +14,63 @@ CACHE_DIR = get_backup_root() / "cache"
 
 MISSING = object()
 
+# The cross-process re-probe cadence for the messages-API headroom fallback.
+# When the usage endpoint is 429-backed-off (so an idle account reports NO usage
+# signal), the supervisor's strand/resume paths fall back to a billable messages
+# probe (see ``oauth.probe_messages_headroom`` / ``registry.build_world``). The
+# verdict is stamped (``_probed_at``) into the SAME shared ``usage.json`` slot as
+# the 429 marker, so an account is re-probed AT MOST once per this many seconds
+# across ALL supervisors — not every tick, and not the whole ``_MAX_USAGE_BACKOFF_S``
+# backoff hour. This is the "intelligent re-probe cadence", deliberately short so
+# a confirmed account is rediscovered quickly while still capping the billable rate.
+PROBE_VERDICT_TTL_S = 120
+
+
+def usage_backoff_active(entry, now: float | None = None) -> bool:
+    """Whether a cached usage entry is a still-active 429 backoff marker.
+
+    A failed usage fetch is cached as ``{"_unavailable": True, "retry_until": <epoch>}``
+    (the epoch is set from the server's ``Retry-After`` on a 429). While
+    ``retry_until`` is in the future the account must not be refetched — the usage
+    endpoint asked the whole client to back off. Returns ``False`` for real usage
+    data, plain ``{"_unavailable": True}`` markers, and elapsed backoffs.
+    """
+    if not (isinstance(entry, dict) and entry.get("_unavailable")):
+        return False
+    until = entry.get("retry_until")
+    if not isinstance(until, (int, float)):
+        return False
+    return until > (now if now is not None else time.time())
+
+
+def probe_recent(entry, now: float | None = None) -> bool:
+    """Whether a cached entry was probe-stamped within :data:`PROBE_VERDICT_TTL_S`.
+
+    Throttles the messages-API headroom re-probe CROSS-PROCESS: while a verdict's
+    ``_probed_at`` is within the cadence, no supervisor re-probes (they all reuse
+    the cached verdict — :func:`probe_ok` distinguishes a confirmed-OK verdict from
+    a no-signal one). Returns ``False`` for non-dicts and entries with no
+    ``_probed_at`` stamp (a plain usage entry or an un-probed failure marker).
+    """
+    if not isinstance(entry, dict):
+        return False
+    at = entry.get("_probed_at")
+    if not isinstance(at, (int, float)):
+        return False
+    return (now if now is not None else time.time()) - at < PROBE_VERDICT_TTL_S
+
+
+def probe_ok(entry) -> bool:
+    """Whether a cached entry is a confirmed-OK headroom-probe verdict.
+
+    A ``True`` messages probe is cached as ``{"_probe_ok": True, "_probed_at": ...}``
+    (it carries no usage windows). This lets :func:`registry.build_world`
+    reconstruct a probe :class:`~claude_swap.balancer.AccountView` from a fresh
+    cached verdict WITHOUT a redundant re-probe. ``False`` for everything else
+    (real usage, no-signal/429 markers, non-dicts).
+    """
+    return isinstance(entry, dict) and entry.get("_probe_ok") is True
+
 
 def read_cache(path: Path, ttl: float, default=MISSING):
     """Read cached JSON data if the file exists and is within TTL.

--- a/src/claude_swap/cache.py
+++ b/src/claude_swap/cache.py
@@ -32,6 +32,16 @@ PROBE_VERDICT_TTL_S = 120
 # over hours, not minutes, so a reading this fresh is a sound optimistic estimate.
 STALE_USAGE_MAX_AGE_S = 2 * 3600
 
+# How long a confirmed logged-out account is left alone before cswap re-attempts a
+# refresh. When an inactive account's refresh returns ``invalid_grant`` the stored
+# refresh token is dead (revoked / already-rotated / expired) and NOTHING short of a
+# manual re-login can recover it — so re-POSTing the dead token on every render and
+# every balancer tick (across several concurrent processes) is pure waste. The
+# logged-out marker carries a ``retry_until`` this far out so the existing
+# :func:`usage_backoff_active` gate throttles re-attempts, while still re-checking
+# often enough that a fresh re-login is picked up without restarting anything.
+LOGGED_OUT_RECHECK_S = 300
+
 
 def usage_backoff_active(entry, now: float | None = None) -> bool:
     """Whether a cached usage entry is a still-active 429 backoff marker.
@@ -77,6 +87,40 @@ def probe_ok(entry) -> bool:
     (real usage, no-signal/429 markers, non-dicts).
     """
     return isinstance(entry, dict) and entry.get("_probe_ok") is True
+
+
+def logged_out(entry) -> bool:
+    """Whether a cached entry is a confirmed logged-out marker.
+
+    Written when an inactive account's OAuth refresh returns ``invalid_grant`` — the
+    stored refresh token is revoked / already-rotated / expired, so the account is
+    logged out and only a manual re-login can recover it. Carried as
+    ``{"_unavailable": True, "_logged_out": True, "retry_until": <epoch>}``:
+    ``_unavailable`` so every "no real usage" path treats it as zero headroom (never
+    a migration target), ``retry_until`` so :func:`usage_backoff_active` throttles
+    pointless re-POSTs of the dead token, and ``_logged_out`` so the render layer can
+    show an actionable "logged out — re-login" instead of a generic "usage
+    unavailable". ``False`` for real usage, plain/429 ``_unavailable`` markers, probe
+    verdicts, and non-dicts.
+    """
+    return isinstance(entry, dict) and entry.get("_logged_out") is True
+
+
+def logged_out_marker(now: float | None = None) -> dict:
+    """Build a fresh logged-out cache marker (see :func:`logged_out`).
+
+    Deliberately carries NO ``_last_known`` snapshot: a logged-out account must never
+    be resurrected as an optimistic ``signal="stale"`` migration target (it cannot
+    even authenticate), so — unlike a 429 backoff marker — it does not thread the
+    prior reading forward. The ``retry_until`` is :data:`LOGGED_OUT_RECHECK_S` out so
+    :func:`usage_backoff_active` throttles re-POSTs of the now-dead refresh token.
+    """
+    now = now if now is not None else time.time()
+    return {
+        "_unavailable": True,
+        "_logged_out": True,
+        "retry_until": now + LOGGED_OUT_RECHECK_S,
+    }
 
 
 def is_real_usage(entry) -> bool:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -124,6 +124,39 @@ def _statusline_command() -> None:
     sys.exit(0)
 
 
+def _statusfailure_command() -> None:
+    """Handle `cswap statusfailure` — internal: Claude Code's ``StopFailure`` hook.
+
+    Pre-dispatched (like `statusline`) and kept bulletproof. Claude Code pipes
+    the failed-turn JSON on stdin and ignores our exit code, but we still mirror
+    ``_statusline_command``'s flush+devnull guard so a broken stdout pipe can
+    never turn into a non-zero exit + traceback. Side-effect-only: at most it
+    records a migration *intent* into the registry so the next turn lands on a
+    fresh account; it never writes credentials and always exits 0.
+    """
+    try:
+        stdin_text = sys.stdin.read()
+    except BaseException:
+        stdin_text = ""
+    try:
+        from claude_swap.statusline import run_statusfailure
+
+        switcher = ClaudeAccountSwitcher()
+        run_statusfailure(switcher, stdin_text)
+    except BaseException:
+        pass
+    finally:
+        try:
+            sys.stdout.flush()
+        except BaseException:
+            pass
+        try:
+            os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+        except BaseException:
+            pass
+    sys.exit(0)
+
+
 def _launch_command(argv: list[str]) -> None:
     """Handle `cswap launch [--no-share] [--debug] [-- <claude args>]`.
 
@@ -145,6 +178,12 @@ def _launch_command(argv: list[str]) -> None:
             "the session automatically as usage limits are reached."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap launch
+  cswap launch -- --resume <id>             # forward args after '--' to claude
+  cswap launch --no-share                   # bare profile (don't share ~/.claude)
+        """,
     )
     parser.add_argument(
         "--no-share",
@@ -197,6 +236,13 @@ def _cmux_command(argv: list[str]) -> None:
             "different account."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap cmux setup                          # install the "Balanced Claude (cswap)" surface
+  cswap cmux 3                              # fan out 3 balancer-managed workspaces
+  cswap cmux fanout 3                       # explicit fanout form
+  cswap cmux 3 -- --resume <id>            # forward args after '--' to each claude
+        """,
     )
     parser.add_argument(
         "target",
@@ -312,6 +358,9 @@ def main() -> None:
     if len(sys.argv) > 1 and sys.argv[1] == "statusline":
         _statusline_command()
         return
+    if len(sys.argv) > 1 and sys.argv[1] == "statusfailure":
+        _statusfailure_command()
+        return
     if len(sys.argv) > 1 and sys.argv[1] == "launch":
         _launch_command(sys.argv[2:])
         return
@@ -342,6 +391,13 @@ Examples:
   %(prog)s --import backup.cswap
   %(prog)s --tui                              # interactive arrow-key menu
   %(prog)s --upgrade                          # self-upgrade to latest version
+  %(prog)s --install                          # embed cswap for load balancing (Beta)
+  %(prog)s --balance                          # load-balancer dashboard + settings (Beta)
+  %(prog)s --set-priority 2:5                 # set Account-2's balancing priority (Beta)
+  %(prog)s launch                             # start a load-balanced session (Beta)
+  %(prog)s launch -- --resume <id>            # forward args after '--' to claude
+  %(prog)s cmux setup                         # add a balanced-Claude command to cmux (macOS)
+  %(prog)s cmux 3                             # fan out 3 managed sessions, one per workspace
         """,
     )
 
@@ -467,7 +523,7 @@ Examples:
     group.add_argument(
         "--balance",
         action="store_true",
-        help="Open the load-balancer dashboard / settings (Beta)",
+        help="Open the load-balancer dashboard + settings: enable, tune, set priorities (Beta)",
     )
     group.add_argument(
         "--set-priority",

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -171,6 +171,126 @@ def _launch_command(argv: list[str]) -> None:
         sys.exit(130)
 
 
+def _cmux_command(argv: list[str]) -> None:
+    """Handle ``cswap cmux <setup | [fanout] N> [-- <claude args>]``.
+
+    Pre-dispatched (like ``run``/``launch``): a positional subcommand can't coexist
+    with main()'s required mutually-exclusive group. macOS-only; emits a clean
+    error (no traceback) when cmux isn't installed or the host isn't macOS.
+
+      cswap cmux setup           install the "Balanced Claude (cswap)" surface
+      cswap cmux 2               fanout: open 2 balancer-managed workspaces
+      cswap cmux fanout 2        explicit fanout form
+      cswap cmux 2 -- --resume   forward args after '--' to each session's claude
+    """
+    if "--" in argv:
+        split = argv.index("--")
+        head, tail = argv[:split], argv[split + 1 :]
+    else:
+        head, tail = argv, []
+
+    parser = argparse.ArgumentParser(
+        prog="cswap cmux",
+        description=(
+            "[BETA] cmux integration (macOS). Install a balancer-managed Claude "
+            "surface into cmux, or fan out N workspaces that each land on a "
+            "different account."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "target",
+        metavar="setup | [fanout] N",
+        help="'setup' to install the surface, or a count N to fan out N sessions",
+    )
+    parser.add_argument(
+        "count",
+        nargs="?",
+        metavar="N",
+        help="Number of workspaces (with the explicit 'fanout' form)",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(head)
+
+    # Resolve the (subcommand, n) intent from the two positionals.
+    sub = args.target.lower()
+    if sub == "setup":
+        if args.count is not None:
+            parser.error("`cswap cmux setup` takes no count")
+        n = None
+    elif sub == "fanout":
+        if args.count is None:
+            parser.error("`cswap cmux fanout` requires a count, e.g. `cswap cmux fanout 2`")
+        n = _parse_positive_int(parser, args.count)
+    else:
+        # Bare `cswap cmux N` shorthand for fanout.
+        if args.count is not None:
+            parser.error(f"unexpected argument '{args.count}'")
+        n = _parse_positive_int(parser, args.target)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        if sys.platform != "win32":
+            if os.geteuid() == 0 and not switcher._is_running_in_container():
+                error("Error: Do not run this script as root (unless running in a container)")
+                sys.exit(1)
+        from claude_swap import cmux
+
+        if n is None:
+            status = cmux.setup(switcher)
+            _print_cmux_setup(status)
+        else:
+            status = cmux.fanout(switcher, n, tail)
+            _print_cmux_fanout(status)
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
+def _parse_positive_int(parser: argparse.ArgumentParser, value: str) -> int:
+    if not value.isdigit() or int(value) < 1:
+        parser.error(f"expected a positive integer count, got '{value}'")
+    return int(value)
+
+
+def _print_cmux_setup(status: dict) -> None:
+    """Render the result of ``cswap cmux setup``."""
+    if status["ok"]:
+        verb = "Updated" if status["changed"] else "Verified"
+        print(accent(f"{verb} the cswap surface in cmux."))
+        print(dimmed(
+            "Open it from cmux's command palette / plus-button as "
+            '"Balanced Claude (cswap)".'
+        ))
+        if status.get("backup_path"):
+            print(muted(f"Backed up cmux.json to {status['backup_path']}"))
+        if not status["reloaded"]:
+            warning("cmux did not reload automatically; run `cmux reload-config`.")
+    else:
+        error("cmux did not accept the config.")
+        for msg in status.get("messages", []):
+            warning(msg)
+        sys.exit(1)
+
+
+def _print_cmux_fanout(status: dict) -> None:
+    """Render the result of a ``cswap cmux N`` fanout."""
+    opened, requested = status["opened"], status["requested"]
+    print(accent(f"Opened {opened}/{requested} balancer-managed cmux workspace(s)."))
+    print(muted(f"Each runs: {status['command']}"))
+    accts = [a for a in status.get("accounts", []) if a]
+    if accts:
+        spread = (
+            "distinct accounts" if status["distinct_accounts"] > 1 else "account"
+        )
+        print(dimmed(f"Landed on {spread}: " + ", ".join(f"Account-{a}" for a in accts)))
+    for msg in status.get("messages", []):
+        warning(msg)
+
+
 def _parse_set_priority(value: str) -> tuple[str, int]:
     """Parse a ``NUM:PRIORITY`` argument for ``--set-priority``."""
     num, sep, pri = value.partition(":")
@@ -194,6 +314,9 @@ def main() -> None:
         return
     if len(sys.argv) > 1 and sys.argv[1] == "launch":
         _launch_command(sys.argv[2:])
+        return
+    if len(sys.argv) > 1 and sys.argv[1] == "cmux":
+        _cmux_command(sys.argv[2:])
         return
 
     parser = argparse.ArgumentParser(

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -7,8 +7,8 @@ import os
 import sys
 
 from claude_swap import __version__
-from claude_swap.exceptions import ClaudeSwitchError
-from claude_swap.printer import dimmed, error, muted
+from claude_swap.exceptions import ClaudeSwitchError, ValidationError
+from claude_swap.printer import accent, dimmed, error, muted, warning
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -88,11 +88,113 @@ Examples:
         sys.exit(130)
 
 
+def _statusline_command() -> None:
+    """Handle `cswap statusline` — internal: Claude Code pipes session JSON on stdin.
+
+    Pre-dispatched (like `run`) and kept bulletproof: it must always print at
+    most one line and exit 0 so it can never break Claude Code's status render.
+    Claude Code may close the stdout pipe before we (or the interpreter's
+    shutdown flush) finish writing; the ``finally`` flushes once and then
+    redirects stdout to /dev/null so the shutdown flush can never raise
+    BrokenPipeError into a non-zero exit + traceback.
+    """
+    try:
+        stdin_text = sys.stdin.read()
+    except BaseException:
+        stdin_text = ""
+    try:
+        from claude_swap.statusline import run_statusline
+
+        switcher = ClaudeAccountSwitcher()
+        run_statusline(switcher, stdin_text)
+    except BaseException:
+        try:
+            print("")
+        except BaseException:
+            pass
+    finally:
+        try:
+            sys.stdout.flush()
+        except BaseException:
+            pass
+        try:
+            os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+        except BaseException:
+            pass
+    sys.exit(0)
+
+
+def _launch_command(argv: list[str]) -> None:
+    """Handle `cswap launch [--no-share] [--debug] [-- <claude args>]`.
+
+    Pre-dispatched before the main parser (a positional subcommand can't coexist
+    with main()'s required mutually-exclusive group). Supervises claude until it
+    exits; mirrors claude's exit code.
+    """
+    if "--" in argv:
+        split = argv.index("--")
+        head, tail = argv[:split], argv[split + 1 :]
+    else:
+        head, tail = argv, []
+
+    parser = argparse.ArgumentParser(
+        prog="cswap launch",
+        description=(
+            "[BETA] Launch a load-balancer-managed Claude Code session. cswap "
+            "picks the best account, embeds a statusline, and migrates / pauses "
+            "the session automatically as usage limits are reached."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--no-share",
+        action="store_true",
+        help="Don't share ~/.claude settings/skills/etc. into the session profile",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(head)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        if sys.platform != "win32":
+            if os.geteuid() == 0 and not switcher._is_running_in_container():
+                error("Error: Do not run this script as root (unless running in a container)")
+                sys.exit(1)
+        from claude_swap.supervisor import launch
+
+        sys.exit(launch(switcher, tail, share=not args.no_share))
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
+def _parse_set_priority(value: str) -> tuple[str, int]:
+    """Parse a ``NUM:PRIORITY`` argument for ``--set-priority``."""
+    num, sep, pri = value.partition(":")
+    num = num.strip()
+    if not sep or not num.isdigit():
+        raise ValidationError("--set-priority expects NUM:PRIORITY (e.g. 2:5)")
+    try:
+        priority = int(pri.strip())
+    except ValueError:
+        raise ValidationError(f"Invalid priority '{pri.strip()}' (must be a whole number)")
+    return num, priority
+
+
 def main() -> None:
     """Main entry point for the CLI."""
     if len(sys.argv) > 1 and sys.argv[1] == "run":
         _run_command(sys.argv[2:])
         return  # only reachable in tests where exec/exit is mocked
+    if len(sys.argv) > 1 and sys.argv[1] == "statusline":
+        _statusline_command()
+        return
+    if len(sys.argv) > 1 and sys.argv[1] == "launch":
+        _launch_command(sys.argv[2:])
+        return
 
     parser = argparse.ArgumentParser(
         description="Multi-Account Switcher for Claude Code",
@@ -234,6 +336,21 @@ Examples:
             "Pass '-' to read from stdin or omit the value to be prompted securely."
         ),
     )
+    group.add_argument(
+        "--install",
+        action="store_true",
+        help="Embed cswap into Claude Code so `cswap launch` sessions auto-balance",
+    )
+    group.add_argument(
+        "--balance",
+        action="store_true",
+        help="Open the load-balancer dashboard / settings (Beta)",
+    )
+    group.add_argument(
+        "--set-priority",
+        metavar="NUM:PRIORITY",
+        help="Set an account's balancing priority (higher = burned through first)",
+    )
 
     args = parser.parse_args()
 
@@ -319,6 +436,33 @@ Examples:
                 )
                 sys.exit(1)
             sys.exit(tui_run(switcher))
+        elif args.install:
+            from claude_swap import embed
+
+            health = embed.install(switcher)
+            if health["ok"]:
+                print(accent("cswap is embedded in Claude Code."))
+                print(dimmed(
+                    "Start a managed session with `cswap launch` — it auto-balances "
+                    "across your accounts. Plain `claude` stays vanilla."
+                ))
+            else:
+                for issue in health["issues"]:
+                    warning(issue)
+        elif args.balance:
+            try:
+                from claude_swap.tui import run_balance
+            except ImportError:
+                error(
+                    "TUI mode requires the 'curses' module. "
+                    "On Windows, install with: pip install windows-curses"
+                )
+                sys.exit(1)
+            sys.exit(run_balance(switcher))
+        elif args.set_priority:
+            num, priority = _parse_set_priority(args.set_priority)
+            switcher.set_account_priority(num, priority)
+            print(f"{accent('Set')} Account-{num} priority to {priority}")
     except ClaudeSwitchError as e:
         error(f"Error: {e}")
         sys.exit(1)

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -4,12 +4,73 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import sys
 
 from claude_swap import __version__
 from claude_swap.exceptions import ClaudeSwitchError, ValidationError
 from claude_swap.printer import accent, dimmed, error, muted, warning
 from claude_swap.switcher import ClaudeAccountSwitcher
+
+# First-token values that are genuine cswap subcommands or flags. Quick-start
+# (the configurable bare-`cswap` alias) only fires when the first arg is NOT one
+# of these, so every existing command keeps its normal behaviour. Kept in sync
+# with the subcommands dispatched in ``main`` and the flags registered on its
+# parser; an unknown token (or no args at all) is treated as quick-start input.
+_RESERVED_FIRST_TOKENS = frozenset({
+    # positional subcommands
+    "run", "statusline", "statusfailure", "launch", "cmux",
+    # help / version
+    "-h", "--help", "--version",
+    # modifier + action flags
+    "--debug", "--token-status", "--slot", "--email", "--account",
+    "--force", "--full", "--add-account", "--remove-account", "--list",
+    "--switch", "--switch-to", "--status", "--purge", "--export", "--import",
+    "--tui", "--upgrade", "--add-token", "--install", "--balance",
+    "--set-priority",
+})
+
+
+def _maybe_quick_start(rest: list[str]) -> bool:
+    """Run the user's Quick-start command if it applies; return whether it fired.
+
+    Fires only when (a) the first token isn't a recognized cswap subcommand/flag
+    and (b) Quick-start is enabled in config. The configured command is parsed
+    with shell rules, any leading ``cswap``/``claude-swap`` is dropped, the user's
+    extra args are appended (alias-with-args), and the result is re-dispatched
+    through ``main`` exactly once (quick-start disabled on the re-entry to rule
+    out loops).
+    """
+    if rest:
+        first = rest[0].split("=", 1)[0]
+        if first in _RESERVED_FIRST_TOKENS:
+            return False
+    try:
+        config = ClaudeAccountSwitcher().get_quick_start_config()
+    except Exception:  # noqa: BLE001 - never let config issues block normal CLI use
+        return False
+    if not config.get("enabled"):
+        return False
+    try:
+        tokens = shlex.split(config["command"])
+    except ValueError:
+        error("Quick-start command is not valid shell syntax; fix it in the TUI.")
+        sys.exit(1)
+    if tokens and os.path.basename(tokens[0]) in ("cswap", "claude-swap"):
+        tokens = tokens[1:]
+    # `cswap -- <args>` is the explicit "everything after -- is extra args" form;
+    # drop that one leading separator so we don't forward a stray `--` on top of
+    # the configured command's own `--` (which would make claude treat the args
+    # as a positional prompt instead of flags).
+    extra = list(rest)
+    if extra and extra[0] == "--":
+        extra = extra[1:]
+    new_argv = tokens + extra
+    if not new_argv:
+        return False
+    sys.argv = ["cswap"] + new_argv
+    main(_allow_quick_start=False)
+    return True
 
 
 def _run_command(argv: list[str]) -> None:
@@ -350,7 +411,7 @@ def _parse_set_priority(value: str) -> tuple[str, int]:
     return num, priority
 
 
-def main() -> None:
+def main(_allow_quick_start: bool = True) -> None:
     """Main entry point for the CLI."""
     if len(sys.argv) > 1 and sys.argv[1] == "run":
         _run_command(sys.argv[2:])
@@ -368,9 +429,22 @@ def main() -> None:
         _cmux_command(sys.argv[2:])
         return
 
+    # Quick start: a configurable default command for an alias-style `cswap`
+    # invocation. Runs only when enabled AND the first token isn't a recognized
+    # subcommand/flag — so `cswap`, `cswap --resume X`, etc. launch the default,
+    # while `cswap --status`, `cswap run 2`, ... keep working unchanged.
+    if _allow_quick_start and _maybe_quick_start(sys.argv[1:]):
+        return
+
     parser = argparse.ArgumentParser(
         description="Multi-Account Switcher for Claude Code",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        # Disable prefix-abbreviation so a token is a real cswap flag iff it is an
+        # exact full spelling — keeping argparse's matching in lockstep with the
+        # exact-match _RESERVED_FIRST_TOKENS check that gates Quick start. Without
+        # this, `cswap --stat` would mean --status to argparse but be hijacked as
+        # quick-start input (the two paths would disagree on the same token).
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s --add-account

--- a/src/claude_swap/cmux.py
+++ b/src/claude_swap/cmux.py
@@ -317,6 +317,25 @@ def _validate(cli: str) -> tuple[bool, str]:
 # --------------------------------------------------------------------------- #
 
 
+def _unique_backup_path(path: Path) -> Path:
+    """A non-colliding ``.bak`` path for ``path``'s timestamped backup (BUG 013).
+
+    ``time.strftime`` has 1-second resolution and ``shutil.copy2`` overwrites, so
+    two setups in the same second would destroy the first backup. If the base
+    timestamped name already exists, append ``-1`` / ``-2`` / … until the path is
+    free, so every backup is preserved.
+    """
+    base = path.with_name(f"cmux.json.{time.strftime('%Y%m%d-%H%M%S')}.bak")
+    if not base.exists():
+        return base
+    n = 1
+    while True:
+        candidate = base.with_name(f"{base.name}-{n}")
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
 def setup(switcher) -> dict:
     """Install the "Balanced Claude (cswap)" surface into cmux.json.
 
@@ -342,7 +361,7 @@ def setup(switcher) -> dict:
     messages: list[str] = []
     backup_path: str | None = None
     if path.exists() and path.stat().st_size > 0:
-        backup = path.with_name(f"cmux.json.{time.strftime('%Y%m%d-%H%M%S')}.bak")
+        backup = _unique_backup_path(path)
         try:
             shutil.copy2(path, backup)
             backup_path = str(backup)
@@ -421,15 +440,18 @@ def _list_workspace_count(cli: str) -> int:
 
 
 def _open_one_workspace(cli: str, cwd: str, command: str, name: str) -> bool:
-    """Create one workspace running ``command``, verifying it appeared.
+    """Create one workspace running ``command``.
 
     Uses ``cmux new-workspace --cwd … --command …`` — the documented headless
-    path (the command is sent to the new workspace's terminal). To defend against
-    the known "typed command silently dropped when unfocused" race, we verify the
-    workspace count grew and retry the create on failure.
+    path (the command is sent to the new workspace's terminal). A ``rc==0`` from
+    ``new-workspace`` is AUTHORITATIVE that the workspace was created, so we
+    return success immediately on it (BUG 010): the previous create→verify→retry
+    loop re-ran ``new-workspace`` whenever ``list-workspaces`` lagged behind the
+    create, producing DUPLICATE workspaces. We only retry on a subprocess error
+    or a non-zero exit; the post-create workspace count is read as a non-gating
+    debug signal, never a re-create trigger.
     """
     for attempt in range(1, _CREATE_VERIFY_RETRIES + 1):
-        before = _list_workspace_count(cli)
         try:
             cp = _run_cli(
                 cli,
@@ -447,11 +469,7 @@ def _open_one_workspace(cli: str, cwd: str, command: str, name: str) -> bool:
             time.sleep(_CREATE_VERIFY_DELAY_S)
             continue
         if cp.returncode == 0:
-            # Verify a new workspace actually appeared before declaring success.
-            time.sleep(_CREATE_VERIFY_DELAY_S)
-            after = _list_workspace_count(cli)
-            if before < 0 or after < 0 or after > before:
-                return True
+            return True
         time.sleep(_CREATE_VERIFY_DELAY_S)
     return False
 

--- a/src/claude_swap/cmux.py
+++ b/src/claude_swap/cmux.py
@@ -1,0 +1,529 @@
+"""cmux integration for cswap (Beta, macOS).
+
+`cmux <https://github.com/manaflow-ai/cmux>`_ is a native macOS terminal that can
+open workspaces (tabs) each running a command. This module wires the cswap load
+balancer into cmux two ways:
+
+* **S1 — a reusable surface.** :func:`setup` merges a named custom command
+  ("Balanced Claude (cswap)") into ``~/.config/cmux/cmux.json`` so the user can
+  spawn a balancer-managed Claude Code session from cmux's plus-button / command
+  palette at any time. It backs the config up to a timestamped ``.bak`` first,
+  merges idempotently (preserving all existing user content), then validates and
+  reloads via the cmux CLI.
+
+* **S2 — a one-shot fanout.** :func:`fanout` opens ``n`` cmux workspaces, each
+  running ``cswap launch`` in the current directory. Because the balancer's
+  online reservation spreads concurrent launches across accounts, the panes land
+  on *different* accounts automatically. Uses the documented, robust
+  ``cmux new-workspace --cwd … --command …`` path with create→verify→retry to
+  defend against the known "typed command silently dropped when unfocused" bug.
+
+The crucial correctness detail is that cmux ships a ``cmux-claude-wrapper`` that
+intercepts ``claude`` and *clears* most auth-selection env before exec'ing the
+real binary — but it honours ``CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS`` (a
+comma/space-separated allow-list of env keys to keep). cswap pins each session to
+its per-session profile via ``CLAUDE_CONFIG_DIR``; so every surface/command we
+emit sets that preserve-key to include ``CLAUDE_CONFIG_DIR``, and the supervisor
+(:meth:`supervisor.Supervisor._session_env`) appends it for the child too. Claude
+Code merges the wrapper's ``--settings`` additively with the profile's
+``settings.json``, so cswap's statusLine and cmux's hooks coexist.
+
+Stdlib only; cmux.json writes go through ``switcher._write_json`` (atomic rename,
+0600). macOS-only: every entry point raises a clear error elsewhere.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from claude_swap import embed, registry
+from claude_swap.exceptions import SessionError
+from claude_swap.models import Platform
+
+# The cmux CLI is not on PATH by default; it lives inside the app bundle.
+_APP_BUNDLE_CLI = Path(
+    "/Applications/cmux.app/Contents/Resources/bin/cmux"
+)
+
+# The named custom-command surface we install into cmux.json. Idempotency keys on
+# this name, so renaming it would orphan a previously-installed entry.
+SURFACE_NAME = "Balanced Claude (cswap)"
+
+# The cmux.json env key that lists auth-selection env vars the cmux-claude-wrapper
+# must NOT strip before exec'ing the real claude. We add CLAUDE_CONFIG_DIR so the
+# per-session profile pin survives.
+PRESERVE_KEYS_ENV = "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"
+CLAUDE_CONFIG_DIR_KEY = "CLAUDE_CONFIG_DIR"
+
+# How long to let the supervisors register their rows before reading them back in
+# :func:`fanout` (each `cswap launch` writes a registry row on startup).
+_FANOUT_SETTLE_S = 8.0
+# new-workspace create -> verify the workspace appeared -> retry budget.
+_CREATE_VERIFY_RETRIES = 3
+_CREATE_VERIFY_DELAY_S = 1.5
+
+
+# --------------------------------------------------------------------------- #
+# Availability / discovery
+# --------------------------------------------------------------------------- #
+
+
+def find_cmux() -> str | None:
+    """Return the cmux CLI path, or ``None`` if cmux is not installed.
+
+    Prefers a ``cmux`` resolvable on ``PATH`` (so a user who symlinked it wins),
+    then falls back to the standard app-bundle location.
+    """
+    on_path = shutil.which("cmux")
+    if on_path:
+        return on_path
+    if _APP_BUNDLE_CLI.exists():
+        return str(_APP_BUNDLE_CLI)
+    return None
+
+
+def is_available() -> bool:
+    """True only on macOS with the cmux CLI present."""
+    return Platform.detect() == Platform.MACOS and find_cmux() is not None
+
+
+def _require_macos_cmux() -> str:
+    """Return the cmux CLI path or raise a clear, actionable error.
+
+    Guards every public entry point so a non-macOS host or a missing cmux
+    install fails with one tidy message instead of a traceback.
+    """
+    if Platform.detect() != Platform.MACOS:
+        raise SessionError("cmux integration is macOS-only.")
+    cli = find_cmux()
+    if not cli:
+        raise SessionError(
+            "cmux was not found. Install the cmux app from https://cmux.com "
+            "(its CLI lives at /Applications/cmux.app/Contents/Resources/bin/cmux)."
+        )
+    return cli
+
+
+def config_path() -> Path:
+    """Path to cmux's primary config file (``~/.config/cmux/cmux.json``)."""
+    return Path.home() / ".config" / "cmux" / "cmux.json"
+
+
+# --------------------------------------------------------------------------- #
+# Surface (custom command) construction
+# --------------------------------------------------------------------------- #
+
+
+def cswap_launch_command() -> str:
+    """The shell command a cmux surface runs to start a managed session.
+
+    Mirrors :func:`embed.cswap_statusline_command`: prefer a resolvable ``cswap``
+    on PATH, else invoke the package with the current interpreter so it always
+    works for the installed environment.
+    """
+    if shutil.which("cswap"):
+        return "cswap launch"
+    return f'"{sys.executable}" -m claude_swap launch'
+
+
+def build_surface() -> dict:
+    """The cswap custom-command entry merged into cmux.json's ``commands`` array.
+
+    A cmux custom command is a named terminal launcher surfaced in the command
+    palette / plus-button. ``env`` sets the wrapper's preserve-key allow-list so
+    ``CLAUDE_CONFIG_DIR`` (cswap's per-session profile pin) survives the
+    cmux-claude-wrapper's auth-env clearing.
+    """
+    return {
+        "name": SURFACE_NAME,
+        "type": "terminal",
+        "command": cswap_launch_command(),
+        "cwd": ".",
+        "env": {PRESERVE_KEYS_ENV: CLAUDE_CONFIG_DIR_KEY},
+    }
+
+
+def merge_preserve_keys(existing: str | None) -> str:
+    """Return a preserve-key list that includes ``CLAUDE_CONFIG_DIR``.
+
+    cmux accepts a comma- or space-separated list. We append our key to any
+    existing value (de-duplicated, order-preserving) rather than clobbering it,
+    so a user (or cmux) preserve list keeps working. Shared with the supervisor's
+    env logic so both sides agree on the format.
+    """
+    keys: list[str] = []
+    if existing:
+        for tok in re.split(r"[,\s]+", existing.strip()):
+            if tok and tok not in keys:
+                keys.append(tok)
+    if CLAUDE_CONFIG_DIR_KEY not in keys:
+        keys.append(CLAUDE_CONFIG_DIR_KEY)
+    return ",".join(keys)
+
+
+# --------------------------------------------------------------------------- #
+# cmux.json read/merge (JSONC-tolerant)
+# --------------------------------------------------------------------------- #
+
+
+def _strip_jsonc(text: str) -> str:
+    """Strip ``//`` line and ``/* */`` block comments outside of strings.
+
+    cmux.json is JSONC (the on-launch template is entirely commented-out keys).
+    A real parser is overkill; this scanner respects string literals and escape
+    sequences so comment markers inside strings are left intact.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_str = False
+    escaped = False
+    while i < n:
+        c = text[i]
+        if in_str:
+            out.append(c)
+            if escaped:
+                escaped = False
+            elif c == "\\":
+                escaped = True
+            elif c == '"':
+                in_str = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def _strip_trailing_commas(text: str) -> str:
+    """Remove trailing commas before ``}``/``]`` (legal in JSONC, not JSON)."""
+    return re.sub(r",(\s*[}\]])", r"\1", text)
+
+
+def load_config(path: Path | None = None) -> dict:
+    """Parse cmux.json (JSONC-tolerant). Missing/empty/corrupt -> ``{}``.
+
+    Returns a plain dict so :func:`merge_surface` can layer our command in.
+    Comments are dropped on parse; the writer re-emits strict JSON, which cmux
+    accepts (verified via ``cmux config validate``).
+    """
+    path = path or config_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    cleaned = _strip_trailing_commas(_strip_jsonc(raw)).strip()
+    if not cleaned:
+        return {}
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def merge_surface(config: dict) -> tuple[dict, bool]:
+    """Merge our custom command into ``config`` idempotently.
+
+    Returns ``(new_config, changed)``. Preserves every existing key (including a
+    user's other custom commands) and only touches the ``commands`` array entry
+    whose ``name`` is :data:`SURFACE_NAME`. ``changed`` is False when the entry
+    already matches, so callers can skip a needless write/reload.
+    """
+    new = dict(config)
+    new.setdefault(
+        "$schema",
+        "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+    )
+    new.setdefault("schemaVersion", 1)
+
+    commands = new.get("commands")
+    if not isinstance(commands, list):
+        commands = []
+    else:
+        commands = list(commands)  # don't mutate the caller's list in place
+
+    surface = build_surface()
+    idx = next(
+        (
+            i
+            for i, c in enumerate(commands)
+            if isinstance(c, dict) and c.get("name") == SURFACE_NAME
+        ),
+        None,
+    )
+    if idx is None:
+        commands.append(surface)
+        changed = True
+    elif commands[idx] != surface:
+        commands[idx] = surface
+        changed = True
+    else:
+        changed = False
+
+    new["commands"] = commands
+    return new, changed
+
+
+# --------------------------------------------------------------------------- #
+# cmux CLI helpers
+# --------------------------------------------------------------------------- #
+
+
+def _run_cli(cli: str, *args: str, timeout: float = 30.0) -> subprocess.CompletedProcess:
+    """Run a cmux CLI subcommand, capturing output. Never raises on nonzero."""
+    return subprocess.run(
+        [cli, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _validate(cli: str) -> tuple[bool, str]:
+    """Run ``cmux config validate``; return ``(ok, message)``."""
+    try:
+        cp = _run_cli(cli, "config", "validate")
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, str(exc)
+    out = (cp.stdout or "") + (cp.stderr or "")
+    ok = cp.returncode == 0 and "JSONC syntax is valid" in out
+    return ok, out.strip()
+
+
+# --------------------------------------------------------------------------- #
+# S1 — install the reusable surface
+# --------------------------------------------------------------------------- #
+
+
+def setup(switcher) -> dict:
+    """Install the "Balanced Claude (cswap)" surface into cmux.json.
+
+    Backs up an existing cmux.json to a timestamped ``.bak``, merges our command
+    idempotently (preserving all user content), validates, and reloads via the
+    cmux CLI. Returns a status dict:
+
+        ``{"ok", "changed", "config_path", "backup_path", "validated",
+           "reloaded", "messages"}``
+
+    Resilient to an absent/empty cmux.json (cmux creates the template on launch;
+    a fresh strict-JSON file with just our command is equally valid). Raises a
+    clear :class:`SessionError` on non-macOS or when cmux isn't installed.
+    """
+    cli = _require_macos_cmux()
+    # Ensure managed-template exists so a session launched from the surface is
+    # immediately embeddable (mirrors `cswap --install`).
+    embed.write_managed_template(switcher)
+
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    messages: list[str] = []
+    backup_path: str | None = None
+    if path.exists() and path.stat().st_size > 0:
+        backup = path.with_name(f"cmux.json.{time.strftime('%Y%m%d-%H%M%S')}.bak")
+        try:
+            shutil.copy2(path, backup)
+            backup_path = str(backup)
+        except OSError as exc:
+            messages.append(f"backup failed: {exc}")
+
+    config = load_config(path)
+    merged, changed = merge_surface(config)
+
+    if changed:
+        # Atomic write via the switcher (0600). cmux accepts strict JSON.
+        switcher._write_json(path, merged)
+    else:
+        messages.append("surface already present and current")
+
+    validated, vmsg = _validate(cli)
+    if not validated:
+        messages.append(f"validation: {vmsg}")
+
+    reloaded = False
+    if validated:
+        try:
+            cp = _run_cli(cli, "reload-config")
+            reloaded = cp.returncode == 0
+            if not reloaded:
+                messages.append(
+                    f"reload-config exit {cp.returncode}: "
+                    f"{((cp.stdout or '') + (cp.stderr or '')).strip()[:200]}"
+                )
+        except (OSError, subprocess.SubprocessError) as exc:
+            messages.append(f"reload-config failed: {exc}")
+
+    return {
+        "ok": validated,
+        "changed": changed,
+        "config_path": str(path),
+        "backup_path": backup_path,
+        "validated": validated,
+        "reloaded": reloaded,
+        "messages": messages,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# S2 — fanout: open N workspaces each running `cswap launch`
+# --------------------------------------------------------------------------- #
+
+
+def _shell_quote(arg: str) -> str:
+    """Single-quote-escape an arg for the shell command cmux types/runs."""
+    return "'" + arg.replace("'", "'\\''") + "'"
+
+
+def _build_launch_command(claude_args: list[str]) -> str:
+    """The shell command line a fanout workspace runs.
+
+    ``cswap launch`` (PATH or interpreter fallback), forwarding any claude args
+    after ``--``. Args are shell-quoted so paths/flags with spaces survive.
+    """
+    cmd = cswap_launch_command()
+    if claude_args:
+        cmd += " -- " + " ".join(_shell_quote(a) for a in claude_args)
+    return cmd
+
+
+def _list_workspace_count(cli: str) -> int:
+    """Best-effort count of current workspaces (for create→verify)."""
+    try:
+        cp = _run_cli(cli, "list-workspaces")
+    except (OSError, subprocess.SubprocessError):
+        return -1
+    if cp.returncode != 0:
+        return -1
+    lines = [ln for ln in (cp.stdout or "").splitlines() if ln.strip()]
+    return len(lines)
+
+
+def _open_one_workspace(cli: str, cwd: str, command: str, name: str) -> bool:
+    """Create one workspace running ``command``, verifying it appeared.
+
+    Uses ``cmux new-workspace --cwd … --command …`` — the documented headless
+    path (the command is sent to the new workspace's terminal). To defend against
+    the known "typed command silently dropped when unfocused" race, we verify the
+    workspace count grew and retry the create on failure.
+    """
+    for attempt in range(1, _CREATE_VERIFY_RETRIES + 1):
+        before = _list_workspace_count(cli)
+        try:
+            cp = _run_cli(
+                cli,
+                "new-workspace",
+                "--name",
+                name,
+                "--cwd",
+                cwd,
+                "--command",
+                command,
+                "--focus",
+                "true",  # focus avoids the unfocused-drop race for the typed cmd
+            )
+        except (OSError, subprocess.SubprocessError):
+            time.sleep(_CREATE_VERIFY_DELAY_S)
+            continue
+        if cp.returncode == 0:
+            # Verify a new workspace actually appeared before declaring success.
+            time.sleep(_CREATE_VERIFY_DELAY_S)
+            after = _list_workspace_count(cli)
+            if before < 0 or after < 0 or after > before:
+                return True
+        time.sleep(_CREATE_VERIFY_DELAY_S)
+    return False
+
+
+def fanout(switcher, n: int, claude_args: list[str] | None = None) -> dict:
+    """Open ``n`` cmux workspaces each running a balancer-managed session.
+
+    Each workspace runs ``cswap launch [-- <claude_args>]`` in the current
+    directory; the balancer's online reservation spreads them across accounts.
+    After a short settle, reads the registry back to report which account each
+    landed on. Returns a status dict::
+
+        {"ok", "requested", "opened", "command", "cwd",
+         "accounts": [<num>, ...], "distinct_accounts": <int>, "messages"}
+
+    Raises :class:`SessionError` on non-macOS / missing cmux, or when there are
+    no managed accounts to balance across.
+    """
+    cli = _require_macos_cmux()
+    if n < 1:
+        raise SessionError("fanout count must be >= 1.")
+
+    seq = switcher._get_sequence_data() or {}
+    if not seq.get("accounts"):
+        raise SessionError(
+            "No managed accounts yet. Add one with `cswap --add-account` first."
+        )
+    if not shutil.which("claude"):
+        raise SessionError(
+            "'claude' was not found on PATH. Install Claude Code first."
+        )
+
+    # Ensure the managed template exists before sessions spawn.
+    embed.write_managed_template(switcher)
+
+    cwd = str(Path.cwd())
+    command = _build_launch_command(list(claude_args or []))
+
+    messages: list[str] = []
+    opened = 0
+    for i in range(n):
+        name = f"cswap {i + 1}/{n}"
+        if _open_one_workspace(cli, cwd, command, name):
+            opened += 1
+        else:
+            messages.append(f"workspace {i + 1} failed to open (after retries)")
+
+    # Let the supervisors register their rows, then read which account each got.
+    if opened:
+        time.sleep(_FANOUT_SETTLE_S)
+    accounts = _recent_session_accounts(switcher, opened)
+    distinct = len({a for a in accounts if a})
+
+    return {
+        "ok": opened == n,
+        "requested": n,
+        "opened": opened,
+        "command": command,
+        "cwd": cwd,
+        "accounts": accounts,
+        "distinct_accounts": distinct,
+        "messages": messages,
+    }
+
+
+def _recent_session_accounts(switcher, limit: int) -> list[str]:
+    """Account numbers of the ``limit`` most-recently-started live sessions.
+
+    Reads the registry (no lock needed — atomic writes) and returns the newest
+    rows' accounts, so the caller can confirm the fanout spread across accounts.
+    """
+    reg = registry.read_registry(switcher)
+    rows = registry.live_sessions(reg)  # oldest-first
+    newest = rows[-limit:] if limit and limit < len(rows) else rows
+    return [str(r.get("account_num", "")) for r in newest]

--- a/src/claude_swap/embed.py
+++ b/src/claude_swap/embed.py
@@ -34,24 +34,83 @@ EFFORT_LEVEL = "xhigh"
 TEMPLATE_DIRNAME = "_template"
 
 
-def cswap_statusline_command() -> str:
-    """Return the shell command Claude Code should run as the statusLine.
+def _cswap_command(subcommand: str) -> str:
+    """Return the shell command Claude Code should run for ``cswap <subcommand>``.
 
     Prefers a resolvable ``cswap`` on PATH; otherwise falls back to invoking the
-    package with the current interpreter (``python -m claude_swap statusline``),
+    package with the current interpreter (``python -m claude_swap <subcommand>``),
     which always works for the installed environment.
     """
     if shutil.which("cswap"):
-        return "cswap statusline"
-    return f'"{sys.executable}" -m claude_swap statusline'
+        return f"cswap {subcommand}"
+    return f'"{sys.executable}" -m claude_swap {subcommand}'
+
+
+def cswap_statusline_command() -> str:
+    """Return the shell command Claude Code should run as the statusLine."""
+    return _cswap_command("statusline")
+
+
+def cswap_statusfailure_command() -> str:
+    """Return the command Claude Code should run for the ``StopFailure`` hook.
+
+    Resolved like the statusLine command (PATH or interpreter fallback).
+    """
+    return _cswap_command("statusfailure")
 
 
 def build_managed_settings() -> dict:
-    """The cswap-owned settings merged into every managed profile."""
+    """The cswap-owned settings merged into every managed profile.
+
+    Carries the statusLine (the balancer's event-driven trigger + display), the
+    effort QoL default, and a ``StopFailure`` hook: a next-turn safety net that
+    fires when a turn fails after claude exhausts its API retries (e.g. a hard
+    rate limit) and migrates the session to a fresh account so the NEXT turn
+    recovers without the user switching manually.
+    """
     return {
         "statusLine": {"type": "command", "command": cswap_statusline_command()},
         "effortLevel": EFFORT_LEVEL,
+        "hooks": {
+            "StopFailure": [
+                {"hooks": [{"type": "command", "command": cswap_statusfailure_command()}]}
+            ]
+        },
     }
+
+
+def _merge_hooks(base_hooks: object, managed_hooks: object) -> dict:
+    """Merge the user's ``hooks`` block with cswap's managed hooks (per event).
+
+    Claude Code's ``hooks`` is ``{event_name: [matcher_group, ...]}``. We keep
+    every event the user defines and append our matcher groups for the events we
+    own (currently ``StopFailure``), so a user with their own ``StopFailure``
+    hook keeps it and ours runs alongside it. Tolerant of a non-dict base.
+    """
+    merged: dict = dict(base_hooks) if isinstance(base_hooks, dict) else {}
+    if not isinstance(managed_hooks, dict):
+        return merged
+    for event, groups in managed_hooks.items():
+        existing = merged.get(event)
+        if isinstance(existing, list):
+            merged[event] = existing + list(groups)
+        else:
+            merged[event] = list(groups)
+    return merged
+
+
+def _has_stopfailure_hook(settings: dict) -> bool:
+    """Whether ``settings`` carries a ``StopFailure`` -> ``statusfailure`` hook."""
+    hooks = settings.get("hooks")
+    groups = hooks.get("StopFailure") if isinstance(hooks, dict) else None
+    if not isinstance(groups, list):
+        return False
+    for group in groups:
+        for hook in (group or {}).get("hooks", []) if isinstance(group, dict) else []:
+            cmd = hook.get("command", "") if isinstance(hook, dict) else ""
+            if "statusfailure" in cmd:
+                return True
+    return False
 
 
 def managed_template_path(switcher) -> Path:
@@ -128,7 +187,12 @@ def install_into_profile(switcher, profile_dir: Path) -> None:
     if isinstance(env, dict):
         base["env"] = {k: v for k, v in env.items() if k not in AUTH_OVERRIDE_ENV_VARS}
 
-    merged = {**base, **build_managed_settings()}
+    managed = build_managed_settings()
+    merged = {**base, **managed}
+    # Shallow-merging ``hooks`` would clobber the user's own hooks. Deep-merge
+    # per event so the user keeps their hooks and our StopFailure safety net is
+    # added (or, for StopFailure, appended) rather than replacing them.
+    merged["hooks"] = _merge_hooks(base.get("hooks"), managed.get("hooks"))
 
     dest = profile_dir / "settings.json"
     # Never write through the share symlink (that would mutate ~/.claude).
@@ -158,6 +222,7 @@ def embed_health(switcher) -> dict:
                 isinstance(sl, dict)
                 and sl.get("command")
                 and t.get("effortLevel") == EFFORT_LEVEL
+                and _has_stopfailure_hook(t)
             ):
                 template_ok = True
     except (OSError, json.JSONDecodeError):

--- a/src/claude_swap/embed.py
+++ b/src/claude_swap/embed.py
@@ -1,0 +1,184 @@
+"""Embed cswap into Claude Code for managed (load-balanced) sessions.
+
+The load balancer only manages sessions launched via ``cswap launch``, each in
+its own per-session profile under ``managed/``. "Embedding" means installing the
+cswap statusline + effort QoL into that profile so the session reports its usage
+back to the registry and renders the compact balancer line.
+
+Crucially it is installed as a **real, merged** ``settings.json`` inside the
+managed profile — the user-settings layer Claude Code definitely reads from a
+``CLAUDE_CONFIG_DIR`` (``settings.local.json`` may be ignored there). The merge
+keeps the user's MCP servers / hooks / plugins from ``~/.claude/settings.json``
+but strips inherited auth-override env keys and lets our statusLine + effort win.
+The user's real settings are never touched (we never write through the share
+symlink), and plain ``claude`` / ``cswap run`` sessions stay completely vanilla.
+A canonical template under ``managed/_template/settings.json`` records what we
+install, so ``cswap --status`` can report embed health and the upgrade migration
+can refresh it on a new version.
+
+Stdlib only; reuses ``switcher._write_json`` for atomic, chmod-0600 writes.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# Persistable approximation of the session-only "ultracode" effort: the highest
+# effort level that can be set via settings/CLI. (True ultracode is set in-session
+# via /effort and cannot be persisted.)
+EFFORT_LEVEL = "xhigh"
+
+TEMPLATE_DIRNAME = "_template"
+
+
+def cswap_statusline_command() -> str:
+    """Return the shell command Claude Code should run as the statusLine.
+
+    Prefers a resolvable ``cswap`` on PATH; otherwise falls back to invoking the
+    package with the current interpreter (``python -m claude_swap statusline``),
+    which always works for the installed environment.
+    """
+    if shutil.which("cswap"):
+        return "cswap statusline"
+    return f'"{sys.executable}" -m claude_swap statusline'
+
+
+def build_managed_settings() -> dict:
+    """The cswap-owned settings merged into every managed profile."""
+    return {
+        "statusLine": {"type": "command", "command": cswap_statusline_command()},
+        "effortLevel": EFFORT_LEVEL,
+    }
+
+
+def managed_template_path(switcher) -> Path:
+    return switcher.managed_dir / TEMPLATE_DIRNAME / "settings.json"
+
+
+def write_managed_template(switcher) -> bool:
+    """Write/refresh the canonical managed-profile template. Returns True if changed.
+
+    Idempotent: a no-op when the on-disk template already matches.
+    """
+    path = managed_template_path(switcher)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    desired = build_managed_settings()
+    try:
+        if path.exists() and json.loads(path.read_text(encoding="utf-8")) == desired:
+            return False
+    except (OSError, json.JSONDecodeError):
+        pass
+    switcher._write_json(path, desired)
+    return True
+
+
+def _drop_settings_from_share_manifest(profile_dir: Path) -> None:
+    """Remove ``settings.json`` from the profile's share manifest.
+
+    The sharing sync symlinks ``settings.json`` from ``~/.claude`` and records
+    it as cswap-managed. Since we replace it with a real merged file, drop it
+    from the manifest so a later sync treats our file as the profile's own copy
+    and never re-symlinks over it. Tolerant of a missing/corrupt manifest.
+    """
+    from claude_swap.session import SHARE_MANIFEST
+
+    manifest_path = profile_dir / SHARE_MANIFEST
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        items = data.get("items", [])
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return
+    if "settings.json" not in items:
+        return
+    data["items"] = [i for i in items if i != "settings.json"]
+    manifest_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def install_into_profile(switcher, profile_dir: Path) -> None:
+    """Install the statusline + effort QoL into a managed profile.
+
+    Writes a real, merged ``settings.json`` (the user-settings layer Claude Code
+    reads for a ``CLAUDE_CONFIG_DIR``): the user's ``~/.claude/settings.json`` as
+    a base (so managed sessions keep their MCP servers / hooks / plugins), with
+    inherited auth-override env keys stripped, and our statusLine + effort layered
+    on top. MUST be called AFTER the profile's sharing sync: it replaces the
+    shared ``settings.json`` symlink with a real file (never writing through the
+    symlink into ``~/.claude``) and drops it from the share manifest so a later
+    sync won't re-symlink over it.
+    """
+    from claude_swap.session import AUTH_OVERRIDE_ENV_VARS
+
+    profile_dir = Path(profile_dir)
+    profile_dir.mkdir(parents=True, exist_ok=True)
+
+    user_settings = Path.home() / ".claude" / "settings.json"
+    try:
+        base = json.loads(user_settings.read_text(encoding="utf-8"))
+        if not isinstance(base, dict):
+            base = {}
+    except (OSError, json.JSONDecodeError):
+        base = {}
+
+    # A managed session must use its profile's subscription creds, never an
+    # inherited API key carried in the user's settings env.
+    env = base.get("env")
+    if isinstance(env, dict):
+        base["env"] = {k: v for k, v in env.items() if k not in AUTH_OVERRIDE_ENV_VARS}
+
+    merged = {**base, **build_managed_settings()}
+
+    dest = profile_dir / "settings.json"
+    # Never write through the share symlink (that would mutate ~/.claude).
+    if dest.is_symlink() or dest.exists():
+        dest.unlink()
+    switcher._write_json(dest, merged)
+
+    _drop_settings_from_share_manifest(profile_dir)
+
+
+def embed_health(switcher) -> dict:
+    """Report whether cswap is embedded so new managed sessions auto-balance.
+
+    Returns ``{"ok", "issues", "template_ok", "cswap_on_path"}``. ``ok`` is True
+    once the managed template is installed and current — the statusline command
+    always resolves (PATH or the interpreter fallback), so ``cswap_on_path`` is
+    informational only.
+    """
+    issues: list[str] = []
+    tpath = managed_template_path(switcher)
+    template_ok = False
+    try:
+        if tpath.exists():
+            t = json.loads(tpath.read_text(encoding="utf-8"))
+            sl = t.get("statusLine") if isinstance(t, dict) else None
+            if (
+                isinstance(sl, dict)
+                and sl.get("command")
+                and t.get("effortLevel") == EFFORT_LEVEL
+            ):
+                template_ok = True
+    except (OSError, json.JSONDecodeError):
+        template_ok = False
+    if not template_ok:
+        issues.append("managed-session template not installed")
+
+    cswap_on_path = shutil.which("cswap") is not None
+    return {
+        "ok": not issues,
+        "issues": issues,
+        "template_ok": template_ok,
+        "cswap_on_path": cswap_on_path,
+    }
+
+
+def install(switcher) -> dict:
+    """One-time embed setup (idempotent): write the managed template.
+
+    Returns :func:`embed_health` after installing.
+    """
+    switcher._setup_directories()
+    write_managed_template(switcher)
+    return embed_health(switcher)

--- a/src/claude_swap/migrations.py
+++ b/src/claude_swap/migrations.py
@@ -478,10 +478,48 @@ def migrate_macos_keyring_to_security(switcher: "ClaudeAccountSwitcher") -> bool
     return True
 
 
+def migrate_install_balancer(switcher: "ClaudeAccountSwitcher") -> bool:
+    """One-time setup for the load balancer (Beta) — runs on upgrade.
+
+    Backfills ``priority: 0`` onto existing accounts and installs the managed-
+    session settings template (so ``cswap launch`` works and ``cswap --status``
+    reports embed health) without any user action after upgrading from a version
+    that predates the feature. Idempotent and self-guarded:
+
+    * skip (``False``) when there is no readable sequence yet (a fresh install or
+      a corrupt file) — a later restore still triggers it,
+    * complete (``True``) once priorities are backfilled and the template is
+      written; re-running is a cheap no-op.
+
+    Never touches live profiles or credentials — only ``sequence.json`` and the
+    template file.
+    """
+    if not switcher.sequence_file.exists():
+        return False
+    data = switcher._get_sequence_data()
+    if data is None:
+        return False  # corrupt/unparseable — never mark; retry after repair.
+
+    changed = False
+    for info in data.get("accounts", {}).values():
+        if isinstance(info, dict) and "priority" not in info:
+            info["priority"] = 0
+            changed = True
+    if changed:
+        data["lastUpdated"] = get_timestamp()
+        switcher._write_json(switcher.sequence_file, data)
+
+    from claude_swap import embed  # noqa: PLC0415 - only needed on this path
+
+    embed.write_managed_template(switcher)
+    return True
+
+
 # Registry of (id, fn). Order matters if migrations ever depend on each other.
 MIGRATIONS: list[tuple[str, Callable[["ClaudeAccountSwitcher"], bool]]] = [
     ("windows_keyring_to_files", migrate_windows_keyring_to_files),
     ("macos_keyring_to_security", migrate_macos_keyring_to_security),
+    ("install_balancer_v1", migrate_install_balancer),
 ]
 
 

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -77,8 +77,33 @@ def is_oauth_token_expired(expires_at: object) -> bool:
     return now_ms + OAUTH_EXPIRY_BUFFER_MS >= int(expires_at)
 
 
-def refresh_oauth_credentials(credentials: str) -> str | None:
-    """Refresh an OAuth access token via direct token endpoint POST."""
+def _is_invalid_grant(body: str) -> bool:
+    """Whether a refresh-token POST failed with a definitive ``invalid_grant``.
+
+    The provider returns this (HTTP 400, ``{"error": "invalid_grant"}``) when the
+    stored refresh token is revoked, already-rotated (single-use reuse), or expired
+    — i.e. the account is logged out and no retry recovers it without a fresh login.
+    Distinguished from transient failures (5xx, timeouts, non-JSON bodies) so the
+    caller can mark the account logged-out (actionable) rather than generically
+    unavailable; anything we can't positively identify as ``invalid_grant`` stays a
+    transient failure.
+    """
+    try:
+        return json.loads(body).get("error") == "invalid_grant"
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        return False
+
+
+def refresh_oauth_credentials(
+    credentials: str, failure_out: dict | None = None
+) -> str | None:
+    """Refresh an OAuth access token via direct token endpoint POST.
+
+    ``failure_out`` (optional): on a definitive ``invalid_grant`` (the refresh token
+    is dead — revoked / already-rotated / expired) sets ``failure_out["invalid_grant"]
+    = True`` so the caller can surface a "logged out — re-login" state instead of a
+    generic "usage unavailable". Transient failures leave it unset.
+    """
     try:
         data = json.loads(credentials)
         oauth = data.get("claudeAiOauth")
@@ -120,6 +145,8 @@ def refresh_oauth_credentials(credentials: str) -> str | None:
     except urllib.error.HTTPError as e:
         body = e.read().decode(errors="replace") if hasattr(e, "read") else ""
         _logger.debug("OAuth refresh failed: %r, body: %s", e, body[:500])
+        if failure_out is not None and _is_invalid_grant(body):
+            failure_out["invalid_grant"] = True
         return None
     except Exception as e:
         _logger.debug("OAuth refresh failed: %r", e)

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -255,6 +255,78 @@ def prime_account(access_token: str) -> bool:
 
 
 
+def probe_messages_headroom(access_token: str, failure_out: dict | None = None) -> bool | None:
+    """Probe whether an account can serve a turn RIGHT NOW via the messages endpoint.
+
+    The messages endpoint (``/v1/messages``) is a SEPARATE rate-limit bucket from
+    the usage endpoint (``/api/oauth/usage``), so this answers "can this account
+    work now?" even while the usage API is 429-backed-off and reporting no signal.
+    Sends the SAME minimal turn :func:`prime_account` does (Haiku 4.5, a 1-token
+    prompt, ``max_tokens=1``), so it COSTS one trivial billable Haiku turn and,
+    like priming, STARTS the 5h window — acceptable only because the caller probes
+    an account it is about to place/resume a session onto.
+
+    Returns:
+      * ``True``  — 2xx (incl. ``stop_reason: max_tokens``): NOT 5h/7d capped =>
+                    the account has headroom now.
+      * ``False`` — 429: capped (out of usage). When ``failure_out`` is not None
+                    the server's ``Retry-After`` (seconds, via
+                    :func:`_retry_after_seconds`, clamped to
+                    :data:`_MAX_USAGE_BACKOFF_S`) is written as
+                    ``failure_out["retry_after"]`` so the caller can carry it into
+                    a backoff marker.
+      * ``None``  — 401 / network / other: UNKNOWN (logged out / offline). Distinct
+                    from ``False`` so the caller never caches a false "capped"
+                    verdict for a transient failure.
+
+    Best-effort, NEVER raises. The tri-state return (vs :func:`prime_account`'s
+    bool, which folds 429 into ``True`` because "window already running" is success
+    for priming) is deliberate: for a HEADROOM probe the three outcomes are
+    semantically distinct and the caller caches each differently.
+
+    The caller MUST pass only an INACTIVE/idle account's token (an active account's
+    credentials are owned by Claude Code and must never be touched) and MUST make
+    this call OUTSIDE the registry FileLock (it is network I/O).
+    """
+    body = json.dumps({
+        "model": PRIME_MODEL,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode()
+    req = urllib.request.Request(
+        _MESSAGES_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "anthropic-beta": OAUTH_BETA_HEADER,
+            "anthropic-version": "2023-06-01",
+            "Content-Type": "application/json",
+            "User-Agent": "claude-swap/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if 200 <= resp.status < 300:
+                return True
+            return None
+    except urllib.error.HTTPError as e:
+        # 429: capped (out of usage on the messages bucket). Surface the server's
+        # Retry-After so the caller can refresh its backoff marker.
+        if e.code == 429:
+            if failure_out is not None:
+                ra = _retry_after_seconds(e)
+                if ra is not None:
+                    failure_out["retry_after"] = ra
+            return False
+        # 401 (logged out) / any other code: unknown, not a "capped" verdict.
+        _logger.debug("headroom probe failed: %r", e)
+        return None
+    except Exception as e:  # noqa: BLE001 - probing is best-effort, never fatal
+        _logger.debug("headroom probe failed: %r", e)
+        return None
+
+
 def build_usage_result(data: dict) -> dict | None:
     """Normalize raw usage API data into the structure used by the CLI."""
     _logger.debug("Usage API response: %s", json.dumps(data, indent=2))
@@ -323,16 +395,41 @@ def fetch_usage(access_token: str) -> dict | None:
         return None
 
 
+# Hard ceiling on a server-supplied ``Retry-After``. A single 429 must never be
+# able to blackhole an account's usage for hours (a buggy/huge header would
+# otherwise pin it at "rate-limited" / no-headroom until the marker elapsed).
+_MAX_USAGE_BACKOFF_S = 3600
+
+
+def _retry_after_seconds(e: urllib.error.HTTPError) -> int | None:
+    """Parse a ``Retry-After`` (seconds) header from a 429, clamped to a sane max."""
+    try:
+        val = int(e.headers.get("Retry-After"))  # type: ignore[union-attr]
+    except (TypeError, ValueError, AttributeError):
+        return None
+    if val <= 0:
+        return None
+    return min(val, _MAX_USAGE_BACKOFF_S)
+
+
 def fetch_usage_for_account(
     account_num: str,
     email: str,
     credentials: str,
     is_active: bool,
     persist_credentials: Callable[[str, str, str], None] | None = None,
+    failure_out: dict | None = None,
 ) -> dict | None:
     """Fetch usage for an account, refreshing expired tokens for inactive accounts only.
 
-    Active accounts are never refreshed — Claude Code owns those credentials.
+    Active accounts are never refreshed — Claude Code owns those credentials, and
+    refreshing rotates the single-use refresh token out from under the live login
+    (forcing a re-login). The caller MUST pass ``is_active=True`` for the current
+    default login and for any account with a live session.
+
+    ``failure_out`` (optional): on a usage-endpoint 429 the server's requested
+    backoff is written as ``failure_out["retry_after"]`` (seconds) so the caller
+    can cache a throttle marker and stop hammering the rate-limited endpoint.
     """
     oauth = extract_oauth_data(credentials)
     access_token = oauth.get("accessToken") if oauth else None
@@ -358,6 +455,13 @@ def fetch_usage_for_account(
         return build_usage_result(data)
     except urllib.error.HTTPError as e:
         _logger.debug("Usage fetch failed: %r", e)
+        if e.code == 429 and failure_out is not None:
+            # Rate-limited by the usage endpoint (client-wide, not token-specific):
+            # surface the server's Retry-After so the caller backs off instead of
+            # re-hitting it every TTL. Refreshing/retrying here would only amplify it.
+            ra = _retry_after_seconds(e)
+            if ra is not None:
+                failure_out["retry_after"] = ra
         if (
             e.code != 401
             or is_active
@@ -381,6 +485,13 @@ def fetch_usage_for_account(
         try:
             data = request_usage_data(new_token)
             return build_usage_result(data)
+        except urllib.error.HTTPError as retry_error:
+            _logger.debug("Usage fetch failed after refresh: %r", retry_error)
+            if retry_error.code == 429 and failure_out is not None:
+                ra = _retry_after_seconds(retry_error)
+                if ra is not None:
+                    failure_out["retry_after"] = ra
+            return None
         except Exception as retry_error:
             _logger.debug("Usage fetch failed after refresh: %r", retry_error)
             return None

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -283,6 +283,12 @@ def build_usage_result(data: dict) -> dict | None:
 
     eu = data.get("extra_usage")
     if eu and eu.get("is_enabled"):
+        # Record that pay-as-you-go / extra-usage is enabled REGARDLESS of whether
+        # the dollar-denominated spend line below can be built (it can't when
+        # ``monthly_limit`` is None = unlimited). The balancer's API-rate last-resort
+        # tier keys off this flag, so it must reflect capability, not just billing
+        # display. See ``balancer._api_capable``.
+        result["extra_usage_enabled"] = True
         # Claude Code returns nullable used_credits, monthly_limit, and utilization
         # (monthly_limit=None = unlimited). All three are needed to render the spend
         # line, so when any is null skip just the spend entry; five_hour/seven_day

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -38,6 +38,36 @@ def extract_oauth_data(credentials: str) -> dict | None:
     return oauth if isinstance(oauth, dict) else None
 
 
+# Subscription tiers that have a 5-hour usage window worth "warming". An account
+# authenticated some other way — pay-as-you-go API / console billing, or a tier
+# we don't recognize — is deliberately excluded so idle-window priming never
+# spends real money on an account with no subscription window to anchor.
+PRIMABLE_SUBSCRIPTION_TYPES = frozenset({"pro", "max", "team", "enterprise"})
+
+
+def extract_subscription_type(credentials: str) -> str | None:
+    """Return the Claude subscription type (lowercased) from a credentials string.
+
+    ``None`` when the credentials carry no OAuth subscription payload (e.g. an
+    API-key / console account) or can't be parsed.
+    """
+    oauth = extract_oauth_data(credentials)
+    if not isinstance(oauth, dict):
+        return None
+    sub = oauth.get("subscriptionType")
+    return sub.lower() if isinstance(sub, str) and sub.strip() else None
+
+
+def is_primable_subscription(subscription_type: str | None) -> bool:
+    """Whether an account's subscription tier has a primeable 5h window.
+
+    Conservative by design: only recognized Claude *subscription* tiers qualify.
+    An API-credit / console account, or any unrecognized/missing type, returns
+    ``False`` so priming never bills a pay-as-you-go account.
+    """
+    return bool(subscription_type) and subscription_type.lower() in PRIMABLE_SUBSCRIPTION_TYPES
+
+
 def is_oauth_token_expired(expires_at: object) -> bool:
     """Return whether an OAuth token is expired or about to expire."""
     if not isinstance(expires_at, (int, float)):

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -116,6 +116,14 @@ def build_token_status(credentials: str) -> str | None:
     return f"oauth: {state}, refresh token {refresh_str}, expires {clock} in {countdown}"
 
 
+def _epoch_seconds(resets_at: str) -> int | None:
+    """Parse an ISO-8601 reset timestamp to epoch seconds; ``None`` if unparseable."""
+    try:
+        return int(datetime.fromisoformat(resets_at).timestamp())
+    except (TypeError, ValueError):
+        return None
+
+
 def format_reset(resets_at: str) -> tuple[str, str]:
     """Return (countdown, clock) for a reset time in local time."""
     reset_utc = datetime.fromisoformat(resets_at)
@@ -145,7 +153,12 @@ def format_reset(resets_at: str) -> tuple[str, str]:
 
 
 def request_usage_data(access_token: str) -> dict:
-    """Request raw utilization data from the Anthropic usage API."""
+    """Request raw utilization data from the Anthropic usage API.
+
+    Note: this is a READ and does NOT consume credits, so it does NOT start an
+    account's 5-hour rate-limit window. Use :func:`prime_account` to start the
+    clock on an idle window.
+    """
     url = "https://api.anthropic.com/api/oauth/usage"
     headers = {
         "Authorization": f"Bearer {access_token}",
@@ -155,6 +168,60 @@ def request_usage_data(access_token: str) -> dict:
     req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req, timeout=5) as resp:
         return json.loads(resp.read().decode())
+
+
+# The cheapest possible credit-consuming turn: Haiku 4.5, a 1-token prompt, and
+# max_tokens=1. One trivial billable turn is enough to START the account's 5h
+# rate-limit window (the window is anchored to the first credit-consuming call of
+# a cycle) so idle accounts' windows stay staggered and fresh capacity keeps
+# cycling online — see the priming feature in the README / supervisor.
+PRIME_MODEL = "claude-haiku-4-5"
+_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+
+
+def prime_account(access_token: str) -> bool:
+    """Send ONE minimal credit-consuming message to start the 5h window. Best-effort.
+
+    Uses the same subscription OAuth auth shape as :func:`request_usage_data`
+    (Bearer access token + the ``anthropic-beta: oauth-2025-04-20`` header). A
+    2xx response (even ``stop_reason: max_tokens``) means the clock started ->
+    ``True``. A 429 means the account is already rate-limited (its window is
+    already running) -> treated as a no-op success (``True``). Any other failure
+    (401 logged out, network error) -> ``False``. NEVER raises.
+
+    The caller MUST only pass an INACTIVE/idle account's token (an active account's
+    credentials are owned by Claude Code and must never be touched) and MUST make
+    this call OUTSIDE the registry FileLock (it is network I/O).
+    """
+    body = json.dumps({
+        "model": PRIME_MODEL,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode()
+    req = urllib.request.Request(
+        _MESSAGES_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "anthropic-beta": OAUTH_BETA_HEADER,
+            "anthropic-version": "2023-06-01",
+            "Content-Type": "application/json",
+            "User-Agent": "claude-swap/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as e:
+        # 429: already rate-limited => the window is already started => no-op done.
+        if e.code == 429:
+            return True
+        _logger.debug("prime call failed: %r", e)
+        return False
+    except Exception as e:  # noqa: BLE001 - priming is best-effort, never fatal
+        _logger.debug("prime call failed: %r", e)
+        return False
 
 
 
@@ -169,6 +236,11 @@ def build_usage_result(data: dict) -> dict | None:
         h5_entry = {"pct": h5["utilization"]}
         if h5.get("resets_at"):
             h5_entry["countdown"], h5_entry["clock"] = format_reset(h5["resets_at"])
+            # Preserve the raw epoch reset alongside the formatted strings so the
+            # idle-window priming detection (which needs to tell a STARTED 5h
+            # window from an unstarted one) and ``soonest_blocking_reset`` work on
+            # cached usage too — not just on the live statusline signal.
+            h5_entry["resets_at"] = _epoch_seconds(h5["resets_at"])
         result["five_hour"] = h5_entry
 
     d7 = data.get("seven_day")
@@ -176,6 +248,7 @@ def build_usage_result(data: dict) -> dict | None:
         d7_entry = {"pct": d7["utilization"]}
         if d7.get("resets_at"):
             d7_entry["countdown"], d7_entry["clock"] = format_reset(d7["resets_at"])
+            d7_entry["resets_at"] = _epoch_seconds(d7["resets_at"])
         result["seven_day"] = d7_entry
 
     eu = data.get("extra_usage")

--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -58,6 +58,49 @@ def get_credentials_path() -> Path:
     return get_claude_config_home() / ".credentials.json"
 
 
+def mark_cwd_trusted(config: dict, cwd: str | os.PathLike | None) -> bool:
+    """Record ``cwd`` as a trusted project in a profile's ``.claude.json`` dict.
+
+    Claude Code shows the interactive "Is this a project you created or one you
+    trust?" dialog on startup whenever the working directory has no
+    ``projects[<abs cwd>].hasTrustDialogAccepted == true`` entry. There is no
+    global "trust everything" key, and ``--dangerously-skip-permissions`` is a
+    SEPARATE boundary (tool permissions) that does NOT suppress it. A managed /
+    balanced launch is already user-authorized — and already auto-prepends
+    ``--dangerously-skip-permissions`` — so pre-seeding trust for the launch
+    directory keeps the spawned session from stopping on that gate. Each managed
+    profile is single-use, so without this the dialog fires on every launch.
+
+    Seeds BOTH the abspath and the symlink-resolved realpath: claude keys the
+    projects map by the child's ``process.cwd()`` (kernel-canonical, symlinks
+    resolved), while a caller-supplied ``--cwd`` may still carry symlink
+    components. Mutates ``config`` in place; existing per-project metadata is
+    preserved.
+
+    Returns True when a trust entry was written, False when ``cwd`` is falsy.
+    """
+    if not cwd:
+        return False
+    projects = config.get("projects")
+    if not isinstance(projects, dict):
+        # A missing or malformed map shadowing the expected shape — (re)create
+        # it rather than crash; the profile is cswap-managed and disposable.
+        projects = {}
+        config["projects"] = projects
+    raw = os.fspath(cwd)
+    variants: list[str] = []
+    for variant in (os.path.abspath(raw), os.path.realpath(raw)):
+        if variant not in variants:
+            variants.append(variant)
+    for variant in variants:
+        entry = projects.get(variant)
+        if not isinstance(entry, dict):
+            entry = {}
+            projects[variant] = entry
+        entry["hasTrustDialogAccepted"] = True
+    return True
+
+
 def get_legacy_backup_root() -> Path:
     """Return the legacy (pre-XDG) backup root: ``~/.claude-swap-backup``."""
     return Path.home() / LEGACY_BACKUP_DIRNAME

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -483,9 +483,16 @@ def build_world(
             usage = _rl_to_usage(live_rl)
             h5_pct, h5_reset = _five_hour_signal(usage)
             d7_pct, d7_reset = _seven_day_signal(usage)
-            # Pay-as-you-go info isn't in the live signal — read it from the
-            # cached usage-API result for this account (best-effort).
-            extra_usage, spend_pct = _spend_signal(cached.get(num))
+            # Pay-as-you-go info isn't in the live statusline signal — it only
+            # comes from the usage API. Read it from the cached usage result; on a
+            # cold cache, fetch once (best-effort) so a live account's extra-usage
+            # capability isn't silently lost — which would otherwise wrongly PAUSE
+            # an API-rate-tier session instead of letting it spill to API rates.
+            spend_src = cached.get(num)
+            if spend_src is None and fetch_idle:
+                spend_src = _fetch_idle_usage(switcher, num, email)
+                fetched[num] = spend_src
+            extra_usage, spend_pct = _spend_signal(spend_src)
             acct_views[num] = AccountView(
                 num=num,
                 priority=priority,

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -42,6 +42,8 @@ from claude_swap.cache import (
     MISSING,
     STALE_USAGE_MAX_AGE_S,
     last_known_usage,
+    logged_out,
+    logged_out_marker,
     merge_last_known,
     probe_ok,
     probe_recent,
@@ -611,6 +613,12 @@ def build_world(
             # Retry-After so we back off for as long as it asked, not just one TTL.
             if usage is not None:
                 fetched[num] = usage
+            elif fail.get("logged_out"):
+                # Dead refresh token -> the account is logged out. A distinct marker
+                # (carrying NO last-known snapshot — a logged-out account can't
+                # authenticate, so it must never be resurrected as an optimistic
+                # stale target) so the render layer shows an actionable "re-login".
+                fetched[num] = logged_out_marker()
             else:
                 marker: dict = {"_unavailable": True}
                 ra = fail.get("retry_after")
@@ -651,6 +659,13 @@ def build_world(
                 usage = stale
                 signal = "stale"
 
+        # A confirmed logged-out account (dead refresh token): surface a distinct
+        # signal so the dashboard shows "logged out — re-login" rather than the
+        # generic "usage unavailable". Checked against the freshly-written marker and
+        # the prior cache so it persists across passes within the recheck throttle.
+        if logged_out(fetched.get(num)) or logged_out(cached_entry) or logged_out(persisted_entry):
+            signal = "logged_out"
+
         is_usage = isinstance(usage, dict)
         h5_pct, h5_reset = _five_hour_signal(usage) if is_usage else (None, None)
         d7_pct, d7_reset = _seven_day_signal(usage) if is_usage else (None, None)
@@ -684,18 +699,33 @@ def _probe_view(num: str, priority: int, resv: float, entry: dict | None) -> Acc
 
     Built only after a messages probe (or a fresh cached OK verdict) confirms the
     account can serve a turn now. ``max_pct`` is the conservative
-    :data:`~claude_swap.balancer.PROBE_CONFIRMED_PCT`, folded through
-    :func:`_with_reserve` so a just-placed online reservation still stacks (keeping
-    two stranded sessions from co-exhausting it). Per-window pct/reset are ``None``
+    :data:`~claude_swap.balancer.PROBE_CONFIRMED_PCT` — UNLESS ``entry`` still carries
+    a fresh last-known REAL reading (the 429 backoff marker / OK verdict threads it
+    via :func:`cache.merge_last_known`), in which case we use ``min(PROBE_CONFIRMED_PCT,
+    real)`` as the base: a probe at an account that was genuinely near-idle (e.g. 27%)
+    really is that available, so pinning it at the pessimistic 80 would wrongly fail
+    ``target_safety`` for a large-context session and strand it on an hour-long pause
+    even though the account is wide open (the observed "auto-resuming in 2h55m while an
+    account was available" bug). We only ever LOWER the value (``min``), never raise it
+    above the conservative probe number — a stale reading could be near-capped and the
+    probe only proves "a turn works now". When ``entry`` has no fresh last-known reading
+    the base stays ``PROBE_CONFIRMED_PCT`` (byte-for-byte the prior behaviour).
+
+    The base is folded through :func:`_with_reserve` so a just-placed online
+    reservation still stacks — THAT (not the flat 80) is what keeps two stranded
+    sessions from co-exhausting the same target. Per-window pct/reset are ``None``
     (a probe yields no window data); ``soonest_reset`` is ``None`` (unknown).
     extra-usage/spend are read best-effort from ``entry`` (usually absent on a
     backoff/probe marker, so typically ``(False, None)``).
     """
     extra_usage, spend_pct = _spend_signal(entry)
+    stale = last_known_usage(entry, STALE_USAGE_MAX_AGE_S)
+    real = _max_pct(stale) if stale is not None else None
+    base = min(PROBE_CONFIRMED_PCT, real) if real is not None else PROBE_CONFIRMED_PCT
     return AccountView(
         num=num,
         priority=priority,
-        max_pct=_with_reserve(PROBE_CONFIRMED_PCT, resv),
+        max_pct=_with_reserve(base, resv),
         soonest_reset=None,
         signal="probe",
         five_hour_pct=None,
@@ -793,6 +823,15 @@ def _maybe_probe(
     """
     if not probe_unavailable:
         return None
+    # A logged-out account (dead refresh token) can't be refreshed and a messages
+    # probe would only 401 — never probe it. Without this the resume/strand path
+    # (build_world(probe_unavailable=True), ~30s cadence) would re-POST the dead
+    # token and re-attempt a billable Haiku turn every pass for the whole strand,
+    # defeating the LOGGED_OUT_RECHECK_S throttle. build_world keeps the logged-out
+    # marker (its usage_backoff_active branch does fetched.setdefault) so the
+    # "logged out" signal and throttle survive.
+    if logged_out(entry):
+        return None
     # Reuse a fresh cached verdict without a network call (cross-process throttle).
     if probe_recent(entry):
         if probe_ok(entry):
@@ -846,6 +885,11 @@ def _maybe_probe(
         merge_last_known(marker, entry, now)
         fetched[num] = marker
         return None
+    # Logged out (the refresh surfaced a dead token): a distinct marker so the
+    # dashboard shows "re-login" and the dead token isn't re-POSTed every tick.
+    if fail.get("logged_out"):
+        fetched[num] = logged_out_marker(now)
+        return None
     # Unknown (None): stamp so the re-probe is throttled, but no retry_until.
     fetched[num] = merge_last_known({"_unavailable": True, "_probed_at": now}, entry, now)
     return None
@@ -878,21 +922,27 @@ def _fetch_idle_usage(
     account out on its next refresh.
     """
     from claude_swap import oauth
-    from claude_swap.locking import FileLock
 
     try:
         creds = switcher.read_account_credentials(str(num), email)
         if not creds or not oauth.extract_access_token(creds):
             return None
 
-        def _persist(acct_num: str, acct_email: str, new_creds: str) -> None:
-            with FileLock(switcher.lock_file):
-                switcher.write_account_credentials(acct_num, acct_email, new_creds)
+        if not is_active:
+            # Refresh the inactive account's single-use OAuth token through the
+            # locked, double-checked chokepoint so concurrent build_world callers
+            # (every statusline migration-plan / balancer tick / `cswap --list`, each
+            # a separate process) can't both POST it and trigger the provider's
+            # token-reuse revocation — the silent-logout root cause. ``failure_out``
+            # carries ``logged_out`` back to the caller on a dead refresh token. Then
+            # fetch with is_active=True so the usage path never refreshes again.
+            creds = switcher.ensure_fresh_inactive_credentials(
+                str(num), email, creds, failure_out=failure_out
+            )
 
         return oauth.fetch_usage_for_account(
             str(num), email, creds,
-            is_active=is_active,
-            persist_credentials=None if is_active else _persist,
+            is_active=True,
             failure_out=failure_out,
         )
     except Exception:  # noqa: BLE001 - usage is best-effort; unknown => not a target
@@ -928,7 +978,6 @@ def _probe_idle_headroom(
     => no headroom, never a target), mirroring the prime invariant exactly.
     """
     from claude_swap import oauth
-    from claude_swap.locking import FileLock
 
     try:
         creds = switcher.read_account_credentials(str(num), email)
@@ -948,23 +997,17 @@ def _probe_idle_headroom(
         if not token:
             return None
 
-        # Refresh an expired token for this INACTIVE account, persisting under the
-        # lock (mirrors the usage path); never refresh an active/live account.
-        if (
-            not is_active
-            and oauth_data.get("refreshToken")
-            and oauth.is_oauth_token_expired(oauth_data.get("expiresAt"))
-        ):
-            refreshed = oauth.refresh_oauth_credentials(creds)
-            if refreshed:
-                token = oauth.extract_access_token(refreshed) or token
-                try:
-                    with FileLock(switcher.lock_file):
-                        switcher.write_account_credentials(str(num), email, refreshed)
-                except Exception:
-                    switcher._logger.debug(
-                        "probe: persist refreshed creds failed for %s", num, exc_info=True
-                    )
+        # Refresh an expired token for this INACTIVE account through the locked,
+        # double-checked chokepoint (mirrors the usage path): two concurrent
+        # supervisors must never both POST the single-use refresh token, or the
+        # provider revokes the whole family and logs the account out. Never refresh
+        # an active/live account. ``failure_out`` carries ``logged_out`` back on a
+        # dead refresh token so the caller can stamp the right marker.
+        if not is_active:
+            creds = switcher.ensure_fresh_inactive_credentials(
+                str(num), email, creds, failure_out=failure_out
+            )
+            token = oauth.extract_access_token(creds) or token
 
         return oauth.probe_messages_headroom(token, failure_out=failure_out)
     except Exception:  # noqa: BLE001 - probing is best-effort; unknown => not a target

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -40,6 +40,9 @@ from pathlib import Path
 from claude_swap.balancer import PROBE_CONFIRMED_PCT, AccountView, SessionView, _pct_cost
 from claude_swap.cache import (
     MISSING,
+    STALE_USAGE_MAX_AGE_S,
+    last_known_usage,
+    merge_last_known,
     probe_ok,
     probe_recent,
     read_cache,
@@ -613,6 +616,9 @@ def build_world(
                 ra = fail.get("retry_after")
                 if isinstance(ra, (int, float)) and ra > 0:
                     marker["retry_until"] = time.time() + ra
+                # Remember the last healthy reading so the optimistic stale view can
+                # keep this account a no-credit target through the backoff window.
+                merge_last_known(marker, persisted_entry)
                 fetched[num] = marker
         else:
             usage = None
@@ -620,6 +626,30 @@ def build_world(
         if probe_view is not None:
             acct_views[num] = probe_view
             continue
+
+        # Optimistic stale fallback: an account whose usage endpoint is backed off
+        # (so ``usage is None``) but which carries a still-recent last-known-good
+        # reading enters the model with THAT reading (``signal="stale"``) instead of
+        # zero headroom — so a stranded session can migrate onto a was-healthy
+        # account without spending a probe credit. The reading may be out of date
+        # (the account could be capped now); if so the session hits a real limit and
+        # recovers again, which is the accepted optimistic-use tradeoff. The balancer
+        # still gates placement on ``target_safety``, so a stale reading near the cap
+        # is ``_usable`` but won't be picked as a target.
+        signal = "cache" if isinstance(usage, dict) else "none"
+        if usage is None:
+            stale_src = fetched.get(num) if num in fetched else persisted_entry
+            # A FRESH probe verdict is authoritative and must trump an older
+            # last-known reading: if a live probe JUST confirmed this account is
+            # capped/unknown (``probe_recent`` and not ``probe_ok``), do NOT resurrect
+            # it as a usable stale target — otherwise the session migrates straight
+            # back onto an account the probe (a paid call) already said is exhausted,
+            # the migrate->limit->migrate loop this feature exists to avoid.
+            fresh_negative_probe = probe_recent(stale_src) and not probe_ok(stale_src)
+            stale = None if fresh_negative_probe else last_known_usage(stale_src, STALE_USAGE_MAX_AGE_S)
+            if stale is not None:
+                usage = stale
+                signal = "stale"
 
         is_usage = isinstance(usage, dict)
         h5_pct, h5_reset = _five_hour_signal(usage) if is_usage else (None, None)
@@ -630,7 +660,7 @@ def build_world(
             priority=priority,
             max_pct=_with_reserve(_max_pct(usage), resv) if is_usage else None,
             soonest_reset=soonest_blocking_reset(usage) if is_usage else None,
-            signal="cache" if is_usage else "none",
+            signal=signal,
             five_hour_pct=h5_pct,
             five_hour_reset=h5_reset,
             seven_day_pct=d7_pct,
@@ -710,7 +740,11 @@ def _claim_probe_slot(switcher, num: str):
             # Another supervisor stamped a fresh verdict in the race -> reuse it.
             return current
         merged = dict(latest)
-        merged[num] = {"_unavailable": True, "_probed_at": time.time()}
+        # Carry last-known-good onto the provisional placeholder so a claim that
+        # races in doesn't drop the stale-view snapshot before the real verdict.
+        merged[num] = merge_last_known(
+            {"_unavailable": True, "_probed_at": time.time()}, current
+        )
         write_cache(usage_cache_path, merged)
         return None
     finally:
@@ -797,17 +831,23 @@ def _maybe_probe(
     )
     now = time.time()
     if verdict is True:
-        fetched[num] = {"_probe_ok": True, "_probed_at": now}
+        # Thread last-known-good forward even on an OK verdict (mirrors the other
+        # marker writes): once this verdict goes un-fresh, a later 429 marker can
+        # inherit the snapshot instead of collapsing the account to zero headroom.
+        fetched[num] = merge_last_known({"_probe_ok": True, "_probed_at": now}, entry, now)
         return _probe_view(num, priority, resv, entry)
     if verdict is False:
         marker: dict = {"_unavailable": True, "_probed_at": now}
         ra = fail.get("retry_after")
         if isinstance(ra, (int, float)) and ra > 0:
             marker["retry_until"] = now + ra
+        # Preserve last-known-good across the probe rewrite (a probe must not wipe
+        # the stale-view snapshot the 429 marker was carrying).
+        merge_last_known(marker, entry, now)
         fetched[num] = marker
         return None
     # Unknown (None): stamp so the re-probe is throttled, but no retry_until.
-    fetched[num] = {"_unavailable": True, "_probed_at": now}
+    fetched[num] = merge_last_known({"_unavailable": True, "_probed_at": now}, entry, now)
     return None
 
 

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -37,8 +37,15 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-from claude_swap.balancer import AccountView, SessionView, _pct_cost
-from claude_swap.cache import MISSING, read_cache, write_cache
+from claude_swap.balancer import PROBE_CONFIRMED_PCT, AccountView, SessionView, _pct_cost
+from claude_swap.cache import (
+    MISSING,
+    probe_ok,
+    probe_recent,
+    read_cache,
+    usage_backoff_active,
+    write_cache,
+)
 from claude_swap.models import get_timestamp
 from claude_swap.process_detection import is_pid_alive
 
@@ -428,7 +435,7 @@ def _with_reserve(max_pct: float | None, reserve: float) -> float | None:
 
 
 def build_world(
-    switcher, reg: dict, *, fetch_idle: bool = True
+    switcher, reg: dict, *, fetch_idle: bool = True, probe_unavailable: bool = False
 ) -> tuple[dict[str, AccountView], list[SessionView]]:
     """Build the immutable snapshot the pure balancer consumes.
 
@@ -438,10 +445,21 @@ def build_world(
       last-reported ``rate_limits`` (free, no network);
     * **cache** — an idle account uses the shared 15s usage cache, fetching via
       the usage API on a miss only when ``fetch_idle`` is set;
-    * **none** — unknown usage (no signal / fetch failed) => ``max_pct=None`` =>
-      zero headroom, so the account is never chosen as a migration target.
+    * **probe** — an idle account whose usage signal is UNAVAILABLE (the usage
+      endpoint is 429-backed-off, or a within-TTL fetch failure) is probed via the
+      messages endpoint (a SEPARATE rate-limit bucket) ONLY when ``probe_unavailable``
+      is set. A 2xx confirms the account can serve a turn now; it enters the model
+      with a conservative synthesized ``max_pct=PROBE_CONFIRMED_PCT`` so a stranded
+      session can resume onto it instead of stalling for the whole backoff window.
+      Costs one billable Haiku turn, throttled cross-process to once per
+      ``PROBE_VERDICT_TTL_S`` and NEVER run for the active default / a live-session
+      account. Default OFF: only the supervisor's strand/resume/placement paths
+      request it; render paths (statusline, dashboard, ``cswap --list``) never do;
+    * **none** — unknown usage (no signal / fetch failed / probe capped-or-unknown)
+      => ``max_pct=None`` => zero headroom, so the account is never a migration target.
 
-    Must be called OUTSIDE ``switcher.lock_file`` (the idle fetch is network I/O).
+    Must be called OUTSIDE ``switcher.lock_file`` (the idle fetch + probe are
+    network I/O).
     """
     seq = switcher._get_sequence_data() or {}
     accounts = seq.get("accounts", {})
@@ -468,6 +486,21 @@ def build_world(
     usage_cache_path = switcher.backup_dir / "cache" / "usage.json"
     cached = read_cache(usage_cache_path, _usage_ttl())
     cached = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
+    # Persisted markers survive the freshness TTL: a 429 backoff marker holds the
+    # cache slot until its server-requested Retry-After elapses, so a rate-limited
+    # usage endpoint isn't re-hit every TTL (the "usage unavailable" feedback loop).
+    persisted = read_cache(usage_cache_path, float("inf"))
+    persisted = persisted if (persisted is not MISSING and isinstance(persisted, dict)) else {}
+
+    # The active default login (current ~/.claude identity). Its OAuth token — and
+    # that of any account with a live session — must NEVER be refreshed by the idle
+    # usage path NOR probed via the messages endpoint: refreshing rotates the
+    # single-use refresh token out from under the live login and forces a re-login,
+    # and probing would touch credentials Claude Code owns. This mirrors the guard
+    # `list_accounts` applies; threading it here closes the asymmetry that was
+    # logging users out. Resolved whenever we may fetch idle usage OR probe — both
+    # need the active/live guard.
+    active_num = switcher.active_account_num() if (fetch_idle or probe_unavailable) else None
 
     acct_views: dict[str, AccountView] = {}
     fetched: dict[str, dict | None] = {}
@@ -507,24 +540,86 @@ def build_world(
             continue
 
         cached_entry = cached.get(num) if isinstance(cached, dict) else None
-        if isinstance(cached_entry, dict) and cached_entry.get("_unavailable"):
-            # A cached fetch FAILURE (e.g. usage-API 429). Treat as no signal and
-            # do NOT refetch: the marker holds the cache slot for the TTL, so a
-            # failing / rate-limited fetch is throttled to once per cache TTL
-            # instead of being retried every supervise tick — the feedback loop
-            # that otherwise pins every account at "usage unavailable" once the
-            # usage endpoint starts returning 429. The shared cache file
-            # coordinates this across all supervisor processes.
+        persisted_entry = persisted.get(num) if isinstance(persisted, dict) else None
+        # A no-signal account whose usage is UNAVAILABLE (429-backed-off endpoint or
+        # a within-TTL failure) is a candidate for the messages-API headroom probe.
+        # The probe view (a synthesized ``"probe"`` AccountView), when produced,
+        # short-circuits the usual usage->AccountView mapping below.
+        probe_view: AccountView | None = None
+        if probe_unavailable and probe_ok(persisted_entry) and probe_recent(persisted_entry):
+            # A fresh cached probe-OK verdict ({"_probe_ok": True, ...}). It carries
+            # no usage windows and no _unavailable marker, so neither the backoff
+            # branch nor the within-TTL-failure branch below would catch it — it
+            # would fall through to ``elif cached_entry is not None`` and become a
+            # signal="cache" view with max_pct=None (zero headroom, never a target),
+            # silently defeating the whole resume-onto-a-probed-account feature on
+            # every build_world pass after the one that fired the live probe. Reuse
+            # the verdict WITHOUT a network call instead. Read from ``persisted_entry``
+            # (inf TTL), not ``cached_entry``: the verdict carries no retry_until, so
+            # it would expire from the 60s freshness cache at half the documented
+            # PROBE_VERDICT_TTL_S cadence — the persisted read keeps it alive for the
+            # full window so the cross-process cadence cap actually holds for OK
+            # verdicts (it already does for the 429/None markers via retry_until).
             usage = None
+            probe_view = _maybe_probe(
+                switcher, num, email, priority, resv,
+                persisted_entry, active_num, probe_unavailable, fetched,
+            )
+        elif usage_backoff_active(persisted_entry):
+            # Under a server-requested 429 backoff: the usage endpoint is no signal
+            # and must NOT be refetched. Fall back to a messages probe (a separate
+            # rate-limit bucket) when asked — THE fix for the hour-long resume stall.
+            usage = None
+            probe_view = _maybe_probe(
+                switcher, num, email, priority, resv,
+                persisted_entry, active_num, probe_unavailable, fetched,
+            )
+            if probe_view is None:
+                # No probe (disabled / active / throttled-and-not-OK): keep the
+                # backoff marker so it survives this write.
+                fetched.setdefault(num, persisted_entry)
+        elif isinstance(cached_entry, dict) and cached_entry.get("_unavailable"):
+            # A cached fetch FAILURE within the freshness TTL. No signal, do NOT
+            # refetch the usage endpoint — but a messages probe can still confirm
+            # headroom (throttled cross-process by the ``_probed_at`` stamp).
+            usage = None
+            probe_view = _maybe_probe(
+                switcher, num, email, priority, resv,
+                cached_entry, active_num, probe_unavailable, fetched,
+            )
         elif cached_entry is not None:
             usage = cached_entry
         elif fetch_idle:
-            usage = _fetch_idle_usage(switcher, num, email)
+            # Never refresh/rotate the token of the active default login or an
+            # account with a live session — that is the credential-invalidation
+            # bug. With is_active=True the fetch skips refresh; a 401 then simply
+            # yields no usage (max_pct=None), which the balancer already treats as
+            # zero headroom — far better than logging the user out.
+            acct_is_active = (
+                (active_num is not None and num == str(active_num))
+                or switcher.has_live_session(num, email)
+            )
+            fail: dict = {}
+            usage = _fetch_idle_usage(
+                switcher, num, email, is_active=acct_is_active, failure_out=fail
+            )
             # Persist the outcome either way — real usage, or a failure marker so
-            # the TTL throttles retries (see above).
-            fetched[num] = usage if usage is not None else {"_unavailable": True}
+            # retries are throttled. On a 429 the marker carries the server's
+            # Retry-After so we back off for as long as it asked, not just one TTL.
+            if usage is not None:
+                fetched[num] = usage
+            else:
+                marker: dict = {"_unavailable": True}
+                ra = fail.get("retry_after")
+                if isinstance(ra, (int, float)) and ra > 0:
+                    marker["retry_until"] = time.time() + ra
+                fetched[num] = marker
         else:
             usage = None
+
+        if probe_view is not None:
+            acct_views[num] = probe_view
+            continue
 
         is_usage = isinstance(usage, dict)
         h5_pct, h5_reset = _five_hour_signal(usage) if is_usage else (None, None)
@@ -554,6 +649,168 @@ def build_world(
     return acct_views, sess_views
 
 
+def _probe_view(num: str, priority: int, resv: float, entry: dict | None) -> AccountView:
+    """A synthesized ``"probe"`` :class:`AccountView` for a confirmed-runnable account.
+
+    Built only after a messages probe (or a fresh cached OK verdict) confirms the
+    account can serve a turn now. ``max_pct`` is the conservative
+    :data:`~claude_swap.balancer.PROBE_CONFIRMED_PCT`, folded through
+    :func:`_with_reserve` so a just-placed online reservation still stacks (keeping
+    two stranded sessions from co-exhausting it). Per-window pct/reset are ``None``
+    (a probe yields no window data); ``soonest_reset`` is ``None`` (unknown).
+    extra-usage/spend are read best-effort from ``entry`` (usually absent on a
+    backoff/probe marker, so typically ``(False, None)``).
+    """
+    extra_usage, spend_pct = _spend_signal(entry)
+    return AccountView(
+        num=num,
+        priority=priority,
+        max_pct=_with_reserve(PROBE_CONFIRMED_PCT, resv),
+        soonest_reset=None,
+        signal="probe",
+        five_hour_pct=None,
+        five_hour_reset=None,
+        seven_day_pct=None,
+        seven_day_reset=None,
+        extra_usage=extra_usage,
+        spend_pct=spend_pct,
+    )
+
+
+def _claim_probe_slot(switcher, num: str):
+    """Compare-and-set a provisional probe claim for ``num`` under the lock.
+
+    The lock-free freshness re-read in :func:`_maybe_probe` leaves a herd window: N
+    supervisors waking together can all see a stale stamp and all probe before any
+    stamp lands. This closes it. Under :attr:`switcher.lock_file`, re-read the
+    account's ``usage.json`` slot and re-check :func:`cache.probe_recent`:
+
+    * if a FRESH verdict raced in (another process already probed), return that
+      entry so the caller reuses it (when OK) or stays no-signal — no probe fires;
+    * otherwise stamp a provisional ``{"_unavailable": True, "_probed_at": now}``
+      placeholder (so every other supervisor now sees a fresh verdict and bows out)
+      and return ``None`` to signal "you won the claim, go probe". The caller's real
+      verdict overwrites this placeholder after the (out-of-lock) network probe.
+
+    Returns ``None`` (go probe) when the slot was claimed OR when the lock could not
+    be acquired — best-effort: a missed claim degrades to the old lock-free behaviour
+    (a possible duplicate probe), never to a crash or a dropped probe.
+    """
+    from claude_swap.locking import FileLock
+
+    usage_cache_path = switcher.backup_dir / "cache" / "usage.json"
+    lock = FileLock(switcher.lock_file, timeout=5)
+    if not lock.acquire():
+        return None
+    try:
+        latest = read_cache(usage_cache_path, float("inf"))
+        latest = latest if (latest is not MISSING and isinstance(latest, dict)) else {}
+        current = latest.get(num)
+        if probe_recent(current):
+            # Another supervisor stamped a fresh verdict in the race -> reuse it.
+            return current
+        merged = dict(latest)
+        merged[num] = {"_unavailable": True, "_probed_at": time.time()}
+        write_cache(usage_cache_path, merged)
+        return None
+    finally:
+        lock.release()
+
+
+def _maybe_probe(
+    switcher,
+    num: str,
+    email: str,
+    priority: int,
+    resv: float,
+    entry: dict | None,
+    active_num,
+    probe_unavailable: bool,
+    fetched: dict[str, dict | None],
+) -> AccountView | None:
+    """Messages-API headroom fallback for a no-signal idle account.
+
+    Returns a ``"probe"`` :class:`AccountView` when the account is confirmed
+    runnable now (via a fresh cached OK verdict, reused WITHOUT a network call, or a
+    live probe that returned ``True``); otherwise ``None`` (probing disabled,
+    account active/live, throttle gate not OK, or the probe came back capped/unknown).
+
+    Gating (ALL must hold to fire a live probe):
+
+    * ``probe_unavailable`` is set (opt-in; only the supervisor's strand/resume
+      paths request it — render paths never do);
+    * the account is NOT the active default login and has NO live session (hard
+      credential-safety invariant — never touch creds Claude Code owns);
+    * no fresh verdict is cached for it (``cache.probe_recent`` — the cross-process
+      cadence cap; while a recent verdict exists every supervisor REUSES it instead
+      of re-probing, so N supervisors never each fire a billable probe).
+
+    Each verdict is written into ``fetched[num]`` (the same shared ``usage.json``
+    slot the 429 marker uses) so the cadence is enforced cross-process:
+      * True  -> ``{"_probe_ok": True, "_probed_at": now}`` + a probe AccountView;
+      * False (429) -> ``{"_unavailable": True, "retry_until": now+Retry-After,
+                          "_probed_at": now}`` (refresh the backoff with the messages
+                          bucket's Retry-After);
+      * None (unknown) -> ``{"_unavailable": True, "_probed_at": now}`` (no
+                          retry_until, so it elapses on the usage TTL; the stamp
+                          still throttles a re-probe for the cadence window).
+
+    Best-effort, never raises (``_probe_idle_headroom`` swallows its own errors).
+    """
+    if not probe_unavailable:
+        return None
+    # Reuse a fresh cached verdict without a network call (cross-process throttle).
+    if probe_recent(entry):
+        if probe_ok(entry):
+            fetched.setdefault(num, entry)
+            return _probe_view(num, priority, resv, entry)
+        # A recent capped/unknown verdict: stay no-signal, no re-probe yet.
+        return None
+    # Never probe the active default login or an account with a live session.
+    acct_is_active = (
+        (active_num is not None and num == str(active_num))
+        or switcher.has_live_session(num, email)
+    )
+    if acct_is_active:
+        return None
+
+    # Close the cross-process herd window (TOCTOU): the freshness re-read above is
+    # lock-free, so N supervisors waking on the same ~30s pause cadence could all
+    # observe a stale stamp and all fire a billable probe before any stamp lands.
+    # Compare-and-set a provisional claim UNDER THE LOCK — re-read this account's
+    # cache slot, re-check probe_recent, and if it is still stale stamp a placeholder
+    # so every other supervisor now sees a fresh verdict and bows out. The billable
+    # probe itself still runs OUTSIDE the lock (it is network I/O) and overwrites the
+    # placeholder with the real verdict below. A reuse-able fresh verdict that landed
+    # in the race is honoured here. Best-effort: if the lock can't be taken we fall
+    # through and probe anyway (degrades to the old behaviour, never worse).
+    raced = _claim_probe_slot(switcher, num)
+    if raced is not None:
+        if probe_ok(raced):
+            fetched.setdefault(num, raced)
+            return _probe_view(num, priority, resv, raced)
+        return None
+
+    fail: dict = {}
+    verdict = _probe_idle_headroom(
+        switcher, num, email, is_active=acct_is_active, failure_out=fail
+    )
+    now = time.time()
+    if verdict is True:
+        fetched[num] = {"_probe_ok": True, "_probed_at": now}
+        return _probe_view(num, priority, resv, entry)
+    if verdict is False:
+        marker: dict = {"_unavailable": True, "_probed_at": now}
+        ra = fail.get("retry_after")
+        if isinstance(ra, (int, float)) and ra > 0:
+            marker["retry_until"] = now + ra
+        fetched[num] = marker
+        return None
+    # Unknown (None): stamp so the re-probe is throttled, but no retry_until.
+    fetched[num] = {"_unavailable": True, "_probed_at": now}
+    return None
+
+
 def _priority_of(info: dict) -> int:
     try:
         return int(info.get("priority", 0))
@@ -567,15 +824,109 @@ def _usage_ttl() -> int:
     return _USAGE_CACHE_TTL
 
 
-def _fetch_idle_usage(switcher, num: str, email: str) -> dict | None:
-    """Fetch one idle account's usage via the usage API. Best-effort, never raises."""
+def _fetch_idle_usage(
+    switcher, num: str, email: str, *, is_active: bool = False, failure_out: dict | None = None
+) -> dict | None:
+    """Fetch one idle account's usage via the usage API. Best-effort, never raises.
+
+    ``is_active`` MUST be True for the active default login or any account with a
+    live session: with it set, the usage path never refreshes/rotates the OAuth
+    token (Claude Code owns those credentials). For a genuinely-idle account whose
+    expired token IS refreshed, the rotated token is persisted back to the canonical
+    backup under the lock — so cswap never leaves its own backup holding a dead
+    (single-use, already-rotated) refresh token, which would otherwise log the
+    account out on its next refresh.
+    """
     from claude_swap import oauth
+    from claude_swap.locking import FileLock
 
     try:
         creds = switcher.read_account_credentials(str(num), email)
         if not creds or not oauth.extract_access_token(creds):
             return None
-        return oauth.fetch_usage_for_account(str(num), email, creds, is_active=False)
+
+        def _persist(acct_num: str, acct_email: str, new_creds: str) -> None:
+            with FileLock(switcher.lock_file):
+                switcher.write_account_credentials(acct_num, acct_email, new_creds)
+
+        return oauth.fetch_usage_for_account(
+            str(num), email, creds,
+            is_active=is_active,
+            persist_credentials=None if is_active else _persist,
+            failure_out=failure_out,
+        )
     except Exception:  # noqa: BLE001 - usage is best-effort; unknown => not a target
         switcher._logger.debug("idle usage fetch failed for %s", num, exc_info=True)
+        return None
+
+
+def _probe_idle_headroom(
+    switcher, num: str, email: str, *, is_active: bool = False, failure_out: dict | None = None
+) -> bool | None:
+    """Probe one idle account's headroom via the messages endpoint. Best-effort.
+
+    Structurally identical to :func:`_fetch_idle_usage` (creds read + the optional
+    expired-token refresh-and-persist happen here; the network probe runs OUTSIDE
+    the lock), but it answers a different question — "can this account serve a turn
+    NOW?" — using the messages bucket, which is unaffected by a 429 on the usage
+    endpoint. Returns the tri-state of :func:`oauth.probe_messages_headroom`
+    (``True``/``False``/``None``); on any local failure, ``None`` (unknown).
+
+    ``is_active`` MUST be True for the active default login / a live-session account
+    (the caller's gate already refuses to probe those); with it set the expired-token
+    refresh is skipped so Claude Code's single-use refresh token is never rotated.
+    For a genuinely-idle account whose token IS refreshed, the rotated token is
+    persisted back under the lock — never leaving cswap holding a dead refresh token.
+
+    Only a recognized Claude *subscription* account is probed. The probe sends the
+    exact same billable ``/v1/messages`` turn as priming, so it MUST carry priming's
+    subscription-tier guard (``oauth.is_primable_subscription``): without it, a
+    pay-as-you-go / API / console account — or a subscription-exhausted account with
+    extra-usage enabled — returns a billed 2xx that the balancer would misread as
+    ~80% subscription headroom, silently charging real dollars and defeating
+    ``onlySubscriptionTokens``. A non-subscription account returns ``None`` (unknown
+    => no headroom, never a target), mirroring the prime invariant exactly.
+    """
+    from claude_swap import oauth
+    from claude_swap.locking import FileLock
+
+    try:
+        creds = switcher.read_account_credentials(str(num), email)
+        if not creds:
+            return None
+        # Never probe a non-subscription account: the messages turn bills real money
+        # and a 2xx can't distinguish "subscription has room" from "PAYG just charged
+        # me". Mirrors supervisor._prime_one_account's guard so the probe never bills
+        # a pay-as-you-go account, regardless of cfg.only_subscription.
+        if not oauth.is_primable_subscription(oauth.extract_subscription_type(creds)):
+            switcher._logger.debug(
+                "probe: skipping %s — not a primeable subscription account", num
+            )
+            return None
+        oauth_data = oauth.extract_oauth_data(creds) or {}
+        token = oauth_data.get("accessToken")
+        if not token:
+            return None
+
+        # Refresh an expired token for this INACTIVE account, persisting under the
+        # lock (mirrors the usage path); never refresh an active/live account.
+        if (
+            not is_active
+            and oauth_data.get("refreshToken")
+            and oauth.is_oauth_token_expired(oauth_data.get("expiresAt"))
+        ):
+            refreshed = oauth.refresh_oauth_credentials(creds)
+            if refreshed:
+                token = oauth.extract_access_token(refreshed) or token
+                try:
+                    with FileLock(switcher.lock_file):
+                        switcher.write_account_credentials(str(num), email, refreshed)
+                except Exception:
+                    switcher._logger.debug(
+                        "probe: persist refreshed creds failed for %s", num, exc_info=True
+                    )
+
+        return oauth.probe_messages_headroom(token, failure_out=failure_out)
+    except Exception:  # noqa: BLE001 - probing is best-effort; unknown => not a target
+        switcher._logger.debug("idle headroom probe failed for %s", num, exc_info=True)
         return None

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -34,9 +34,10 @@ Two layers live here on purpose:
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
-from claude_swap.balancer import AccountView, SessionView
+from claude_swap.balancer import AccountView, SessionView, _pct_cost
 from claude_swap.cache import MISSING, read_cache, write_cache
 from claude_swap.models import get_timestamp
 from claude_swap.process_detection import is_pid_alive
@@ -47,6 +48,12 @@ REGISTRY_VERSION = 1
 # Drop a migration intent that has sat unconsumed for this long (its owning
 # supervisor is gone or wedged); the next rising edge re-derives it.
 _INTENT_TTL_S = 1800
+
+# A just-placed session (``rate_limits is None``) counts as synthetic load on its
+# account for this long after its ``reserved_at`` stamp, so concurrent launchers
+# don't all pile onto the same account before real usage lands. The reservation
+# naturally stops the moment real ``rate_limits`` arrive or the TTL expires.
+_RESERVE_TTL_S = 90
 
 
 # --------------------------------------------------------------------------- #
@@ -250,6 +257,46 @@ def _max_pct(usage: dict | None) -> float | None:
     return _max_usage_pct(usage)
 
 
+def _reserve_load_by_account(rows: list[dict], now: float) -> dict[str, float]:
+    """Synthetic placement-reservation load per account (BUG 003).
+
+    A just-placed managed session has ``rate_limits=None`` (no usage reported
+    yet), so ``build_world`` would otherwise see zero load for it and every
+    concurrent launcher would pick the same account. To spread concurrent
+    ``cswap launch`` processes, each such not-yet-reported session counts as a
+    reservation worth :func:`balancer._pct_cost` of its context size, but only
+    while its ``reserved_at`` stamp is within :data:`_RESERVE_TTL_S`. The
+    reservation evaporates the moment real ``rate_limits`` arrive or the TTL
+    lapses, so it never lingers as phantom load.
+    """
+    reserve: dict[str, float] = {}
+    for e in rows:
+        if e.get("rate_limits") is not None:
+            continue
+        reserved_at = e.get("reserved_at")
+        if not isinstance(reserved_at, (int, float)):
+            continue
+        if (now - float(reserved_at)) > _RESERVE_TTL_S:
+            continue
+        acct = str(e.get("account_num", ""))
+        if not acct:
+            continue
+        reserve[acct] = reserve.get(acct, 0.0) + _pct_cost(int(e.get("ctx_tokens") or 0))
+    return reserve
+
+
+def _with_reserve(max_pct: float | None, reserve: float) -> float | None:
+    """Raise a known ``max_pct`` by the reservation load (clamped to 100).
+
+    Unknown usage (``max_pct is None``) is left as-is — an account with no usage
+    signal already has zero headroom and is never a target, so there is nothing
+    to reserve against.
+    """
+    if max_pct is None or reserve <= 0.0:
+        return max_pct
+    return min(100.0, max_pct + reserve)
+
+
 def build_world(
     switcher, reg: dict, *, fetch_idle: bool = True
 ) -> tuple[dict[str, AccountView], list[SessionView]]:
@@ -271,6 +318,11 @@ def build_world(
 
     rows = live_sessions(reg)
     sess_views = session_views(reg)
+
+    # Synthetic placement-reservation load (BUG 003): a just-placed session not
+    # yet reporting usage counts as load on its account so concurrent launchers
+    # spread instead of stacking. Folded into each account's max_pct below.
+    reserve = _reserve_load_by_account(rows, time.time())
 
     # Best live rate_limits per account (most-recently-seen wins).
     live_rl_by_account: dict[str, dict] = {}
@@ -294,13 +346,15 @@ def build_world(
         priority = _priority_of(info)
         email = info.get("email", "")
 
+        resv = reserve.get(num, 0.0)
+
         live_rl = live_rl_by_account.get(num)
         if live_rl is not None:
             usage = _rl_to_usage(live_rl)
             acct_views[num] = AccountView(
                 num=num,
                 priority=priority,
-                max_pct=_max_pct(usage),
+                max_pct=_with_reserve(_max_pct(usage), resv),
                 soonest_reset=soonest_blocking_reset(usage),
                 signal="live",
             )
@@ -314,7 +368,7 @@ def build_world(
         acct_views[num] = AccountView(
             num=num,
             priority=priority,
-            max_pct=_max_pct(usage) if isinstance(usage, dict) else None,
+            max_pct=_with_reserve(_max_pct(usage), resv) if isinstance(usage, dict) else None,
             soonest_reset=soonest_blocking_reset(usage) if isinstance(usage, dict) else None,
             signal="cache" if isinstance(usage, dict) else "none",
         )

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -314,6 +314,26 @@ def _five_hour_signal(usage: dict | None) -> tuple[float | None, int | None]:
     return pct, reset
 
 
+def _seven_day_signal(usage: dict | None) -> tuple[float | None, int | None]:
+    """Return ``(seven_day_pct, seven_day_reset)`` from a normalized usage dict.
+
+    Mirror of :func:`_five_hour_signal` for the weekly window. Expects the
+    ``{window: {pct, resets_at}}`` shape; either element is ``None`` when absent.
+    Surfaced on :class:`AccountView` so the dashboard can show the 5h and weekly
+    caps independently of ``max_pct`` (which is only their max).
+    """
+    if not isinstance(usage, dict):
+        return None, None
+    entry = usage.get("seven_day")
+    if not isinstance(entry, dict):
+        return None, None
+    pct = entry.get("pct")
+    pct = float(pct) if isinstance(pct, (int, float)) else None
+    reset = entry.get("resets_at")
+    reset = int(reset) if isinstance(reset, (int, float)) else None
+    return pct, reset
+
+
 def soonest_blocking_reset(usage: dict | None) -> int | None:
     """Return the epoch reset of the window that is *currently capping* an account.
 
@@ -442,6 +462,7 @@ def build_world(
         if live_rl is not None:
             usage = _rl_to_usage(live_rl)
             h5_pct, h5_reset = _five_hour_signal(usage)
+            d7_pct, d7_reset = _seven_day_signal(usage)
             acct_views[num] = AccountView(
                 num=num,
                 priority=priority,
@@ -450,6 +471,8 @@ def build_world(
                 signal="live",
                 five_hour_pct=h5_pct,
                 five_hour_reset=h5_reset,
+                seven_day_pct=d7_pct,
+                seven_day_reset=d7_reset,
             )
             continue
 
@@ -460,6 +483,7 @@ def build_world(
 
         is_usage = isinstance(usage, dict)
         h5_pct, h5_reset = _five_hour_signal(usage) if is_usage else (None, None)
+        d7_pct, d7_reset = _seven_day_signal(usage) if is_usage else (None, None)
         acct_views[num] = AccountView(
             num=num,
             priority=priority,
@@ -468,6 +492,8 @@ def build_world(
             signal="cache" if is_usage else "none",
             five_hour_pct=h5_pct,
             five_hour_reset=h5_reset,
+            seven_day_pct=d7_pct,
+            seven_day_reset=d7_reset,
         )
 
     # Persist any freshly-fetched idle usages back into the shared cache so the

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -1,0 +1,356 @@
+"""Live registry of cswap-managed Claude Code sessions + world-building.
+
+A *managed* session is one launched by cswap's supervisor (``cswap launch``)
+with its own per-session profile directory under ``<backup_dir>/managed/<id>``
+(a SEPARATE root from the per-account ``cswap run`` profiles under
+``sessions/`` — so the per-account guards keyed on ``session_dir_for`` never
+fire on managed sessions). Each managed session has a private credential store,
+so its owning supervisor can re-point it to a different account in place, and
+its in-session statusline reports live usage back here.
+
+The registry is the shared, lock-guarded source of truth: the statusline writes
+a heartbeat (and migration *intents*) on each render; the owning supervisor and
+the TUI dashboard read it. Liveness is authoritative via the OS process table
+(:func:`process_detection.is_pid_alive` on the supervisor PID), never heartbeat
+timeouts — a crashed session is reaped, an idle one is kept.
+
+Functions take the :class:`~claude_swap.switcher.ClaudeAccountSwitcher` so they
+reuse its lock (``switcher.lock_file``), atomic writer (``_write_json``), and
+account/credential/usage machinery — nothing here is reimplemented. ``switcher``
+is only ever a *parameter*; this module never imports it at module scope, to
+keep the import graph acyclic (switcher imports registry lazily on its read
+paths).
+
+Two layers live here on purpose:
+
+* a thin state store (``read_registry`` / ``write_registry`` / ``reap_dead`` /
+  ``upsert_session`` / intents) operating on a plain ``reg`` dict, and
+* :func:`build_world`, which turns the registry + the account list + live/idle
+  usage signals into the immutable :class:`~claude_swap.balancer.AccountView` /
+  :class:`~claude_swap.balancer.SessionView` snapshots the pure balancer
+  consumes. ``build_world`` may do network I/O (idle-account usage fetches) and
+  therefore MUST be called *outside* the lock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from claude_swap.balancer import AccountView, SessionView
+from claude_swap.cache import MISSING, read_cache, write_cache
+from claude_swap.models import get_timestamp
+from claude_swap.process_detection import is_pid_alive
+
+REGISTRY_FILENAME = "registry.json"
+REGISTRY_VERSION = 1
+
+# Drop a migration intent that has sat unconsumed for this long (its owning
+# supervisor is gone or wedged); the next rising edge re-derives it.
+_INTENT_TTL_S = 1800
+
+
+# --------------------------------------------------------------------------- #
+# State store (operates on a plain reg dict)
+# --------------------------------------------------------------------------- #
+
+
+def registry_path(switcher) -> Path:
+    return switcher.backup_dir / REGISTRY_FILENAME
+
+
+def _skeleton() -> dict:
+    return {"version": REGISTRY_VERSION, "sessions": {}, "last_balanced_at": 0.0}
+
+
+def read_registry(switcher) -> dict:
+    """Return the parsed registry (lock-free). Missing/corrupt -> fresh skeleton.
+
+    Lock-free is safe because :meth:`switcher._write_json` commits via an atomic
+    rename, so a concurrent reader sees either the old or the new file whole.
+    """
+    data = switcher._read_json(registry_path(switcher))
+    if not isinstance(data, dict):
+        return _skeleton()
+    if not isinstance(data.get("sessions"), dict):
+        data["sessions"] = {}
+    data.setdefault("version", REGISTRY_VERSION)
+    data.setdefault("last_balanced_at", 0.0)
+    return data
+
+
+def write_registry(switcher, reg: dict) -> None:
+    """Persist the registry atomically. The caller MUST hold ``switcher.lock_file``."""
+    switcher._write_json(registry_path(switcher), reg)
+
+
+def reap_dead(reg: dict) -> bool:
+    """Drop sessions whose supervisor process is gone. Returns True if changed.
+
+    Liveness is by the supervisor PID (the resident cswap parent), which owns the
+    profile lifecycle. Rows without a recorded ``supervisor_pid`` yet (a
+    heartbeat that landed before the pid was known) are kept.
+    """
+    sessions = reg.get("sessions", {})
+    dead = [
+        sid
+        for sid, e in sessions.items()
+        if isinstance(e.get("supervisor_pid"), int)
+        and not is_pid_alive(e["supervisor_pid"])
+    ]
+    for sid in dead:
+        sessions.pop(sid, None)
+    return bool(dead)
+
+
+def expire_intents(reg: dict, now: float) -> bool:
+    """Drop migration intents older than the TTL. Returns True if changed."""
+    changed = False
+    for entry in reg.get("sessions", {}).values():
+        intent = entry.get("migration")
+        if intent and (now - intent.get("decided_at", 0)) > _INTENT_TTL_S:
+            entry["migration"] = None
+            changed = True
+    return changed
+
+
+def upsert_session(reg: dict, session_id: str, **fields) -> dict:
+    """Create or update a session row in ``reg`` (in place); return the row.
+
+    ``started_at`` is stamped once on first sight. ``None`` values in ``fields``
+    are ignored so a heartbeat that omits a field (e.g. ``rate_limits`` before
+    the first API response) never clobbers a previously-known value.
+    """
+    sessions = reg.setdefault("sessions", {})
+    entry = sessions.get(session_id)
+    if entry is None:
+        entry = {
+            "session_id": session_id,
+            "account_num": "",
+            "started_at": get_timestamp(),
+            "paused_until": None,
+            "pinned_account": None,
+            "last_migrated_at": 0.0,
+            "migration_count": 0,
+            "migration": None,
+        }
+        sessions[session_id] = entry
+    for key, value in fields.items():
+        if value is not None:
+            entry[key] = value
+    return entry
+
+
+def set_intent(reg: dict, session_id: str, to_account: str, now: float) -> None:
+    """Record a migration intent for the owning supervisor to consume."""
+    entry = reg.get("sessions", {}).get(session_id)
+    if entry is not None:
+        entry["migration"] = {"to": str(to_account), "decided_at": now}
+
+
+def clear_intent(reg: dict, session_id: str) -> None:
+    entry = reg.get("sessions", {}).get(session_id)
+    if entry is not None:
+        entry["migration"] = None
+
+
+def session_is_live(entry: dict) -> bool:
+    pid = entry.get("supervisor_pid")
+    return not isinstance(pid, int) or is_pid_alive(pid)
+
+
+def live_sessions(reg: dict) -> list[dict]:
+    """Registry rows whose supervisor is alive, oldest first (stable order)."""
+    rows = [e for e in reg.get("sessions", {}).values() if session_is_live(e)]
+    rows.sort(key=lambda e: e.get("started_at", ""))
+    return rows
+
+
+def session_views(reg: dict) -> list[SessionView]:
+    """Pure :class:`SessionView` snapshot of the live registry rows (no I/O).
+
+    Shared by the statusline planner and the supervisor so both feed the pure
+    balancer identical inputs.
+    """
+    return [
+        SessionView(
+            session_id=e["session_id"],
+            account_num=str(e.get("account_num", "")),
+            ctx_tokens=int(e.get("ctx_tokens") or 0),
+            last_seen=float(e.get("last_seen") or 0.0),
+            paused_until=e.get("paused_until"),
+            last_migrated_at=float(e.get("last_migrated_at") or 0.0),
+            pinned_account=e.get("pinned_account"),
+        )
+        for e in live_sessions(reg)
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Usage-signal normalization (the live-vs-cached schema seam)
+# --------------------------------------------------------------------------- #
+
+
+def _rl_to_usage(rate_limits: dict | None) -> dict | None:
+    """Normalize the statusline ``rate_limits`` shape to the usage-dict shape.
+
+    Statusline stdin uses ``{window: {used_percentage, resets_at(epoch s)}}``;
+    the rest of the codebase (``oauth.build_usage_result``) uses
+    ``{window: {pct, ...}}``. Converting to ``{window: {pct, resets_at}}`` lets
+    ``switcher._max_usage_pct`` and the reset math work uniformly on both the
+    live (statusline) and cached (usage API) signals.
+    """
+    if not isinstance(rate_limits, dict):
+        return None
+    out: dict = {}
+    for window in ("five_hour", "seven_day"):
+        entry = rate_limits.get(window)
+        if isinstance(entry, dict):
+            pct = entry.get("used_percentage")
+            if pct is None:
+                pct = entry.get("pct")  # tolerate an already-normalized entry
+            if isinstance(pct, (int, float)):
+                norm = {"pct": float(pct)}
+                resets = entry.get("resets_at")
+                if isinstance(resets, (int, float)):
+                    norm["resets_at"] = int(resets)
+                out[window] = norm
+    return out or None
+
+
+def soonest_blocking_reset(usage: dict | None) -> int | None:
+    """Return the epoch reset of the window that is *currently capping* an account.
+
+    That is the window equal to ``max(5h, 7d)`` utilization — a 5h reset must not
+    be treated as freeing an account whose 7d window is the one over the limit.
+    Expects the normalized ``{window: {pct, resets_at}}`` shape.
+    """
+    if not isinstance(usage, dict):
+        return None
+    best_pct: float | None = None
+    best_reset: int | None = None
+    for window in ("five_hour", "seven_day"):
+        entry = usage.get(window)
+        if isinstance(entry, dict) and isinstance(entry.get("pct"), (int, float)):
+            pct = float(entry["pct"])
+            if best_pct is None or pct > best_pct:
+                best_pct = pct
+                best_reset = entry.get("resets_at")
+    return best_reset
+
+
+# --------------------------------------------------------------------------- #
+# World building (MUST run outside the lock — may do network I/O)
+# --------------------------------------------------------------------------- #
+
+
+def _max_pct(usage: dict | None) -> float | None:
+    # Lazy import keeps the switcher <-> registry import graph acyclic.
+    from claude_swap.switcher import _max_usage_pct
+
+    return _max_usage_pct(usage)
+
+
+def build_world(
+    switcher, reg: dict, *, fetch_idle: bool = True
+) -> tuple[dict[str, AccountView], list[SessionView]]:
+    """Build the immutable snapshot the pure balancer consumes.
+
+    Account usage comes from the best available signal:
+
+    * **live** — an account hosting a live managed session uses that session's
+      last-reported ``rate_limits`` (free, no network);
+    * **cache** — an idle account uses the shared 15s usage cache, fetching via
+      the usage API on a miss only when ``fetch_idle`` is set;
+    * **none** — unknown usage (no signal / fetch failed) => ``max_pct=None`` =>
+      zero headroom, so the account is never chosen as a migration target.
+
+    Must be called OUTSIDE ``switcher.lock_file`` (the idle fetch is network I/O).
+    """
+    seq = switcher._get_sequence_data() or {}
+    accounts = seq.get("accounts", {})
+
+    rows = live_sessions(reg)
+    sess_views = session_views(reg)
+
+    # Best live rate_limits per account (most-recently-seen wins).
+    live_rl_by_account: dict[str, dict] = {}
+    live_seen_at: dict[str, float] = {}
+    for e in rows:
+        rl = e.get("rate_limits")
+        acct = str(e.get("account_num", ""))
+        seen = float(e.get("last_seen") or 0.0)
+        if isinstance(rl, dict) and acct and seen >= live_seen_at.get(acct, -1.0):
+            live_rl_by_account[acct] = rl
+            live_seen_at[acct] = seen
+
+    usage_cache_path = switcher.backup_dir / "cache" / "usage.json"
+    cached = read_cache(usage_cache_path, _usage_ttl())
+    cached = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
+
+    acct_views: dict[str, AccountView] = {}
+    fetched: dict[str, dict | None] = {}
+    for num, info in accounts.items():
+        num = str(num)
+        priority = _priority_of(info)
+        email = info.get("email", "")
+
+        live_rl = live_rl_by_account.get(num)
+        if live_rl is not None:
+            usage = _rl_to_usage(live_rl)
+            acct_views[num] = AccountView(
+                num=num,
+                priority=priority,
+                max_pct=_max_pct(usage),
+                soonest_reset=soonest_blocking_reset(usage),
+                signal="live",
+            )
+            continue
+
+        usage = cached.get(num) if isinstance(cached, dict) else None
+        if usage is None and fetch_idle:
+            usage = _fetch_idle_usage(switcher, num, email)
+            fetched[num] = usage
+
+        acct_views[num] = AccountView(
+            num=num,
+            priority=priority,
+            max_pct=_max_pct(usage) if isinstance(usage, dict) else None,
+            soonest_reset=soonest_blocking_reset(usage) if isinstance(usage, dict) else None,
+            signal="cache" if isinstance(usage, dict) else "none",
+        )
+
+    # Persist any freshly-fetched idle usages back into the shared cache so the
+    # next render / `cswap --list` reuses them within the TTL.
+    if fetched:
+        merged = dict(cached)
+        merged.update({k: v for k, v in fetched.items() if v is not None})
+        write_cache(usage_cache_path, merged)
+
+    return acct_views, sess_views
+
+
+def _priority_of(info: dict) -> int:
+    try:
+        return int(info.get("priority", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _usage_ttl() -> int:
+    from claude_swap.switcher import _USAGE_CACHE_TTL
+
+    return _USAGE_CACHE_TTL
+
+
+def _fetch_idle_usage(switcher, num: str, email: str) -> dict | None:
+    """Fetch one idle account's usage via the usage API. Best-effort, never raises."""
+    from claude_swap import oauth
+
+    try:
+        creds = switcher.read_account_credentials(str(num), email)
+        if not creds or not oauth.extract_access_token(creds):
+            return None
+        return oauth.fetch_usage_for_account(str(num), email, creds, is_active=False)
+    except Exception:  # noqa: BLE001 - usage is best-effort; unknown => not a target
+        switcher._logger.debug("idle usage fetch failed for %s", num, exc_info=True)
+        return None

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -334,6 +334,26 @@ def _seven_day_signal(usage: dict | None) -> tuple[float | None, int | None]:
     return pct, reset
 
 
+def _spend_signal(usage: dict | None) -> tuple[bool, float | None]:
+    """Return ``(extra_usage_enabled, spend_pct)`` from a usage-API result dict.
+
+    Only the usage API result (``oauth.build_usage_result``) carries pay-as-you-go
+    info — ``extra_usage_enabled`` and the dollar-denominated ``spend`` entry; the
+    live statusline ``rate_limits`` signal does NOT. So ``build_world`` reads this
+    from the cached usage even for a live account. ``spend_pct`` is the monthly
+    extra-usage budget utilization (0-100), or ``None`` when absent/unlimited.
+    Feeds the balancer's API-rate last-resort tier (:func:`balancer._api_capable`).
+    """
+    if not isinstance(usage, dict):
+        return False, None
+    enabled = bool(usage.get("extra_usage_enabled"))
+    spend = usage.get("spend")
+    pct = None
+    if isinstance(spend, dict) and isinstance(spend.get("pct"), (int, float)):
+        pct = float(spend["pct"])
+    return enabled, pct
+
+
 def soonest_blocking_reset(usage: dict | None) -> int | None:
     """Return the epoch reset of the window that is *currently capping* an account.
 
@@ -463,6 +483,9 @@ def build_world(
             usage = _rl_to_usage(live_rl)
             h5_pct, h5_reset = _five_hour_signal(usage)
             d7_pct, d7_reset = _seven_day_signal(usage)
+            # Pay-as-you-go info isn't in the live signal — read it from the
+            # cached usage-API result for this account (best-effort).
+            extra_usage, spend_pct = _spend_signal(cached.get(num))
             acct_views[num] = AccountView(
                 num=num,
                 priority=priority,
@@ -473,6 +496,8 @@ def build_world(
                 five_hour_reset=h5_reset,
                 seven_day_pct=d7_pct,
                 seven_day_reset=d7_reset,
+                extra_usage=extra_usage,
+                spend_pct=spend_pct,
             )
             continue
 
@@ -484,6 +509,7 @@ def build_world(
         is_usage = isinstance(usage, dict)
         h5_pct, h5_reset = _five_hour_signal(usage) if is_usage else (None, None)
         d7_pct, d7_reset = _seven_day_signal(usage) if is_usage else (None, None)
+        extra_usage, spend_pct = _spend_signal(usage) if is_usage else (False, None)
         acct_views[num] = AccountView(
             num=num,
             priority=priority,
@@ -494,6 +520,8 @@ def build_world(
             five_hour_reset=h5_reset,
             seven_day_pct=d7_pct,
             seven_day_reset=d7_reset,
+            extra_usage=extra_usage,
+            spend_pct=spend_pct,
         )
 
     # Persist any freshly-fetched idle usages back into the shared cache so the

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -483,16 +483,14 @@ def build_world(
             usage = _rl_to_usage(live_rl)
             h5_pct, h5_reset = _five_hour_signal(usage)
             d7_pct, d7_reset = _seven_day_signal(usage)
-            # Pay-as-you-go info isn't in the live statusline signal — it only
-            # comes from the usage API. Read it from the cached usage result; on a
-            # cold cache, fetch once (best-effort) so a live account's extra-usage
-            # capability isn't silently lost — which would otherwise wrongly PAUSE
-            # an API-rate-tier session instead of letting it spill to API rates.
-            spend_src = cached.get(num)
-            if spend_src is None and fetch_idle:
-                spend_src = _fetch_idle_usage(switcher, num, email)
-                fetched[num] = spend_src
-            extra_usage, spend_pct = _spend_signal(spend_src)
+            # Pay-as-you-go info isn't in the live statusline signal — read it
+            # from the cached usage-API result (best-effort). We deliberately do
+            # NOT fetch it for a live account: that adds usage-API load (which can
+            # trip the endpoint's rate limit) and could refresh an active account's
+            # token. On a cold cache extra-usage is simply unknown until an idle
+            # fetch / ``cswap --status`` populates it — acceptable since the
+            # API-rate tier is opt-in and off by default.
+            extra_usage, spend_pct = _spend_signal(cached.get(num))
             acct_views[num] = AccountView(
                 num=num,
                 priority=priority,
@@ -508,10 +506,25 @@ def build_world(
             )
             continue
 
-        usage = cached.get(num) if isinstance(cached, dict) else None
-        if usage is None and fetch_idle:
+        cached_entry = cached.get(num) if isinstance(cached, dict) else None
+        if isinstance(cached_entry, dict) and cached_entry.get("_unavailable"):
+            # A cached fetch FAILURE (e.g. usage-API 429). Treat as no signal and
+            # do NOT refetch: the marker holds the cache slot for the TTL, so a
+            # failing / rate-limited fetch is throttled to once per cache TTL
+            # instead of being retried every supervise tick — the feedback loop
+            # that otherwise pins every account at "usage unavailable" once the
+            # usage endpoint starts returning 429. The shared cache file
+            # coordinates this across all supervisor processes.
+            usage = None
+        elif cached_entry is not None:
+            usage = cached_entry
+        elif fetch_idle:
             usage = _fetch_idle_usage(switcher, num, email)
-            fetched[num] = usage
+            # Persist the outcome either way — real usage, or a failure marker so
+            # the TTL throttles retries (see above).
+            fetched[num] = usage if usage is not None else {"_unavailable": True}
+        else:
+            usage = None
 
         is_usage = isinstance(usage, dict)
         h5_pct, h5_reset = _five_hour_signal(usage) if is_usage else (None, None)

--- a/src/claude_swap/registry.py
+++ b/src/claude_swap/registry.py
@@ -55,6 +55,18 @@ _INTENT_TTL_S = 1800
 # naturally stops the moment real ``rate_limits`` arrive or the TTL expires.
 _RESERVE_TTL_S = 90
 
+# Idle-5h-window priming (feature #3): a prime sweep runs at most once per this
+# interval across ALL resident supervisors (gated by the ``last_primed_sweep_at``
+# registry stamp under the lock — only one supervisor wins each interval, so N
+# supervisors never fire N redundant billable calls).
+_PRIME_SWEEP_INTERVAL_S = 300
+# After an account is primed, suppress re-priming it for this long. The prime POST
+# starts the window immediately, but the usage cache (which feeds the "started"
+# detection) can lag by its TTL; this per-account guard bridges that gap so a
+# second sweep can't double-bill before the started-window signal propagates. Once
+# the window shows started, the pure detection rejects it regardless of the guard.
+_PRIME_ACCOUNT_GUARD_S = 1800
+
 
 # --------------------------------------------------------------------------- #
 # State store (operates on a plain reg dict)
@@ -160,6 +172,62 @@ def clear_intent(reg: dict, session_id: str) -> None:
         entry["migration"] = None
 
 
+# --------------------------------------------------------------------------- #
+# Idle-5h-window prime guards (feature #3) — all operate on the reg dict under
+# the lock; the network prime itself runs OUTSIDE the lock in the supervisor.
+# --------------------------------------------------------------------------- #
+
+
+def claim_prime_sweep(reg: dict, now: float) -> bool:
+    """Claim the once-per-interval prime sweep; stamp it. Returns True if claimed.
+
+    Exactly one resident supervisor wins the claim per :data:`_PRIME_SWEEP_INTERVAL_S`
+    (the others see a recent stamp and bow out), so concurrent supervisors don't
+    each run a redundant sweep. The CALLER must hold the lock and persist ``reg``.
+    """
+    last = reg.get("last_primed_sweep_at", 0.0)
+    if isinstance(last, (int, float)) and (now - float(last)) < _PRIME_SWEEP_INTERVAL_S:
+        return False
+    reg["last_primed_sweep_at"] = now
+    return True
+
+
+def prime_guarded(reg: dict, num: str, now: float) -> bool:
+    """Whether account ``num`` was primed too recently to prime again (per-account guard).
+
+    Bridges the lag between a successful prime POST and the started-window signal
+    landing in the usage cache, so a second sweep can't double-bill the same
+    account in that gap.
+    """
+    primed = reg.get("primed")
+    if not isinstance(primed, dict):
+        return False
+    at = primed.get(str(num))
+    return isinstance(at, (int, float)) and (now - float(at)) < _PRIME_ACCOUNT_GUARD_S
+
+
+def stamp_primed(reg: dict, num: str, now: float) -> None:
+    """Record that account ``num`` was just primed. Caller holds the lock + persists."""
+    primed = reg.setdefault("primed", {})
+    if isinstance(primed, dict):
+        primed[str(num)] = now
+
+
+def prune_primed(reg: dict, now: float) -> bool:
+    """Drop per-account prime stamps older than the guard window. True if changed."""
+    primed = reg.get("primed")
+    if not isinstance(primed, dict):
+        return False
+    stale = [
+        num
+        for num, at in primed.items()
+        if not isinstance(at, (int, float)) or (now - float(at)) >= _PRIME_ACCOUNT_GUARD_S
+    ]
+    for num in stale:
+        primed.pop(num, None)
+    return bool(stale)
+
+
 def session_is_live(entry: dict) -> bool:
     pid = entry.get("supervisor_pid")
     return not isinstance(pid, int) or is_pid_alive(pid)
@@ -222,6 +290,28 @@ def _rl_to_usage(rate_limits: dict | None) -> dict | None:
                     norm["resets_at"] = int(resets)
                 out[window] = norm
     return out or None
+
+
+def _five_hour_signal(usage: dict | None) -> tuple[float | None, int | None]:
+    """Return ``(five_hour_pct, five_hour_reset)`` from a normalized usage dict.
+
+    Expects the ``{window: {pct, resets_at}}`` shape (the output of
+    :func:`_rl_to_usage` and of ``oauth.build_usage_result``). ``pct`` is the 5h
+    utilization percent; ``resets_at`` is the 5h reset epoch when present (the API
+    only emits one once the window is running). Either element is ``None`` when
+    absent — the idle-window priming detection treats a missing reset + ~0 pct as
+    an unstarted clock (see :func:`balancer.accounts_needing_prime`).
+    """
+    if not isinstance(usage, dict):
+        return None, None
+    entry = usage.get("five_hour")
+    if not isinstance(entry, dict):
+        return None, None
+    pct = entry.get("pct")
+    pct = float(pct) if isinstance(pct, (int, float)) else None
+    reset = entry.get("resets_at")
+    reset = int(reset) if isinstance(reset, (int, float)) else None
+    return pct, reset
 
 
 def soonest_blocking_reset(usage: dict | None) -> int | None:
@@ -351,12 +441,15 @@ def build_world(
         live_rl = live_rl_by_account.get(num)
         if live_rl is not None:
             usage = _rl_to_usage(live_rl)
+            h5_pct, h5_reset = _five_hour_signal(usage)
             acct_views[num] = AccountView(
                 num=num,
                 priority=priority,
                 max_pct=_with_reserve(_max_pct(usage), resv),
                 soonest_reset=soonest_blocking_reset(usage),
                 signal="live",
+                five_hour_pct=h5_pct,
+                five_hour_reset=h5_reset,
             )
             continue
 
@@ -365,12 +458,16 @@ def build_world(
             usage = _fetch_idle_usage(switcher, num, email)
             fetched[num] = usage
 
+        is_usage = isinstance(usage, dict)
+        h5_pct, h5_reset = _five_hour_signal(usage) if is_usage else (None, None)
         acct_views[num] = AccountView(
             num=num,
             priority=priority,
-            max_pct=_with_reserve(_max_pct(usage), resv) if isinstance(usage, dict) else None,
-            soonest_reset=soonest_blocking_reset(usage) if isinstance(usage, dict) else None,
-            signal="cache" if isinstance(usage, dict) else "none",
+            max_pct=_with_reserve(_max_pct(usage), resv) if is_usage else None,
+            soonest_reset=soonest_blocking_reset(usage) if is_usage else None,
+            signal="cache" if is_usage else "none",
+            five_hour_pct=h5_pct,
+            five_hour_reset=h5_reset,
         )
 
     # Persist any freshly-fetched idle usages back into the shared cache so the

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -45,6 +45,7 @@ from claude_swap.macos_keychain import KeychainError
 from claude_swap.locking import FileLock
 from claude_swap.models import Platform
 from claude_swap.oauth import refresh_oauth_credentials
+from claude_swap.paths import mark_cwd_trusted
 from claude_swap.printer import accent, dimmed, muted, warning
 from claude_swap.process_detection import ClaudeSession, list_sessions
 
@@ -379,6 +380,10 @@ class SessionManager:
         existing["oauthAccount"] = oauth_account
         existing["hasCompletedOnboarding"] = True
         existing.setdefault("theme", config_data.get("theme") or "dark")
+        # Pre-trust the directory this session will launch in (inherited cwd —
+        # `cswap run` execs claude without changing cwd) so claude skips the
+        # folder trust dialog. See paths.mark_cwd_trusted.
+        mark_cwd_trusted(existing, os.getcwd())
         config_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
         if sys.platform != "win32":
             os.chmod(config_path, 0o600)

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -287,7 +287,15 @@ class SessionManager:
             self._sync_sharing(session_dir, share)
             return session_dir, account_num, email
 
-        with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
+        # Acquire the PER-ACCOUNT refresh lock BEFORE the global lock (the same
+        # lock + ordering ensure_fresh_inactive_credentials uses), so _bootstrap's
+        # refresh of this account's single-use OAuth token can't race a concurrent
+        # idle build_world refresh of the SAME token (during bootstrap the profile
+        # isn't live yet, so the idle path treats the account as idle and would POST
+        # the same token -> provider token-reuse revocation -> silent logout).
+        with FileLock(
+            self.switcher._refresh_lock_path(account_num), timeout=_BOOTSTRAP_LOCK_TIMEOUT
+        ), FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
             # Re-evaluate the marker under the lock, then re-check validity:
             # another `cswap run` may have bootstrapped while we waited.
             if (session_dir / STALE_MARKER).exists() and not live_sessions_for(

--- a/src/claude_swap/statusline.py
+++ b/src/claude_swap/statusline.py
@@ -190,6 +190,61 @@ def _run(switcher, stdin_text: str) -> int:
 # leaves them to claude's own retry / ``--fallback-model``.
 _SERVER_SIDE_ERROR_TYPES = frozenset({"overloaded", "server_error"})
 
+# Case-insensitive substrings that mark a TRANSIENT / network failure (a dropped
+# socket, connection reset, timeout, a brief 5xx / overload). These are not
+# account-level problems: switching accounts or refreshing creds wouldn't help
+# and could actively HARM (a "401 The socket connection was closed unexpectedly"
+# is a closed socket, not bad credentials). Extra in-turn retries
+# (``CLAUDE_CODE_MAX_RETRIES``) absorb these; the safety net deliberately ignores
+# them so it never misreacts to a connection glitch.
+_TRANSIENT_PATTERNS = (
+    "socket",
+    "connection",
+    "closed",
+    "timeout",
+    "timed out",
+    "econnreset",
+    "econnrefused",
+    "epipe",
+    "network",
+    "fetch failed",
+    "overloaded",
+    "server_error",
+    "503",
+    "502",
+    "504",
+)
+
+# StopFailure stdin field names that MAY carry a human-readable error message.
+# Claude Code's exact schema for this hook is unverified, so be tolerant: check a
+# few likely keys and stringify whatever is present.
+_MESSAGE_FIELDS = ("message", "error", "reason", "detail")
+
+
+def _failure_signal(payload: dict) -> str:
+    """All available error text from a StopFailure payload, lowercased.
+
+    Concatenates the ``error_type`` with any message-ish field (the field name is
+    unverified, so several likely keys are tried and stringified). Used purely for
+    transient/connection classification — never raises.
+    """
+    parts: list[str] = []
+    for key in ("error_type", *_MESSAGE_FIELDS):
+        val = payload.get(key)
+        if val is not None:
+            parts.append(str(val))
+    return " ".join(parts).lower()
+
+
+def _is_transient_error(signal: str) -> bool:
+    """Whether ``signal`` looks like a transient/network failure (case-insensitive).
+
+    ``signal`` is the already-lowercased concatenation of the error_type and any
+    message field (see :func:`_failure_signal`). A transient error is left entirely
+    alone by the safety net — no migration, no auth recovery.
+    """
+    return any(pat in signal for pat in _TRANSIENT_PATTERNS)
+
 
 def _is_auth_error(error_type: str) -> bool:
     """Whether ``error_type`` indicates an authentication failure (a 401).
@@ -213,6 +268,11 @@ def run_statusfailure(switcher, stdin_text: str) -> int:
     doesn't re-read creds on a 429/401 — but we record the owning supervisor's
     *intent* so the NEXT turn recovers:
 
+    * a **transient / connection failure** (dropped socket, reset, timeout, brief
+      5xx) -> NOTHING. This takes precedence over every other branch: it's not an
+      account-level problem (a "401 socket closed" is a closed socket, not bad
+      creds), so the extra in-turn retries (``CLAUDE_CODE_MAX_RETRIES``) absorb it
+      and the safety net leaves it strictly alone — no migration, no auth recovery;
     * a **429 rate limit** on an at/over-threshold account -> a migration intent
       (the supervisor re-points the session to a fresh account); and
     * a **401 auth failure** -> an ``auth_recover`` flag (the supervisor refreshes
@@ -248,12 +308,25 @@ def _run_failure(switcher, stdin_text: str) -> int:
     error_type = payload.get("error_type")
     error_type = error_type if isinstance(error_type, str) else ""
 
+    # Gather every available signal (error_type + any message-ish field, the field
+    # name is unverified so we're tolerant) for the transient/connection check.
+    signal = _failure_signal(payload)
+
     reg0 = registry.read_registry(switcher)
     row0 = reg0.get("sessions", {}).get(managed_id)
     if not isinstance(row0, dict):
         return 0  # no registry row for this session
     own_account = str(row0.get("account_num", "") or "")
     if not own_account:
+        return 0
+
+    # (0) TRANSIENT / connection failure (dropped socket, reset, timeout, brief
+    # 5xx). This is NOT an account-level problem — switching accounts or refreshing
+    # creds wouldn't help and a "401 socket closed" is a closed socket, not bad
+    # credentials — so do NOTHING and let claude's extra in-turn retries
+    # (CLAUDE_CODE_MAX_RETRIES) absorb it. This check takes PRECEDENCE over the auth
+    # and rate-limit branches so we never misreact to a connection glitch.
+    if _is_transient_error(signal):
         return 0
 
     # (c) AUTH failure (a 401 "Please run /login"): the account's seeded creds are

--- a/src/claude_swap/statusline.py
+++ b/src/claude_swap/statusline.py
@@ -191,6 +191,18 @@ def _run(switcher, stdin_text: str) -> int:
 _SERVER_SIDE_ERROR_TYPES = frozenset({"overloaded", "server_error"})
 
 
+def _is_auth_error(error_type: str) -> bool:
+    """Whether ``error_type`` indicates an authentication failure (a 401).
+
+    Documented values include ``"authentication_failed"``, but be tolerant of
+    casing/variants — any ``error_type`` *containing* ``"auth"`` is treated as
+    an auth failure (e.g. a "Please run /login · API Error: 401 Invalid
+    authentication credentials" turn). An absent/unknown ``error_type`` is NOT
+    auth (it falls through to the usage-driven 429 path).
+    """
+    return "auth" in error_type.lower()
+
+
 def run_statusfailure(switcher, stdin_text: str) -> int:
     """Entry point for ``cswap statusfailure`` (the ``StopFailure`` hook).
 
@@ -198,9 +210,14 @@ def run_statusfailure(switcher, stdin_text: str) -> int:
     threshold migration. Claude Code fires ``StopFailure`` when a turn ends due
     to an API error after retries are exhausted (the "Retrying … attempt N/10"
     storm). We can't rescue the failed turn — no hook can block a turn and claude
-    doesn't re-read creds on a 429 — but when the session's account is genuinely
-    rate-limited we record a migration *intent* so the owning supervisor
-    re-points it and the NEXT turn lands on a fresh account.
+    doesn't re-read creds on a 429/401 — but we record the owning supervisor's
+    *intent* so the NEXT turn recovers:
+
+    * a **429 rate limit** on an at/over-threshold account -> a migration intent
+      (the supervisor re-points the session to a fresh account); and
+    * a **401 auth failure** -> an ``auth_recover`` flag (the supervisor refreshes
+      and re-seeds this account's credentials, or migrates if the account is
+      logged out). Auth isn't usage-driven, so it is NOT gated on the threshold.
 
     Side-effect-only and bulletproof: never raises, always returns 0, and (like
     the statusline) only ever writes registry state — never credentials.
@@ -237,6 +254,24 @@ def _run_failure(switcher, stdin_text: str) -> int:
         return 0  # no registry row for this session
     own_account = str(row0.get("account_num", "") or "")
     if not own_account:
+        return 0
+
+    # (c) AUTH failure (a 401 "Please run /login"): the account's seeded creds are
+    # invalid/expired. This is NOT usage-driven, so don't gate it on the exhaust
+    # threshold and don't write a migration intent — flag ``auth_recover`` and let
+    # the owning supervisor refresh+re-seed the SAME account (or migrate if it's
+    # logged out). Credential work is the supervisor's job; we only flag intent.
+    if _is_auth_error(error_type):
+        lock = FileLock(switcher.lock_file, timeout=5)
+        if lock.acquire():
+            try:
+                reg = registry.read_registry(switcher)
+                row = reg.get("sessions", {}).get(managed_id)
+                if isinstance(row, dict):
+                    row["auth_recover"] = time.time()
+                    registry.write_registry(switcher, reg)
+            finally:
+                lock.release()
         return 0
 
     # (b) Skip plainly-not-account-specific failures: switching accounts can't

--- a/src/claude_swap/statusline.py
+++ b/src/claude_swap/statusline.py
@@ -1,0 +1,246 @@
+"""The ``cswap statusline`` command — the event-driven balancer trigger + display.
+
+Claude Code runs this once per assistant message (and on a few UI events) inside
+every *managed* session, passing a JSON blob on stdin that includes the live
+``rate_limits`` for the session's account. That makes it a genuine usage event
+source — no polling loop, no daemon. On each invocation it:
+
+1. **heartbeats** the session's live state into ``registry.json`` (usage, cwd,
+   context size, claude's session id for ``--resume``);
+2. on a *rising edge* (its account crossing from below to above the exhaust
+   threshold) **plans** a rebalance with the pure :mod:`~claude_swap.balancer`
+   and **records the resulting intents** into the registry; and
+3. **renders** a compact status line.
+
+It NEVER rewrites another session's credentials — it only writes registry state.
+Each owning :class:`~claude_swap.supervisor.Supervisor` consumes its own intent
+and performs the actual re-point (the credential-ownership invariant). The
+statusline must always succeed fast and print exactly one line, so the whole
+body is defensive: any error prints an empty line and exits 0 rather than
+breaking Claude's render.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from claude_swap import balancer, registry
+from claude_swap.locking import FileLock
+
+_BAR_WIDTH = 8
+
+
+def run_statusline(switcher, stdin_text: str) -> int:
+    """Entry point for ``cswap statusline``. Always returns 0."""
+    try:
+        return _run(switcher, stdin_text)
+    except Exception:  # noqa: BLE001 - never break Claude Code's status render
+        try:
+            switcher._logger.debug("statusline failed", exc_info=True)
+        except Exception:
+            pass
+        print("")
+        return 0
+
+
+def _run(switcher, stdin_text: str) -> int:
+    try:
+        payload = json.loads(stdin_text)
+    except (json.JSONDecodeError, TypeError):
+        print("")
+        return 0
+    if not isinstance(payload, dict):
+        print("")
+        return 0
+
+    profile_dir = os.environ.get("CLAUDE_CONFIG_DIR", "")
+    managed_id = Path(profile_dir).name if profile_dir else ""
+    if not managed_id:
+        # Not a managed session (the statusline is only installed into managed
+        # profiles, but be safe): render nothing.
+        print("")
+        return 0
+
+    rl = payload.get("rate_limits")
+    rl = rl if isinstance(rl, dict) else None
+    cw = payload.get("context_window") or {}
+    ctx_tokens = int(
+        cw.get("total_input_tokens")
+        or (cw.get("current_usage") or {}).get("input_tokens")
+        or 0
+    )
+    model_id = (payload.get("model") or {}).get("id", "")
+    cwd = payload.get("cwd", "")
+    claude_sid = payload.get("session_id", "")
+
+    own_usage = registry._rl_to_usage(rl)
+    own_max = _max_pct(own_usage)
+    own_reset = registry.soonest_blocking_reset(own_usage)
+
+    bcfg = switcher.get_auto_balance_config()
+    cfg = balancer.config_from_dict(bcfg)
+    enabled = bool(bcfg["enabled"])
+    now = time.time()
+
+    # Lock-free pre-read: discover our account + whether this is a rising edge.
+    reg0 = registry.read_registry(switcher)
+    row0 = reg0.get("sessions", {}).get(managed_id) or {}
+    own_account = str(row0.get("account_num", "") or "")
+    prev_max = row0.get("_prev_max_pct")
+    rising = (
+        enabled
+        and bool(own_account)
+        and own_max is not None
+        and own_max >= cfg.exhaust_threshold
+        and not (isinstance(prev_max, (int, float)) and prev_max >= cfg.exhaust_threshold)
+        and not row0.get("paused_until")
+    )
+
+    # Build the world OUTSIDE the lock only when we actually need to plan
+    # (it may do network I/O for idle accounts). Prefer this tick's fresh usage
+    # for our own account.
+    acct_views = None
+    if rising:
+        acct_views, _ = registry.build_world(switcher, reg0, fetch_idle=True)
+        prev_av = acct_views.get(own_account)
+        acct_views[own_account] = balancer.AccountView(
+            num=own_account,
+            priority=prev_av.priority if prev_av else 0,
+            max_pct=own_max,
+            soonest_reset=own_reset,
+            signal="live",
+        )
+
+    render_row = dict(row0)
+    live_rows = registry.live_sessions(reg0)
+
+    lock = FileLock(switcher.lock_file, timeout=5)
+    if lock.acquire():
+        try:
+            reg = registry.read_registry(switcher)
+            registry.reap_dead(reg)
+            registry.expire_intents(reg, now)
+            row = registry.upsert_session(
+                reg,
+                managed_id,
+                profile_dir=profile_dir,
+                cwd=cwd,
+                claude_session_id=claude_sid,
+                rate_limits=rl,
+                ctx_tokens=ctx_tokens,
+                model_id=model_id,
+                claude_pid=os.getppid(),
+                last_seen=now,
+            )
+            row["_prev_max_pct"] = own_max
+            if own_reset is not None:
+                row["resets_at"] = own_reset
+            own_account = str(row.get("account_num", "") or own_account)
+
+            if rising and acct_views is not None:
+                sess_views = registry.session_views(reg)
+                plan = balancer.rebalance(acct_views, sess_views, now, cfg)
+                _apply_plan(reg, plan, now)
+                reg["last_balanced_at"] = now
+
+            registry.write_registry(switcher, reg)
+            render_row = dict(reg["sessions"].get(managed_id) or {})
+            live_rows = registry.live_sessions(reg)
+        finally:
+            lock.release()
+
+    total = len(live_rows)
+    index = next(
+        (i + 1 for i, e in enumerate(live_rows) if e.get("session_id") == managed_id),
+        total,
+    )
+    print(render_line(render_row, own_max, total, index))
+    return 0
+
+
+def _apply_plan(reg: dict, plan, now: float) -> None:
+    """Record a plan's decisions into the registry as state/intents.
+
+    The statusline only ever writes registry state — never credentials. The
+    owning supervisor of each session consumes its own ``migration`` intent /
+    ``paused_until`` and performs the side effects.
+    """
+    sessions = reg.get("sessions", {})
+    for act in plan.actions:
+        target = sessions.get(act.session_id)
+        if target is None:
+            continue
+        if act.kind == "MIGRATE":
+            registry.set_intent(reg, act.session_id, act.to_account, now)
+        elif act.kind == "PAUSE":
+            target["paused_until"] = act.resume_at
+        elif act.kind == "RESUME":
+            target["paused_until"] = None
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def render_line(row: dict, own_max: float | None, total: int, index: int) -> str:
+    """Compact one-line status, e.g. ``⇄ a2 ▕███████▁▏88% · s2/5``.
+
+    ``→a5`` when a migration to account 5 is pending, ``⏸ a2 1h12m`` when paused
+    until reset. Falls back to ASCII (``>a2 [#######-] 88% s2/5``) on terminals
+    that can't render the box-drawing glyphs.
+    """
+    ascii_mode = not _supports_unicode()
+    acct = row.get("account_num") or "?"
+    pos = f"s{index}/{total}" if total else "s?"
+
+    paused_until = row.get("paused_until")
+    if isinstance(paused_until, (int, float)) and paused_until > time.time():
+        head = (f"PAUSED a{acct} {_countdown(paused_until)}" if ascii_mode
+                else f"⏸ a{acct} {_countdown(paused_until)}")
+        return f"{head} · {pos}"
+
+    intent = row.get("migration")
+    if isinstance(intent, dict) and intent.get("to"):
+        head = (f">a{intent['to']}" if ascii_mode else f"→a{intent['to']}")
+    else:
+        head = (f"a{acct}" if ascii_mode else f"⇄ a{acct}")
+
+    pct_s = f"{own_max:.0f}%" if own_max is not None else "··%"
+    return f"{head} {_bar(own_max, ascii_mode)}{pct_s} · {pos}"
+
+
+def _bar(pct: float | None, ascii_mode: bool) -> str:
+    if pct is None:
+        return ("[" + "?" * _BAR_WIDTH + "] ") if ascii_mode else ("▕" + "·" * _BAR_WIDTH + "▏")
+    filled = max(0, min(_BAR_WIDTH, round(pct / 100 * _BAR_WIDTH)))
+    if ascii_mode:
+        return "[" + "#" * filled + "-" * (_BAR_WIDTH - filled) + "] "
+    return "▕" + "█" * filled + "▁" * (_BAR_WIDTH - filled) + "▏"
+
+
+def _countdown(epoch: float) -> str:
+    secs = max(0, int(epoch - time.time()))
+    days, rem = divmod(secs, 86400)
+    hours, rem = divmod(rem, 3600)
+    mins = rem // 60
+    if days:
+        return f"{days}d{hours}h"
+    if hours:
+        return f"{hours}h{mins}m"
+    return f"{mins}m"
+
+
+def _supports_unicode() -> bool:
+    return "utf" in (sys.stdout.encoding or "").lower()
+
+
+def _max_pct(usage: dict | None) -> float | None:
+    if not usage:
+        return None
+    pcts = [w["pct"] for w in usage.values() if isinstance(w.get("pct"), (int, float))]
+    return max(pcts) if pcts else None

--- a/src/claude_swap/statusline.py
+++ b/src/claude_swap/statusline.py
@@ -91,14 +91,25 @@ def _run(switcher, stdin_text: str) -> int:
     row0 = reg0.get("sessions", {}).get(managed_id) or {}
     own_account = str(row0.get("account_num", "") or "")
     prev_max = row0.get("_prev_max_pct")
-    rising = (
+    # Plan when the account is at/over the exhaust threshold and not paused — on
+    # the rising EDGE (first crossing) OR, as a level-based re-arm, whenever the
+    # account is over threshold with no migration intent pending on the row (BUG
+    # 012). Without the re-arm, ``_prev_max_pct`` stays >= threshold every tick
+    # once crossed, so a migration intent that fails to consume (e.g. its target
+    # account vanished mid-flight) would never re-fire and the session would be
+    # stranded over-threshold until claude hard-exits.
+    over_threshold = (
         enabled
         and bool(own_account)
         and own_max is not None
         and own_max >= cfg.exhaust_threshold
-        and not (isinstance(prev_max, (int, float)) and prev_max >= cfg.exhaust_threshold)
         and not row0.get("paused_until")
     )
+    rising_edge = not (isinstance(prev_max, (int, float)) and prev_max >= cfg.exhaust_threshold)
+    no_pending_intent = not (
+        isinstance(row0.get("migration"), dict) and row0["migration"].get("to")
+    )
+    rising = over_threshold and (rising_edge or no_pending_intent)
 
     # Build the world OUTSIDE the lock only when we actually need to plan
     # (it may do network I/O for idle accounts). Prefer this tick's fresh usage

--- a/src/claude_swap/statusline.py
+++ b/src/claude_swap/statusline.py
@@ -18,6 +18,14 @@ and performs the actual re-point (the credential-ownership invariant). The
 statusline must always succeed fast and print exactly one line, so the whole
 body is defensive: any error prints an empty line and exits 0 rather than
 breaking Claude's render.
+
+This module also hosts :func:`run_statusfailure` — the ``cswap statusfailure``
+handler behind Claude Code's ``StopFailure`` hook. It is a *next-turn* safety
+net layered under the statusline's proactive threshold migration: when a turn
+fails after claude exhausts its API retries because the session's ACCOUNT is
+rate-limited, it records a migration intent so the next turn lands on a fresh
+account. Like the statusline it only ever writes registry state, never raises,
+and always exits 0.
 """
 
 from __future__ import annotations
@@ -170,6 +178,112 @@ def _run(switcher, stdin_text: str) -> int:
         total,
     )
     print(render_line(render_row, own_max, total, index))
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# StopFailure safety net
+# --------------------------------------------------------------------------- #
+
+# Error types that are plainly NOT account-specific: switching accounts won't
+# help (it's a server-side / overload failure), so the StopFailure safety net
+# leaves them to claude's own retry / ``--fallback-model``.
+_SERVER_SIDE_ERROR_TYPES = frozenset({"overloaded", "server_error"})
+
+
+def run_statusfailure(switcher, stdin_text: str) -> int:
+    """Entry point for ``cswap statusfailure`` (the ``StopFailure`` hook).
+
+    A *next-turn* safety net layered under the statusline's proactive
+    threshold migration. Claude Code fires ``StopFailure`` when a turn ends due
+    to an API error after retries are exhausted (the "Retrying … attempt N/10"
+    storm). We can't rescue the failed turn — no hook can block a turn and claude
+    doesn't re-read creds on a 429 — but when the session's account is genuinely
+    rate-limited we record a migration *intent* so the owning supervisor
+    re-points it and the NEXT turn lands on a fresh account.
+
+    Side-effect-only and bulletproof: never raises, always returns 0, and (like
+    the statusline) only ever writes registry state — never credentials.
+    """
+    try:
+        return _run_failure(switcher, stdin_text)
+    except Exception:  # noqa: BLE001 - the StopFailure hook must never raise
+        try:
+            switcher._logger.debug("statusfailure failed", exc_info=True)
+        except Exception:
+            pass
+        return 0
+
+
+def _run_failure(switcher, stdin_text: str) -> int:
+    try:
+        payload = json.loads(stdin_text)
+    except (json.JSONDecodeError, TypeError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    profile_dir = os.environ.get("CLAUDE_CONFIG_DIR", "")
+    managed_id = Path(profile_dir).name if profile_dir else ""
+    if not managed_id:
+        return 0  # not a managed session
+
+    error_type = payload.get("error_type")
+    error_type = error_type if isinstance(error_type, str) else ""
+
+    reg0 = registry.read_registry(switcher)
+    row0 = reg0.get("sessions", {}).get(managed_id)
+    if not isinstance(row0, dict):
+        return 0  # no registry row for this session
+    own_account = str(row0.get("account_num", "") or "")
+    if not own_account:
+        return 0
+
+    # (b) Skip plainly-not-account-specific failures: switching accounts can't
+    # help an overload / server error (claude's retry / --fallback-model owns
+    # those). An absent/unknown error_type falls through to the usage check (a).
+    if error_type in _SERVER_SIDE_ERROR_TYPES:
+        return 0
+
+    bcfg = switcher.get_auto_balance_config()
+    cfg = balancer.config_from_dict(bcfg)
+    now = time.time()
+
+    # (a) Only migrate when this session's account is ACTUALLY rate-limited
+    # (at/over the exhaust threshold). Build the world OUTSIDE the lock — it may
+    # do network I/O for idle accounts.
+    acct_views, _ = registry.build_world(switcher, reg0, fetch_idle=True)
+    if not balancer._exhausted(acct_views.get(own_account), cfg):
+        return 0
+
+    # Build this session's SessionView from its registry row (mirrors the
+    # statusline's session_views shape; include ctx_tokens so the target's
+    # headroom reserve is sized correctly) and pick a migration target.
+    sv = balancer.SessionView(
+        session_id=managed_id,
+        account_num=own_account,
+        ctx_tokens=int(row0.get("ctx_tokens") or 0),
+        last_seen=float(row0.get("last_seen") or 0.0),
+        paused_until=row0.get("paused_until"),
+        last_migrated_at=float(row0.get("last_migrated_at") or 0.0),
+        pinned_account=row0.get("pinned_account"),
+    )
+    target = balancer.choose_migration_target(sv, acct_views, {}, cfg)
+    if not target:
+        return 0  # nothing has headroom -> leave it; the statusline will pause
+
+    # Record the migration intent under the lock (mirror the statusline's
+    # set_intent path). The owning supervisor consumes it and re-points; we
+    # never touch credentials here.
+    lock = FileLock(switcher.lock_file, timeout=5)
+    if lock.acquire():
+        try:
+            reg = registry.read_registry(switcher)
+            if managed_id in reg.get("sessions", {}):
+                registry.set_intent(reg, managed_id, target, now)
+                registry.write_registry(switcher, reg)
+        finally:
+            lock.release()
     return 0
 
 

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -386,6 +386,14 @@ class Supervisor:
             return False
         if not creds:
             return False
+        # Never prime a pay-as-you-go API / console account (or an unrecognized
+        # auth type): priming bills real money and there is no 5h subscription
+        # window to warm. Only recognized Claude subscription tiers qualify.
+        if not oauth.is_primable_subscription(oauth.extract_subscription_type(creds)):
+            self._logger.debug(
+                "prime: skipping %s — not a primeable subscription account", num
+            )
+            return False
         token = oauth.extract_access_token(creds)
         if not token:
             return False

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -433,6 +433,14 @@ class Supervisor:
         effort = self.switcher.get_auto_balance_config()["effortLevel"]
         if effort:
             env["CLAUDE_CODE_EFFORT_LEVEL"] = effort
+        # When launched inside a cmux workspace, the cmux-claude-wrapper strips
+        # auth-selection env before exec'ing the real claude — which would drop
+        # our CLAUDE_CONFIG_DIR profile pin. cmux honours an allow-list env key;
+        # ensure CLAUDE_CONFIG_DIR is on it (appending, never clobbering).
+        if env.get("CMUX_SURFACE_ID"):
+            from claude_swap.cmux import PRESERVE_KEYS_ENV, merge_preserve_keys
+
+            env[PRESERVE_KEYS_ENV] = merge_preserve_keys(env.get(PRESERVE_KEYS_ENV))
         return env
 
     def _qol_args(self, claude_args: list[str]) -> list[str]:

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -499,9 +499,16 @@ class Supervisor:
         account that is below the loose ``_usable`` line but still too full to
         actually host the session — the asymmetry that would otherwise cause a
         relaunch livelock.
+
+        When the API-rate last-resort tier is enabled (``not only_subscription``),
+        the current account staying runnable via its own pay-as-you-go capacity
+        also counts — ``choose_migration_target`` returns ``None`` in that case
+        (it keeps the session put rather than thrashing), so check it explicitly.
         """
+        cur = acct_views.get(self.account)
         return (
-            balancer._usable(acct_views.get(self.account), cfg)
+            balancer._usable(cur, cfg)
+            or (not cfg.only_subscription and balancer._api_capable(cur, cfg))
             or balancer.choose_migration_target(sv, acct_views, {}, cfg) is not None
         )
 

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -22,6 +22,7 @@ owning supervisor consumes its own intent and re-points its own profile via
 from __future__ import annotations
 
 import os
+import select
 import shutil
 import signal
 import subprocess
@@ -33,7 +34,7 @@ from pathlib import Path
 from claude_swap import balancer, embed, oauth, registry
 from claude_swap.exceptions import SessionError
 from claude_swap.locking import FileLock
-from claude_swap.printer import accent, dimmed, muted, warning
+from claude_swap.printer import accent, bold_accent, dimmed, muted, warning
 from claude_swap.session import AUTH_OVERRIDE_ENV_VARS, SessionManager
 
 # How long to wait for a SIGTERM'd child to exit before force-killing it.
@@ -696,23 +697,14 @@ class Supervisor:
         if not token:
             return False
 
-        # Refresh an expired token for this INACTIVE account, persisting under the
-        # lock via the same callback shape the usage path uses. A live session on
-        # this account => treat as active (don't rotate its refresh token).
-        data = oauth.extract_oauth_data(creds) or {}
-        if (
-            not self.switcher._live_session_pids(num, email)
-            and data.get("refreshToken")
-            and oauth.is_oauth_token_expired(data.get("expiresAt"))
-        ):
-            refreshed = oauth.refresh_oauth_credentials(creds)
-            if refreshed:
-                token = oauth.extract_access_token(refreshed) or token
-                try:
-                    with FileLock(self.switcher.lock_file, timeout=5):
-                        self.switcher._write_account_credentials(num, email, refreshed)
-                except Exception:
-                    self._logger.debug("prime: persist refreshed creds failed for %s", num, exc_info=True)
+        # Refresh an expired token for this INACTIVE account through the locked,
+        # double-checked chokepoint so two concurrent supervisors/renders never both
+        # POST the single-use refresh token (which would revoke the family and log the
+        # account out). A live session on this account => treat as active (claude owns
+        # its credentials; don't rotate its refresh token).
+        if not self.switcher._live_session_pids(num, email):
+            creds = self.switcher.ensure_fresh_inactive_credentials(num, email, creds)
+            token = oauth.extract_access_token(creds) or token
         return oauth.prime_account(token)
 
     def _stamp_primed(self, num: str) -> None:
@@ -837,39 +829,211 @@ class Supervisor:
             self._wait_for_reset()
         self._reassign_for_resume()
 
+    def _pause_status_lines(self, acct_views: dict, cfg) -> list[str]:
+        """Compact per-account usage lines shown beneath the pause countdown.
+
+        Uses the best-available signal already in ``acct_views`` (live / cache /
+        probe / stale) and, for an account whose usage endpoint is 429-backed-off so
+        it has NO signal (``max_pct is None``), falls back to the last-known cached
+        reading — so an idle account that is really at ~27% shows that number rather
+        than a bare "unknown" while the usage API is rate-limited. Tags the session's
+        current account and any account usable as a resume target right now, so when
+        the balancer pauses despite a healthy account the discrepancy is visible (and
+        the user can press Enter to re-check). Best-effort: never raises.
+        """
+        from claude_swap.cache import (
+            MISSING,
+            STALE_USAGE_MAX_AGE_S,
+            last_known_usage,
+            read_cache,
+        )
+
+        try:
+            data = self.switcher._get_sequence_data() or {}
+            accounts = data.get("accounts", {})
+            order = [str(n) for n in data.get("sequence", [])]
+            for num in accounts:
+                if str(num) not in order:
+                    order.append(str(num))
+            persisted = read_cache(
+                self.switcher.backup_dir / "cache" / "usage.json", float("inf")
+            )
+            persisted = persisted if (persisted is not MISSING and isinstance(persisted, dict)) else {}
+
+            lines: list[str] = []
+            for num in order:
+                av = acct_views.get(num)
+                email = accounts.get(num, {}).get("email", "") or "?"
+                # Usage / status text from the best signal available.
+                if av is not None and av.signal == "logged_out":
+                    usage = dimmed("logged out — re-login")
+                elif av is not None and av.max_pct is not None:
+                    h5, d7 = av.five_hour_pct, av.seven_day_pct
+                    if h5 is not None or d7 is not None:
+                        parts = []
+                        if h5 is not None:
+                            parts.append(f"5h {h5:>3.0f}%")
+                        if d7 is not None:
+                            parts.append(f"7d {d7:>3.0f}%")
+                        usage = muted("  ".join(parts))
+                    else:
+                        usage = muted(f"~{av.max_pct:>3.0f}%")
+                    if av.signal == "probe":
+                        usage += dimmed(" (probe-ok)")
+                    elif av.signal == "stale":
+                        usage += dimmed(" (cached)")
+                else:
+                    lk = last_known_usage(persisted.get(num), STALE_USAGE_MAX_AGE_S)
+                    pcts = [
+                        w["pct"]
+                        for w in (lk.values() if isinstance(lk, dict) else [])
+                        if isinstance(w, dict) and isinstance(w.get("pct"), (int, float))
+                    ]
+                    usage = (
+                        muted(f"~{max(pcts):>3.0f}% (cached)") if pcts else dimmed("checking…")
+                    )
+                # Tag: current session account, else a usable resume target.
+                if str(num) == str(self.account):
+                    tag = "  " + bold_accent("(current)")
+                elif balancer._usable(av, cfg):
+                    tag = "  " + muted("available")
+                else:
+                    tag = ""
+                lines.append(f"  {dimmed('a' + str(num))} {email:<28} {usage}{tag}")
+            return lines
+        except Exception:  # noqa: BLE001 - the pause display is best-effort
+            self._logger.debug("pause status render failed", exc_info=True)
+            return []
+
     def _wait_for_reset(self) -> None:
         """Foreground wait until the pause horizon OR the session becomes resumable.
 
-        Interruptible (Ctrl-C propagates). Renders a countdown so the wait is
-        always visible — never a hidden background sleep. The early break uses the
-        same ``_resumable`` gate as placement, so it can't wake into a still-full
-        account.
+        Interruptible (Ctrl-C propagates). Renders a live countdown PLUS a compact
+        per-account usage list (so the user can see which account has headroom), and
+        lets the user press **Enter** to force an immediate re-check instead of
+        waiting out the up-to-30s tick. The early break uses the same ``_resumable``
+        gate as placement, so it can't wake into a still-full account.
+
+        Rendering degrades gracefully off a TTY (printed once, no ANSI, no per-tick
+        spam); the Enter shortcut is POSIX-tty only (falls back to a plain sleep on
+        Windows / piped stdin). Ctrl-C is never swallowed — it propagates to
+        :meth:`run`'s handler.
         """
         resume_at = getattr(self, "_pending_resume_at", int(time.time()))
         cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
         sv = self._self_session_view()
-        while True:
-            now = time.time()
-            remaining = int(resume_at - now)
-            if remaining <= 0:
-                break
-            reg = registry.read_registry(self.switcher)
-            # Probe a usage-backed-off idle target so the wait wakes the instant a
-            # probe confirms headroom, rather than sleeping out the whole timer.
-            acct_views, _ = registry.build_world(
-                self.switcher, reg, fetch_idle=True, probe_unavailable=True
-            )
-            if self._resumable(acct_views, sv, cfg):
-                break
-            mins, secs = divmod(remaining, 60)
-            hours, mins = divmod(mins, 60)
-            cd = f"{hours}h{mins:02d}m" if hours else f"{mins}m{secs:02d}s"
-            sys.stdout.write(
-                f"\r{dimmed('Usage limit reached — auto-resuming in ' + cd + '  ')}"
-            )
-            sys.stdout.flush()
-            time.sleep(min(30.0, max(1.0, remaining)))
-        sys.stdout.write("\r" + " " * 60 + "\r")
+        is_tty = self._stdout_isatty()
+        # Enter-to-recheck only when we can poll a real stdin tty (not Windows, not a
+        # pipe). EOF on stdin disables it mid-wait to avoid a busy-loop (see below).
+        can_select = (
+            sys.platform != "win32"
+            and hasattr(sys.stdin, "isatty")
+            and self._safe_isatty(sys.stdin)
+        )
+        prev_lines = 0
+        try:
+            while True:
+                now = time.time()
+                remaining = int(resume_at - now)
+                if remaining <= 0:
+                    break
+                reg = registry.read_registry(self.switcher)
+                # Probe a usage-backed-off idle target so the wait wakes the instant a
+                # probe confirms headroom, rather than sleeping out the whole timer.
+                acct_views, _ = registry.build_world(
+                    self.switcher, reg, fetch_idle=True, probe_unavailable=True
+                )
+                if self._resumable(acct_views, sv, cfg):
+                    break
+                mins, secs = divmod(remaining, 60)
+                hours, mins = divmod(mins, 60)
+                cd = f"{hours}h{mins:02d}m" if hours else f"{mins}m{secs:02d}s"
+                hint = "  (press Enter to re-check now)" if (can_select and is_tty) else ""
+                head = dimmed(f"Usage limit reached — auto-resuming in {cd}{hint}")
+                block = self._pause_status_lines(acct_views, cfg)
+                prev_lines = self._render_pause_frame(head, block, prev_lines, is_tty)
+
+                timeout = min(30.0, max(1.0, remaining))
+                if can_select:
+                    try:
+                        readable, _, _ = select.select([sys.stdin], [], [], timeout)
+                    except (OSError, ValueError):
+                        # stdin not selectable after all -> stop trying, sleep instead.
+                        can_select = False
+                        time.sleep(timeout)
+                    else:
+                        if readable:
+                            line = self._consume_stdin_line()
+                            if line == "":
+                                # EOF (Ctrl-D / closed pipe): select would report it
+                                # readable forever -> disable to avoid a busy-loop.
+                                can_select = False
+                            # Enter (or any input) pressed -> loop now for an
+                            # immediate re-check, skipping the rest of the wait.
+                else:
+                    time.sleep(timeout)
+        finally:
+            self._clear_pause_frame(prev_lines, is_tty)
+
+    @staticmethod
+    def _stdout_isatty() -> bool:
+        try:
+            return bool(sys.stdout.isatty())
+        except Exception:  # noqa: BLE001 - non-tty / closed stream
+            return False
+
+    @staticmethod
+    def _safe_isatty(stream) -> bool:
+        try:
+            return bool(stream.isatty())
+        except Exception:  # noqa: BLE001
+            return False
+
+    @staticmethod
+    def _consume_stdin_line() -> str:
+        """Read one pending line from stdin (the Enter press). ``""`` on EOF/error."""
+        try:
+            return sys.stdin.readline()
+        except (OSError, ValueError):
+            return ""
+
+    def _render_pause_frame(
+        self, head: str, block: list[str], prev_lines: int, is_tty: bool
+    ) -> int:
+        """Draw the countdown + account block, returning the line count drawn.
+
+        On a TTY each tick moves the cursor back to the top of the previous frame
+        and clears to end-of-screen (``\\033[J``) before redrawing, so a frame that
+        grows or shrinks (an account logging out / a probe landing) never smears.
+        Off a TTY the frame is printed exactly ONCE (when ``prev_lines == 0``) with no
+        ANSI, so a piped/redirected stdout isn't spammed every tick.
+        """
+        lines = [head, *block]
+        if not is_tty:
+            if prev_lines == 0:
+                sys.stdout.write("\n".join(lines) + "\n")
+                sys.stdout.flush()
+                return len(lines)
+            return prev_lines
+        out = []
+        if prev_lines:
+            out.append(f"\033[{prev_lines}A")  # cursor up to the top of the frame
+        out.append("\r\033[J")  # clear from here to end of screen
+        # Trailing newline leaves the cursor on the line BELOW the block, so the
+        # next tick's cursor-up count is exactly the line count drawn here.
+        out.append("\n".join(lines) + "\n")
+        sys.stdout.write("".join(out))
+        sys.stdout.flush()
+        return len(lines)
+
+    def _clear_pause_frame(self, prev_lines: int, is_tty: bool) -> None:
+        """Erase the rendered pause frame so the next message starts clean."""
+        if not prev_lines:
+            return
+        if is_tty:
+            sys.stdout.write(f"\033[{prev_lines}A\r\033[J")
+        else:
+            sys.stdout.write("\n")
         sys.stdout.flush()
 
     def _reassign_for_resume(self) -> None:

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -441,7 +441,9 @@ class Supervisor:
         except Exception:
             self._logger.warning("migrate: cannot resolve account %s", to_account)
             return
-        self.switcher.seed_profile_credentials(self.profile_dir, num, email)
+        self.switcher.seed_profile_credentials(
+            self.profile_dir, num, email, cwd=self.cwd
+        )
         lock = FileLock(self.switcher.lock_file, timeout=10)
         if lock.acquire():
             try:
@@ -591,7 +593,10 @@ class Supervisor:
         num, email, _ = self.switcher.resolve_account(self.account)
         # Verbatim seed (no refresh side-effects), share ~/.claude items, then
         # install the non-shared statusline + effort layer over the symlink.
-        self.switcher.seed_profile_credentials(self.profile_dir, num, email)
+        # Pre-trust the launch cwd so claude skips the folder trust dialog.
+        self.switcher.seed_profile_credentials(
+            self.profile_dir, num, email, cwd=self.cwd
+        )
         SessionManager(self.switcher)._sync_sharing(self.profile_dir, self.share)
         embed.install_into_profile(self.switcher, self.profile_dir)
         if self.share:

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -81,6 +81,140 @@ _MAX_AUTH_RECOVER_ATTEMPTS = 2
 # there is nothing to restore in ``finally``.
 _NO_SIGNAL = object()
 
+# Injected as the first turn whenever the supervisor AUTO-resumes a session after a
+# rate-limit or auth interruption. Without it, ``claude --resume`` reloads the
+# transcript and then idles at a blank prompt waiting for the user — so the
+# "auto-resume" never actually continues the work. This nudge makes the recovered
+# session pick up where it left off. The session's ``/goal``, model, and effort ride
+# along automatically (the goal + model live in the resumed transcript; effort is in
+# ``CLAUDE_CODE_EFFORT_LEVEL`` on the env), and the launch FLAGS below are re-passed.
+_RECOVERY_PROMPT = "Sorry for the interruption, please gracefully recover and continue."
+
+# claude launch flags that consume EXACTLY the next token as their value (from
+# ``claude --help``). Used to walk an argv the way claude's own parser does so the
+# trailing positional prompt can be told apart from a flag value.
+_VALUE_FLAGS = frozenset({
+    "--agent", "--agents", "--append-system-prompt", "--append-system-prompt-file",
+    "--debug-file", "--effort", "--fallback-model", "--json-schema",
+    "--max-budget-usd", "--max-turns", "--model", "-m", "--name", "-n",
+    "--output-format", "--input-format", "--permission-mode",
+    "--permission-prompt-tool", "--session-id", "--settings", "--setting-sources",
+    "--system-prompt", "--system-prompt-file",
+})
+# Variadic launch flags: greedily consume following non-flag tokens as values
+# (matches commander's parsing in claude).
+_VARIADIC_FLAGS = frozenset({
+    "--add-dir", "--allowedTools", "--allowed-tools", "--disallowedTools",
+    "--disallowed-tools", "--betas", "--file", "--mcp-config",
+})
+# Optional-value flags: a following non-flag token is their value (a session id,
+# PR ref, debug filter), but they are also valid bare. They must be recognized so a
+# value like ``--resume <sid>`` isn't mistaken for the positional prompt.
+_OPTVALUE_FLAGS = frozenset({"--resume", "--from-pr", "--debug", "-d"})
+# Resume-control flags stripped from the preserved set when the supervisor supplies
+# its OWN ``--resume <sid>`` — re-passing the user's would double-resume / conflict.
+# ``--print``/``-p`` is dropped too: an auto-resume MUST be interactive (the injected
+# recovery prompt is a first turn the user then continues), and ``-p`` would relaunch
+# headless and exit after one response.
+_DROP_ON_RESUME_NOVALUE = frozenset({"--continue", "-c", "--fork-session", "--print", "-p"})
+_DROP_ON_RESUME_OPTVALUE = frozenset({"--resume", "--from-pr"})  # optional trailing value
+_DROP_ON_RESUME_VALUE = frozenset({"--session-id"})  # required trailing value
+
+
+def _flag_name(tok: str) -> str:
+    """The flag name without an inline ``=value`` (``--model=opus`` -> ``--model``)."""
+    return tok.split("=", 1)[0]
+
+
+def _strip_trailing_prompt(args: list[str]) -> list[str]:
+    """Return ``args`` with a trailing positional prompt removed.
+
+    Walks left-to-right consuming flags and their values exactly as claude's parser
+    does; the first bare token (not a flag and not consumed as a flag value) is the
+    positional prompt — it and everything after it are dropped. A flags-only argv
+    (the managed-launch norm) is returned unchanged.
+    """
+    out: list[str] = []
+    i, n = 0, len(args)
+    while i < n:
+        tok = args[i]
+        if not tok.startswith("-"):
+            break  # first bare positional == the prompt; drop it and the rest
+        out.append(tok)
+        name = _flag_name(tok)
+        if "=" in tok:
+            i += 1
+            continue
+        if name in _VALUE_FLAGS:
+            if i + 1 < n:
+                out.append(args[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+        if name in _VARIADIC_FLAGS:
+            i += 1
+            while i < n and not args[i].startswith("-"):
+                out.append(args[i])
+                i += 1
+            continue
+        if name in _OPTVALUE_FLAGS:
+            if i + 1 < n and not args[i + 1].startswith("-"):
+                out.append(args[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+        i += 1
+    return out
+
+
+def _resume_launch_args(base_args: list[str], sid: str, prompt: str) -> list[str]:
+    """Build the argv for an auto-resume relaunch.
+
+    ``["--resume", <sid>]`` + the original launch FLAGS (model / settings /
+    skip-permissions / fallback-model / add-dir / … so the recovered session keeps
+    them) + ``prompt`` as the first turn. The user's original positional prompt is
+    dropped (it already lives in the resumed transcript) and any resume-control
+    flags they passed are dropped (the supervisor supplies its own ``--resume``).
+    Each flag is kept or dropped together with the value tokens it consumes, so a
+    dropped flag never strands a value and a kept flag's value is never re-read as a
+    flag.
+    """
+    flags = _strip_trailing_prompt(base_args)
+    out: list[str] = []
+    i, n = 0, len(flags)
+    while i < n:
+        tok = flags[i]
+        name = _flag_name(tok)
+        group = [tok]
+        i += 1
+        if "=" not in tok:
+            if name in _VALUE_FLAGS or name in _DROP_ON_RESUME_VALUE:
+                if i < n:
+                    group.append(flags[i])
+                    i += 1
+            elif name in _VARIADIC_FLAGS:
+                while i < n and not flags[i].startswith("-"):
+                    group.append(flags[i])
+                    i += 1
+            elif name in _DROP_ON_RESUME_OPTVALUE:
+                if i < n and not flags[i].startswith("-"):
+                    group.append(flags[i])
+                    i += 1
+        if (
+            name in _DROP_ON_RESUME_NOVALUE
+            or name in _DROP_ON_RESUME_OPTVALUE
+            or name in _DROP_ON_RESUME_VALUE
+        ):
+            continue  # drop the flag and any value(s) it consumed
+        out.extend(group)
+    # Terminate options with ``--`` so the recovery prompt is ALWAYS the positional
+    # prompt — never swallowed as the value of a trailing variadic (``--add-dir``…)
+    # or optional-value (``--debug``…) flag, which would leave the resumed session
+    # idling at a blank prompt instead of continuing its work.
+    return ["--resume", sid, *out, "--", prompt]
+
 
 def launch(
     switcher, claude_args: list[str], *, cwd: str | None = None, share: bool = True
@@ -175,7 +309,14 @@ class Supervisor:
                 # on it would launch the first auto-resume fresh and leave later
                 # ones off-by-one. The authoritative value lives in the row.
                 sid = self._current_claude_session_id()
-                args = (["--resume", sid] if resume and sid
+                # An auto-resume after a rate-limit / auth interruption: resume the
+                # session, re-pass the launch flags so model/settings/permissions
+                # survive the account switch, and inject the recovery prompt so the
+                # session actually continues its work instead of idling at a blank
+                # prompt. A fresh launch (no session id recorded yet) falls back to
+                # the original args verbatim.
+                args = (_resume_launch_args(base_args, sid, _RECOVERY_PROMPT)
+                        if resume and sid
                         else list(base_args))
                 # Let claude own Ctrl-C — but ONLY while it is the live foreground
                 # process. The supervisor shares the foreground process group + TTY
@@ -198,6 +339,11 @@ class Supervisor:
 
                 if outcome == "exit":
                     if self._should_handle_limit_exit():
+                        # The child launched and RAN (it hit a usage limit), so its
+                        # credentials were fine — reset the consecutive-auth-failure
+                        # counter so a long-lived session that recovered from earlier
+                        # auth blips isn't torn down on a later, unrelated one.
+                        self._auth_recover_attempts = 0
                         self._pause_and_resume()  # migrate now, or pause + auto-resume
                     elif self._should_recover_auth_exit(rc):
                         # An auth-failure exit: claude hard-exited on invalid/expired
@@ -226,6 +372,8 @@ class Supervisor:
                         return rc
                 else:
                     # outcome == "pause": child was SIGTERM'd to honour a pause.
+                    # It ran fine up to the pause, so its creds were good -> reset.
+                    self._auth_recover_attempts = 0
                     self._pause_and_resume()
                 resume = True
         except KeyboardInterrupt:

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -355,6 +355,15 @@ class Supervisor:
 
     # -- profile + registry helpers --------------------------------------
 
+    # Session-history items symlinked from the default ~/.claude into a managed
+    # profile so a balanced session is continuous with the user's normal claude
+    # history: `cswap launch -- --resume <id>` / `--continue` can resume sessions
+    # started with plain claude, and a managed session's own transcript shows up
+    # in the user's regular history. (Unlike `cswap run`, a balanced session is
+    # account-agnostic — it migrates across accounts — so per-account history is
+    # not wanted here. Credentials stay isolated; only history is shared.)
+    _SHARED_HISTORY = ("projects", "todos", "shell-snapshots")
+
     def _bootstrap_profile(self) -> None:
         self.switcher.managed_dir.mkdir(parents=True, exist_ok=True)
         self.profile_dir.mkdir(parents=True, exist_ok=True)
@@ -366,6 +375,31 @@ class Supervisor:
         self.switcher.seed_profile_credentials(self.profile_dir, num, email)
         SessionManager(self.switcher)._sync_sharing(self.profile_dir, self.share)
         embed.install_into_profile(self.switcher, self.profile_dir)
+        if self.share:
+            self._share_history()
+
+    def _share_history(self) -> None:
+        """Symlink the default profile's session history into this managed profile.
+
+        Makes ``--resume``/``--continue`` of externally-started sessions work and
+        unifies history. POSIX only (symlinks); on Windows a managed profile keeps
+        isolated history, so resuming a session started outside cswap is
+        unsupported there. Best-effort: a failure just leaves that item unshared.
+        """
+        if sys.platform == "win32":
+            return
+        source_root = Path.home() / ".claude"
+        for name in self._SHARED_HISTORY:
+            src = source_root / name
+            dest = self.profile_dir / name
+            if not src.exists() or dest.exists() or dest.is_symlink():
+                continue
+            try:
+                dest.symlink_to(src)
+            except OSError:
+                self._logger.debug(
+                    "could not share %s into managed profile", name, exc_info=True
+                )
 
     def _register(self) -> None:
         with FileLock(self.switcher.lock_file):

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -29,7 +29,7 @@ import time
 import uuid
 from pathlib import Path
 
-from claude_swap import balancer, embed, registry
+from claude_swap import balancer, embed, oauth, registry
 from claude_swap.exceptions import SessionError
 from claude_swap.locking import FileLock
 from claude_swap.printer import accent, dimmed, muted, warning
@@ -45,6 +45,12 @@ _WATCH_TICK_S = 1.0
 # hook flags should be consumed on the very next supervisor tick; a flag older than
 # this was left by a crash and is ignored (cleared without recovering).
 _AUTH_RECOVER_TTL_S = 300.0
+
+# Idle-5h-window priming (feature #3): the resident supervisor attempts a prime
+# sweep at most this often *per process* (a cheap local clock that avoids building
+# the world every tick); the cross-process gate (one sweep per interval across ALL
+# supervisors) is the registry ``last_primed_sweep_at`` stamp claimed under the lock.
+_PRIME_LOCAL_INTERVAL_S = 300.0
 
 # Secondary model managed sessions auto-fall-back to when the primary model is
 # overloaded (HTTP 529). Unlike a 429 rate limit (which is account-specific and
@@ -200,6 +206,11 @@ class Supervisor:
                 return ("exit", rc)
             except subprocess.TimeoutExpired:
                 pass
+            # Idle-5h-window priming rides this resident loop (NO new daemon): a
+            # best-effort sweep that self-gates to once per interval (locally and
+            # cross-process) and does its network I/O outside the lock, so it can't
+            # stall the tick on the common path or block any render.
+            self._maybe_prime_idle_windows()
             mtime = self._registry_mtime()
             if mtime == last_mtime:
                 continue
@@ -287,6 +298,128 @@ class Supervisor:
                 "headroom. Re-login on one account (e.g. `cswap --add-account`)."
             )
 
+    # -- idle-5h-window priming (feature #3) ------------------------------
+
+    def _maybe_prime_idle_windows(self) -> None:
+        """Best-effort prime sweep of idle managed accounts; never raises/blocks long.
+
+        Rides the resident watch loop (no new daemon). Self-gates three ways so it
+        is cheap and safe:
+
+        * a per-process local clock (skip most ticks without any I/O);
+        * the balancer must be enabled (priming only matters while balancing);
+        * a cross-process registry claim (``claim_prime_sweep`` under the lock) so
+          exactly ONE supervisor sweeps per interval — no thundering herd.
+
+        The decision of WHICH accounts to prime is the pure
+        ``balancer.accounts_needing_prime`` (built from a world snapshot OUTSIDE
+        the lock); each prime POST also runs OUTSIDE the lock. Only the sweep
+        claim and the per-account guard stamps touch the registry, under the lock.
+        Active accounts are never primed — only idle/inactive ones (we never touch
+        an in-use account's credentials).
+        """
+        try:
+            now = time.time()
+            if (now - getattr(self, "_last_prime_attempt", 0.0)) < _PRIME_LOCAL_INTERVAL_S:
+                return
+            self._last_prime_attempt = now
+            # Priming requires BOTH the balancer being enabled AND the dedicated,
+            # default-OFF ``primeIdleWindows`` opt-in: it spends real credits on the
+            # as-yet-unverified fixed-from-first-use 5h-window premise, so it must
+            # never run by default. (Kept after the cheap local-interval check so a
+            # disabled flag still costs ~nothing per tick.)
+            bcfg = self.switcher.get_auto_balance_config()
+            if not (bcfg["enabled"] and bcfg.get("primeIdleWindows")):
+                return
+
+            # (1) Claim the cross-process sweep under the lock (cheap, no network).
+            lock = FileLock(self.switcher.lock_file, timeout=5)
+            if not lock.acquire():
+                return
+            try:
+                reg = registry.read_registry(self.switcher)
+                if not registry.claim_prime_sweep(reg, now):
+                    return  # another supervisor owns this interval
+                registry.prune_primed(reg, now)
+                guarded = {
+                    num for num in reg.get("primed", {})
+                    if registry.prime_guarded(reg, num, now)
+                }
+                registry.write_registry(self.switcher, reg)
+            finally:
+                lock.release()
+
+            # (2) Build the world + decide candidates OUTSIDE the lock (network I/O).
+            cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
+            reg = registry.read_registry(self.switcher)
+            acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+            candidates = [
+                num for num in balancer.accounts_needing_prime(acct_views, cfg)
+                if num != self.account and num not in guarded
+            ]
+            if not candidates:
+                return
+
+            # (3) Prime each candidate OUTSIDE the lock; stamp successes under it.
+            for num in candidates:
+                if self._prime_one_account(num):
+                    self._stamp_primed(num)
+        except Exception:  # noqa: BLE001 - priming is strictly best-effort
+            self._logger.debug("prime sweep failed", exc_info=True)
+
+    def _prime_one_account(self, num: str) -> bool:
+        """Send one minimal credit-consuming call to start ``num``'s 5h window.
+
+        Best-effort, never raises. Reads the INACTIVE account's stored credentials,
+        refreshes an expired token (inactive accounts only — never an active one,
+        whose creds Claude Code owns) persisting under the lock, then performs the
+        prime POST OUTSIDE the lock. Returns whether the clock was started.
+        """
+        try:
+            num, email, _ = self.switcher.resolve_account(num)
+        except Exception:
+            return False
+        try:
+            creds = self.switcher.read_account_credentials(num, email)
+        except Exception:
+            self._logger.debug("prime: cannot read creds for %s", num, exc_info=True)
+            return False
+        if not creds:
+            return False
+        token = oauth.extract_access_token(creds)
+        if not token:
+            return False
+
+        # Refresh an expired token for this INACTIVE account, persisting under the
+        # lock via the same callback shape the usage path uses. A live session on
+        # this account => treat as active (don't rotate its refresh token).
+        data = oauth.extract_oauth_data(creds) or {}
+        if (
+            not self.switcher._live_session_pids(num, email)
+            and data.get("refreshToken")
+            and oauth.is_oauth_token_expired(data.get("expiresAt"))
+        ):
+            refreshed = oauth.refresh_oauth_credentials(creds)
+            if refreshed:
+                token = oauth.extract_access_token(refreshed) or token
+                try:
+                    with FileLock(self.switcher.lock_file, timeout=5):
+                        self.switcher._write_account_credentials(num, email, refreshed)
+                except Exception:
+                    self._logger.debug("prime: persist refreshed creds failed for %s", num, exc_info=True)
+        return oauth.prime_account(token)
+
+    def _stamp_primed(self, num: str) -> None:
+        lock = FileLock(self.switcher.lock_file, timeout=5)
+        if not lock.acquire():
+            return
+        try:
+            reg = registry.read_registry(self.switcher)
+            registry.stamp_primed(reg, num, time.time())
+            registry.write_registry(self.switcher, reg)
+        finally:
+            lock.release()
+
     # -- actions ----------------------------------------------------------
 
     def _migrate(self, to_account: str) -> None:
@@ -307,10 +440,23 @@ class Supervisor:
                 reg = registry.read_registry(self.switcher)
                 row = reg.get("sessions", {}).get(self.managed_id)
                 if row is not None:
+                    now = time.time()
                     row["account_num"] = num
-                    row["last_migrated_at"] = time.time()
+                    row["last_migrated_at"] = now
                     row["migration_count"] = int(row.get("migration_count", 0)) + 1
                     row["rate_limits"] = None    # don't judge the new account by old numbers
+                    # Re-arm the cross-process headroom reservation on the NEW account
+                    # (BUG-003): a just-migrated session is not yet reporting real
+                    # usage, so without this it would contribute ZERO synthetic load
+                    # and a second, independently-stranded session's separate
+                    # build_world pass would see this target as ~empty and stack onto
+                    # it, co-exhausting it. Stamping reserved_at makes
+                    # _reserve_load_by_account attribute _pct_cost(ctx_tokens) of load
+                    # to the new account for _RESERVE_TTL_S (exactly like a freshly
+                    # launched session) until the real rate_limits land — so the
+                    # second session sees the target as full and pauses/spreads
+                    # instead of stacking. Closes the co-exhaust race with no timer.
+                    row["reserved_at"] = now
                     row["_prev_max_pct"] = None   # fresh rising-edge basis on next tick
                     row["paused_until"] = None    # re-pointed to a fresh account -> running, not paused
                     row["migration"] = None

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -41,6 +41,11 @@ _TERMINATE_GRACE_S = 5.0
 # the registry for an intent/pause (only re-reads when the file's mtime moved).
 _WATCH_TICK_S = 1.0
 
+# How recent an ``auth_recover`` flag must be to act on it. A 401 the statusfailure
+# hook flags should be consumed on the very next supervisor tick; a flag older than
+# this was left by a crash and is ignored (cleared without recovering).
+_AUTH_RECOVER_TTL_S = 300.0
+
 # Secondary model managed sessions auto-fall-back to when the primary model is
 # overloaded (HTTP 529). Unlike a 429 rate limit (which is account-specific and
 # triggers a migration), a 529 is server/model-side — every account hits the same
@@ -194,10 +199,11 @@ class Supervisor:
             if decision == "pause":
                 self._terminate(proc)
                 return ("pause", None)
-            # "migrate" was applied in place (no relaunch); keep watching.
+            # "migrate"/"auth" recovery was applied in place (no relaunch); the
+            # session recovers on its next turn. Keep watching.
 
     def _consume_own_state(self) -> str | None:
-        """Act on this session's own registry row: migration intent or pause.
+        """Act on this session's own registry row: auth recovery, migration, pause.
 
         Degrades gracefully under lock contention — a tick we can't lock is
         simply skipped and retried on the next registry change, never an error
@@ -213,14 +219,28 @@ class Supervisor:
                 return None
             intent = row.get("migration")
             paused_until = row.get("paused_until")
+            # A 401 the statusfailure hook flagged: refresh+re-seed this account
+            # (or migrate if it's logged out). Only honour a RECENT flag so a
+            # stale one left by a crash can't trigger a spurious recovery.
+            auth_recover = row.get("auth_recover")
+            do_auth_recover = (
+                isinstance(auth_recover, (int, float))
+                and (time.time() - auth_recover) <= _AUTH_RECOVER_TTL_S
+            )
+            if auth_recover is not None:
+                row["auth_recover"] = None  # clear it whether or not it's recent
             if intent and intent.get("to"):
                 to_account = str(intent["to"])
                 registry.clear_intent(reg, self.managed_id)
-                registry.write_registry(self.switcher, reg)
             else:
                 to_account = None
+            if do_auth_recover or to_account is not None or auth_recover is not None:
+                registry.write_registry(self.switcher, reg)
         finally:
             lock.release()
+        if do_auth_recover:
+            self._recover_auth()
+            return "auth"
         if to_account is not None:
             self._migrate(to_account)
             return "migrate"
@@ -228,6 +248,35 @@ class Supervisor:
             self._pending_resume_at = int(paused_until)
             return "pause"
         return None
+
+    def _recover_auth(self) -> None:
+        """Recover this session from a 401 so the NEXT turn re-authenticates.
+
+        First try to refresh + re-seed the SAME account's credentials in place
+        (``refresh_account_and_reseed`` owns the credential work). If that fails
+        the account is logged out: build the world (OUTSIDE the lock — it may do
+        network I/O), pick a healthy migration target, and re-point to it via the
+        existing credential-owning ``_migrate``. If no account has headroom either,
+        warn the user that every account needs a re-login and leave the session as
+        is — no crash, no relaunch loop.
+        """
+        if self.switcher.refresh_account_and_reseed(self.account, self.profile_dir):
+            print(f"\n{accent('Re-authenticated')} Account-{self.account}")
+            return
+        # Same-account refresh impossible (refresh token dead / logged out) ->
+        # migrate to a healthy account.
+        cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
+        reg = registry.read_registry(self.switcher)
+        acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+        sv = self._self_session_view()
+        target = balancer.choose_migration_target(sv, acct_views, {}, cfg)
+        if target:
+            self._migrate(target)
+        else:
+            warning(
+                "Managed session's account is logged out and no other account has "
+                "headroom. Re-login on one account (e.g. `cswap --add-account`)."
+            )
 
     # -- actions ----------------------------------------------------------
 

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -127,7 +127,14 @@ class Supervisor:
         proc = None  # stays None if Ctrl-C lands during the first Popen
         try:
             while True:
-                args = (["--resume", self._claude_session_id] if resume and self._claude_session_id
+                # Re-read claude's own session id from the registry row right
+                # before each Popen. The cached ``_claude_session_id`` is only
+                # refreshed in ``_set_pids`` (just AFTER the previous Popen,
+                # before the new claude has rendered its statusline), so relying
+                # on it would launch the first auto-resume fresh and leave later
+                # ones off-by-one. The authoritative value lives in the row.
+                sid = self._current_claude_session_id()
+                args = (["--resume", sid] if resume and sid
                         else list(base_args))
                 proc = subprocess.Popen([claude_bin, *args], env=env, cwd=self.cwd)
                 self._set_pids(proc.pid)
@@ -287,7 +294,7 @@ class Supervisor:
         is no tight relaunch loop. Interruptible via Ctrl-C.
         """
         cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
-        sv = balancer.SessionView(self.managed_id, self.account)
+        sv = self._self_session_view()
         while True:
             reg = registry.read_registry(self.switcher)
             acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
@@ -309,7 +316,7 @@ class Supervisor:
         """
         resume_at = getattr(self, "_pending_resume_at", int(time.time()))
         cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
-        sv = balancer.SessionView(self.managed_id, self.account)
+        sv = self._self_session_view()
         while True:
             now = time.time()
             remaining = int(resume_at - now)
@@ -339,7 +346,7 @@ class Supervisor:
         cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
         reg = registry.read_registry(self.switcher)
         acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
-        sv = balancer.SessionView(self.managed_id, self.account)
+        sv = self._self_session_view()
         if not balancer._usable(acct_views.get(self.account), cfg):
             target = balancer.choose_migration_target(sv, acct_views, {}, cfg)
             if target and target != self.account:
@@ -372,6 +379,12 @@ class Supervisor:
                 cwd=self.cwd,
                 supervisor_pid=os.getpid(),
                 last_seen=time.time(),
+                # Mark the moment this session was placed so concurrent launchers
+                # count it as load until its real usage lands (BUG 003): a
+                # freshly-registered row has ``rate_limits=None`` (zero apparent
+                # load), so without a reservation every parallel `cswap launch`
+                # picks the same account and breaks the `cmux N` spread.
+                reserved_at=time.time(),
             )
             registry.write_registry(self.switcher, reg)
 
@@ -418,6 +431,47 @@ class Supervisor:
         reg = registry.read_registry(self.switcher)
         acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
         return acct_views.get(self.account)
+
+    def _current_claude_session_id(self) -> str:
+        """Read claude's own session id for ``--resume`` from this session's row.
+
+        The statusline records ``claude_session_id`` once claude has rendered at
+        least once, so this is the authoritative value for an auto-resume — read
+        it fresh under the lock right before each (re)launch rather than trusting
+        the cached ``_claude_session_id`` (which lags by one Popen). Degrades to
+        ``""`` (launch fresh) when the lock can't be acquired or the row is gone.
+        """
+        lock = FileLock(self.switcher.lock_file, timeout=5)
+        if not lock.acquire():
+            return ""
+        try:
+            reg = registry.read_registry(self.switcher)
+            row = reg.get("sessions", {}).get(self.managed_id)
+            if row is None:
+                return ""
+            return row.get("claude_session_id", "") or ""
+        finally:
+            lock.release()
+
+    def _self_session_view(self) -> balancer.SessionView:
+        """Build this session's :class:`balancer.SessionView` from its registry row.
+
+        The recovery paths (pause/resume/reassign) feed the pure balancer a view
+        of *this* session. Reading the live row keeps ``ctx_tokens`` (and the
+        pause/migration/pin fields) accurate so the per-session cost reserve
+        (``_pct_cost``) and the placement gate aren't undersized by defaulting
+        everything to zero. Falls back to a bare view when the row is absent.
+        """
+        reg = registry.read_registry(self.switcher)
+        row = reg.get("sessions", {}).get(self.managed_id) or {}
+        return balancer.SessionView(
+            self.managed_id,
+            self.account,
+            ctx_tokens=int(row.get("ctx_tokens") or 0),
+            paused_until=row.get("paused_until"),
+            last_migrated_at=float(row.get("last_migrated_at") or 0.0),
+            pinned_account=row.get("pinned_account"),
+        )
 
     def _registry_mtime(self) -> float:
         try:

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -41,6 +41,13 @@ _TERMINATE_GRACE_S = 5.0
 # the registry for an intent/pause (only re-reads when the file's mtime moved).
 _WATCH_TICK_S = 1.0
 
+# Secondary model managed sessions auto-fall-back to when the primary model is
+# overloaded (HTTP 529). Unlike a 429 rate limit (which is account-specific and
+# triggers a migration), a 529 is server/model-side — every account hits the same
+# overloaded model — so the fix is claude's NATIVE ``--fallback-model``, not an
+# account switch. Override per-launch with ``cswap launch -- --fallback-model X``.
+_DEFAULT_FALLBACK_MODEL = "sonnet"
+
 
 def launch(
     switcher, claude_args: list[str], *, cwd: str | None = None, share: bool = True
@@ -541,6 +548,11 @@ class Supervisor:
             prefix += ["--model", bcfg["model"]]
         if "--dangerously-skip-permissions" not in joined and "--permission-mode" not in joined:
             prefix += ["--dangerously-skip-permissions"]
+        # Auto-fall-back to a secondary model on a 529 Overloaded (server/model-
+        # side; an account switch wouldn't help). User-supplied --fallback-model
+        # wins, so only add ours when they didn't pass one.
+        if "--fallback-model" not in args:
+            prefix += ["--fallback-model", _DEFAULT_FALLBACK_MODEL]
         return prefix + args
 
     def _terminate(self, proc: subprocess.Popen) -> None:

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -67,6 +68,18 @@ _DEFAULT_FALLBACK_MODEL = "sonnet"
 # only handles account-level problems like 429/401, not transient network glitches).
 # Only applied when the user hasn't set ``CLAUDE_CODE_MAX_RETRIES`` themselves.
 _DEFAULT_MAX_RETRIES = "20"
+
+# Bounded auth-failure recovery on a child EXIT (distinct from the in-session
+# StopFailure path, which recovers while claude stays alive). When claude hard-
+# exits on invalid/expired credentials, the exit branch recovers and relaunches —
+# but ``choose_migration_target`` has no auth-health filter, so an unbounded
+# relaunch could hop between logged-out accounts forever. Cap total attempts per
+# launch, then surface the re-login guidance instead of spinning.
+_MAX_AUTH_RECOVER_ATTEMPTS = 2
+
+# Sentinel: the passive-SIGINT install didn't run (e.g. off the main thread), so
+# there is nothing to restore in ``finally``.
+_NO_SIGNAL = object()
 
 
 def launch(
@@ -137,6 +150,7 @@ class Supervisor:
         self.share = share
         self._logger = switcher._logger
         self._claude_session_id = ""
+        self._auth_recover_attempts = 0
 
     # -- lifecycle --------------------------------------------------------
 
@@ -163,22 +177,66 @@ class Supervisor:
                 sid = self._current_claude_session_id()
                 args = (["--resume", sid] if resume and sid
                         else list(base_args))
-                proc = subprocess.Popen([claude_bin, *args], env=env, cwd=self.cwd)
-                self._set_pids(proc.pid)
-                outcome, rc = self._supervise(proc)
+                # Let claude own Ctrl-C — but ONLY while it is the live foreground
+                # process. The supervisor shares the foreground process group + TTY
+                # with the child, so a kernel-delivered SIGINT (Ctrl-C in a cooked-
+                # mode window) would otherwise raise KeyboardInterrupt here and tear
+                # the session down, killing claude via SIGTERM before it can run its
+                # own interrupt/quit handling and print its resume hint. A no-op
+                # handler (NOT SIG_IGN, which the child would inherit across exec)
+                # keeps the parent passive while claude is alive — just like the
+                # exec'd `cswap run` path. It is restored the instant the child is
+                # gone so the pause/auto-resume countdown below stays Ctrl-C-
+                # interruptible (no child owns Ctrl-C then).
+                prev_sigint = self._install_passive_sigint()
+                try:
+                    proc = subprocess.Popen([claude_bin, *args], env=env, cwd=self.cwd)
+                    self._set_pids(proc.pid)
+                    outcome, rc = self._supervise(proc)
+                finally:
+                    self._restore_sigint(prev_sigint)
 
                 if outcome == "exit":
-                    if not self._should_handle_limit_exit():
-                        self._deregister()  # clean user quit on a healthy account
+                    if self._should_handle_limit_exit():
+                        self._pause_and_resume()  # migrate now, or pause + auto-resume
+                    elif self._should_recover_auth_exit(rc):
+                        # An auth-failure exit: claude hard-exited on invalid/expired
+                        # login credentials (the in-session StopFailure path only
+                        # helps while claude stays alive). Recover — refresh+reseed
+                        # this account, or migrate to a healthy one — then relaunch.
+                        # Bounded so a permanently-dead login can never spin.
+                        if self._auth_recover_attempts >= _MAX_AUTH_RECOVER_ATTEMPTS:
+                            warning(
+                                f"Managed session keeps failing to authenticate "
+                                f"(Account-{self.account}). Re-login on an account "
+                                f"(e.g. `cswap --add-account`)."
+                            )
+                            self._deregister()
+                            return rc
+                        self._auth_recover_attempts += 1
+                        if self._recover_auth():
+                            resume = True
+                            continue
+                        self._deregister()  # logged out, no target -> guidance printed
                         return rc
-                    self._pause_and_resume()  # migrate now, or pause + auto-resume
+                    else:
+                        # Clean user quit on a healthy account.
+                        self._print_resume_hint()  # before deregister (reads the row)
+                        self._deregister()
+                        return rc
                 else:
                     # outcome == "pause": child was SIGTERM'd to honour a pause.
                     self._pause_and_resume()
                 resume = True
         except KeyboardInterrupt:
+            # Ctrl-C while the child was live (a SIGINT that slipped through the
+            # passive handler's install window) OR during the pause/auto-resume
+            # countdown (default handler restored). Reap claude if it is still
+            # exiting on its own rather than killing it, so its quit/hint path can
+            # finish; an already-exited child returns immediately.
             if proc is not None:
-                self._terminate(proc)
+                self._reap_or_terminate(proc)
+            self._print_resume_hint()
             self._deregister()
             print(f"\n{dimmed('Managed session stopped')}")
             return 130
@@ -269,7 +327,7 @@ class Supervisor:
             return "pause"
         return None
 
-    def _recover_auth(self) -> None:
+    def _recover_auth(self) -> bool:
         """Recover this session from a 401 so the NEXT turn re-authenticates.
 
         First try to refresh + re-seed the SAME account's credentials in place
@@ -279,24 +337,110 @@ class Supervisor:
         existing credential-owning ``_migrate``. If no account has headroom either,
         warn the user that every account needs a re-login and leave the session as
         is — no crash, no relaunch loop.
+
+        Returns whether the profile now holds (or has been pointed at) usable
+        credentials — ``True`` after a successful refresh/migrate, ``False`` when
+        the account is logged out and no healthy target exists. The exit-driven
+        caller uses this to decide between relaunching and giving up.
         """
         if self.switcher.refresh_account_and_reseed(self.account, self.profile_dir):
             print(f"\n{accent('Re-authenticated')} Account-{self.account}")
-            return
+            return True
         # Same-account refresh impossible (refresh token dead / logged out) ->
         # migrate to a healthy account.
         cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
         reg = registry.read_registry(self.switcher)
-        acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+        # A logged-out account's session benefits from a probe-confirmed idle
+        # target: spend one credit to land on a runnable account rather than fail.
+        acct_views, _ = registry.build_world(
+            self.switcher, reg, fetch_idle=True, probe_unavailable=True
+        )
         sv = self._self_session_view()
         target = balancer.choose_migration_target(sv, acct_views, {}, cfg)
         if target:
             self._migrate(target)
-        else:
-            warning(
-                "Managed session's account is logged out and no other account has "
-                "headroom. Re-login on one account (e.g. `cswap --add-account`)."
+            return True
+        warning(
+            "Managed session's account is logged out and no other account has "
+            "headroom. Re-login on one account (e.g. `cswap --add-account`)."
+        )
+        return False
+
+    def _should_recover_auth_exit(self, rc: int | None) -> bool:
+        """Whether a child EXIT looks like an auth failure we should recover from.
+
+        Claude Code hard-exits when its credentials are invalid/expired and it
+        cannot start a turn (e.g. a revoked/logged-out login at launch). That exit
+        is NOT a rate-limit exit (a 401 doesn't raise usage), so without this it
+        would be treated as a clean user quit and the session would silently end.
+
+        Detection, in order (the per-launch attempt cap is enforced by the
+        caller in :meth:`run`, which prints re-login guidance once exhausted):
+
+        * a clean (rc 0/None) exit, or a signal-killed child (negative rc, e.g.
+          ``-11`` SIGSEGV / ``-9`` SIGKILL), is never an auth failure;
+        * a RECENT ``auth_recover`` flag the StopFailure hook left (precise for an
+          in-session 401 that then exited) — read-and-cleared under the lock;
+        * otherwise, only when claude exited BEFORE its statusline ever recorded a
+          session id (a launch-time / pre-render failure), pay for a credit-free
+          local auth probe. A normal interactive session has a session id and is
+          covered by the flag path above, so clean quits never pay the probe cost.
+        """
+        if not rc or rc < 0:  # None/0 (clean) or signal-killed -> not auth
+            return False
+        if self._consume_recent_auth_flag():
+            return True
+        if self._current_claude_session_id():
+            return False
+        return self._profile_auth_invalid()
+
+    def _consume_recent_auth_flag(self) -> bool:
+        """Read-and-clear this session's ``auth_recover`` flag; True if it was recent.
+
+        Mirrors the in-session consumption in :meth:`_consume_own_state` so the exit
+        path can act on a 401 the StopFailure hook flagged just before claude died.
+        Double-consumption with the alive-loop is benign (whichever clears it first
+        wins; the other branch falls through to the probe, which passes post-reseed).
+        """
+        lock = FileLock(self.switcher.lock_file, timeout=5)
+        if not lock.acquire():
+            return False
+        try:
+            reg = registry.read_registry(self.switcher)
+            row = reg.get("sessions", {}).get(self.managed_id)
+            if row is None:
+                return False
+            flag = row.get("auth_recover")
+            if flag is None:
+                return False
+            row["auth_recover"] = None
+            registry.write_registry(self.switcher, reg)
+            return (
+                isinstance(flag, (int, float))
+                and (time.time() - flag) <= _AUTH_RECOVER_TTL_S
             )
+        finally:
+            lock.release()
+
+    def _profile_auth_invalid(self) -> bool:
+        """Credit-free probe: does claude see this managed profile as logged-out?
+
+        Uses ``claude auth status --json`` (a local check that makes NO API call,
+        so it costs no credits) against the managed profile. Best-effort: a server-
+        revoked-but-unexpired token can still pass the probe, so this may miss —
+        the bounded attempt cap keeps that safe. Never raises.
+        """
+        try:
+            _, email, org = self.switcher.resolve_account(self.account)
+        except Exception:
+            return False
+        try:
+            return not SessionManager(self.switcher)._is_session_valid(
+                self.profile_dir, email, org
+            )
+        except Exception:
+            self._logger.debug("auth probe failed", exc_info=True)
+            return False
 
     # -- idle-5h-window priming (feature #3) ------------------------------
 
@@ -378,6 +522,12 @@ class Supervisor:
         try:
             num, email, _ = self.switcher.resolve_account(num)
         except Exception:
+            return False
+        # Never prime/refresh the active default login: rotating its single-use
+        # refresh token would force a re-login (same invariant build_world now
+        # enforces). Its 5h window is anyway warmed by the user's own usage.
+        if num == str(self.switcher.active_account_num() or ""):
+            self._logger.debug("prime: skipping active-default account %s", num)
             return False
         try:
             creds = self.switcher.read_account_credentials(num, email)
@@ -525,7 +675,12 @@ class Supervisor:
         sv = self._self_session_view()
         while True:
             reg = registry.read_registry(self.switcher)
-            acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+            # THE incident fix: probe a usage-429-backed-off idle account so a
+            # stranded session discovers it has headroom and migrates instead of
+            # pausing an hour. A credit is worth avoiding the stall.
+            acct_views, _ = registry.build_world(
+                self.switcher, reg, fetch_idle=True, probe_unavailable=True
+            )
             if self._resumable(acct_views, sv, cfg):
                 break
             action = balancer.pause_decision(sv, acct_views, time.time(), cfg)
@@ -551,7 +706,11 @@ class Supervisor:
             if remaining <= 0:
                 break
             reg = registry.read_registry(self.switcher)
-            acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+            # Probe a usage-backed-off idle target so the wait wakes the instant a
+            # probe confirms headroom, rather than sleeping out the whole timer.
+            acct_views, _ = registry.build_world(
+                self.switcher, reg, fetch_idle=True, probe_unavailable=True
+            )
             if self._resumable(acct_views, sv, cfg):
                 break
             mins, secs = divmod(remaining, 60)
@@ -573,7 +732,11 @@ class Supervisor:
         """
         cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
         reg = registry.read_registry(self.switcher)
-        acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+        # Probe on wake so this pass agrees with the _resumable gate that let it
+        # proceed (it must see the same probe-confirmed account to migrate onto).
+        acct_views, _ = registry.build_world(
+            self.switcher, reg, fetch_idle=True, probe_unavailable=True
+        )
         sv = self._self_session_view()
         if not balancer._usable(acct_views.get(self.account), cfg):
             target = balancer.choose_migration_target(sv, acct_views, {}, cfg)
@@ -757,6 +920,18 @@ class Supervisor:
         # within the turn instead of failing it. Respect an explicit user override.
         if "CLAUDE_CODE_MAX_RETRIES" not in env:
             env["CLAUDE_CODE_MAX_RETRIES"] = _DEFAULT_MAX_RETRIES
+        # Force main-transcript persistence. cmux sets ``CLAUDE_CODE_CHILD_SESSION=1``
+        # in the surface env a managed launch inherits; Claude Code treats that — for
+        # an INTERACTIVE, non-subagent session with no ``TMUX`` marker — as a throwaway
+        # child session and SKIPS writing the ``<sessionId>.jsonl`` transcript (the file
+        # ``claude --resume`` loads), while still writing aux artifacts. A managed
+        # session is first-class and its transcript MUST persist so the auto-resume /
+        # ``cswap launch -- --resume <id>`` contract works and no chat history is lost.
+        # ``CLAUDE_CODE_FORCE_SESSION_PERSISTENCE`` re-enables it (verified against
+        # Claude Code 2.1.178; the cmux wrapper passes this key through untouched).
+        # Respect an explicit user override.
+        if "CLAUDE_CODE_FORCE_SESSION_PERSISTENCE" not in env:
+            env["CLAUDE_CODE_FORCE_SESSION_PERSISTENCE"] = "1"
         # When launched inside a cmux workspace, the cmux-claude-wrapper strips
         # auth-selection env before exec'ing the real claude — which would drop
         # our CLAUDE_CONFIG_DIR profile pin. cmux honours an allow-list env key;
@@ -795,3 +970,59 @@ class Supervisor:
                 proc.kill()
         except Exception:
             self._logger.debug("terminate failed", exc_info=True)
+
+    def _reap_or_terminate(self, proc: subprocess.Popen) -> None:
+        """Wait briefly for a child exiting on its own, force-terminate if wedged.
+
+        On Ctrl-C the child received the same SIGINT and is running its own quit
+        path (printing its resume hint); give it the grace period to finish before
+        escalating, so we don't SIGTERM it out from under its own clean exit.
+        """
+        try:
+            proc.wait(timeout=_TERMINATE_GRACE_S)
+        except subprocess.TimeoutExpired:
+            self._terminate(proc)
+        except Exception:
+            self._terminate(proc)
+
+    def _install_passive_sigint(self):
+        """Make the parent ignore SIGINT so the child (claude) owns Ctrl-C.
+
+        A no-op *function* handler — deliberately not ``SIG_IGN``: a caught handler
+        is reset to the default on the child's ``exec`` (POSIX), so claude still
+        receives SIGINT and handles it itself, whereas ``SIG_IGN`` would be
+        inherited and leave claude unable to react to Ctrl-C. Returns the previous
+        handler to restore, or ``_NO_SIGNAL`` when signals can't be set here (e.g.
+        not the main thread).
+        """
+        try:
+            return signal.signal(signal.SIGINT, lambda *_: None)
+        except (ValueError, OSError):
+            return _NO_SIGNAL
+
+    def _restore_sigint(self, prev) -> None:
+        if prev is _NO_SIGNAL or prev is None:
+            return
+        try:
+            signal.signal(signal.SIGINT, prev)
+        except (ValueError, OSError, TypeError):
+            self._logger.debug("restore SIGINT failed", exc_info=True)
+
+    def _print_resume_hint(self) -> None:
+        """Print a balancer-aware resume hint on a clean user quit.
+
+        claude prints its own ``claude --resume <id>`` hint, but resuming that way
+        escapes the balancer (no managed profile, no migration). Point the user at
+        the managed resume instead. Only meaningful when history is shared (the
+        default): with ``--no-share`` the managed transcript is isolated, so the
+        hint is suppressed. Must be called BEFORE ``_deregister`` (it reads the row).
+        """
+        if not self.share:
+            return
+        sid = self._current_claude_session_id()
+        if not sid:
+            return
+        print(
+            f"{dimmed('Resume this balanced session with:')} "
+            f"{accent(f'cswap launch -- --resume {sid}')}"
+        )

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -53,6 +53,15 @@ _AUTH_RECOVER_TTL_S = 300.0
 # account switch. Override per-launch with ``cswap launch -- --fallback-model X``.
 _DEFAULT_FALLBACK_MODEL = "sonnet"
 
+# How many times claude retries a turn's API call before giving up. Managed
+# sessions raise this well above claude's default so TRANSIENT failures (a
+# dropped socket, connection reset, timeout, a brief 502/503/overload) get more
+# native retry-with-backoff and are far more likely to self-heal WITHIN the turn
+# — rather than failing the turn and bothering the StopFailure safety net (which
+# only handles account-level problems like 429/401, not transient network glitches).
+# Only applied when the user hasn't set ``CLAUDE_CODE_MAX_RETRIES`` themselves.
+_DEFAULT_MAX_RETRIES = "20"
+
 
 def launch(
     switcher, claude_args: list[str], *, cwd: str | None = None, share: bool = True
@@ -577,6 +586,11 @@ class Supervisor:
         effort = self.switcher.get_auto_balance_config()["effortLevel"]
         if effort:
             env["CLAUDE_CODE_EFFORT_LEVEL"] = effort
+        # Transient resilience: give managed turns more native retry-with-backoff
+        # so a dropped socket / connection reset / timeout / brief 5xx self-heals
+        # within the turn instead of failing it. Respect an explicit user override.
+        if "CLAUDE_CODE_MAX_RETRIES" not in env:
+            env["CLAUDE_CODE_MAX_RETRIES"] = _DEFAULT_MAX_RETRIES
         # When launched inside a cmux workspace, the cmux-claude-wrapper strips
         # auth-selection env before exec'ing the real claude — which would drop
         # our CLAUDE_CONFIG_DIR profile pin. cmux honours an allow-list env key;

--- a/src/claude_swap/supervisor.py
+++ b/src/claude_swap/supervisor.py
@@ -1,0 +1,460 @@
+"""The managed-session launcher + supervisor (``cswap launch``).
+
+Unlike ``cswap run`` (which ``exec``s claude and is replaced), a *managed*
+session keeps cswap resident as the parent process so it can: execute migration
+intents the balancer enqueues, and — for single-subscription users — pause a
+session when its account is exhausted and **auto-resume it** via native
+``claude --resume`` once the rate-limit window resets, instead of losing the
+in-flight workflow.
+
+This is not a daemon: it is a foreground, terminal-bound parent the user
+started and can Ctrl-C, exactly like the existing Windows branch of
+``session._exec`` (which already stays resident wrapping claude) — generalized
+to every platform because supervision requires a live parent.
+
+Credential-ownership invariant: a managed profile's credentials are written
+ONLY here, by the supervisor that owns that profile — never by another session's
+statusline. The statusline records a ``migration`` *intent* in the registry; the
+owning supervisor consumes its own intent and re-points its own profile via
+``switcher.seed_profile_credentials`` (verbatim seed, no refresh side-effects).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+from claude_swap import balancer, embed, registry
+from claude_swap.exceptions import SessionError
+from claude_swap.locking import FileLock
+from claude_swap.printer import accent, dimmed, muted, warning
+from claude_swap.session import AUTH_OVERRIDE_ENV_VARS, SessionManager
+
+# How long to wait for a SIGTERM'd child to exit before force-killing it.
+_TERMINATE_GRACE_S = 5.0
+# Supervisor wake cadence: block on the child for at most this long, then check
+# the registry for an intent/pause (only re-reads when the file's mtime moved).
+_WATCH_TICK_S = 1.0
+
+
+def launch(
+    switcher, claude_args: list[str], *, cwd: str | None = None, share: bool = True
+) -> int:
+    """Start a balancer-managed Claude Code session in this terminal.
+
+    Picks the best account for the new session (highest-priority with headroom),
+    bootstraps a per-session profile, embeds the statusline + QoL, and supervises
+    claude until it exits. Returns claude's exit code.
+    """
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        raise SessionError(
+            "'claude' was not found on PATH. Install Claude Code first."
+        )
+
+    seq = switcher._get_sequence_data() or {}
+    if not seq.get("accounts"):
+        raise SessionError(
+            "No managed accounts yet. Add one with `cswap --add-account` first."
+        )
+
+    # Ensure the managed template exists (first run before any upgrade migration).
+    embed.write_managed_template(switcher)
+
+    cwd = cwd or os.getcwd()
+    managed_id = uuid.uuid4().hex[:12]
+    profile_dir = switcher.managed_dir / managed_id
+
+    # Pick the initial account (outside any lock; may fetch idle usage).
+    account = _pick_initial_account(switcher)
+
+    sup = Supervisor(switcher, managed_id, profile_dir, account, cwd=cwd, share=share)
+    return sup.run(claude_args, claude_bin)
+
+
+def _pick_initial_account(switcher) -> str:
+    """Highest-priority account with headroom; falls back so launch never refuses."""
+    bcfg = switcher.get_auto_balance_config()
+    cfg = balancer.config_from_dict(bcfg)
+    reg = registry.read_registry(switcher)
+    acct_views, _ = registry.build_world(switcher, reg, fetch_idle=True)
+    chosen = balancer.assign_new_session(acct_views, 0, time.time(), cfg)
+    if chosen:
+        return chosen
+    # Nothing has clear headroom — fall back to the highest-priority account so
+    # the session still starts (the balancer pauses it on the first rising edge
+    # if it is genuinely capped).
+    if acct_views:
+        return sorted(
+            acct_views.values(),
+            key=lambda a: (-a.priority, balancer._num_key(a.num)),
+        )[0].num
+    seq = switcher._get_sequence_data() or {}
+    return str(sorted((int(n) for n in seq.get("accounts", {})))[0])
+
+
+class Supervisor:
+    """Owns one managed session's profile, registry row, and child process."""
+
+    def __init__(self, switcher, managed_id, profile_dir, account, *, cwd, share):
+        self.switcher = switcher
+        self.managed_id = managed_id
+        self.profile_dir = Path(profile_dir)
+        self.account = str(account)
+        self.cwd = cwd
+        self.share = share
+        self._logger = switcher._logger
+        self._claude_session_id = ""
+
+    # -- lifecycle --------------------------------------------------------
+
+    def run(self, claude_args: list[str], claude_bin: str) -> int:
+        self._bootstrap_profile()
+        self._register()
+        num, email, _ = self.switcher.resolve_account(self.account)
+        print(
+            f"{accent('Launching')} managed session on Account-{num} ({email}) "
+            f"{muted('[load balancer]')}"
+        )
+        env = self._session_env()
+        base_args = self._qol_args(claude_args)
+        resume = False
+        proc = None  # stays None if Ctrl-C lands during the first Popen
+        try:
+            while True:
+                args = (["--resume", self._claude_session_id] if resume and self._claude_session_id
+                        else list(base_args))
+                proc = subprocess.Popen([claude_bin, *args], env=env, cwd=self.cwd)
+                self._set_pids(proc.pid)
+                outcome, rc = self._supervise(proc)
+
+                if outcome == "exit":
+                    if not self._should_handle_limit_exit():
+                        self._deregister()  # clean user quit on a healthy account
+                        return rc
+                    self._pause_and_resume()  # migrate now, or pause + auto-resume
+                else:
+                    # outcome == "pause": child was SIGTERM'd to honour a pause.
+                    self._pause_and_resume()
+                resume = True
+        except KeyboardInterrupt:
+            if proc is not None:
+                self._terminate(proc)
+            self._deregister()
+            print(f"\n{dimmed('Managed session stopped')}")
+            return 130
+        except BaseException:
+            # Never orphan the child or leave a ghost registry row on an
+            # unexpected failure (e.g. a LockError under contention): clean up
+            # the child + our row first, then re-raise.
+            if proc is not None:
+                self._terminate(proc)
+            self._deregister()
+            raise
+
+    # -- supervise loop ---------------------------------------------------
+
+    def _supervise(self, proc: subprocess.Popen) -> tuple[str, int | None]:
+        """Block on the child; wake on registry changes to consume intents.
+
+        Returns ``("exit", rc)`` when the child exits on its own, or
+        ``("pause", None)`` when we SIGTERM it to honour a pause decision.
+        """
+        last_mtime = self._registry_mtime()
+        while True:
+            try:
+                rc = proc.wait(timeout=_WATCH_TICK_S)
+                return ("exit", rc)
+            except subprocess.TimeoutExpired:
+                pass
+            mtime = self._registry_mtime()
+            if mtime == last_mtime:
+                continue
+            last_mtime = mtime
+            decision = self._consume_own_state()
+            if decision == "pause":
+                self._terminate(proc)
+                return ("pause", None)
+            # "migrate" was applied in place (no relaunch); keep watching.
+
+    def _consume_own_state(self) -> str | None:
+        """Act on this session's own registry row: migration intent or pause.
+
+        Degrades gracefully under lock contention — a tick we can't lock is
+        simply skipped and retried on the next registry change, never an error
+        that tears down the session.
+        """
+        lock = FileLock(self.switcher.lock_file, timeout=5)
+        if not lock.acquire():
+            return None
+        try:
+            reg = registry.read_registry(self.switcher)
+            row = reg.get("sessions", {}).get(self.managed_id)
+            if row is None:
+                return None
+            intent = row.get("migration")
+            paused_until = row.get("paused_until")
+            if intent and intent.get("to"):
+                to_account = str(intent["to"])
+                registry.clear_intent(reg, self.managed_id)
+                registry.write_registry(self.switcher, reg)
+            else:
+                to_account = None
+        finally:
+            lock.release()
+        if to_account is not None:
+            self._migrate(to_account)
+            return "migrate"
+        if isinstance(paused_until, (int, float)) and paused_until > time.time():
+            self._pending_resume_at = int(paused_until)
+            return "pause"
+        return None
+
+    # -- actions ----------------------------------------------------------
+
+    def _migrate(self, to_account: str) -> None:
+        """Re-point this session's own profile to ``to_account`` (no relaunch).
+
+        claude re-reads the seeded credentials on its keychain-cache / 401 cycle,
+        the same contract the global switch relies on.
+        """
+        try:
+            num, email, _ = self.switcher.resolve_account(to_account)
+        except Exception:
+            self._logger.warning("migrate: cannot resolve account %s", to_account)
+            return
+        self.switcher.seed_profile_credentials(self.profile_dir, num, email)
+        lock = FileLock(self.switcher.lock_file, timeout=10)
+        if lock.acquire():
+            try:
+                reg = registry.read_registry(self.switcher)
+                row = reg.get("sessions", {}).get(self.managed_id)
+                if row is not None:
+                    row["account_num"] = num
+                    row["last_migrated_at"] = time.time()
+                    row["migration_count"] = int(row.get("migration_count", 0)) + 1
+                    row["rate_limits"] = None    # don't judge the new account by old numbers
+                    row["_prev_max_pct"] = None   # fresh rising-edge basis on next tick
+                    row["paused_until"] = None    # re-pointed to a fresh account -> running, not paused
+                    row["migration"] = None
+                    registry.write_registry(self.switcher, reg)
+            finally:
+                lock.release()
+        self.account = num
+        print(f"\n{accent('Migrated')} managed session to Account-{num} ({email})")
+
+    def _should_handle_limit_exit(self) -> bool:
+        """Whether a child exit looks like a rate-limit exit we should recover from.
+
+        Claude Code hard-exits when a subscription limit is hit. We treat an exit
+        as limit-driven when the balancer is enabled and this session's account is
+        currently at/over the exhaust threshold. (A clean user quit on a healthy
+        account just ends the session.)
+        """
+        if not self.switcher.get_auto_balance_config()["enabled"]:
+            return False
+        cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
+        av = self._account_view()
+        return av is not None and av.max_pct is not None and av.max_pct >= cfg.exhaust_threshold
+
+    def _resumable(self, acct_views: dict, sv, cfg) -> bool:
+        """Whether the session can run again right now.
+
+        True when its current account has recovered below the hysteresis line OR
+        a fitting migration target exists. This matches the *placement* gate
+        (``choose_migration_target`` / ``_fits``), so we never resume onto an
+        account that is below the loose ``_usable`` line but still too full to
+        actually host the session — the asymmetry that would otherwise cause a
+        relaunch livelock.
+        """
+        return (
+            balancer._usable(acct_views.get(self.account), cfg)
+            or balancer.choose_migration_target(sv, acct_views, {}, cfg) is not None
+        )
+
+    def _pause_and_resume(self) -> None:
+        """Get the session onto a runnable account, pausing as long as needed.
+
+        If a fitting account exists now, re-point and return immediately (the
+        migrate-on-exhaustion fast path). Otherwise pause to the soonest real
+        reset, wait, and re-check on wake — only returning once the session is
+        genuinely resumable. Never resumes into a still-capped account, so there
+        is no tight relaunch loop. Interruptible via Ctrl-C.
+        """
+        cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
+        sv = balancer.SessionView(self.managed_id, self.account)
+        while True:
+            reg = registry.read_registry(self.switcher)
+            acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+            if self._resumable(acct_views, sv, cfg):
+                break
+            action = balancer.pause_decision(sv, acct_views, time.time(), cfg)
+            self._pending_resume_at = action.resume_at or int(time.time() + cfg.pause_fallback_s)
+            self._mark_paused(self._pending_resume_at)
+            self._wait_for_reset()
+        self._reassign_for_resume()
+
+    def _wait_for_reset(self) -> None:
+        """Foreground wait until the pause horizon OR the session becomes resumable.
+
+        Interruptible (Ctrl-C propagates). Renders a countdown so the wait is
+        always visible — never a hidden background sleep. The early break uses the
+        same ``_resumable`` gate as placement, so it can't wake into a still-full
+        account.
+        """
+        resume_at = getattr(self, "_pending_resume_at", int(time.time()))
+        cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
+        sv = balancer.SessionView(self.managed_id, self.account)
+        while True:
+            now = time.time()
+            remaining = int(resume_at - now)
+            if remaining <= 0:
+                break
+            reg = registry.read_registry(self.switcher)
+            acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+            if self._resumable(acct_views, sv, cfg):
+                break
+            mins, secs = divmod(remaining, 60)
+            hours, mins = divmod(mins, 60)
+            cd = f"{hours}h{mins:02d}m" if hours else f"{mins}m{secs:02d}s"
+            sys.stdout.write(
+                f"\r{dimmed('Usage limit reached — auto-resuming in ' + cd + '  ')}"
+            )
+            sys.stdout.flush()
+            time.sleep(min(30.0, max(1.0, remaining)))
+        sys.stdout.write("\r" + " " * 60 + "\r")
+        sys.stdout.flush()
+
+    def _reassign_for_resume(self) -> None:
+        """Point the profile at the best runnable account, then clear the pause.
+
+        Only called once :meth:`_resumable` holds, so either the current account
+        recovered (keep it) or a fitting target exists (migrate to it).
+        """
+        cfg = balancer.config_from_dict(self.switcher.get_auto_balance_config())
+        reg = registry.read_registry(self.switcher)
+        acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+        sv = balancer.SessionView(self.managed_id, self.account)
+        if not balancer._usable(acct_views.get(self.account), cfg):
+            target = balancer.choose_migration_target(sv, acct_views, {}, cfg)
+            if target and target != self.account:
+                self._migrate(target)
+        self._mark_paused(None)
+
+    # -- profile + registry helpers --------------------------------------
+
+    def _bootstrap_profile(self) -> None:
+        self.switcher.managed_dir.mkdir(parents=True, exist_ok=True)
+        self.profile_dir.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(self.profile_dir, 0o700)
+        num, email, _ = self.switcher.resolve_account(self.account)
+        # Verbatim seed (no refresh side-effects), share ~/.claude items, then
+        # install the non-shared statusline + effort layer over the symlink.
+        self.switcher.seed_profile_credentials(self.profile_dir, num, email)
+        SessionManager(self.switcher)._sync_sharing(self.profile_dir, self.share)
+        embed.install_into_profile(self.switcher, self.profile_dir)
+
+    def _register(self) -> None:
+        with FileLock(self.switcher.lock_file):
+            reg = registry.read_registry(self.switcher)
+            registry.reap_dead(reg)
+            registry.upsert_session(
+                reg,
+                self.managed_id,
+                account_num=self.account,
+                profile_dir=str(self.profile_dir),
+                cwd=self.cwd,
+                supervisor_pid=os.getpid(),
+                last_seen=time.time(),
+            )
+            registry.write_registry(self.switcher, reg)
+
+    def _deregister(self) -> None:
+        try:
+            with FileLock(self.switcher.lock_file, timeout=5):
+                reg = registry.read_registry(self.switcher)
+                reg.get("sessions", {}).pop(self.managed_id, None)
+                registry.write_registry(self.switcher, reg)
+        except Exception:
+            self._logger.debug("deregister failed", exc_info=True)
+
+    def _set_pids(self, claude_pid: int) -> None:
+        lock = FileLock(self.switcher.lock_file, timeout=5)
+        if not lock.acquire():
+            return
+        try:
+            reg = registry.read_registry(self.switcher)
+            row = reg.get("sessions", {}).get(self.managed_id)
+            if row is not None:
+                row["claude_pid"] = claude_pid
+                row["supervisor_pid"] = os.getpid()
+                # Capture claude's own session id for --resume from the registry
+                # (the statusline records it once it has rendered at least once).
+                self._claude_session_id = row.get("claude_session_id", "") or self._claude_session_id
+                registry.write_registry(self.switcher, reg)
+        finally:
+            lock.release()
+
+    def _mark_paused(self, until: int | None) -> None:
+        lock = FileLock(self.switcher.lock_file, timeout=5)
+        if not lock.acquire():
+            return
+        try:
+            reg = registry.read_registry(self.switcher)
+            row = reg.get("sessions", {}).get(self.managed_id)
+            if row is not None:
+                row["paused_until"] = until
+                registry.write_registry(self.switcher, reg)
+        finally:
+            lock.release()
+
+    def _account_view(self) -> balancer.AccountView | None:
+        reg = registry.read_registry(self.switcher)
+        acct_views, _ = registry.build_world(self.switcher, reg, fetch_idle=True)
+        return acct_views.get(self.account)
+
+    def _registry_mtime(self) -> float:
+        try:
+            return registry.registry_path(self.switcher).stat().st_mtime
+        except OSError:
+            return 0.0
+
+    # -- env / args / process --------------------------------------------
+
+    def _session_env(self) -> dict[str, str]:
+        env = {k: v for k, v in os.environ.items() if k not in AUTH_OVERRIDE_ENV_VARS}
+        env["CLAUDE_CONFIG_DIR"] = str(self.profile_dir)
+        effort = self.switcher.get_auto_balance_config()["effortLevel"]
+        if effort:
+            env["CLAUDE_CODE_EFFORT_LEVEL"] = effort
+        return env
+
+    def _qol_args(self, claude_args: list[str]) -> list[str]:
+        """Prepend QoL launch flags, skipping any the user already passed."""
+        bcfg = self.switcher.get_auto_balance_config()
+        args = list(claude_args)
+        joined = " ".join(args)
+        prefix: list[str] = []
+        if "--model" not in args and "-m" not in args:
+            prefix += ["--model", bcfg["model"]]
+        if "--dangerously-skip-permissions" not in joined and "--permission-mode" not in joined:
+            prefix += ["--dangerously-skip-permissions"]
+        return prefix + args
+
+    def _terminate(self, proc: subprocess.Popen) -> None:
+        if proc.poll() is not None:
+            return
+        try:
+            proc.terminate()
+            try:
+                proc.wait(timeout=_TERMINATE_GRACE_S)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        except Exception:
+            self._logger.debug("terminate failed", exc_info=True)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -63,6 +63,30 @@ SETUP_TOKEN_SCOPES = ("user:inference",)
 # Usage cache
 _USAGE_CACHE_TTL = 15  # seconds
 
+# Auto-switch (Beta): when the active account's 5h/7d usage reaches this
+# percentage, the TUI monitor rotates to the next managed account.
+DEFAULT_AUTO_SWITCH_THRESHOLD = 95
+
+
+def _max_usage_pct(usage: dict | None) -> float | None:
+    """Return the highest 5h/7d utilization percentage in a usage dict.
+
+    Only the rate-limit windows (``five_hour``/``seven_day``) are considered —
+    the dollar-denominated ``spend`` entry is intentionally ignored, since it is
+    not the limit that blocks Claude Code sessions. Returns ``None`` when no
+    usable percentage is present.
+    """
+    if not isinstance(usage, dict):
+        return None
+    pcts: list[float] = []
+    for key in ("five_hour", "seven_day"):
+        entry = usage.get(key)
+        if isinstance(entry, dict):
+            pct = entry.get("pct")
+            if isinstance(pct, (int, float)):
+                pcts.append(float(pct))
+    return max(pcts) if pcts else None
+
 
 def _format_usage_lines(usage: dict) -> list[str]:
     lines: list[str] = []
@@ -1226,6 +1250,110 @@ class ClaudeAccountSwitcher:
                         print(f"  {dimmed(connector)} {muted(line)}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
+
+    # ------------------------------------------------------------------ #
+    # Auto-switch (Beta)
+    # ------------------------------------------------------------------ #
+
+    def get_auto_switch_config(self) -> dict:
+        """Return the persisted auto-switch (Beta) settings.
+
+        Auto-switch is opt-in and stored in ``sequence.json`` under the
+        ``autoSwitch`` key. Defaults to disabled at
+        ``DEFAULT_AUTO_SWITCH_THRESHOLD``%.
+        """
+        data = self._get_sequence_data() or {}
+        cfg = data.get("autoSwitch") or {}
+        try:
+            threshold = int(cfg.get("threshold", DEFAULT_AUTO_SWITCH_THRESHOLD))
+        except (TypeError, ValueError):
+            threshold = DEFAULT_AUTO_SWITCH_THRESHOLD
+        return {
+            "enabled": bool(cfg.get("enabled", False)),
+            "threshold": threshold,
+        }
+
+    def set_auto_switch_config(
+        self, *, enabled: bool | None = None, threshold: int | None = None
+    ) -> dict:
+        """Persist auto-switch (Beta) settings, returning the merged config.
+
+        Only the provided fields are updated; the rest keep their stored (or
+        default) values.
+
+        Raises:
+            ValidationError: if ``threshold`` is outside the 1-100 range.
+        """
+        self._setup_directories()
+        self._init_sequence_file()
+        data = self._get_sequence_data() or {}
+        cfg = dict(data.get("autoSwitch") or {})
+        if enabled is not None:
+            cfg["enabled"] = bool(enabled)
+        if threshold is not None:
+            t = int(threshold)
+            if not 1 <= t <= 100:
+                raise ValidationError("Threshold must be between 1 and 100")
+            cfg["threshold"] = t
+        cfg.setdefault("enabled", False)
+        cfg.setdefault("threshold", DEFAULT_AUTO_SWITCH_THRESHOLD)
+        data["autoSwitch"] = cfg
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        return {"enabled": cfg["enabled"], "threshold": cfg["threshold"]}
+
+    def get_active_usage_pct(self) -> float | None:
+        """Return the highest 5h/7d utilization pct for the active account.
+
+        Used by the auto-switch monitor. Returns ``None`` when there is no
+        active login, no usable credentials, or the usage API is unreachable.
+
+        Reuses the same short-lived usage cache as ``list_accounts()`` /
+        ``status()`` so repeated polling stays cheap and consistent. The active
+        account is never refreshed (``is_active=True``) — Claude Code owns those
+        credentials.
+        """
+        identity = self._get_current_account()
+        if identity is None:
+            return None
+        current_email, current_org_uuid = identity
+
+        creds = self._read_credentials() or ""
+        if not creds or not oauth.extract_access_token(creds):
+            return None
+
+        # Resolve the active account number for cache keying (best-effort).
+        account_num = None
+        data = self._get_sequence_data() or {}
+        for num, account in data.get("accounts", {}).items():
+            if (account.get("email") == current_email and
+                    account.get("organizationUuid", "") == current_org_uuid):
+                account_num = num
+                break
+
+        usage_cache_path = self.backup_dir / "cache" / "usage.json"
+        usage = None
+        if account_num is not None:
+            cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
+            if (cached is not MISSING and isinstance(cached, dict)
+                    and account_num in cached):
+                usage = cached[account_num]
+
+        if usage is None:
+            usage = oauth.fetch_usage_for_account(
+                account_num or "active", current_email, creds, is_active=True,
+            )
+            if account_num is not None and isinstance(usage, dict):
+                existing = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
+                existing = (
+                    existing
+                    if (existing is not MISSING and isinstance(existing, dict))
+                    else {}
+                )
+                existing[account_num] = usage
+                write_cache(usage_cache_path, existing)
+
+        return _max_usage_pct(usage)
 
     def _first_run_setup(self) -> None:
         """First-run setup workflow."""

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -50,6 +50,11 @@ from claude_swap.paths import (
     migrate_legacy_backup_dir,
 )
 from claude_swap.process_detection import get_running_instances
+from claude_swap.balancer import (
+    DEFAULT_HYSTERESIS_BAND,
+    DEFAULT_MIGRATION_COOLDOWN,
+    DEFAULT_TARGET_SAFETY,
+)
 
 # Service name under which the legacy ``keyring`` backend stored per-account
 # backup credentials on macOS (kept for the one-time keyring → security migration
@@ -166,6 +171,10 @@ class ClaudeAccountSwitcher:
         self.sequence_file = self.backup_dir / "sequence.json"
         self.configs_dir = self.backup_dir / "configs"
         self.credentials_dir = self.backup_dir / "credentials"
+        # Per-session profiles for the load balancer (cswap launch). A SEPARATE
+        # root from the per-account `cswap run` profiles under sessions/, so the
+        # per-account guards keyed on session_dir_for never fire on these.
+        self.managed_dir = self.backup_dir / "managed"
         self.lock_file = self.backup_dir / ".lock"
         self._logger = setup_logging(self.backup_dir, debug=debug)
 
@@ -1291,11 +1300,16 @@ class ClaudeAccountSwitcher:
         print(bolded("Accounts:"))
         for i, ((num, email, org_name, org_uuid, is_active, _), usage) in enumerate(zip(accounts_info, usages)):
             tag = self._get_display_tag(email, org_name, org_uuid)
+            try:
+                pri = int(data.get("accounts", {}).get(str(num), {}).get("priority", 0))
+            except (TypeError, ValueError):
+                pri = 0
+            pri_tag = f" {dimmed(f'· pri {pri}')}" if pri else ""
             if is_active:
                 marker = f" {bold_accent('(active)')}"
-                print(f"  {num}: {email} {muted(f'[{tag}]')}{marker}")
+                print(f"  {num}: {email} {muted(f'[{tag}]')}{marker}{pri_tag}")
             else:
-                print(f"  {num}: {email} {muted(f'[{tag}]')}")
+                print(f"  {num}: {email} {muted(f'[{tag}]')}{pri_tag}")
             if isinstance(usage, str):
                 print(f"     {dimmed(usage)}")
             elif usage is None:
@@ -1351,12 +1365,14 @@ class ClaudeAccountSwitcher:
         identity = self._get_current_account()
         if identity is None:
             print(f"{bolded('Status:')} {dimmed('No active Claude account')}")
+            self._print_balancer_status()
             return
         current_email, current_org_uuid = identity
 
         data = self._get_sequence_data_migrated()
         if not data:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
+            self._print_balancer_status()
             return
 
         account_num = None
@@ -1402,6 +1418,8 @@ class ClaudeAccountSwitcher:
                         print(f"  {dimmed(connector)} {muted(line)}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
+
+        self._print_balancer_status()
 
     # ------------------------------------------------------------------ #
     # Auto-switch (Beta)
@@ -1506,6 +1524,230 @@ class ClaudeAccountSwitcher:
                 write_cache(usage_cache_path, existing)
 
         return _max_usage_pct(usage)
+
+    # ------------------------------------------------------------------ #
+    # Load balancer (Beta) — config, priority, profile seeding
+    # ------------------------------------------------------------------ #
+
+    def get_auto_balance_config(self) -> dict:
+        """Return the persisted load-balancer (Beta) settings.
+
+        Stored in ``sequence.json`` under ``autoBalance`` (alongside the legacy
+        ``autoSwitch``). All fields default to sane values; ``targetSafety`` is
+        the projected-usage ceiling a migration target must stay under, kept
+        below ``threshold`` so a move never immediately re-exhausts the target.
+        """
+        data = self._get_sequence_data() or {}
+        cfg = data.get("autoBalance") or {}
+
+        def _int(key: str, default: int) -> int:
+            try:
+                return int(cfg.get(key, default))
+            except (TypeError, ValueError):
+                return default
+
+        threshold = _int("threshold", DEFAULT_AUTO_SWITCH_THRESHOLD)
+        if not 1 <= threshold <= 100:
+            threshold = DEFAULT_AUTO_SWITCH_THRESHOLD
+        target_safety = _int("targetSafety", DEFAULT_TARGET_SAFETY)
+        if not 1 <= target_safety <= 100:
+            target_safety = DEFAULT_TARGET_SAFETY
+        return {
+            "enabled": bool(cfg.get("enabled", False)),
+            "threshold": threshold,
+            "targetSafety": min(target_safety, threshold - 1),
+            "hysteresisBand": max(0, _int("hysteresisBand", DEFAULT_HYSTERESIS_BAND)),
+            "cooldownSeconds": max(0, _int("cooldownSeconds", DEFAULT_MIGRATION_COOLDOWN)),
+            "model": str(cfg.get("model") or "opus"),
+            "effortLevel": str(cfg.get("effortLevel") or "xhigh"),
+        }
+
+    def set_auto_balance_config(
+        self,
+        *,
+        enabled: bool | None = None,
+        threshold: int | None = None,
+        target_safety: int | None = None,
+        hysteresis_band: int | None = None,
+        cooldown_seconds: int | None = None,
+        model: str | None = None,
+        effort_level: str | None = None,
+    ) -> dict:
+        """Persist load-balancer (Beta) settings, returning the merged config.
+
+        Only provided fields change. ``targetSafety`` is clamped below
+        ``threshold`` so the stored config is always self-consistent.
+
+        Raises:
+            ValidationError: if ``threshold``/``target_safety`` is outside 1-100.
+        """
+        self._setup_directories()
+        self._init_sequence_file()
+        data = self._get_sequence_data() or {}
+        cfg = dict(data.get("autoBalance") or {})
+        if enabled is not None:
+            cfg["enabled"] = bool(enabled)
+        if threshold is not None:
+            t = int(threshold)
+            if not 1 <= t <= 100:
+                raise ValidationError("Threshold must be between 1 and 100")
+            cfg["threshold"] = t
+        if target_safety is not None:
+            ts = int(target_safety)
+            if not 1 <= ts <= 100:
+                raise ValidationError("Target safety must be between 1 and 100")
+            cfg["targetSafety"] = ts
+        if hysteresis_band is not None:
+            cfg["hysteresisBand"] = max(0, int(hysteresis_band))
+        if cooldown_seconds is not None:
+            cfg["cooldownSeconds"] = max(0, int(cooldown_seconds))
+        if model is not None:
+            cfg["model"] = str(model)
+        if effort_level is not None:
+            cfg["effortLevel"] = str(effort_level)
+
+        cfg.setdefault("enabled", False)
+        cfg.setdefault("threshold", DEFAULT_AUTO_SWITCH_THRESHOLD)
+        cfg.setdefault("targetSafety", DEFAULT_TARGET_SAFETY)
+        cfg.setdefault("hysteresisBand", DEFAULT_HYSTERESIS_BAND)
+        cfg.setdefault("cooldownSeconds", DEFAULT_MIGRATION_COOLDOWN)
+        cfg.setdefault("model", "opus")
+        cfg.setdefault("effortLevel", "xhigh")
+        # Keep targetSafety strictly below threshold (self-heals an odd combo).
+        cfg["targetSafety"] = min(int(cfg["targetSafety"]), int(cfg["threshold"]) - 1)
+        if cfg["targetSafety"] < 1:
+            cfg["targetSafety"] = 1
+
+        data["autoBalance"] = cfg
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        return cfg
+
+    def get_account_priority(self, account_num: str) -> int:
+        """Return an account's balancing priority (higher = burned first; default 0)."""
+        data = self._get_sequence_data() or {}
+        info = data.get("accounts", {}).get(str(account_num), {})
+        try:
+            return int(info.get("priority", 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def set_account_priority(self, account_num: str, priority: int) -> None:
+        """Set an account's balancing priority (higher = burned through first).
+
+        Raises:
+            AccountNotFoundError: the account number is not managed.
+        """
+        data = self._get_sequence_data()
+        if not data or str(account_num) not in data.get("accounts", {}):
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+        data["accounts"][str(account_num)]["priority"] = int(priority)
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        self._logger.info(f"Set priority of account {account_num} to {priority}")
+
+    def seed_profile_credentials(
+        self, profile_dir: Path, account_num: str, email: str
+    ) -> None:
+        """Point a managed session profile at an account's stored credentials.
+
+        Used to migrate a live managed session to a different account WITHOUT a
+        relaunch: claude re-reads the profile's credentials on its keychain-cache
+        / 401 cycle (the same contract the global switch relies on).
+
+        Seeds the stored credentials VERBATIM. Deliberately does NOT refresh the
+        token or write back to the account backup via ``_write_account_credentials``
+        — that path fires the live-session stale-marking side-effect against the
+        per-account dir and multiplies refresh-token drift. claude refreshes the
+        access token in-process.
+        """
+        profile_dir = Path(profile_dir)
+        creds = self._read_account_credentials(str(account_num), email)
+        if not creds:
+            raise SwitchError(
+                f"Account-{account_num} has no stored credentials. "
+                f"Re-add with: cswap --add-account --slot {account_num}"
+            )
+        config_text = self._read_account_config(str(account_num), email)
+        try:
+            config_data = json.loads(config_text) if config_text else {}
+        except json.JSONDecodeError:
+            config_data = {}
+        oauth_account = config_data.get("oauthAccount")
+        if not oauth_account:
+            raise SwitchError(
+                f"Account-{account_num} has no stored config backup. "
+                f"Re-add with: cswap --add-account --slot {account_num}"
+            )
+
+        from claude_swap.session import delete_macos_keychain_entry
+
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(profile_dir, 0o700)
+        # A stale hashed keychain entry would shadow the fresh plaintext seed.
+        delete_macos_keychain_entry(profile_dir)
+
+        creds_path = profile_dir / ".credentials.json"
+        creds_path.write_text(creds, encoding="utf-8")
+        if sys.platform != "win32":
+            os.chmod(creds_path, 0o600)
+
+        # Merge identity into any existing profile config so projects/history
+        # survive a re-point (mirrors session._bootstrap's merge).
+        config_path = profile_dir / ".claude.json"
+        existing: dict = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text(encoding="utf-8")) or {}
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+        existing["oauthAccount"] = oauth_account
+        existing["hasCompletedOnboarding"] = True
+        existing.setdefault("theme", config_data.get("theme") or "dark")
+        config_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+        if sys.platform != "win32":
+            os.chmod(config_path, 0o600)
+        self._logger.info(
+            f"Seeded managed profile {profile_dir.name} -> account {account_num} ({email})"
+        )
+
+    def _print_balancer_status(self) -> None:
+        """Print the load-balancer (Beta) + embed-health section for ``status()``."""
+        from claude_swap import embed, registry
+
+        bcfg = self.get_auto_balance_config()
+        reg = registry.read_registry(self)
+        # Reap ghost rows (crashed supervisors) on this read path.
+        if registry.reap_dead(reg):
+            try:
+                with FileLock(self.lock_file):
+                    fresh = registry.read_registry(self)
+                    registry.reap_dead(fresh)
+                    registry.write_registry(self, fresh)
+                reg = fresh
+            except Exception:
+                self._logger.debug("registry reap on status failed", exc_info=True)
+        sessions = registry.live_sessions(reg)
+        paused = sum(1 for s in sessions if s.get("paused_until"))
+
+        print()
+        state = bold_accent("ON") if bcfg["enabled"] else dimmed("OFF")
+        summary = (
+            f"threshold {bcfg['threshold']}% · {len(sessions)} managed session(s)"
+        )
+        if paused:
+            summary += f" · {paused} paused"
+        print(f"{bolded('Load balancer (Beta):')} {state} {dimmed('· ' + summary)}")
+
+        health = embed.embed_health(self)
+        if health["ok"]:
+            print(f"  {dimmed('└')} {muted('Embedded in Claude Code — new managed sessions auto-balance')}")
+        else:
+            print(f"  {dimmed('├')} {accent('Not embedded in Claude Code')}")
+            for issue in health["issues"]:
+                print(f"  {dimmed('│')}   {muted(issue)}")
+            print(f"  {dimmed('└')} {muted('Run `cswap --install` to embed cswap into Claude Code')}")
 
     def _first_run_setup(self) -> None:
         """First-run setup workflow."""

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1743,6 +1743,84 @@ class ClaudeAccountSwitcher:
             f"Seeded managed profile {profile_dir.name} -> account {account_num} ({email})"
         )
 
+    def refresh_account_and_reseed(self, account_num, profile_dir) -> bool:
+        """Refresh an account's OAuth token and re-seed a managed profile with it.
+
+        The 401 auto-recovery for a managed (``cswap launch``) session: when a
+        turn fails with a 401 the seeded creds are invalid/expired, so refresh the
+        account's BACKUP credentials and re-point the managed profile at the fresh
+        token, in place (claude re-reads them on its keychain-cache / 401 cycle).
+
+        Returns ``True`` when the profile now holds usable, fresh credentials and
+        ``False`` when the account can't be recovered (no backup creds, or its
+        refresh token is dead — i.e. the account is logged out and the caller
+        should migrate to a healthy account instead). Never raises.
+
+        Concurrency: the whole read-refresh-write-reseed runs under
+        ``FileLock(self.lock_file)`` so two managed sessions on the same account
+        serialize. The expiry re-check makes the second one a cheap reseed (the
+        first sibling already refreshed the shared backup). No network I/O races
+        the registry because this method touches credentials only — callers
+        (the supervisor's ``_recover_auth``) build the world OUTSIDE the lock.
+        """
+        account_num = str(account_num)
+        try:
+            data = self._get_sequence_data() or {}
+            record = data.get("accounts", {}).get(account_num)
+            if not record:
+                self._logger.warning(
+                    "refresh_account_and_reseed: account %s not found", account_num
+                )
+                return False
+            email = record.get("email", "")
+
+            with FileLock(self.lock_file):
+                creds = self._read_account_credentials(account_num, email)
+                if not creds:
+                    self._logger.warning(
+                        "refresh_account_and_reseed: account %s has no backup creds",
+                        account_num,
+                    )
+                    return False
+
+                # A concurrent sibling on the same account may have already
+                # refreshed the shared backup. If the stored access token is
+                # still fresh, skip the network refresh and just re-seed.
+                oauth_data = oauth.extract_oauth_data(creds)
+                expires_at = oauth_data.get("expiresAt") if oauth_data else None
+                if not oauth.is_oauth_token_expired(expires_at):
+                    self.seed_profile_credentials(profile_dir, account_num, email)
+                    return True
+
+                refreshed = oauth.refresh_oauth_credentials(creds)
+                if not refreshed:
+                    # Refresh token is dead -> the account is logged out.
+                    self._logger.warning(
+                        "refresh_account_and_reseed: refresh failed for account %s "
+                        "(logged out?)",
+                        account_num,
+                    )
+                    return False
+
+                # Persist the fresh creds to the canonical backup, then re-seed the
+                # managed profile with them. ``_write_account_credentials`` is the
+                # existing canonical writer (its live-session stale-marking side
+                # effect is acceptable here).
+                self._write_account_credentials(account_num, email, refreshed)
+                self.seed_profile_credentials(profile_dir, account_num, email)
+                self._logger.info(
+                    "Re-authenticated account %s (%s) and re-seeded managed profile",
+                    account_num,
+                    email,
+                )
+                return True
+        except Exception:
+            self._logger.warning(
+                "refresh_account_and_reseed failed for account %s", account_num,
+                exc_info=True,
+            )
+            return False
+
     def _print_balancer_status(self) -> None:
         """Print the load-balancer (Beta) + embed-health section for ``status()``."""
         from claude_swap import embed, registry

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -79,7 +79,7 @@ _USAGE_CACHE_TTL = 15  # seconds
 
 # Auto-switch (Beta): when the active account's 5h/7d usage reaches this
 # percentage, the TUI monitor rotates to the next managed account.
-DEFAULT_AUTO_SWITCH_THRESHOLD = 95
+DEFAULT_AUTO_SWITCH_THRESHOLD = 90
 
 # Default command for the Quick-start alias (bare ``cswap`` when enabled): launch
 # a load-balanced session with the QoL defaults baked in. Extra args the user

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -47,6 +47,7 @@ from claude_swap.paths import (
     get_credentials_path,
     get_global_config_path,
     get_legacy_backup_root,
+    mark_cwd_trusted,
     migrate_legacy_backup_dir,
 )
 from claude_swap.process_detection import get_running_instances
@@ -1740,7 +1741,12 @@ class ClaudeAccountSwitcher:
         self._logger.info(f"Set priority of account {account_num} to {priority}")
 
     def seed_profile_credentials(
-        self, profile_dir: Path, account_num: str, email: str
+        self,
+        profile_dir: Path,
+        account_num: str,
+        email: str,
+        *,
+        cwd: str | Path | None = None,
     ) -> None:
         """Point a managed session profile at an account's stored credentials.
 
@@ -1753,6 +1759,9 @@ class ClaudeAccountSwitcher:
         — that path fires the live-session stale-marking side-effect against the
         per-account dir and multiplies refresh-token drift. claude refreshes the
         access token in-process.
+
+        ``cwd`` (the session's launch directory) is pre-trusted so the spawned
+        claude skips the folder trust dialog — see ``paths.mark_cwd_trusted``.
         """
         profile_dir = Path(profile_dir)
         creds = self._read_account_credentials(str(account_num), email)
@@ -1799,6 +1808,7 @@ class ClaudeAccountSwitcher:
         existing["oauthAccount"] = oauth_account
         existing["hasCompletedOnboarding"] = True
         existing.setdefault("theme", config_data.get("theme") or "dark")
+        mark_cwd_trusted(existing, cwd)
         # ``_write_json`` commits via an atomic rename (+ chmod 0600), so claude's
         # live read of ``.claude.json`` likewise never races a truncate+write.
         self._write_json(config_path, existing)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1601,6 +1601,12 @@ class ClaudeAccountSwitcher:
             # premise (the 5h window being fixed-from-first-use, not rolling), so
             # it stays gated behind its own explicit opt-in until confirmed.
             "primeIdleWindows": bool(cfg.get("primeIdleWindows", False)),
+            # Default True: never spend tokens billed at API rates. A session
+            # whose subscription accounts are all exhausted pauses until a window
+            # resets rather than spilling into pay-as-you-go extra-usage / an API
+            # account. Set False to let those become a last-resort tier so work
+            # continues instead of stopping.
+            "onlySubscriptionTokens": bool(cfg.get("onlySubscriptionTokens", True)),
             "model": str(cfg.get("model") or "opus"),
             "effortLevel": str(cfg.get("effortLevel") or "xhigh"),
         }
@@ -1613,6 +1619,7 @@ class ClaudeAccountSwitcher:
         target_safety: int | None = None,
         hysteresis_band: int | None = None,
         prime_idle_windows: bool | None = None,
+        only_subscription_tokens: bool | None = None,
         model: str | None = None,
         effort_level: str | None = None,
     ) -> dict:
@@ -1644,6 +1651,8 @@ class ClaudeAccountSwitcher:
             cfg["hysteresisBand"] = max(0, int(hysteresis_band))
         if prime_idle_windows is not None:
             cfg["primeIdleWindows"] = bool(prime_idle_windows)
+        if only_subscription_tokens is not None:
+            cfg["onlySubscriptionTokens"] = bool(only_subscription_tokens)
         if model is not None:
             cfg["model"] = str(model)
         if effort_level is not None:
@@ -1654,6 +1663,7 @@ class ClaudeAccountSwitcher:
         cfg.setdefault("targetSafety", DEFAULT_TARGET_SAFETY)
         cfg.setdefault("hysteresisBand", DEFAULT_HYSTERESIS_BAND)
         cfg.setdefault("primeIdleWindows", False)
+        cfg.setdefault("onlySubscriptionTokens", True)
         cfg.setdefault("model", "opus")
         cfg.setdefault("effortLevel", "xhigh")
         # Keep targetSafety strictly below threshold (self-heals an odd combo).

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1555,7 +1555,7 @@ class ClaudeAccountSwitcher:
         return _max_usage_pct(usage)
 
     # ------------------------------------------------------------------ #
-    # Load balancer (Beta) — config, priority, profile seeding
+    # Auto-swap + multi-session load balancer (beta) — config, priority, seeding
     # ------------------------------------------------------------------ #
 
     def get_auto_balance_config(self) -> dict:
@@ -1850,7 +1850,10 @@ class ClaudeAccountSwitcher:
         )
         if paused:
             summary += f" · {paused} paused"
-        print(f"{bolded('Load balancer (Beta):')} {state} {dimmed('· ' + summary)}")
+        print(
+            f"{bolded('Auto-swap + multi-session load balancer (beta):')} "
+            f"{state} {dimmed('· ' + summary)}"
+        )
 
         health = embed.embed_health(self)
         if health["ok"]:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -9,6 +9,7 @@ import os
 import re
 import shutil
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -24,7 +25,7 @@ from claude_swap.exceptions import (
     ValidationError,
 )
 from claude_swap import oauth
-from claude_swap.cache import MISSING, read_cache, write_cache
+from claude_swap.cache import MISSING, read_cache, usage_backoff_active, write_cache
 from claude_swap.locking import FileLock
 from claude_swap.logging_config import setup_logging
 from claude_swap.models import Platform, SwitchTransaction, get_timestamp
@@ -138,6 +139,27 @@ def _format_usage_lines(usage: dict) -> list[str]:
         else:
             lines.append(f"7d: {d7['pct']:>3.0f}%")
     return lines
+
+
+def _usage_status_line(usage) -> str | None:
+    """Render the one-line text for a usage *failure* entry, or None for real usage.
+
+    A 429 backoff marker (``{"_unavailable": True, "retry_until": <epoch>}``) is a
+    dict but carries no usage windows, so it would otherwise fall through to
+    :func:`_format_usage_lines` and render a BLANK line. Returns the user-facing
+    "rate-limited … / unavailable" text for a marker or ``None`` usage; returns
+    ``None`` (the sentinel) for real usage so the caller formats it normally.
+    Shared by ``list_accounts`` and ``status`` so the two render paths can't drift.
+    """
+    if usage is None:
+        return "usage unavailable"
+    if isinstance(usage, dict) and usage.get("_unavailable"):
+        until = usage.get("retry_until")
+        if isinstance(until, (int, float)) and until > time.time():
+            mins = max(1, int((until - time.time()) / 60))
+            return f"usage rate-limited — retry in ~{mins}m"
+        return "usage unavailable"
+    return None
 
 
 def _sweep_legacy_keyring(usernames: list[str], removed_items: list[str]) -> None:
@@ -703,6 +725,39 @@ class ClaudeAccountSwitcher:
 
         organization_uuid = oauth.get("organizationUuid", "") or ""
         return (email, organization_uuid)
+
+    def active_account_num(self) -> str | None:
+        """Account number whose identity matches the current ``~/.claude`` login.
+
+        The "active default" account — the one Claude Code owns credentials for
+        right now (whatever vanilla ``claude`` or the last ``cswap <num>`` switch
+        points at). ``None`` when no managed account matches the current identity.
+
+        Used to keep the balancer's idle-usage path (``registry.build_world``) and
+        idle-window priming from ever refreshing/rotating this account's OAuth
+        token: doing so rotates the single-use refresh token out from under the
+        live login and forces a re-login. Mirrors the guard ``list_accounts``
+        already applies; centralized here so the two paths can't drift.
+
+        Reads the org-field-migrated sequence so a legacy account (added before
+        ``organizationUuid`` was stored) still matches the current login — without
+        the backfill the org comparison would fail and the active account would be
+        left unguarded (the credential-rotation bug would re-open for it).
+        """
+        ident = self._get_current_account()
+        if ident is None:
+            return None
+        email, org_uuid = ident
+        data = self._get_sequence_data_migrated() or {}
+        for num, account in data.get("accounts", {}).items():
+            if (account.get("email") == email and
+                    (account.get("organizationUuid", "") or "") == org_uuid):
+                return str(num)
+        return None
+
+    def has_live_session(self, account_num: str, email: str) -> bool:
+        """Whether a session-mode (``cswap run``) claude is live for this account."""
+        return bool(self._live_session_pids(str(account_num), email))
 
     def _account_exists(self, email: str, organization_uuid: str) -> bool:
         """Check if account exists by (email, organizationUuid) composite key."""
@@ -1274,17 +1329,10 @@ class ClaudeAccountSwitcher:
             return
 
         data = self._get_sequence_data_migrated()
-        current_identity = self._get_current_account()
 
-        # Find active account number by (email, organizationUuid) composite key
-        active_num = None
-        if current_identity is not None:
-            current_email, current_org_uuid = current_identity
-            for num, account in data.get("accounts", {}).items():
-                if (account.get("email") == current_email and
-                        account.get("organizationUuid", "") == current_org_uuid):
-                    active_num = num
-                    break
+        # The active default account (current ~/.claude identity). Shared with
+        # registry.build_world via active_account_num() so the two never drift.
+        active_num = self.active_account_num()
 
         accounts_info = []
         for num in data.get("sequence", []):
@@ -1320,20 +1368,40 @@ class ClaudeAccountSwitcher:
             # unavailable until the session exits.
             has_live_session = bool(self._live_session_pids(str(num), email))
 
-            return oauth.fetch_usage_for_account(
+            fail: dict = {}
+            result = oauth.fetch_usage_for_account(
                 str(num), email, creds,
                 is_active=is_active or has_live_session,
                 persist_credentials=persist,
+                failure_out=fail,
             )
+            # On a usage-endpoint 429, cache a backoff marker carrying the
+            # server's Retry-After so we stop re-hitting the rate-limited
+            # endpoint every invocation (the "usage unavailable" feedback loop).
+            if result is None and fail.get("retry_after"):
+                return {"_unavailable": True, "retry_until": time.time() + fail["retry_after"]}
+            return result
 
         usage_cache_path = self.backup_dir / "cache" / "usage.json"
+        # Persisted backoff markers survive the freshness TTL until their
+        # server-requested Retry-After elapses, so a rate-limited account is not
+        # refetched every `cswap --list` while the endpoint asked for silence.
+        persisted = read_cache(usage_cache_path, float("inf"))
+        persisted = persisted if (persisted is not MISSING and isinstance(persisted, dict)) else {}
+
+        def fetch_or_skip(account_info):
+            num = str(account_info[0])
+            if usage_backoff_active(persisted.get(num)):
+                return persisted.get(num)
+            return fetch(account_info)
+
         cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
         account_keys = {str(info[0]) for info in accounts_info}
         if cached is not MISSING and isinstance(cached, dict) and cached.keys() == account_keys:
             usages = [cached.get(str(info[0])) for info in accounts_info]
         else:
             with ThreadPoolExecutor() as executor:
-                usages = list(executor.map(fetch, accounts_info))
+                usages = list(executor.map(fetch_or_skip, accounts_info))
             write_cache(usage_cache_path, {
                 str(info[0]): usage
                 for info, usage in zip(accounts_info, usages)
@@ -1353,9 +1421,9 @@ class ClaudeAccountSwitcher:
             else:
                 print(f"  {num}: {email} {muted(f'[{tag}]')}{pri_tag}")
             if isinstance(usage, str):
-                print(f"     {dimmed(usage)}")
-            elif usage is None:
-                print(f"     {dimmed('usage unavailable')}")
+                print(f"     {dimmed(usage)}")  # e.g. "no credentials"
+            elif (status_line := _usage_status_line(usage)) is not None:
+                print(f"     {dimmed(status_line)}")  # unavailable / rate-limited
             else:
                 lines = _format_usage_lines(usage)
                 for j, line in enumerate(lines):
@@ -1453,7 +1521,12 @@ class ClaudeAccountSwitcher:
                     existing = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
                     existing[account_num] = usage
                     write_cache(usage_cache_path, existing)
-                if isinstance(usage, dict):
+                status_line = _usage_status_line(usage)
+                if status_line is not None:
+                    # None usage or a 429 backoff marker -> a clear line, never a
+                    # blank one (a marker would otherwise format to nothing).
+                    print(f"  {dimmed(status_line)}")
+                elif isinstance(usage, dict):
                     lines = _format_usage_lines(usage)
                     for j, line in enumerate(lines):
                         connector = "└" if j == len(lines) - 1 else "├"

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -29,6 +29,8 @@ from claude_swap.cache import (
     MISSING,
     STALE_USAGE_MAX_AGE_S,
     last_known_usage,
+    logged_out,
+    logged_out_marker,
     merge_last_known,
     read_cache,
     usage_backoff_active,
@@ -161,6 +163,10 @@ def _usage_status_line(usage) -> str | None:
     """
     if usage is None:
         return "usage unavailable"
+    if logged_out(usage):
+        # A dead refresh token: actionable, and checked BEFORE the rate-limited
+        # branch because a logged-out marker also carries a (throttle) retry_until.
+        return "logged out — re-login with `cswap --add-account`"
     if isinstance(usage, dict) and usage.get("_unavailable"):
         until = usage.get("retry_until")
         if isinstance(until, (int, float)) and until > time.time():
@@ -183,6 +189,10 @@ def _stale_usage_render(usage, now: float | None = None) -> tuple[str, list[str]
     """
     if not (isinstance(usage, dict) and usage.get("_unavailable")):
         return None
+    if logged_out(usage):
+        # A logged-out account can't authenticate at all — never resurrect it as an
+        # optimistic stale reading; show the actionable status line instead.
+        return None
     now = now if now is not None else time.time()
     lk = last_known_usage(usage, STALE_USAGE_MAX_AGE_S, now)
     if lk is None:
@@ -199,6 +209,56 @@ def _stale_usage_render(usage, now: float | None = None) -> tuple[str, list[str]
     else:
         note = "last-known usage (cached — endpoint unavailable)"
     return note, lines
+
+
+def _enrich_reset_strings(usage: dict) -> None:
+    """Add (countdown, clock) display strings to live-derived usage windows in place.
+
+    The live statusline ``rate_limits`` signal carries only the reset epoch
+    (``resets_at``); a real usage-API reading also carries the formatted
+    ``countdown``/``clock`` that :func:`_format_usage_lines` renders. Format them
+    here from the epoch so an account rendered from its live signal shows the same
+    ``resets HH:MM in Nh Nm`` line a real reading would, instead of dropping the
+    reset time. Best-effort per window — a missing/zero reset just leaves that
+    window's strings absent (rendered as a bare ``5h: N%``).
+    """
+    from datetime import datetime, timezone
+
+    for window in ("five_hour", "seven_day"):
+        entry = usage.get(window)
+        if not isinstance(entry, dict):
+            continue
+        reset = entry.get("resets_at")
+        if not isinstance(reset, (int, float)) or reset <= 0:
+            continue
+        try:
+            iso = datetime.fromtimestamp(int(reset), tz=timezone.utc).isoformat()
+            entry["countdown"], entry["clock"] = oauth.format_reset(iso)
+        except Exception:  # noqa: BLE001 - display enrichment is best-effort
+            pass
+
+
+def _merge_spend_from_cache(usage: dict, cached_entry) -> None:
+    """Carry pay-as-you-go (extra-usage/spend) from a real cached reading onto a
+    live-derived usage dict, in place.
+
+    The live statusline signal never carries the dollar-denominated ``spend`` /
+    ``extra_usage_enabled`` info (only the usage API does — see
+    ``oauth.build_usage_result``), so an account rendered from its live signal
+    would drop the ``$$`` line. When the shared usage cache still holds a REAL
+    prior reading for the account, copy its extra-usage info forward so the line
+    survives. No-op when the cache holds no real reading (a marker / None / probe
+    verdict) — then ``$$`` is simply omitted, which ``_format_usage_lines`` handles.
+    """
+    from claude_swap.cache import is_real_usage
+
+    if not is_real_usage(cached_entry):
+        return
+    if cached_entry.get("extra_usage_enabled"):
+        usage["extra_usage_enabled"] = True
+    spend = cached_entry.get("spend")
+    if isinstance(spend, dict):
+        usage["spend"] = spend
 
 
 def _sweep_legacy_keyring(usernames: list[str], removed_items: list[str]) -> None:
@@ -528,6 +588,34 @@ class ClaudeAccountSwitcher:
             mark_session_stale(self._session_dir(account_num, email))
         else:
             self._invalidate_session_credentials(account_num, email)
+        # Fresh credentials supersede any cached logged-out verdict: drop a stale
+        # logged-out marker so a re-login (--add-account / --import) shows real usage
+        # on the next read instead of telling the user to re-login for up to
+        # LOGGED_OUT_RECHECK_S after they already did. Guarded so a routine
+        # refresh-token rotation (which also lands here) never wipes good cached usage.
+        self._clear_logged_out_usage_marker(account_num)
+
+    def _clear_logged_out_usage_marker(self, account_num: str) -> None:
+        """Drop a logged-out usage marker for an account after its creds change.
+
+        Best-effort and guarded: only removes the cache entry when it is a
+        logged-out marker (see :func:`cache.logged_out`); real usage and 429 backoff
+        markers are left intact, so a refresh-token rotation can't erase good cached
+        usage. The next render/balancer pass re-fetches with the fresh credentials.
+        """
+        usage_cache_path = self.backup_dir / "cache" / "usage.json"
+        try:
+            cached = read_cache(usage_cache_path, float("inf"))
+            if not (isinstance(cached, dict) and logged_out(cached.get(str(account_num)))):
+                return
+            write_cache(
+                usage_cache_path,
+                {k: v for k, v in cached.items() if k != str(account_num)},
+            )
+        except Exception:
+            self._logger.debug(
+                "clear logged-out marker failed for %s", account_num, exc_info=True
+            )
 
     def _delete_account_credentials(self, account_num: str, email: str) -> None:
         """Delete account credentials from backup.
@@ -653,6 +741,103 @@ class ClaudeAccountSwitcher:
         process (see the v0.7.3 deadlock history).
         """
         self._write_account_credentials(account_num, email, credentials)
+
+    def _refresh_lock_path(self, account_num: str) -> Path:
+        """Per-account lock that serializes OAuth refreshes of one slot's token.
+
+        Distinct from ``self.lock_file`` (the global credential-store lock) so two
+        DIFFERENT accounts still refresh in parallel — only refreshes of the SAME
+        single-use refresh token serialize (see
+        :meth:`ensure_fresh_inactive_credentials`).
+        """
+        return self.backup_dir / f".refresh-{account_num}.lock"
+
+    def ensure_fresh_inactive_credentials(
+        self,
+        account_num: str,
+        email: str,
+        credentials: str,
+        *,
+        failure_out: dict | None = None,
+    ) -> str:
+        """Non-expired credentials for an INACTIVE account, refreshed race-free.
+
+        The OAuth refresh token is SINGLE-USE: a successful refresh rotates it, and the
+        provider treats a second POST of the now-consumed token as token reuse and
+        revokes the WHOLE family — so every cswap copy goes dead and the account logs
+        itself out until a manual re-login. Many cswap code paths refresh the same idle
+        account concurrently — every balancer tick, every ``cswap --list``, and a
+        statusline migration-plan all call ``build_world(fetch_idle=True)``, and a user
+        commonly has several Claude sessions open at once — so that reuse race is easy
+        to hit and is the root cause of idle accounts silently logging out.
+
+        This is the single chokepoint that makes the read→refresh→persist atomic per
+        account: it serializes refreshes of ONE account across processes (a per-account
+        :meth:`_refresh_lock_path`) and double-checks the on-disk token after taking the
+        lock, so exactly one process POSTs the refresh while the losers reuse the
+        freshly-persisted token instead of re-POSTing a consumed one. Different accounts
+        still refresh in parallel.
+
+        The caller MUST pass only an INACTIVE account's credentials — never the active
+        default login or a live-session account (Claude Code owns those; rotating their
+        token forces a re-login). Returns fresh credentials (refreshed here, the
+        winner's already-fresh token, or the unchanged input when it was not expired).
+        On a definitive ``invalid_grant`` sets ``failure_out["logged_out"] = True`` (when
+        provided) and returns the unchanged credentials so the caller can surface a
+        "logged out — re-login" state instead of hammering a dead token.
+        """
+        oauth_data = oauth.extract_oauth_data(credentials)
+        if not oauth_data or not oauth_data.get("refreshToken"):
+            return credentials  # nothing to refresh (e.g. a --add-token account)
+        if not oauth.is_oauth_token_expired(oauth_data.get("expiresAt")):
+            return credentials  # still fresh -> no network POST, no lock needed
+
+        # Bounded to the render budget (statusline/list use a 5s lock budget): the
+        # winner holds this lock across its refresh POST, and this runs on render
+        # paths (build_world from a statusline migration-plan / `cswap --list`), so a
+        # loser must not stall the prompt for the POST's full 10s. On timeout it
+        # degrades gracefully (stored creds -> no usage this tick, fixed next pass).
+        lock = FileLock(self._refresh_lock_path(account_num), timeout=5.0)
+        if not lock.acquire():
+            # Couldn't serialize in time: skip the refresh rather than risk a racing
+            # POST that could revoke the family. The caller then fetches with the
+            # expired token -> no usage this tick (recovered on the next pass).
+            self._logger.debug(
+                "refresh lock busy for account %s; using stored creds", account_num
+            )
+            return credentials
+        try:
+            # Double-check under the lock: a concurrent winner may have just refreshed
+            # and persisted, in which case reuse its fresh token with NO POST.
+            disk = self._read_account_credentials(account_num, email) or credentials
+            disk_oauth = oauth.extract_oauth_data(disk)
+            if (
+                disk_oauth
+                and disk_oauth.get("accessToken")
+                and not oauth.is_oauth_token_expired(disk_oauth.get("expiresAt"))
+            ):
+                return disk
+            # Refresh from the freshest token on disk (the winner may have rotated it
+            # even if it then expired again); fall back to the caller's copy.
+            base = disk if (disk_oauth and disk_oauth.get("refreshToken")) else credentials
+            refresh_fail: dict = {}
+            refreshed = oauth.refresh_oauth_credentials(base, failure_out=refresh_fail)
+            if refreshed:
+                try:
+                    with FileLock(self.lock_file):
+                        self._write_account_credentials(account_num, email, refreshed)
+                except Exception:
+                    self._logger.debug(
+                        "persist refreshed creds failed for account %s",
+                        account_num,
+                        exc_info=True,
+                    )
+                return refreshed
+            if failure_out is not None and refresh_fail.get("invalid_grant"):
+                failure_out["logged_out"] = True
+            return base
+        finally:
+            lock.release()
 
     def read_account_config(self, account_num: str, email: str) -> str:
         """Public wrapper for session bootstrap. Empty string when missing."""
@@ -797,6 +982,72 @@ class ClaudeAccountSwitcher:
     def has_live_session(self, account_num: str, email: str) -> bool:
         """Whether a session-mode (``cswap run``) claude is live for this account."""
         return bool(self._live_session_pids(str(account_num), email))
+
+    def _live_usage_by_account(self) -> dict[str, dict]:
+        """Most-recent live usage per account, derived from the registry (lock-free).
+
+        A *managed* session's statusline writes its account's live ``rate_limits``
+        into the registry on every render (see :mod:`claude_swap.statusline`). That
+        signal is FREE and is NEVER subject to the usage endpoint's 429 rate limit —
+        unlike the usage API. The display/poll paths (:meth:`list_accounts`,
+        :meth:`status`, :meth:`get_active_usage_pct`) reuse it here so that:
+
+        * an account hosting a live session (typically the active account, where
+          managed sessions run) shows its REAL consumption instead of
+          "usage rate-limited — retry in ~Nm" whenever the usage endpoint is
+          429-backed-off, and
+        * those paths stop hitting (and being blocked by) the rate-limited usage
+          endpoint for an account the registry already has a fresh reading for —
+          which is the dominant unnecessary call source feeding the 429 loop.
+
+        Mirrors ``registry.build_world``'s live-signal selection exactly so the
+        display and the balancer never disagree: only sessions whose supervisor
+        process is still alive count (``registry.live_sessions``), the
+        most-recently-seen session wins per account (``last_seen``), and the live
+        ``rate_limits`` shape is normalized via ``registry._rl_to_usage``. The reset
+        epoch is formatted to the same countdown/clock a real reading carries
+        (:func:`_enrich_reset_strings`), and pay-as-you-go/spend — absent from the
+        live signal — is merged best-effort from the fresh usage cache
+        (:func:`_merge_spend_from_cache`), exactly as ``build_world`` does for a
+        live account.
+
+        Returns ``{account_num: usage_dict}`` for accounts with a usable live
+        reading; accounts without one are absent (the caller falls back to the
+        cache / usage API). Never raises — any failure yields an empty map.
+        """
+        from claude_swap import registry
+        from claude_swap.cache import MISSING, read_cache
+
+        try:
+            reg = registry.read_registry(self)
+            live_rl: dict[str, dict] = {}
+            seen_at: dict[str, float] = {}
+            for e in registry.live_sessions(reg):
+                rl = e.get("rate_limits")
+                acct = str(e.get("account_num", ""))
+                seen = float(e.get("last_seen") or 0.0)
+                if isinstance(rl, dict) and acct and seen >= seen_at.get(acct, -1.0):
+                    live_rl[acct] = rl
+                    seen_at[acct] = seen
+            if not live_rl:
+                return {}
+
+            usage_cache_path = self.backup_dir / "cache" / "usage.json"
+            cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
+            cached = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
+
+            out: dict[str, dict] = {}
+            for acct, rl in live_rl.items():
+                usage = registry._rl_to_usage(rl)
+                if not usage:
+                    continue
+                _enrich_reset_strings(usage)
+                _merge_spend_from_cache(usage, cached.get(acct))
+                out[acct] = usage
+            return out
+        except Exception:  # noqa: BLE001 - best-effort; caller fetches as before
+            self._logger.debug("live usage map build failed", exc_info=True)
+            return {}
 
     def _account_exists(self, email: str, organization_uuid: str) -> bool:
         """Check if account exists by (email, organizationUuid) composite key."""
@@ -1395,24 +1646,28 @@ class ClaudeAccountSwitcher:
             if not creds or not oauth.extract_access_token(creds):
                 return "no credentials"
 
-            def persist(acct_num: str, acct_email: str, new_creds: str) -> None:
-                with FileLock(self.lock_file):
-                    self._write_account_credentials(acct_num, acct_email, new_creds)
-
             # An account running in session mode is "inactive" here but live
             # in its own config dir, where claude manages the token. Treat it
-            # like the active account (no proactive refresh / 401-retry):
-            # refreshing the backup copy could rotate the refresh token out
-            # from under the live session. Worst case its usage shows as
-            # unavailable until the session exits.
+            # like the active account (no proactive refresh): refreshing the
+            # backup copy could rotate the refresh token out from under the live
+            # session. Worst case its usage shows as unavailable until it exits.
             has_live_session = bool(self._live_session_pids(str(num), email))
+            treat_active = is_active or has_live_session
 
             fail: dict = {}
+            if not treat_active:
+                # A genuinely-idle account: refresh its single-use OAuth token through
+                # the locked, double-checked chokepoint so two concurrent cswap
+                # processes can't both POST it and get the family revoked (the
+                # silent-logout root cause). Then fetch with is_active=True so the
+                # usage path never refreshes again.
+                creds = self.ensure_fresh_inactive_credentials(
+                    str(num), email, creds, failure_out=fail
+                )
+                if fail.get("logged_out"):
+                    return logged_out_marker()
             result = oauth.fetch_usage_for_account(
-                str(num), email, creds,
-                is_active=is_active or has_live_session,
-                persist_credentials=persist,
-                failure_out=fail,
+                str(num), email, creds, is_active=True, failure_out=fail,
             )
             # On a usage-endpoint 429, cache a backoff marker carrying the
             # server's Retry-After so we stop re-hitting the rate-limited
@@ -1431,8 +1686,22 @@ class ClaudeAccountSwitcher:
         persisted = read_cache(usage_cache_path, float("inf"))
         persisted = persisted if (persisted is not MISSING and isinstance(persisted, dict)) else {}
 
+        # The registry's free, never-rate-limited live signal for any account
+        # hosting a live managed session (typically the active account). Built once
+        # and used to (a) skip the usage-API fetch for those accounts below and
+        # (b) overlay their real reading for display — so `cswap --list` never shows
+        # "usage rate-limited" for an account the registry already has a reading for.
+        live_usage = self._live_usage_by_account()
+
         def fetch_or_skip(account_info):
             num = str(account_info[0])
+            if num in live_usage:
+                # Don't fetch a live account — the registry already has its reading
+                # (overlaid for display below). Return the PERSISTED entry so the
+                # cache write keeps its existing value (e.g. a real reading with
+                # spend) and never stores a live-derived value (which lacks the
+                # usage-API's spend/extra-usage and would mislead other readers).
+                return persisted.get(num)
             if usage_backoff_active(persisted.get(num)):
                 return persisted.get(num)
             return fetch(account_info)
@@ -1448,6 +1717,16 @@ class ClaudeAccountSwitcher:
                 str(info[0]): usage
                 for info, usage in zip(accounts_info, usages)
             })
+
+        # Overlay the live reading LAST (after any cache write) for accounts with a
+        # live managed session: it is the freshest signal and is never 429-blocked,
+        # and is deliberately kept out of the persisted cache above (it lacks the
+        # usage-API's spend/extra-usage and would pollute the shared slot).
+        if live_usage:
+            usages = [
+                live_usage.get(str(info[0]), usage)
+                for info, usage in zip(accounts_info, usages)
+            ]
 
         print(bolded("Accounts:"))
         for i, ((num, email, org_name, org_uuid, is_active, _), usage) in enumerate(zip(accounts_info, usages)):
@@ -1552,35 +1831,45 @@ class ClaudeAccountSwitcher:
             print(f"  {dimmed(f'Total managed accounts: {total}')}")
             creds = self._read_credentials() or ""
             if creds and oauth.extract_access_token(creds):
-                # Reuse the cache list_accounts writes (cache-first). On miss,
-                # fetch with is_active=True (Claude Code owns active credentials,
-                # cswap must not refresh them) and merge into existing entries so
-                # other accounts' rows survive.
-                usage_cache_path = self.backup_dir / "cache" / "usage.json"
-                # Persisted backoff markers survive the freshness TTL until their
-                # Retry-After elapses, so `cswap --status` doesn't re-hit a
-                # rate-limited endpoint once the 60s cache expires (the gap that
-                # re-armed the "usage unavailable" loop on this path).
-                persisted = read_cache(usage_cache_path, float("inf"))
-                persisted = persisted if (persisted is not MISSING and isinstance(persisted, dict)) else {}
-                cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
-                if (cached is not MISSING and isinstance(cached, dict)
-                        and account_num in cached):
-                    usage = cached[account_num]
-                elif usage_backoff_active(persisted.get(account_num)):
-                    usage = persisted.get(account_num)  # honor the backoff, no refetch
+                # Prefer the registry's free, never-rate-limited live signal when
+                # this (active) account hosts a live managed session: it shows the
+                # real reading instead of "usage rate-limited" while the usage
+                # endpoint is 429-backed-off, and avoids re-hitting it. Live values
+                # are deliberately NOT persisted to the shared cache below (they
+                # lack the usage-API's spend/extra-usage).
+                live = self._live_usage_by_account().get(account_num)
+                if live is not None:
+                    usage = live
                 else:
-                    fail: dict = {}
-                    usage = oauth.fetch_usage_for_account(
-                        account_num, current_email, creds,
-                        is_active=True, failure_out=fail,
-                    )
-                    if usage is None and fail.get("retry_after"):
-                        marker = {"_unavailable": True, "retry_until": time.time() + fail["retry_after"]}
-                        usage = merge_last_known(marker, persisted.get(account_num))
-                    existing = dict(persisted)
-                    existing[account_num] = usage
-                    write_cache(usage_cache_path, existing)
+                    # Reuse the cache list_accounts writes (cache-first). On miss,
+                    # fetch with is_active=True (Claude Code owns active credentials,
+                    # cswap must not refresh them) and merge into existing entries so
+                    # other accounts' rows survive.
+                    usage_cache_path = self.backup_dir / "cache" / "usage.json"
+                    # Persisted backoff markers survive the freshness TTL until their
+                    # Retry-After elapses, so `cswap --status` doesn't re-hit a
+                    # rate-limited endpoint once the 60s cache expires (the gap that
+                    # re-armed the "usage unavailable" loop on this path).
+                    persisted = read_cache(usage_cache_path, float("inf"))
+                    persisted = persisted if (persisted is not MISSING and isinstance(persisted, dict)) else {}
+                    cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
+                    if (cached is not MISSING and isinstance(cached, dict)
+                            and account_num in cached):
+                        usage = cached[account_num]
+                    elif usage_backoff_active(persisted.get(account_num)):
+                        usage = persisted.get(account_num)  # honor the backoff, no refetch
+                    else:
+                        fail: dict = {}
+                        usage = oauth.fetch_usage_for_account(
+                            account_num, current_email, creds,
+                            is_active=True, failure_out=fail,
+                        )
+                        if usage is None and fail.get("retry_after"):
+                            marker = {"_unavailable": True, "retry_until": time.time() + fail["retry_after"]}
+                            usage = merge_last_known(marker, persisted.get(account_num))
+                        existing = dict(persisted)
+                        existing[account_num] = usage
+                        write_cache(usage_cache_path, existing)
                 stale = _stale_usage_render(usage)
                 if stale is not None:
                     # Backed off, but a recent last-known reading exists -> show it.
@@ -1682,6 +1971,15 @@ class ClaudeAccountSwitcher:
                     account.get("organizationUuid", "") == current_org_uuid):
                 account_num = num
                 break
+
+        # Prefer the registry's free, never-rate-limited live signal when the
+        # active account hosts a live managed session: a real reading even while
+        # the usage endpoint is 429-backed-off (where the cache/fetch path would
+        # return None and stall the auto-switch monitor), and no usage-API hit.
+        if account_num is not None:
+            live = self._live_usage_by_account().get(account_num)
+            if live is not None:
+                return _max_usage_pct(live)
 
         usage_cache_path = self.backup_dir / "cache" / "usage.json"
         # Persisted backoff markers (inf TTL) gate the refetch so a 429-backed-off
@@ -1995,12 +2293,15 @@ class ClaudeAccountSwitcher:
         refresh token is dead — i.e. the account is logged out and the caller
         should migrate to a healthy account instead). Never raises.
 
-        Concurrency: the whole read-refresh-write-reseed runs under
-        ``FileLock(self.lock_file)`` so two managed sessions on the same account
-        serialize. The expiry re-check makes the second one a cheap reseed (the
-        first sibling already refreshed the shared backup). No network I/O races
-        the registry because this method touches credentials only — callers
-        (the supervisor's ``_recover_auth``) build the world OUTSIDE the lock.
+        Concurrency: the network refresh runs under the PER-ACCOUNT refresh lock
+        (:meth:`_refresh_lock_path`) acquired BEFORE ``FileLock(self.lock_file)`` —
+        the same lock and ordering :meth:`ensure_fresh_inactive_credentials` uses — so
+        this managed-recovery POST can't race an idle ``build_world`` refresh of the
+        SAME account's single-use token (a managed account isn't covered by
+        ``has_live_session``, so the idle path would otherwise treat it as idle and
+        POST concurrently, revoking the token family). The expiry re-check under the
+        lock makes a sibling a cheap reseed. Callers (``_recover_auth``) build the
+        world OUTSIDE both locks.
         """
         account_num = str(account_num)
         try:
@@ -2013,7 +2314,7 @@ class ClaudeAccountSwitcher:
                 return False
             email = record.get("email", "")
 
-            with FileLock(self.lock_file):
+            with FileLock(self._refresh_lock_path(account_num)), FileLock(self.lock_file):
                 creds = self._read_account_credentials(account_num, email)
                 if not creds:
                     self._logger.warning(

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -75,7 +75,10 @@ CLAUDE_CODE_KEYCHAIN_SERVICE = "Claude Code-credentials"
 SETUP_TOKEN_SCOPES = ("user:inference",)
 
 # Usage cache
-_USAGE_CACHE_TTL = 15  # seconds
+_USAGE_CACHE_TTL = 60  # seconds — idle-account usage changes over hours, not
+# seconds, and the live statusline signal covers active accounts in real time. A
+# longer TTL keeps usage-API fetches (and 429-failure retries, which reuse this
+# same cache slot) gentle so the endpoint's own rate limit is never tripped.
 
 # Auto-switch (Beta): when the active account's 5h/7d usage reaches this
 # percentage, the TUI monitor rotates to the next managed account.

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -52,7 +52,6 @@ from claude_swap.paths import (
 from claude_swap.process_detection import get_running_instances
 from claude_swap.balancer import (
     DEFAULT_HYSTERESIS_BAND,
-    DEFAULT_MIGRATION_COOLDOWN,
     DEFAULT_TARGET_SAFETY,
 )
 
@@ -1587,7 +1586,11 @@ class ClaudeAccountSwitcher:
             "threshold": threshold,
             "targetSafety": min(target_safety, threshold - 1),
             "hysteresisBand": max(0, _int("hysteresisBand", DEFAULT_HYSTERESIS_BAND)),
-            "cooldownSeconds": max(0, _int("cooldownSeconds", DEFAULT_MIGRATION_COOLDOWN)),
+            # Idle-5h-window priming (feature #3). Default OFF and independent of
+            # ``enabled``: priming spends real credits on an as-yet-unverified
+            # premise (the 5h window being fixed-from-first-use, not rolling), so
+            # it stays gated behind its own explicit opt-in until confirmed.
+            "primeIdleWindows": bool(cfg.get("primeIdleWindows", False)),
             "model": str(cfg.get("model") or "opus"),
             "effortLevel": str(cfg.get("effortLevel") or "xhigh"),
         }
@@ -1599,7 +1602,7 @@ class ClaudeAccountSwitcher:
         threshold: int | None = None,
         target_safety: int | None = None,
         hysteresis_band: int | None = None,
-        cooldown_seconds: int | None = None,
+        prime_idle_windows: bool | None = None,
         model: str | None = None,
         effort_level: str | None = None,
     ) -> dict:
@@ -1629,8 +1632,8 @@ class ClaudeAccountSwitcher:
             cfg["targetSafety"] = ts
         if hysteresis_band is not None:
             cfg["hysteresisBand"] = max(0, int(hysteresis_band))
-        if cooldown_seconds is not None:
-            cfg["cooldownSeconds"] = max(0, int(cooldown_seconds))
+        if prime_idle_windows is not None:
+            cfg["primeIdleWindows"] = bool(prime_idle_windows)
         if model is not None:
             cfg["model"] = str(model)
         if effort_level is not None:
@@ -1640,7 +1643,7 @@ class ClaudeAccountSwitcher:
         cfg.setdefault("threshold", DEFAULT_AUTO_SWITCH_THRESHOLD)
         cfg.setdefault("targetSafety", DEFAULT_TARGET_SAFETY)
         cfg.setdefault("hysteresisBand", DEFAULT_HYSTERESIS_BAND)
-        cfg.setdefault("cooldownSeconds", DEFAULT_MIGRATION_COOLDOWN)
+        cfg.setdefault("primeIdleWindows", False)
         cfg.setdefault("model", "opus")
         cfg.setdefault("effortLevel", "xhigh")
         # Keep targetSafety strictly below threshold (self-heals an odd combo).

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -80,6 +80,15 @@ _USAGE_CACHE_TTL = 15  # seconds
 # percentage, the TUI monitor rotates to the next managed account.
 DEFAULT_AUTO_SWITCH_THRESHOLD = 95
 
+# Default command for the Quick-start alias (bare ``cswap`` when enabled): launch
+# a load-balanced session with the QoL defaults baked in. Extra args the user
+# passes on the command line are appended to this verbatim.
+DEFAULT_QUICK_START_COMMAND = (
+    "cswap launch -- --dangerously-skip-permissions "
+    "--model claude-opus-4-8 "
+    "--settings '{\"ultracode\": true}'"
+)
+
 
 def _max_usage_pct(usage: dict | None) -> float | None:
     """Return the highest 5h/7d utilization percentage in a usage dict.
@@ -1652,6 +1661,57 @@ class ClaudeAccountSwitcher:
             cfg["targetSafety"] = 1
 
         data["autoBalance"] = cfg
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        return cfg
+
+    def get_quick_start_config(self) -> dict:
+        """Return the persisted Quick-start settings (the bare-``cswap`` default).
+
+        Stored in ``sequence.json`` under ``quickStart``. Default OFF; when on,
+        running ``cswap`` with no recognized subcommand/flag runs ``command``
+        (with any extra args appended), acting like a configurable alias. A blank
+        or missing command falls back to :data:`DEFAULT_QUICK_START_COMMAND`.
+        """
+        data = self._get_sequence_data() or {}
+        cfg = data.get("quickStart") or {}
+        command = cfg.get("command")
+        if not isinstance(command, str) or not command.strip():
+            command = DEFAULT_QUICK_START_COMMAND
+        return {
+            "enabled": bool(cfg.get("enabled", False)),
+            "command": command,
+        }
+
+    def set_quick_start_config(
+        self, *, enabled: bool | None = None, command: str | None = None
+    ) -> dict:
+        """Persist Quick-start settings, returning the merged config.
+
+        Only provided fields change. To reset the command, pass
+        :data:`DEFAULT_QUICK_START_COMMAND` explicitly (as the TUI's "Reset"
+        action does); a *provided* blank/whitespace command is rejected rather
+        than silently reset. A missing/blank *persisted* value still falls back
+        to the default on read.
+
+        Raises:
+            ValidationError: if ``command`` is provided but empty/whitespace.
+        """
+        self._setup_directories()
+        self._init_sequence_file()
+        data = self._get_sequence_data() or {}
+        cfg = dict(data.get("quickStart") or {})
+        if enabled is not None:
+            cfg["enabled"] = bool(enabled)
+        if command is not None:
+            stripped = command.strip()
+            if not stripped:
+                raise ValidationError("Quick-start command cannot be empty")
+            cfg["command"] = stripped
+        cfg.setdefault("enabled", False)
+        if not isinstance(cfg.get("command"), str) or not cfg["command"].strip():
+            cfg["command"] = DEFAULT_QUICK_START_COMMAND
+        data["quickStart"] = cfg
         data["lastUpdated"] = get_timestamp()
         self._write_json(self.sequence_file, data)
         return cfg

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -346,6 +346,36 @@ class ClaudeAccountSwitcher:
             except Exception as e:
                 raise CredentialWriteError(f"Failed to write credentials: {e}")
 
+    def _atomic_write_text(self, path: Path, text: str) -> None:
+        """Write ``text`` to ``path`` atomically with 0600 perms.
+
+        Same mkstemp + ``os.write`` + ``os.close`` + ``os.replace`` + chmod
+        pattern as :meth:`_write_credentials` (the file-backup branch): the
+        rename is atomic, so a concurrent reader (e.g. a live claude reading a
+        managed profile's ``.credentials.json``) sees the old or the new file
+        whole, never a truncated one. Cleans up the temp file on any failure.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        import tempfile
+
+        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            os.write(fd, text.encode("utf-8"))
+            os.close(fd)
+            fd = -1
+            os.replace(tmp_path, str(path))
+            if sys.platform != "win32":
+                os.chmod(str(path), 0o600)
+        except BaseException:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
     def _uses_file_backup_backend(self) -> bool:
         """Whether per-account backup credentials live in files vs. the Keychain.
 
@@ -1688,10 +1718,11 @@ class ClaudeAccountSwitcher:
         # A stale hashed keychain entry would shadow the fresh plaintext seed.
         delete_macos_keychain_entry(profile_dir)
 
+        # Write ATOMICALLY (mkstemp + os.replace) so a live claude reading the
+        # profile during a migrate-without-relaunch never observes a truncated
+        # file — it sees either the old credentials or the new ones, whole.
         creds_path = profile_dir / ".credentials.json"
-        creds_path.write_text(creds, encoding="utf-8")
-        if sys.platform != "win32":
-            os.chmod(creds_path, 0o600)
+        self._atomic_write_text(creds_path, creds)
 
         # Merge identity into any existing profile config so projects/history
         # survive a re-point (mirrors session._bootstrap's merge).
@@ -1705,9 +1736,9 @@ class ClaudeAccountSwitcher:
         existing["oauthAccount"] = oauth_account
         existing["hasCompletedOnboarding"] = True
         existing.setdefault("theme", config_data.get("theme") or "dark")
-        config_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
-        if sys.platform != "win32":
-            os.chmod(config_path, 0o600)
+        # ``_write_json`` commits via an atomic rename (+ chmod 0600), so claude's
+        # live read of ``.claude.json`` likewise never races a truncate+write.
+        self._write_json(config_path, existing)
         self._logger.info(
             f"Seeded managed profile {profile_dir.name} -> account {account_num} ({email})"
         )

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -25,7 +25,15 @@ from claude_swap.exceptions import (
     ValidationError,
 )
 from claude_swap import oauth
-from claude_swap.cache import MISSING, read_cache, usage_backoff_active, write_cache
+from claude_swap.cache import (
+    MISSING,
+    STALE_USAGE_MAX_AGE_S,
+    last_known_usage,
+    merge_last_known,
+    read_cache,
+    usage_backoff_active,
+    write_cache,
+)
 from claude_swap.locking import FileLock
 from claude_swap.logging_config import setup_logging
 from claude_swap.models import Platform, SwitchTransaction, get_timestamp
@@ -160,6 +168,37 @@ def _usage_status_line(usage) -> str | None:
             return f"usage rate-limited — retry in ~{mins}m"
         return "usage unavailable"
     return None
+
+
+def _stale_usage_render(usage, now: float | None = None) -> tuple[str, list[str]] | None:
+    """Render a backed-off account from its last-known-good reading, if recent.
+
+    When ``usage`` is an ``_unavailable`` marker carrying a still-recent
+    ``_last_known`` snapshot (see ``cache.merge_last_known``), surface the cached
+    numbers instead of a bare "usage unavailable" — the same optimistic reading the
+    balancer treats as headroom. Returns ``(note, lines)`` where ``note`` flags the
+    data as cached (and how long the endpoint is backed off), or ``None`` when there
+    is no fresh last-known reading (the caller then falls back to
+    :func:`_usage_status_line`).
+    """
+    if not (isinstance(usage, dict) and usage.get("_unavailable")):
+        return None
+    now = now if now is not None else time.time()
+    lk = last_known_usage(usage, STALE_USAGE_MAX_AGE_S, now)
+    if lk is None:
+        return None
+    lines = _format_usage_lines(lk)
+    if not lines:
+        # No renderable windows (e.g. only extra-usage data) -> don't print a
+        # contentless header; let the caller fall back to _usage_status_line.
+        return None
+    until = usage.get("retry_until")
+    if isinstance(until, (int, float)) and until > now:
+        mins = max(1, int((until - now) / 60))
+        note = f"last-known usage (cached — endpoint rate-limited, retry in ~{mins}m)"
+    else:
+        note = "last-known usage (cached — endpoint unavailable)"
+    return note, lines
 
 
 def _sweep_legacy_keyring(usernames: list[str], removed_items: list[str]) -> None:
@@ -1378,8 +1417,11 @@ class ClaudeAccountSwitcher:
             # On a usage-endpoint 429, cache a backoff marker carrying the
             # server's Retry-After so we stop re-hitting the rate-limited
             # endpoint every invocation (the "usage unavailable" feedback loop).
+            # Carry the last healthy reading forward so the optimistic stale view
+            # survives (mirrors build_world's marker write).
             if result is None and fail.get("retry_after"):
-                return {"_unavailable": True, "retry_until": time.time() + fail["retry_after"]}
+                marker = {"_unavailable": True, "retry_until": time.time() + fail["retry_after"]}
+                return merge_last_known(marker, persisted.get(str(num)))
             return result
 
         usage_cache_path = self.backup_dir / "cache" / "usage.json"
@@ -1422,6 +1464,12 @@ class ClaudeAccountSwitcher:
                 print(f"  {num}: {email} {muted(f'[{tag}]')}{pri_tag}")
             if isinstance(usage, str):
                 print(f"     {dimmed(usage)}")  # e.g. "no credentials"
+            elif (stale := _stale_usage_render(usage)) is not None:
+                note, lines = stale  # backed off, but a recent last-known reading
+                print(f"     {dimmed(note)}")
+                for j, line in enumerate(lines):
+                    connector = "└" if j == len(lines) - 1 else "├"
+                    print(f"     {dimmed(connector)} {muted(line)}")
             elif (status_line := _usage_status_line(usage)) is not None:
                 print(f"     {dimmed(status_line)}")  # unavailable / rate-limited
             else:
@@ -1509,20 +1557,39 @@ class ClaudeAccountSwitcher:
                 # cswap must not refresh them) and merge into existing entries so
                 # other accounts' rows survive.
                 usage_cache_path = self.backup_dir / "cache" / "usage.json"
+                # Persisted backoff markers survive the freshness TTL until their
+                # Retry-After elapses, so `cswap --status` doesn't re-hit a
+                # rate-limited endpoint once the 60s cache expires (the gap that
+                # re-armed the "usage unavailable" loop on this path).
+                persisted = read_cache(usage_cache_path, float("inf"))
+                persisted = persisted if (persisted is not MISSING and isinstance(persisted, dict)) else {}
                 cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
                 if (cached is not MISSING and isinstance(cached, dict)
                         and account_num in cached):
                     usage = cached[account_num]
+                elif usage_backoff_active(persisted.get(account_num)):
+                    usage = persisted.get(account_num)  # honor the backoff, no refetch
                 else:
+                    fail: dict = {}
                     usage = oauth.fetch_usage_for_account(
                         account_num, current_email, creds,
-                        is_active=True,
+                        is_active=True, failure_out=fail,
                     )
-                    existing = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
+                    if usage is None and fail.get("retry_after"):
+                        marker = {"_unavailable": True, "retry_until": time.time() + fail["retry_after"]}
+                        usage = merge_last_known(marker, persisted.get(account_num))
+                    existing = dict(persisted)
                     existing[account_num] = usage
                     write_cache(usage_cache_path, existing)
-                status_line = _usage_status_line(usage)
-                if status_line is not None:
+                stale = _stale_usage_render(usage)
+                if stale is not None:
+                    # Backed off, but a recent last-known reading exists -> show it.
+                    note, lines = stale
+                    print(f"  {dimmed(note)}")
+                    for j, line in enumerate(lines):
+                        connector = "└" if j == len(lines) - 1 else "├"
+                        print(f"  {dimmed(connector)} {muted(line)}")
+                elif (status_line := _usage_status_line(usage)) is not None:
                     # None usage or a 429 backoff marker -> a clear line, never a
                     # blank one (a marker would otherwise format to nothing).
                     print(f"  {dimmed(status_line)}")
@@ -1617,27 +1684,40 @@ class ClaudeAccountSwitcher:
                 break
 
         usage_cache_path = self.backup_dir / "cache" / "usage.json"
+        # Persisted backoff markers (inf TTL) gate the refetch so a 429-backed-off
+        # active account isn't re-polled every call once the freshness cache lapses.
+        persisted = read_cache(usage_cache_path, float("inf"))
+        persisted = persisted if (persisted is not MISSING and isinstance(persisted, dict)) else {}
         usage = None
+        backed_off = False
         if account_num is not None:
             cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
             if (cached is not MISSING and isinstance(cached, dict)
                     and account_num in cached):
                 usage = cached[account_num]
+            elif usage_backoff_active(persisted.get(account_num)):
+                usage = persisted.get(account_num)  # honor the backoff, no refetch
+                backed_off = True
 
-        if usage is None:
+        if usage is None and not backed_off:
+            fail: dict = {}
             usage = oauth.fetch_usage_for_account(
-                account_num or "active", current_email, creds, is_active=True,
+                account_num or "active", current_email, creds,
+                is_active=True, failure_out=fail,
             )
+            if usage is None and fail.get("retry_after") and account_num is not None:
+                # Cache the backoff so the next poll honors it instead of re-hitting
+                # the rate-limited endpoint (the throttle gap on this path).
+                marker = {"_unavailable": True, "retry_until": time.time() + fail["retry_after"]}
+                usage = merge_last_known(marker, persisted.get(account_num))
             if account_num is not None and isinstance(usage, dict):
-                existing = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
-                existing = (
-                    existing
-                    if (existing is not MISSING and isinstance(existing, dict))
-                    else {}
-                )
+                existing = dict(persisted)
                 existing[account_num] = usage
                 write_cache(usage_cache_path, existing)
 
+        # A backoff/failure marker has no windows -> _max_usage_pct returns None
+        # (unknown), so the auto-switch monitor won't act on a stale guess — the
+        # session keeps running until a real limit, matching run-until-limit intent.
         return _max_usage_pct(usage)
 
     # ------------------------------------------------------------------ #

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import curses
 import sys
+import time
+from datetime import datetime
 from typing import Callable
 
 from claude_swap.exceptions import ClaudeSwitchError
@@ -26,6 +28,9 @@ from claude_swap.switcher import ClaudeAccountSwitcher
 # Minimum terminal size we render in. Below this, we bail to plain CLI advice.
 _MIN_ROWS = 12
 _MIN_COLS = 60
+
+# How often the auto-switch (Beta) monitor polls the active account's usage.
+_AUTO_POLL_SECONDS = 60
 
 
 def run(switcher: ClaudeAccountSwitcher) -> int:
@@ -66,6 +71,7 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
             ("Refresh credentials (current login, in-place)", "refresh"),
             ("List accounts (with usage)", "list"),
             ("Status", "status"),
+            ("Auto-switch at limit (Beta)", "auto"),
             ("Quit", "quit"),
         ]
         choice = _select_from(
@@ -90,6 +96,8 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
                 _shell_out(stdscr, lambda: switcher.list_accounts())
             elif choice == "status":
                 _shell_out(stdscr, switcher.status)
+            elif choice == "auto":
+                _do_auto_switch(stdscr, switcher)
         except ClaudeSwitchError as e:
             _show_message(stdscr, f"Error: {e}", is_error=True)
         except KeyboardInterrupt:
@@ -172,6 +180,174 @@ def _do_refresh(stdscr, switcher: ClaudeAccountSwitcher) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Auto-switch (Beta)
+# ---------------------------------------------------------------------------
+
+
+def _should_auto_switch(pct: float | None, threshold: int) -> bool:
+    """Whether the active account's usage warrants an automatic switch."""
+    return pct is not None and pct >= threshold
+
+
+def _do_auto_switch(stdscr, switcher: ClaudeAccountSwitcher) -> None:
+    """Settings + launcher for auto-switch (Beta).
+
+    Lets the user toggle automatic rotation to the next account when the active
+    account's 5h/7d usage reaches a threshold, tune that threshold, and start
+    the foreground monitor. Settings persist in ``sequence.json``.
+
+    No Claude Code restart is needed for the switch to take effect — on
+    Linux/Windows the new credentials are picked up on the next message, and on
+    macOS once the Keychain cache expires.
+    """
+    while True:
+        cfg = switcher.get_auto_switch_config()
+        state = "ON" if cfg["enabled"] else "OFF"
+        subtitle = (
+            f"Beta · currently {state} · threshold {cfg['threshold']}%  ·  "
+            "rotates to the next account at the limit"
+        )
+        items: list[tuple[str, str | None]] = [
+            ("Disable" if cfg["enabled"] else "Enable", "toggle"),
+            (f"Set threshold (now {cfg['threshold']}%)", "threshold"),
+            ("Start monitor now", "start"),
+            ("-- Back --", None),
+        ]
+        choice = _select_from(
+            stdscr,
+            "Auto-switch at limit (Beta)",
+            items=items,
+            subtitle=subtitle,
+        )
+        if choice is None:
+            return
+
+        if choice == "toggle":
+            switcher.set_auto_switch_config(enabled=not cfg["enabled"])
+        elif choice == "threshold":
+            raw = _prompt_text(stdscr, "Switch when usage reaches (%): ")
+            if raw:
+                try:
+                    switcher.set_auto_switch_config(threshold=int(raw))
+                except ValueError:
+                    _show_message(
+                        stdscr, "Threshold must be a whole number.", is_error=True
+                    )
+                except ClaudeSwitchError as e:
+                    _show_message(stdscr, f"Invalid threshold: {e}", is_error=True)
+        elif choice == "start":
+            cfg = switcher.get_auto_switch_config()
+            if not cfg["enabled"]:
+                # Starting the monitor implies enabling the feature.
+                cfg = switcher.set_auto_switch_config(enabled=True)
+            _run_auto_monitor(stdscr, switcher, cfg["threshold"])
+
+
+def _run_auto_monitor(
+    stdscr, switcher: ClaudeAccountSwitcher, threshold: int
+) -> None:
+    """Foreground watcher loop: poll active usage and switch at the threshold.
+
+    Polls every ``_AUTO_POLL_SECONDS`` (press ``s`` to check immediately,
+    ``q``/Esc to stop). When the active account reaches ``threshold``%, it
+    shells out to ``switcher.switch()`` to rotate to the next account, then
+    keeps watching the new active account.
+    """
+    curses.curs_set(0)
+    stdscr.timeout(1000)  # getch() returns -1 after ~1s, driving the countdown
+    last_pct: float | None = None
+    last_checked = "never"
+    message = "Monitoring started."
+    seconds_to_next = 0  # poll immediately on entry
+    try:
+        while True:
+            if seconds_to_next <= 0:
+                last_pct = switcher.get_active_usage_pct()
+                last_checked = datetime.now().strftime("%H:%M:%S")
+                seconds_to_next = _AUTO_POLL_SECONDS
+                if _should_auto_switch(last_pct, threshold):
+                    switched = _auto_perform_switch(stdscr, switcher)
+                    message = (
+                        f"Reached {last_pct:.0f}% — switched account."
+                        if switched
+                        else f"Reached {last_pct:.0f}% — switch failed (see above)."
+                    )
+                    # Re-read the new active account's usage on the next tick.
+                    last_pct = None
+                else:
+                    message = "Monitoring active account."
+
+            _draw_monitor(
+                stdscr, threshold, last_pct, last_checked, seconds_to_next, message
+            )
+            key = stdscr.getch()
+            if key in (27, ord("q"), ord("Q")):
+                return
+            if key in (ord("s"), ord("S")):
+                seconds_to_next = 0
+                continue
+            seconds_to_next -= 1
+    finally:
+        stdscr.timeout(-1)
+
+
+def _auto_perform_switch(stdscr, switcher: ClaudeAccountSwitcher) -> bool:
+    """Suspend curses, run ``switcher.switch()``, then resume. No Enter prompt."""
+    curses.def_prog_mode()
+    curses.endwin()
+    switched = True
+    try:
+        try:
+            switcher.switch()
+        except ClaudeSwitchError as e:
+            print(f"Auto-switch error: {e}")
+            switched = False
+        except KeyboardInterrupt:
+            print("\nOperation cancelled.")
+            switched = False
+        print()
+        time.sleep(2.5)  # brief pause so the output is readable
+    finally:
+        curses.reset_prog_mode()
+        stdscr.refresh()
+    return switched
+
+
+def _draw_monitor(
+    stdscr,
+    threshold: int,
+    pct: float | None,
+    last_checked: str,
+    seconds_to_next: int,
+    message: str,
+) -> None:
+    """Render the auto-switch monitor screen."""
+    stdscr.erase()
+    rows, cols = stdscr.getmaxyx()
+    _draw_header(
+        stdscr,
+        "Auto-switch monitor (Beta)",
+        f"threshold {threshold}%  ·  polling every {_AUTO_POLL_SECONDS}s",
+        cols,
+    )
+    pct_str = f"{pct:.0f}%" if pct is not None else "unavailable"
+    lines = [
+        f"Active account usage : {pct_str}",
+        f"Last checked         : {last_checked}",
+        f"Next check in        : {max(0, seconds_to_next)}s",
+        "",
+        message,
+    ]
+    for i, line in enumerate(lines):
+        if 4 + i >= rows - 2:
+            break
+        stdscr.addstr(4 + i, 2, line[: cols - 4])
+    footer = "[s] check now  [q/Esc] stop monitor"
+    stdscr.addstr(rows - 1, 2, footer[: cols - 4], curses.A_DIM)
+    stdscr.refresh()
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -187,7 +363,11 @@ def _status_line(switcher: ClaudeAccountSwitcher) -> str:
         email, org = identity
         tag = "personal" if not org else org[:8]
         active = f"{email} [{tag}]"
-    return f"Active: {active}  ·  {n} managed"
+    line = f"Active: {active}  ·  {n} managed"
+    cfg = switcher.get_auto_switch_config()
+    if cfg["enabled"]:
+        line += f"  ·  auto-switch ON ({cfg['threshold']}%)"
+    return line
 
 
 def _account_items(switcher: ClaudeAccountSwitcher) -> list[tuple[str, str]]:

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -561,8 +561,11 @@ def _account_block(
         header.append((" · cached", dim))
 
     # Tree children: usage windows (only those with data), then the session count.
-    if av.signal == "none":
-        children: list[list[Segment]] = [[("usage unavailable", muted)]]
+    if av.signal == "logged_out":
+        # A dead refresh token: actionable, distinct from a transient no-signal read.
+        children: list[list[Segment]] = [[("logged out — re-login", muted)]]
+    elif av.signal == "none":
+        children = [[("usage unavailable", muted)]]
     else:
         # Mirror ``_format_usage_lines``: render a window only when it has a
         # percentage. A 0% window with no reset is still data (a cold/unstarted

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -388,6 +388,7 @@ def _balancer_dashboard(stdscr, switcher: ClaudeAccountSwitcher) -> None:
     thread (the quit key stays responsive even when an account is slow/unreachable).
     """
     curses.curs_set(0)
+    _init_colors()
     stdscr.timeout(_DASH_TICK_MS)
     stop = threading.Event()
     worker = threading.Thread(
@@ -434,10 +435,10 @@ def _draw_dashboard(stdscr, switcher, sessions, acct_views) -> None:
 
     y = 4
     if not sessions:
-        stdscr.addstr(y, 2, "No active sessions. Start one with `cswap launch`."[: cols - 4])
+        _safe_addstr(stdscr, y, 2, "No active sessions. Start one with `cswap launch`."[: cols - 4])
         y += 2
     else:
-        stdscr.addstr(y, 2, "Sessions:"[: cols - 4], curses.A_BOLD)
+        _safe_addstr(stdscr, y, 2, "Sessions:"[: cols - 4], curses.A_BOLD)
         y += 1
         for i, e in enumerate(sessions):
             if y >= rows - 3:
@@ -454,26 +455,35 @@ def _draw_dashboard(stdscr, switcher, sessions, acct_views) -> None:
             else:
                 state_s = _ascii_bar(pct)
             line = f"  s{i + 1:<2} a{acct:<3} {state_s:<16} {_abbrev(e.get('cwd', ''))}"
-            stdscr.addstr(y, 2, line[: cols - 4])
+            _safe_addstr(stdscr, y, 2, line[: cols - 4])
             y += 1
         y += 1
 
     if acct_views and y < rows - 2:
-        header = "Accounts:  (usage% · resets-in, per 5h and 7d window)"
-        stdscr.addstr(y, 2, header[: cols - 4], curses.A_BOLD)
+        _safe_addstr(stdscr, y, 2, "Accounts:"[: cols - 4], curses.A_BOLD)
         y += 1
-        for num in sorted(acct_views, key=lambda n: (-acct_views[n].priority, _num_key(n))):
-            if y >= rows - 2:
-                break
-            av = acct_views[num]
-            stdscr.addstr(
-                y, 2,
-                _account_row(av, sess_by_account.get(num, 0), now, prime_on)[: cols - 4],
+        meta = _accounts_meta(switcher)
+        order = sorted(acct_views, key=lambda n: (-acct_views[n].priority, _num_key(n)))
+        for idx, num in enumerate(order):
+            email, tag, is_active = meta.get(num, (num, "", False))
+            block = _account_block(
+                acct_views[num], email, tag, is_active,
+                sess_by_account.get(num, 0), now, prime_on,
             )
-            y += 1
+            # Only start a block if the WHOLE thing fits — never paint a header
+            # with no tree rows beneath it (a dangling fragment `cswap --list`
+            # never shows). Lower-priority accounts that don't fit are dropped.
+            if y + len(block) > rows - 2:
+                break
+            for segments in block:
+                _draw_segments(stdscr, y, 2, segments, cols - 4)
+                y += 1
+            # Blank separator between account blocks (matches `cswap --list`).
+            if idx < len(order) - 1 and y < rows - 2:
+                y += 1
 
     footer = "[q/Esc] back  ·  refreshes automatically"
-    stdscr.addstr(rows - 1, 2, footer[: cols - 4], curses.A_DIM)
+    _safe_addstr(stdscr, rows - 1, 2, footer[: cols - 4], curses.A_DIM)
     stdscr.refresh()
 
 
@@ -482,46 +492,253 @@ def _num_key(num: str):
     return (0, int(num)) if str(num).isdigit() else (1, str(num))
 
 
-def _account_row(av, sess_count: int, now: float, show_warm: bool) -> str:
-    """One Accounts-section line: priority, session count, 5h + 7d usage/reset.
+Segment = tuple[str, int]  # (text, curses attribute)
 
-    Idle accounts (no live session) still render their cached/fetched usage, so
-    the view covers every account. ``signal == "none"`` means usage is unknown
-    (logged out or a failed read) — shown explicitly rather than as a fake 0%.
+
+def _accounts_meta(switcher) -> dict[str, tuple[str, str, bool]]:
+    """Map account number -> (email, org tag, is_active) for dashboard headers.
+
+    Mirrors ``list_accounts``' active detection (the ``(email, organizationUuid)``
+    composite key) so the dashboard marks the same account ``(active)`` as
+    ``cswap --list``. Pure-local reads only (no network); best-effort — any
+    failure yields an empty map and each header falls back to a bare number.
     """
-    head = f"  a{av.num:<3} P{av.priority:<2} {sess_count} sess"
+    try:
+        seq = switcher._get_sequence_data_migrated() or {}
+        accounts = seq.get("accounts", {})
+        identity = switcher._get_current_account()
+        active_email, active_uuid = identity if identity else (None, None)
+        meta: dict[str, tuple[str, str, bool]] = {}
+        for num, acc in accounts.items():
+            email = acc.get("email", "?")
+            org_name = acc.get("organizationName", "") or ""
+            org_uuid = acc.get("organizationUuid", "") or ""
+            tag = switcher._get_display_tag(email, org_name, org_uuid)
+            is_active = email == active_email and org_uuid == active_uuid
+            meta[str(num)] = (email, tag, is_active)
+        return meta
+    except Exception:  # noqa: BLE001 - headers are cosmetic; never break the dashboard
+        return {}
+
+
+def _account_block(
+    av,
+    email: str,
+    tag: str,
+    is_active: bool,
+    sess_count: int,
+    now: float,
+    show_warm: bool,
+) -> list[list[Segment]]:
+    """Render one account as a ``cswap --list``-style block of styled rows.
+
+    Returns a list of rows, each a list of ``(text, attribute)`` segments, so the
+    caller paints per-segment styling. The layout mirrors
+    ``switcher._format_usage_lines`` / ``list_accounts`` — an identity header
+    (``num: email [tag] (active) · pri N``) over a tree of the 5h and 7d windows
+    (usage% · reset clock · countdown) — with the live session count added as the
+    final tree row (the dashboard-specific third row). Idle accounts still render
+    their cached usage; ``signal == "none"`` (logged out / failed read) shows
+    ``usage unavailable`` rather than a fake 0%.
+    """
+    dim = _sty("dim")
+    muted = _sty("muted")
+
+    header: list[Segment] = [
+        (f"{av.num}: ", _sty("accent")),
+        (email or "?", _sty("bold")),
+    ]
+    if tag:
+        header.append((f" [{tag}]", muted))
+    if is_active:
+        header.append((" (active)", _sty("accent")))
+    if av.priority:
+        header.append((f" · pri {av.priority}", dim))
+
+    # Tree children: usage windows (only those with data), then the session count.
     if av.signal == "none":
-        return f"{head}  usage unavailable"
-    # Fixed-width reset field so the 7d column lines up across rows regardless of
-    # whether a window shows a countdown or "(no reset)".
-    h5 = f"5h {_fmt_pct(av.five_hour_pct)} {_fmt_reset(av.five_hour_reset, now):<14}"
-    d7 = f"7d {_fmt_pct(av.seven_day_pct)} {_fmt_reset(av.seven_day_reset, now):<14}"
-    row = f"{head}  {h5} {d7}"
+        children: list[list[Segment]] = [[("usage unavailable", muted)]]
+    else:
+        # Mirror ``_format_usage_lines``: render a window only when it has a
+        # percentage. A 0% window with no reset is still data (a cold/unstarted
+        # 5h window -> "not started"); a ``None`` pct is *absent* data and is
+        # omitted, exactly as ``cswap --list`` omits the missing window.
+        children = []
+        if av.five_hour_pct is not None:
+            children.append(_usage_row("5h", av.five_hour_pct, av.five_hour_reset, now, muted))
+        if av.seven_day_pct is not None:
+            children.append(_usage_row("7d", av.seven_day_pct, av.seven_day_reset, now, muted))
+
+    sess_seg: list[Segment] = [
+        (f"{sess_count} session{'' if sess_count == 1 else 's'}", _sty("normal")),
+    ]
+    # Warm/cold reflects the 5h window state. ``five_hour_warm`` is tri-state;
+    # ``None`` means unknown 5h usage (logged out, or a signal carrying no 5h
+    # pct), which we leave unannotated rather than print a meaningless bare "?".
     if show_warm:
         warm = balancer.five_hour_warm(av)
-        row += f" {'warm' if warm else 'cold' if warm is False else '?'}"
-    return row
+        if warm is not None:
+            sess_seg.append((f"  · {'warm' if warm else 'cold'}", dim))
+    children.append(sess_seg)
+
+    rows: list[list[Segment]] = [header]
+    for i, child in enumerate(children):
+        connector = "└" if i == len(children) - 1 else "├"
+        rows.append([(f"   {connector} ", dim), *child])
+    return rows
+
+
+def _usage_row(
+    label: str, pct: float | None, reset: int | None, now: float, attr: int
+) -> list[Segment]:
+    """One window row's segments: ``5h:  27%   resets 21:09         in 2h 58m``."""
+    text = f"{label}: {_fmt_pct(pct)}"
+    clause = _reset_clause(reset, now)
+    if clause:
+        text += f"   {clause}"
+    return [(text, attr)]
 
 
 def _fmt_pct(pct: float | None) -> str:
     return f"{pct:3.0f}%" if isinstance(pct, (int, float)) else "  — "
 
 
-def _fmt_reset(reset: int | None, now: float) -> str:
-    """``(resets 2h13m)`` / ``(resets 4d05h)`` for a future reset.
+def _reset_clause(reset: int | None, now: float) -> str:
+    """``cswap --list``-style reset clause for a window's reset epoch.
 
-    ``(no reset)`` means the window has no clock running (unstarted/cold — what
-    ``balancer.five_hour_warm`` reports as cold), reserved for ``reset is None``.
-    A reset epoch that has just elapsed (the window is rolling over but the ~15s
-    usage cache hasn't refreshed yet) reads ``(resetting)`` rather than
-    ``(no reset)``, so the 5h column can't contradict a ``warm`` token derived
-    from the same still-present reset timestamp.
+    A future reset reads ``resets 21:09         in 2h 58m`` — local wall-clock
+    time plus a countdown, matching ``oauth.format_reset``'s wording and column
+    widths so the dashboard and plain ``--list`` align. ``reset is None`` is an
+    unstarted/cold 5h window (what ``balancer.five_hour_warm`` reports as cold)
+    -> ``not started``; an already-elapsed epoch is a window rolling over before
+    the usage cache refreshes -> ``resetting`` (never ``not started``, so the row
+    can't contradict a ``warm`` token derived from the same timestamp). Anchored
+    to the passed ``now`` (not wall-clock) so rendering stays deterministic.
     """
     if not isinstance(reset, (int, float)):
-        return "(no reset)"
+        return "not started"
     if reset <= now:
-        return "(resetting)"
-    return f"(resets {_short_countdown(reset - now)})"
+        return "resetting"
+    return f"resets {_reset_clock(int(reset), now):<12}  in {_list_countdown(reset - now)}"
+
+
+def _reset_clock(reset: int, now: float) -> str:
+    """Local clock for a reset epoch: ``21:09`` today, ``Jun 18 05:59`` otherwise.
+
+    Mirrors ``oauth.format_reset``'s clock format but anchored to the passed
+    ``now`` rather than wall-clock, keeping the dashboard deterministic.
+    """
+    from datetime import datetime
+
+    reset_dt = datetime.fromtimestamp(reset)
+    now_dt = datetime.fromtimestamp(now)
+    if reset_dt.date() == now_dt.date():
+        return reset_dt.strftime("%H:%M")
+    return reset_dt.strftime(f"%b {reset_dt.day} %H:%M")
+
+
+def _list_countdown(secs: float) -> str:
+    """``cswap --list``-style countdown: ``2d 11h`` / ``2h 58m`` / ``42m``.
+
+    Matches ``oauth.format_reset``'s spacing (distinct from :func:`_short_countdown`,
+    which is the compact, space-free ``2h58m`` used in the Sessions section).
+    """
+    secs = max(0, int(secs))
+    days, rem = divmod(secs, 86400)
+    hours, rem = divmod(rem, 3600)
+    mins = rem // 60
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {mins}m"
+    return f"{mins}m"
+
+
+def _safe_addstr(stdscr, y: int, x: int, s: str, attr: int = 0) -> None:
+    """``addstr`` that swallows ``curses.error``.
+
+    The dashboard re-renders on a 2s timer, so a terminal resized below the
+    minimum size *after* entry would otherwise let an out-of-bounds write raise
+    out of the render loop and crash the TUI. Used for the dashboard's header /
+    section / footer lines (the per-account rows already go through the equally
+    guarded :func:`_draw_segments`).
+    """
+    try:
+        stdscr.addstr(y, x, s, attr)
+    except curses.error:
+        pass
+
+
+def _draw_segments(stdscr, y: int, x: int, segments: list[Segment], maxw: int) -> None:
+    """Paint ``(text, attr)`` segments left-to-right on row ``y``, clipped to ``maxw``.
+
+    Lets one rendered line carry several styles (a bold header next to a dim tag)
+    without the caller juggling column math. Each ``addstr`` is guarded so a stray
+    ``curses.error`` at a screen edge can never crash the dashboard loop.
+    """
+    cur = x
+    budget = maxw
+    for text, attr in segments:
+        if budget <= 0:
+            break
+        chunk = text[:budget]
+        if chunk:
+            try:
+                stdscr.addstr(y, cur, chunk, attr)
+            except curses.error:
+                pass
+            cur += len(chunk)
+            budget -= len(chunk)
+
+
+# Color attributes resolved once inside curses (best-effort). 0 means "not set",
+# so :func:`_sty` falls back to a monochrome attribute — the dashboard renders
+# fine without 256-color support and stays deterministic under test (where the
+# curses screen, and thus colors, are never initialized).
+_C_ACCENT = 0
+_C_MUTED = 0
+
+
+def _init_colors() -> None:
+    """Set up the dashboard's accent/muted color pairs if the terminal supports them.
+
+    Mirrors ``printer.py``'s palette (warm salmon accent #173, soft gray #250) so
+    the in-curses dashboard reads like the ANSI ``cswap --list`` output. Purely
+    cosmetic and fully guarded: any failure (no color, no 256-color, no
+    default-bg support) leaves the globals at 0 and the UI falls back to
+    bold/dim attributes.
+    """
+    global _C_ACCENT, _C_MUTED
+    try:
+        if not curses.has_colors():
+            return
+        curses.start_color()
+        try:
+            curses.use_default_colors()
+            bg = -1
+        except curses.error:
+            bg = 0
+        if curses.COLORS >= 256:
+            curses.init_pair(1, 173, bg)
+            curses.init_pair(2, 250, bg)
+            _C_ACCENT = curses.color_pair(1)
+            _C_MUTED = curses.color_pair(2)
+    except Exception:  # noqa: BLE001 - color is cosmetic; never break the dashboard
+        pass
+
+
+def _sty(kind: str) -> int:
+    """Curses attribute for a style role, with a monochrome fallback when color
+    isn't available: ``accent`` -> salmon+bold / bold, ``muted`` -> gray / dim."""
+    if kind == "accent":
+        return (_C_ACCENT | curses.A_BOLD) if _C_ACCENT else curses.A_BOLD
+    if kind == "muted":
+        return _C_MUTED or curses.A_DIM
+    if kind == "dim":
+        return curses.A_DIM
+    if kind == "bold":
+        return curses.A_BOLD
+    return curses.A_NORMAL
 
 
 def _ascii_bar(pct: float | None, width: int = 8) -> str:
@@ -704,9 +921,9 @@ def _show_message(stdscr, msg: str, is_error: bool = False) -> None:
 
 
 def _draw_header(stdscr, title: str, subtitle: str, cols: int) -> None:
-    stdscr.addstr(1, 2, title[: cols - 4], curses.A_BOLD)
+    _safe_addstr(stdscr, 1, 2, title[: max(0, cols - 4)], curses.A_BOLD)
     if subtitle:
-        stdscr.addstr(2, 2, subtitle[: cols - 4], curses.A_DIM)
+        _safe_addstr(stdscr, 2, 2, subtitle[: max(0, cols - 4)], curses.A_DIM)
 
 
 def _shell_out(stdscr, fn: Callable[[], None]) -> None:

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -22,7 +22,7 @@ from typing import Callable
 
 from claude_swap import registry
 from claude_swap.exceptions import ClaudeSwitchError
-from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.switcher import DEFAULT_QUICK_START_COMMAND, ClaudeAccountSwitcher
 
 
 # Minimum terminal size we render in. Below this, we bail to plain CLI advice.
@@ -69,6 +69,7 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
             ("List accounts (with usage)", "list"),
             ("Status", "status"),
             ("Auto-swap + multi-session load balancer (beta)", "balance"),
+            ("Quick start (default `cswap` command)", "quickstart"),
             ("Quit", "quit"),
         ]
         choice = _select_from(
@@ -95,6 +96,8 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
                 _shell_out(stdscr, switcher.status)
             elif choice == "balance":
                 _do_balancer(stdscr, switcher)
+            elif choice == "quickstart":
+                _do_quick_start(stdscr, switcher)
         except ClaudeSwitchError as e:
             _show_message(stdscr, f"Error: {e}", is_error=True)
         except KeyboardInterrupt:
@@ -224,7 +227,7 @@ def _do_balancer(stdscr, switcher: ClaudeAccountSwitcher) -> None:
             ("Disable" if cfg["enabled"] else "Enable", "toggle"),
             (f"Set threshold (now {cfg['threshold']}%)", "threshold"),
             (f"Set target safety (now {cfg['targetSafety']}%)", "target"),
-            (f"Prime idle 5h windows: {prime_state} (spends credits)", "prime"),
+            (f"Keep 5h sessions warm (spends a very small amount of credits): {prime_state}", "prime"),
             ("Edit account priorities", "priorities"),
             ("Live dashboard", "dashboard"),
             ("-- Back --", None),
@@ -302,6 +305,42 @@ def _edit_priorities(stdscr, switcher: ClaudeAccountSwitcher) -> None:
             _show_message(stdscr, "Priority must be a whole number.", is_error=True)
         except ClaudeSwitchError as e:
             _show_message(stdscr, f"Error: {e}", is_error=True)
+
+
+def _do_quick_start(stdscr, switcher: ClaudeAccountSwitcher) -> None:
+    """Configure Quick start: the default command a bare ``cswap`` runs.
+
+    Default OFF. When on, running ``cswap`` with no recognized subcommand/flag
+    runs the configured command (extra args appended), like a configurable alias.
+    """
+    while True:
+        cfg = switcher.get_quick_start_config()
+        state = "ON" if cfg["enabled"] else "OFF"
+        items: list[tuple[str, str | None]] = [
+            ("Disable" if cfg["enabled"] else "Enable", "toggle"),
+            ("Edit command", "edit"),
+            ("Reset command to default", "reset"),
+            ("-- Back --", None),
+        ]
+        choice = _select_from(
+            stdscr,
+            "Quick start",
+            items=items,
+            subtitle=f"{state} · runs on bare `cswap` · {cfg['command']}",
+        )
+        if choice is None:
+            return
+        if choice == "toggle":
+            switcher.set_quick_start_config(enabled=not cfg["enabled"])
+        elif choice == "edit":
+            raw = _prompt_text(stdscr, "Quick-start command: ")
+            if raw:
+                try:
+                    switcher.set_quick_start_config(command=raw)
+                except ClaudeSwitchError as e:
+                    _show_message(stdscr, f"Invalid command: {e}", is_error=True)
+        elif choice == "reset":
+            switcher.set_quick_start_config(command=DEFAULT_QUICK_START_COMMAND)
 
 
 def _balancer_dashboard(stdscr, switcher: ClaudeAccountSwitcher) -> None:

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -554,6 +554,11 @@ def _account_block(
         header.append((" (active)", _sty("accent")))
     if av.priority:
         header.append((f" · pri {av.priority}", dim))
+    # An optimistic stale view: the usage endpoint is backed off, so these numbers
+    # are the last-known reading (possibly out of date), not a live signal. Flag it
+    # so the percentages aren't mistaken for current.
+    if av.signal == "stale":
+        header.append((" · cached", dim))
 
     # Tree children: usage windows (only those with data), then the session count.
     if av.signal == "none":

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 
 import curses
 import sys
+import threading
 import time
 from typing import Callable
 
-from claude_swap import registry
+from claude_swap import balancer, registry
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.switcher import DEFAULT_QUICK_START_COMMAND, ClaudeAccountSwitcher
 
@@ -343,25 +344,60 @@ def _do_quick_start(stdscr, switcher: ClaudeAccountSwitcher) -> None:
             switcher.set_quick_start_config(command=DEFAULT_QUICK_START_COMMAND)
 
 
+# How often the background worker refreshes idle-account usage into the shared
+# cache. The UI thread itself never fetches (it would block on network I/O and
+# freeze the quit key); it only ever reads the worker-warmed cache + live signals.
+_IDLE_REFRESH_S = 15
+_DASH_TICK_MS = 2000
+
+
+def _idle_usage_refresher(switcher: ClaudeAccountSwitcher, stop: threading.Event) -> None:
+    """Background worker that keeps the shared usage cache warm for the dashboard.
+
+    Each pass calls ``build_world(fetch_idle=True)``, which fetches every idle
+    (no live session) account's usage on a cache miss and writes it into the 15s
+    usage cache the UI loop reads. Runs OFF the curses thread so the (per-account,
+    possibly-slow) network reads never block rendering or the quit key. Best-effort
+    — a failed pass is swallowed and retried next cycle; exits when ``stop`` is set.
+    """
+    while not stop.is_set():
+        try:
+            reg = registry.read_registry(switcher)
+            registry.build_world(switcher, reg, fetch_idle=True)
+        except Exception:  # noqa: BLE001 - usage is best-effort; keep the worker alive
+            switcher._logger.debug("dashboard idle-usage refresh failed", exc_info=True)
+        stop.wait(_IDLE_REFRESH_S)
+
+
 def _balancer_dashboard(stdscr, switcher: ClaudeAccountSwitcher) -> None:
     """Read-only live view of managed sessions and accounts (event-driven).
 
     Refreshes on a timer for liveness; performs NO migrations (the supervisors
-    do). Idle-account usage is shown only from the shared cache — no network in
-    the UI loop — so the view stays snappy.
+    do). Idle-account usage (for accounts not hosting a live session) is fetched
+    by a background worker that warms the shared usage cache, so every account
+    shows its 5h/weekly consumption without the network read ever blocking the UI
+    thread (the quit key stays responsive even when an account is slow/unreachable).
     """
     curses.curs_set(0)
-    stdscr.timeout(2000)
+    stdscr.timeout(_DASH_TICK_MS)
+    stop = threading.Event()
+    worker = threading.Thread(
+        target=_idle_usage_refresher, args=(switcher, stop), daemon=True
+    )
+    worker.start()
     try:
         while True:
             reg = registry.read_registry(switcher)
             sessions = registry.live_sessions(reg)
+            # UI thread NEVER hits the network — it reads the worker-warmed cache
+            # and live session signals only, so rendering can't stall.
             acct_views, _ = registry.build_world(switcher, reg, fetch_idle=False)
             _draw_dashboard(stdscr, switcher, sessions, acct_views)
             key = stdscr.getch()
             if key in (27, ord("q"), ord("Q")):
                 return
     finally:
+        stop.set()
         stdscr.timeout(-1)
 
 
@@ -370,20 +406,30 @@ def _draw_dashboard(stdscr, switcher, sessions, acct_views) -> None:
     rows, cols = stdscr.getmaxyx()
     cfg = switcher.get_auto_balance_config()
     state = "ON" if cfg["enabled"] else "OFF"
+    prime_on = bool(cfg.get("primeIdleWindows"))
+    now = time.time()
     _draw_header(
         stdscr,
         "Auto-swap + multi-session load balancer — dashboard (beta)",
-        f"{state} · threshold {cfg['threshold']}% · {len(sessions)} managed session(s)",
+        f"{state} · threshold {cfg['threshold']}% · {len(sessions)} session(s) · "
+        f"warming {'ON' if prime_on else 'OFF'}",
         cols,
     )
+
+    # How many live sessions are pinned to each account (shown per account, so
+    # even idle accounts read as "0 sess").
+    sess_by_account: dict[str, int] = {}
+    for e in sessions:
+        acct = str(e.get("account_num", ""))
+        sess_by_account[acct] = sess_by_account.get(acct, 0) + 1
+
     y = 4
     if not sessions:
-        stdscr.addstr(y, 2, "No managed sessions. Start one with `cswap launch`."[: cols - 4])
+        stdscr.addstr(y, 2, "No active sessions. Start one with `cswap launch`."[: cols - 4])
         y += 2
     else:
         stdscr.addstr(y, 2, "Sessions:"[: cols - 4], curses.A_BOLD)
         y += 1
-        now = time.time()
         for i, e in enumerate(sessions):
             if y >= rows - 3:
                 break
@@ -404,19 +450,69 @@ def _draw_dashboard(stdscr, switcher, sessions, acct_views) -> None:
         y += 1
 
     if acct_views and y < rows - 2:
-        stdscr.addstr(y, 2, "Accounts:"[: cols - 4], curses.A_BOLD)
+        header = "Accounts:  (usage% · resets-in, per 5h and 7d window)"
+        stdscr.addstr(y, 2, header[: cols - 4], curses.A_BOLD)
         y += 1
-        for num in sorted(acct_views, key=lambda n: (-acct_views[n].priority, n)):
+        for num in sorted(acct_views, key=lambda n: (-acct_views[n].priority, _num_key(n))):
             if y >= rows - 2:
                 break
             av = acct_views[num]
-            pct_s = f"{av.max_pct:.0f}%" if av.max_pct is not None else "  —"
-            stdscr.addstr(y, 2, f"  a{num:<3} pri {av.priority:<3} {pct_s:>5}"[: cols - 4])
+            stdscr.addstr(
+                y, 2,
+                _account_row(av, sess_by_account.get(num, 0), now, prime_on)[: cols - 4],
+            )
             y += 1
 
     footer = "[q/Esc] back  ·  refreshes automatically"
     stdscr.addstr(rows - 1, 2, footer[: cols - 4], curses.A_DIM)
     stdscr.refresh()
+
+
+def _num_key(num: str):
+    """Order numeric account ids numerically, others lexically (stable display)."""
+    return (0, int(num)) if str(num).isdigit() else (1, str(num))
+
+
+def _account_row(av, sess_count: int, now: float, show_warm: bool) -> str:
+    """One Accounts-section line: priority, session count, 5h + 7d usage/reset.
+
+    Idle accounts (no live session) still render their cached/fetched usage, so
+    the view covers every account. ``signal == "none"`` means usage is unknown
+    (logged out or a failed read) — shown explicitly rather than as a fake 0%.
+    """
+    head = f"  a{av.num:<3} P{av.priority:<2} {sess_count} sess"
+    if av.signal == "none":
+        return f"{head}  usage unavailable"
+    # Fixed-width reset field so the 7d column lines up across rows regardless of
+    # whether a window shows a countdown or "(no reset)".
+    h5 = f"5h {_fmt_pct(av.five_hour_pct)} {_fmt_reset(av.five_hour_reset, now):<14}"
+    d7 = f"7d {_fmt_pct(av.seven_day_pct)} {_fmt_reset(av.seven_day_reset, now):<14}"
+    row = f"{head}  {h5} {d7}"
+    if show_warm:
+        warm = balancer.five_hour_warm(av)
+        row += f" {'warm' if warm else 'cold' if warm is False else '?'}"
+    return row
+
+
+def _fmt_pct(pct: float | None) -> str:
+    return f"{pct:3.0f}%" if isinstance(pct, (int, float)) else "  — "
+
+
+def _fmt_reset(reset: int | None, now: float) -> str:
+    """``(resets 2h13m)`` / ``(resets 4d05h)`` for a future reset.
+
+    ``(no reset)`` means the window has no clock running (unstarted/cold — what
+    ``balancer.five_hour_warm`` reports as cold), reserved for ``reset is None``.
+    A reset epoch that has just elapsed (the window is rolling over but the ~15s
+    usage cache hasn't refreshed yet) reads ``(resetting)`` rather than
+    ``(no reset)``, so the 5h column can't contradict a ``warm`` token derived
+    from the same still-present reset timestamp.
+    """
+    if not isinstance(reset, (int, float)):
+        return "(no reset)"
+    if reset <= now:
+        return "(resetting)"
+    return f"(resets {_short_countdown(reset - now)})"
 
 
 def _ascii_bar(pct: float | None, width: int = 8) -> str:
@@ -427,9 +523,14 @@ def _ascii_bar(pct: float | None, width: int = 8) -> str:
 
 
 def _short_countdown(secs: float) -> str:
+    """Compact countdown: ``4d05h`` for multi-day (weekly) resets, ``2h13m`` for
+    hours, ``42m`` under an hour."""
     secs = max(0, int(secs))
-    hours, rem = divmod(secs, 3600)
+    days, rem = divmod(secs, 86400)
+    hours, rem = divmod(rem, 3600)
     mins = rem // 60
+    if days:
+        return f"{days}d{hours:02d}h"
     return f"{hours}h{mins:02d}m" if hours else f"{mins}m"
 
 

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -224,10 +224,12 @@ def _do_balancer(stdscr, switcher: ClaudeAccountSwitcher) -> None:
             f"target {cfg['targetSafety']}%"
         )
         prime_state = "ON" if cfg.get("primeIdleWindows") else "OFF"
+        sub_only_state = "ON" if cfg.get("onlySubscriptionTokens", True) else "OFF"
         items: list[tuple[str, str | None]] = [
             ("Disable" if cfg["enabled"] else "Enable", "toggle"),
             (f"Set threshold (now {cfg['threshold']}%)", "threshold"),
             (f"Set target safety (now {cfg['targetSafety']}%)", "target"),
+            (f"Only use subscription tokens (pause rather than bill at API rates): {sub_only_state}", "sub_only"),
             (f"Keep 5h sessions warm (spends a very small amount of credits): {prime_state}", "prime"),
             ("Edit account priorities", "priorities"),
             ("Live dashboard", "dashboard"),
@@ -247,6 +249,13 @@ def _do_balancer(stdscr, switcher: ClaudeAccountSwitcher) -> None:
             _set_balance_int(stdscr, switcher, "threshold", "Migrate when usage reaches (%): ")
         elif choice == "target":
             _set_balance_int(stdscr, switcher, "target_safety", "Target safety ceiling (%): ")
+        elif choice == "sub_only":
+            # Default-ON cost guard: when on, a session pauses once every
+            # subscription account is exhausted instead of spilling into
+            # pay-as-you-go extra-usage / an API account. Off => API-rate tier.
+            switcher.set_auto_balance_config(
+                only_subscription_tokens=not cfg.get("onlySubscriptionTokens", True)
+            )
         elif choice == "prime":
             # Default-OFF, credit-spending opt-in (feature #3): toggle the
             # dedicated primeIdleWindows flag, independent of the balancer enable.

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 import curses
 import sys
 import time
-from datetime import datetime
 from typing import Callable
 
+from claude_swap import registry
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.switcher import ClaudeAccountSwitcher
 
@@ -28,9 +28,6 @@ from claude_swap.switcher import ClaudeAccountSwitcher
 # Minimum terminal size we render in. Below this, we bail to plain CLI advice.
 _MIN_ROWS = 12
 _MIN_COLS = 60
-
-# How often the auto-switch (Beta) monitor polls the active account's usage.
-_AUTO_POLL_SECONDS = 60
 
 
 def run(switcher: ClaudeAccountSwitcher) -> int:
@@ -71,7 +68,7 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
             ("Refresh credentials (current login, in-place)", "refresh"),
             ("List accounts (with usage)", "list"),
             ("Status", "status"),
-            ("Auto-switch at limit (Beta)", "auto"),
+            ("Load balancer (Beta)", "balance"),
             ("Quit", "quit"),
         ]
         choice = _select_from(
@@ -96,8 +93,8 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
                 _shell_out(stdscr, lambda: switcher.list_accounts())
             elif choice == "status":
                 _shell_out(stdscr, switcher.status)
-            elif choice == "auto":
-                _do_auto_switch(stdscr, switcher)
+            elif choice == "balance":
+                _do_balancer(stdscr, switcher)
         except ClaudeSwitchError as e:
             _show_message(stdscr, f"Error: {e}", is_error=True)
         except KeyboardInterrupt:
@@ -180,171 +177,217 @@ def _do_refresh(stdscr, switcher: ClaudeAccountSwitcher) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Auto-switch (Beta)
+# Load balancer (Beta)
 # ---------------------------------------------------------------------------
 
 
-def _should_auto_switch(pct: float | None, threshold: int) -> bool:
-    """Whether the active account's usage warrants an automatic switch."""
-    return pct is not None and pct >= threshold
+def run_balance(switcher: ClaudeAccountSwitcher) -> int:
+    """Entry point for ``cswap --balance``. Opens the balancer page directly."""
+    try:
+        return curses.wrapper(_balance_entry, switcher)
+    except _ExitRequested:
+        return 0
 
 
-def _do_auto_switch(stdscr, switcher: ClaudeAccountSwitcher) -> None:
-    """Settings + launcher for auto-switch (Beta).
+def _balance_entry(stdscr, switcher: ClaudeAccountSwitcher) -> int:
+    rows, cols = stdscr.getmaxyx()
+    if rows < _MIN_ROWS or cols < _MIN_COLS:
+        curses.endwin()
+        sys.stderr.write(
+            f"Terminal too small ({rows}x{cols}, need at least "
+            f"{_MIN_ROWS}x{_MIN_COLS}).\n"
+        )
+        return 2
+    curses.curs_set(0)
+    _do_balancer(stdscr, switcher)
+    return 0
 
-    Lets the user toggle automatic rotation to the next account when the active
-    account's 5h/7d usage reaches a threshold, tune that threshold, and start
-    the foreground monitor. Settings persist in ``sequence.json``.
 
-    No Claude Code restart is needed for the switch to take effect — on
-    Linux/Windows the new credentials are picked up on the next message, and on
-    macOS once the Keychain cache expires.
+def _do_balancer(stdscr, switcher: ClaudeAccountSwitcher) -> None:
+    """Settings + live dashboard for the event-driven load balancer (Beta).
+
+    The balancer is driven entirely by each managed session's statusline — there
+    is no polling loop and no daemon. When an account crosses the threshold, its
+    sessions migrate to a higher-priority account with headroom, or pause until
+    the limit resets. This page only configures it and shows a read-only view;
+    it never performs migrations itself (the per-session supervisors do).
     """
     while True:
-        cfg = switcher.get_auto_switch_config()
+        cfg = switcher.get_auto_balance_config()
         state = "ON" if cfg["enabled"] else "OFF"
         subtitle = (
-            f"Beta · currently {state} · threshold {cfg['threshold']}%  ·  "
-            "rotates to the next account at the limit"
+            f"Beta · {state} · threshold {cfg['threshold']}% · "
+            f"target {cfg['targetSafety']}% · cooldown {cfg['cooldownSeconds']}s"
         )
         items: list[tuple[str, str | None]] = [
             ("Disable" if cfg["enabled"] else "Enable", "toggle"),
             (f"Set threshold (now {cfg['threshold']}%)", "threshold"),
-            ("Start monitor now", "start"),
+            (f"Set target safety (now {cfg['targetSafety']}%)", "target"),
+            (f"Set cooldown (now {cfg['cooldownSeconds']}s)", "cooldown"),
+            ("Edit account priorities", "priorities"),
+            ("Live dashboard", "dashboard"),
             ("-- Back --", None),
         ]
         choice = _select_from(
-            stdscr,
-            "Auto-switch at limit (Beta)",
-            items=items,
-            subtitle=subtitle,
+            stdscr, "Load balancer (Beta)", items=items, subtitle=subtitle
         )
         if choice is None:
             return
-
         if choice == "toggle":
-            switcher.set_auto_switch_config(enabled=not cfg["enabled"])
+            switcher.set_auto_balance_config(enabled=not cfg["enabled"])
         elif choice == "threshold":
-            raw = _prompt_text(stdscr, "Switch when usage reaches (%): ")
-            if raw:
-                try:
-                    switcher.set_auto_switch_config(threshold=int(raw))
-                except ValueError:
-                    _show_message(
-                        stdscr, "Threshold must be a whole number.", is_error=True
-                    )
-                except ClaudeSwitchError as e:
-                    _show_message(stdscr, f"Invalid threshold: {e}", is_error=True)
-        elif choice == "start":
-            cfg = switcher.get_auto_switch_config()
-            if not cfg["enabled"]:
-                # Starting the monitor implies enabling the feature.
-                cfg = switcher.set_auto_switch_config(enabled=True)
-            _run_auto_monitor(stdscr, switcher, cfg["threshold"])
+            _set_balance_int(stdscr, switcher, "threshold", "Migrate when usage reaches (%): ")
+        elif choice == "target":
+            _set_balance_int(stdscr, switcher, "target_safety", "Target safety ceiling (%): ")
+        elif choice == "cooldown":
+            _set_balance_int(stdscr, switcher, "cooldown_seconds", "Min seconds between migrations: ")
+        elif choice == "priorities":
+            _edit_priorities(stdscr, switcher)
+        elif choice == "dashboard":
+            _balancer_dashboard(stdscr, switcher)
 
 
-def _run_auto_monitor(
-    stdscr, switcher: ClaudeAccountSwitcher, threshold: int
-) -> None:
-    """Foreground watcher loop: poll active usage and switch at the threshold.
+def _set_balance_int(stdscr, switcher: ClaudeAccountSwitcher, field: str, label: str) -> None:
+    raw = _prompt_text(stdscr, label)
+    if not raw:
+        return
+    try:
+        value = int(raw)
+    except ValueError:
+        _show_message(stdscr, "Please enter a whole number.", is_error=True)
+        return
+    try:
+        switcher.set_auto_balance_config(**{field: value})
+    except ClaudeSwitchError as e:
+        _show_message(stdscr, f"Invalid value: {e}", is_error=True)
 
-    Polls every ``_AUTO_POLL_SECONDS`` (press ``s`` to check immediately,
-    ``q``/Esc to stop). When the active account reaches ``threshold``%, it
-    shells out to ``switcher.switch()`` to rotate to the next account, then
-    keeps watching the new active account.
+
+def _edit_priorities(stdscr, switcher: ClaudeAccountSwitcher) -> None:
+    """Set per-account balancing priority (higher = burned through first)."""
+    while True:
+        seq = switcher._get_sequence_data_migrated() or {}
+        accounts = seq.get("accounts", {})
+        if not accounts:
+            _show_message(stdscr, "No managed accounts.")
+            return
+        items: list[tuple[str, str | None]] = []
+        for num in sorted(seq.get("sequence", []), key=int):
+            acc = accounts.get(str(num), {})
+            email = acc.get("email", "?")
+            pri = switcher.get_account_priority(str(num))
+            items.append((f"{num}  {email:<28.28}  priority {pri}", str(num)))
+        items.append(("-- Back --", None))
+        choice = _select_from(
+            stdscr,
+            "Edit priorities — pick an account",
+            items=items,
+            subtitle="Higher priority is burned through first",
+        )
+        if choice is None:
+            return
+        raw = _prompt_text(stdscr, f"New priority for account {choice}: ")
+        if not raw:
+            continue
+        try:
+            switcher.set_account_priority(choice, int(raw))
+        except ValueError:
+            _show_message(stdscr, "Priority must be a whole number.", is_error=True)
+        except ClaudeSwitchError as e:
+            _show_message(stdscr, f"Error: {e}", is_error=True)
+
+
+def _balancer_dashboard(stdscr, switcher: ClaudeAccountSwitcher) -> None:
+    """Read-only live view of managed sessions and accounts (event-driven).
+
+    Refreshes on a timer for liveness; performs NO migrations (the supervisors
+    do). Idle-account usage is shown only from the shared cache — no network in
+    the UI loop — so the view stays snappy.
     """
     curses.curs_set(0)
-    stdscr.timeout(1000)  # getch() returns -1 after ~1s, driving the countdown
-    last_pct: float | None = None
-    last_checked = "never"
-    message = "Monitoring started."
-    seconds_to_next = 0  # poll immediately on entry
+    stdscr.timeout(2000)
     try:
         while True:
-            if seconds_to_next <= 0:
-                last_pct = switcher.get_active_usage_pct()
-                last_checked = datetime.now().strftime("%H:%M:%S")
-                seconds_to_next = _AUTO_POLL_SECONDS
-                if _should_auto_switch(last_pct, threshold):
-                    switched = _auto_perform_switch(stdscr, switcher)
-                    message = (
-                        f"Reached {last_pct:.0f}% — switched account."
-                        if switched
-                        else f"Reached {last_pct:.0f}% — switch failed (see above)."
-                    )
-                    # Re-read the new active account's usage on the next tick.
-                    last_pct = None
-                else:
-                    message = "Monitoring active account."
-
-            _draw_monitor(
-                stdscr, threshold, last_pct, last_checked, seconds_to_next, message
-            )
+            reg = registry.read_registry(switcher)
+            sessions = registry.live_sessions(reg)
+            acct_views, _ = registry.build_world(switcher, reg, fetch_idle=False)
+            _draw_dashboard(stdscr, switcher, sessions, acct_views)
             key = stdscr.getch()
             if key in (27, ord("q"), ord("Q")):
                 return
-            if key in (ord("s"), ord("S")):
-                seconds_to_next = 0
-                continue
-            seconds_to_next -= 1
     finally:
         stdscr.timeout(-1)
 
 
-def _auto_perform_switch(stdscr, switcher: ClaudeAccountSwitcher) -> bool:
-    """Suspend curses, run ``switcher.switch()``, then resume. No Enter prompt."""
-    curses.def_prog_mode()
-    curses.endwin()
-    switched = True
-    try:
-        try:
-            switcher.switch()
-        except ClaudeSwitchError as e:
-            print(f"Auto-switch error: {e}")
-            switched = False
-        except KeyboardInterrupt:
-            print("\nOperation cancelled.")
-            switched = False
-        print()
-        time.sleep(2.5)  # brief pause so the output is readable
-    finally:
-        curses.reset_prog_mode()
-        stdscr.refresh()
-    return switched
-
-
-def _draw_monitor(
-    stdscr,
-    threshold: int,
-    pct: float | None,
-    last_checked: str,
-    seconds_to_next: int,
-    message: str,
-) -> None:
-    """Render the auto-switch monitor screen."""
+def _draw_dashboard(stdscr, switcher, sessions, acct_views) -> None:
     stdscr.erase()
     rows, cols = stdscr.getmaxyx()
+    cfg = switcher.get_auto_balance_config()
+    state = "ON" if cfg["enabled"] else "OFF"
     _draw_header(
         stdscr,
-        "Auto-switch monitor (Beta)",
-        f"threshold {threshold}%  ·  polling every {_AUTO_POLL_SECONDS}s",
+        "Load balancer dashboard (Beta)",
+        f"{state} · threshold {cfg['threshold']}% · {len(sessions)} managed session(s)",
         cols,
     )
-    pct_str = f"{pct:.0f}%" if pct is not None else "unavailable"
-    lines = [
-        f"Active account usage : {pct_str}",
-        f"Last checked         : {last_checked}",
-        f"Next check in        : {max(0, seconds_to_next)}s",
-        "",
-        message,
-    ]
-    for i, line in enumerate(lines):
-        if 4 + i >= rows - 2:
-            break
-        stdscr.addstr(4 + i, 2, line[: cols - 4])
-    footer = "[s] check now  [q/Esc] stop monitor"
+    y = 4
+    if not sessions:
+        stdscr.addstr(y, 2, "No managed sessions. Start one with `cswap launch`."[: cols - 4])
+        y += 2
+    else:
+        stdscr.addstr(y, 2, "Sessions:"[: cols - 4], curses.A_BOLD)
+        y += 1
+        now = time.time()
+        for i, e in enumerate(sessions):
+            if y >= rows - 3:
+                break
+            acct = e.get("account_num", "?")
+            av = acct_views.get(str(acct))
+            pct = av.max_pct if av else None
+            paused = e.get("paused_until")
+            intent = e.get("migration")
+            if isinstance(paused, (int, float)) and paused > now:
+                state_s = f"paused {_short_countdown(paused - now)}"
+            elif isinstance(intent, dict) and intent.get("to"):
+                state_s = f"-> a{intent['to']}"
+            else:
+                state_s = _ascii_bar(pct)
+            line = f"  s{i + 1:<2} a{acct:<3} {state_s:<16} {_abbrev(e.get('cwd', ''))}"
+            stdscr.addstr(y, 2, line[: cols - 4])
+            y += 1
+        y += 1
+
+    if acct_views and y < rows - 2:
+        stdscr.addstr(y, 2, "Accounts:"[: cols - 4], curses.A_BOLD)
+        y += 1
+        for num in sorted(acct_views, key=lambda n: (-acct_views[n].priority, n)):
+            if y >= rows - 2:
+                break
+            av = acct_views[num]
+            pct_s = f"{av.max_pct:.0f}%" if av.max_pct is not None else "  —"
+            stdscr.addstr(y, 2, f"  a{num:<3} pri {av.priority:<3} {pct_s:>5}"[: cols - 4])
+            y += 1
+
+    footer = "[q/Esc] back  ·  refreshes automatically"
     stdscr.addstr(rows - 1, 2, footer[: cols - 4], curses.A_DIM)
     stdscr.refresh()
+
+
+def _ascii_bar(pct: float | None, width: int = 8) -> str:
+    if pct is None:
+        return "[--------] —"
+    filled = max(0, min(width, round(pct / 100 * width)))
+    return "[" + "#" * filled + "-" * (width - filled) + f"] {pct:.0f}%"
+
+
+def _short_countdown(secs: float) -> str:
+    secs = max(0, int(secs))
+    hours, rem = divmod(secs, 3600)
+    mins = rem // 60
+    return f"{hours}h{mins:02d}m" if hours else f"{mins}m"
+
+
+def _abbrev(path: str, maxlen: int = 28) -> str:
+    return path if len(path) <= maxlen else "..." + path[-(maxlen - 3):]
 
 
 # ---------------------------------------------------------------------------
@@ -364,9 +407,9 @@ def _status_line(switcher: ClaudeAccountSwitcher) -> str:
         tag = "personal" if not org else org[:8]
         active = f"{email} [{tag}]"
     line = f"Active: {active}  ·  {n} managed"
-    cfg = switcher.get_auto_switch_config()
+    cfg = switcher.get_auto_balance_config()
     if cfg["enabled"]:
-        line += f"  ·  auto-switch ON ({cfg['threshold']}%)"
+        line += f"  ·  balancer ON ({cfg['threshold']}%)"
     return line
 
 

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -68,7 +68,7 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
             ("Refresh credentials (current login, in-place)", "refresh"),
             ("List accounts (with usage)", "list"),
             ("Status", "status"),
-            ("Load balancer (Beta)", "balance"),
+            ("Auto-swap + multi-session load balancer (beta)", "balance"),
             ("Quit", "quit"),
         ]
         choice = _select_from(
@@ -177,7 +177,7 @@ def _do_refresh(stdscr, switcher: ClaudeAccountSwitcher) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Load balancer (Beta)
+# Auto-swap + multi-session load balancer (beta)
 # ---------------------------------------------------------------------------
 
 
@@ -230,7 +230,10 @@ def _do_balancer(stdscr, switcher: ClaudeAccountSwitcher) -> None:
             ("-- Back --", None),
         ]
         choice = _select_from(
-            stdscr, "Load balancer (Beta)", items=items, subtitle=subtitle
+            stdscr,
+            "Auto-swap + multi-session load balancer (beta)",
+            items=items,
+            subtitle=subtitle,
         )
         if choice is None:
             return
@@ -330,7 +333,7 @@ def _draw_dashboard(stdscr, switcher, sessions, acct_views) -> None:
     state = "ON" if cfg["enabled"] else "OFF"
     _draw_header(
         stdscr,
-        "Load balancer dashboard (Beta)",
+        "Auto-swap + multi-session load balancer — dashboard (beta)",
         f"{state} · threshold {cfg['threshold']}% · {len(sessions)} managed session(s)",
         cols,
     )

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -217,13 +217,14 @@ def _do_balancer(stdscr, switcher: ClaudeAccountSwitcher) -> None:
         state = "ON" if cfg["enabled"] else "OFF"
         subtitle = (
             f"Beta · {state} · threshold {cfg['threshold']}% · "
-            f"target {cfg['targetSafety']}% · cooldown {cfg['cooldownSeconds']}s"
+            f"target {cfg['targetSafety']}%"
         )
+        prime_state = "ON" if cfg.get("primeIdleWindows") else "OFF"
         items: list[tuple[str, str | None]] = [
             ("Disable" if cfg["enabled"] else "Enable", "toggle"),
             (f"Set threshold (now {cfg['threshold']}%)", "threshold"),
             (f"Set target safety (now {cfg['targetSafety']}%)", "target"),
-            (f"Set cooldown (now {cfg['cooldownSeconds']}s)", "cooldown"),
+            (f"Prime idle 5h windows: {prime_state} (spends credits)", "prime"),
             ("Edit account priorities", "priorities"),
             ("Live dashboard", "dashboard"),
             ("-- Back --", None),
@@ -239,8 +240,12 @@ def _do_balancer(stdscr, switcher: ClaudeAccountSwitcher) -> None:
             _set_balance_int(stdscr, switcher, "threshold", "Migrate when usage reaches (%): ")
         elif choice == "target":
             _set_balance_int(stdscr, switcher, "target_safety", "Target safety ceiling (%): ")
-        elif choice == "cooldown":
-            _set_balance_int(stdscr, switcher, "cooldown_seconds", "Min seconds between migrations: ")
+        elif choice == "prime":
+            # Default-OFF, credit-spending opt-in (feature #3): toggle the
+            # dedicated primeIdleWindows flag, independent of the balancer enable.
+            switcher.set_auto_balance_config(
+                prime_idle_windows=not cfg.get("primeIdleWindows")
+            )
         elif choice == "priorities":
             _edit_priorities(stdscr, switcher)
         elif choice == "dashboard":

--- a/tests/test_auto_switch.py
+++ b/tests/test_auto_switch.py
@@ -1,0 +1,227 @@
+"""Tests for the auto-switch (Beta) feature.
+
+Covers the switcher-side config/usage helpers and the TUI monitor logic.
+Curses primitives are mocked exactly as in ``test_tui.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_swap import tui
+from claude_swap.exceptions import ValidationError
+from claude_swap.switcher import (
+    DEFAULT_AUTO_SWITCH_THRESHOLD,
+    ClaudeAccountSwitcher,
+    _max_usage_pct,
+)
+
+
+def _stub_screen(rows: int = 30, cols: int = 100) -> MagicMock:
+    screen = MagicMock()
+    screen.getmaxyx.return_value = (rows, cols)
+    return screen
+
+
+def _login(temp_home: Path, email: str = "u@example.com") -> None:
+    config = {"oauthAccount": {"emailAddress": email}}
+    (temp_home / ".claude.json").write_text(json.dumps(config))
+
+
+# --------------------------------------------------------------------------- #
+# _max_usage_pct                                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestMaxUsagePct:
+    def test_none_when_no_usage(self):
+        assert _max_usage_pct(None) is None
+        assert _max_usage_pct({}) is None
+        assert _max_usage_pct("no credentials") is None
+
+    def test_returns_highest_of_5h_7d(self):
+        usage = {"five_hour": {"pct": 40}, "seven_day": {"pct": 95}}
+        assert _max_usage_pct(usage) == 95.0
+
+    def test_ignores_spend_entry(self):
+        usage = {"five_hour": {"pct": 10}, "spend": {"pct": 99}}
+        assert _max_usage_pct(usage) == 10.0
+
+    def test_handles_missing_pct(self):
+        assert _max_usage_pct({"five_hour": {}}) is None
+
+
+# --------------------------------------------------------------------------- #
+# Config persistence                                                          #
+# --------------------------------------------------------------------------- #
+
+
+class TestAutoSwitchConfig:
+    def test_default_is_disabled(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        cfg = switcher.get_auto_switch_config()
+        assert cfg == {
+            "enabled": False,
+            "threshold": DEFAULT_AUTO_SWITCH_THRESHOLD,
+        }
+
+    def test_enable_and_persist(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        switcher.set_auto_switch_config(enabled=True)
+        # A fresh instance reads the persisted value.
+        assert ClaudeAccountSwitcher().get_auto_switch_config()["enabled"] is True
+
+    def test_set_threshold(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        cfg = switcher.set_auto_switch_config(threshold=80)
+        assert cfg["threshold"] == 80
+        assert switcher.get_auto_switch_config()["threshold"] == 80
+
+    def test_partial_update_keeps_other_field(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        switcher.set_auto_switch_config(enabled=True, threshold=70)
+        switcher.set_auto_switch_config(threshold=60)
+        cfg = switcher.get_auto_switch_config()
+        assert cfg == {"enabled": True, "threshold": 60}
+
+    @pytest.mark.parametrize("bad", [0, -5, 101, 999])
+    def test_invalid_threshold_rejected(self, temp_home: Path, bad: int):
+        switcher = ClaudeAccountSwitcher()
+        with pytest.raises(ValidationError):
+            switcher.set_auto_switch_config(threshold=bad)
+
+    def test_does_not_clobber_accounts(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["1"] = {"email": "a@x.com"}
+        switcher._write_json(switcher.sequence_file, data)
+        switcher.set_auto_switch_config(enabled=True)
+        assert "1" in switcher._get_sequence_data()["accounts"]
+
+
+# --------------------------------------------------------------------------- #
+# get_active_usage_pct                                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestActiveUsagePct:
+    def test_none_without_login(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        assert switcher.get_active_usage_pct() is None
+
+    def test_none_without_credentials(self, temp_home: Path):
+        _login(temp_home)
+        switcher = ClaudeAccountSwitcher()
+        with patch.object(switcher, "_read_credentials", return_value=""):
+            assert switcher.get_active_usage_pct() is None
+
+    def test_returns_pct_from_usage_api(self, temp_home: Path):
+        _login(temp_home)
+        switcher = ClaudeAccountSwitcher()
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        usage = {"five_hour": {"pct": 96}, "seven_day": {"pct": 20}}
+        with patch.object(switcher, "_read_credentials", return_value=creds), \
+             patch(
+                 "claude_swap.oauth.fetch_usage_for_account",
+                 return_value=usage,
+             ):
+            assert switcher.get_active_usage_pct() == 96.0
+
+    def test_none_when_api_unavailable(self, temp_home: Path):
+        _login(temp_home)
+        switcher = ClaudeAccountSwitcher()
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        with patch.object(switcher, "_read_credentials", return_value=creds), \
+             patch(
+                 "claude_swap.oauth.fetch_usage_for_account",
+                 return_value=None,
+             ):
+            assert switcher.get_active_usage_pct() is None
+
+
+# --------------------------------------------------------------------------- #
+# TUI decision helper                                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestShouldAutoSwitch:
+    def test_below_threshold(self):
+        assert tui._should_auto_switch(94, 95) is False
+
+    def test_at_threshold(self):
+        assert tui._should_auto_switch(95, 95) is True
+
+    def test_above_threshold(self):
+        assert tui._should_auto_switch(99.5, 95) is True
+
+    def test_none_pct(self):
+        assert tui._should_auto_switch(None, 95) is False
+
+
+# --------------------------------------------------------------------------- #
+# TUI settings sub-flow                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestDoAutoSwitch:
+    def test_toggle_enables(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        # Enter on "Enable" (idx 0), then Esc to leave the settings screen.
+        screen.getch.side_effect = [10, 27]
+        tui._do_auto_switch(screen, switcher)
+        assert switcher.get_auto_switch_config()["enabled"] is True
+
+    def test_back_does_nothing(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        screen.getch.side_effect = [27]  # Esc immediately
+        tui._do_auto_switch(screen, switcher)
+        assert switcher.get_auto_switch_config()["enabled"] is False
+
+    def test_set_threshold_via_prompt(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        # Down to "Set threshold" (idx 1) + Enter, type "80" + Enter, then Esc.
+        keys = [tui.curses.KEY_DOWN, 10]
+        keys += [ord("8"), ord("0"), 10]
+        keys += [27]
+        screen.getch.side_effect = keys
+        with patch("claude_swap.tui.curses.curs_set"):
+            tui._do_auto_switch(screen, switcher)
+        assert switcher.get_auto_switch_config()["threshold"] == 80
+
+
+# --------------------------------------------------------------------------- #
+# TUI monitor loop                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestRunAutoMonitor:
+    def test_quits_without_switching_below_threshold(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        screen.getch.side_effect = [ord("q")]
+        with patch.object(switcher, "get_active_usage_pct", return_value=10.0), \
+             patch("claude_swap.tui._auto_perform_switch") as mock_switch, \
+             patch("claude_swap.tui.curses.curs_set"):
+            tui._run_auto_monitor(screen, switcher, threshold=95)
+        mock_switch.assert_not_called()
+
+    def test_switches_when_threshold_reached(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        screen.getch.side_effect = [ord("q")]
+        with patch.object(switcher, "get_active_usage_pct", return_value=96.0), \
+             patch(
+                 "claude_swap.tui._auto_perform_switch", return_value=True
+             ) as mock_switch, \
+             patch("claude_swap.tui.curses.curs_set"):
+            tui._run_auto_monitor(screen, switcher, threshold=95)
+        mock_switch.assert_called_once()

--- a/tests/test_auto_switch.py
+++ b/tests/test_auto_switch.py
@@ -180,16 +180,28 @@ class TestDoBalancer:
         assert switcher.get_auto_balance_config()["threshold"] == 80
 
     def test_toggle_prime_idle_windows(self, temp_home: Path):
-        # The "Prime idle 5h windows" item is at idx 3 (after Enable/threshold/
-        # target). Default OFF; one toggle turns it ON.
+        # The "Keep 5h sessions warm" item is at idx 4 (after Enable/threshold/
+        # target/only-subscription). Default OFF; one toggle turns it ON.
         switcher = ClaudeAccountSwitcher()
         assert switcher.get_auto_balance_config()["primeIdleWindows"] is False
+        screen = _stub_screen()
+        keys = [tui.curses.KEY_DOWN] * 4 + [10, 27]
+        screen.getch.side_effect = keys
+        with patch("claude_swap.tui.curses.curs_set"):
+            tui._do_balancer(screen, switcher)
+        assert switcher.get_auto_balance_config()["primeIdleWindows"] is True
+
+    def test_toggle_only_subscription_tokens(self, temp_home: Path):
+        # The "Only use subscription tokens" item is at idx 3 (after Enable/
+        # threshold/target). Default ON; one toggle turns it OFF.
+        switcher = ClaudeAccountSwitcher()
+        assert switcher.get_auto_balance_config()["onlySubscriptionTokens"] is True
         screen = _stub_screen()
         keys = [tui.curses.KEY_DOWN] * 3 + [10, 27]
         screen.getch.side_effect = keys
         with patch("claude_swap.tui.curses.curs_set"):
             tui._do_balancer(screen, switcher)
-        assert switcher.get_auto_balance_config()["primeIdleWindows"] is True
+        assert switcher.get_auto_balance_config()["onlySubscriptionTokens"] is False
 
 
 class TestPrimeIdleWindowsConfig:
@@ -214,6 +226,29 @@ class TestPrimeIdleWindowsConfig:
         cfg = sw.get_auto_balance_config()
         assert cfg["enabled"] is True
         assert cfg["primeIdleWindows"] is False
+
+
+class TestOnlySubscriptionTokensConfig:
+    """`onlySubscriptionTokens` defaults ON (never bill at API rates) and
+    round-trips through set/get."""
+
+    def test_defaults_on(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        assert sw.get_auto_balance_config()["onlySubscriptionTokens"] is True
+
+    def test_set_and_round_trip(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        sw.set_auto_balance_config(only_subscription_tokens=False)
+        assert sw.get_auto_balance_config()["onlySubscriptionTokens"] is False
+        sw.set_auto_balance_config(only_subscription_tokens=True)
+        assert sw.get_auto_balance_config()["onlySubscriptionTokens"] is True
+
+    def test_other_writes_preserve_it(self, temp_home: Path):
+        # Flipping it off must survive an unrelated config write.
+        sw = ClaudeAccountSwitcher()
+        sw.set_auto_balance_config(only_subscription_tokens=False)
+        sw.set_auto_balance_config(threshold=80)
+        assert sw.get_auto_balance_config()["onlySubscriptionTokens"] is False
 
 
 class TestEditPriorities:

--- a/tests/test_auto_switch.py
+++ b/tests/test_auto_switch.py
@@ -178,6 +178,42 @@ class TestDoBalancer:
             tui._do_balancer(screen, switcher)
         assert switcher.get_auto_balance_config()["threshold"] == 80
 
+    def test_toggle_prime_idle_windows(self, temp_home: Path):
+        # The "Prime idle 5h windows" item is at idx 3 (after Enable/threshold/
+        # target). Default OFF; one toggle turns it ON.
+        switcher = ClaudeAccountSwitcher()
+        assert switcher.get_auto_balance_config()["primeIdleWindows"] is False
+        screen = _stub_screen()
+        keys = [tui.curses.KEY_DOWN] * 3 + [10, 27]
+        screen.getch.side_effect = keys
+        with patch("claude_swap.tui.curses.curs_set"):
+            tui._do_balancer(screen, switcher)
+        assert switcher.get_auto_balance_config()["primeIdleWindows"] is True
+
+
+class TestPrimeIdleWindowsConfig:
+    """The primeIdleWindows opt-in is default-OFF, round-trips, and is independent
+    of `enabled` (review fix #3)."""
+
+    def test_defaults_off(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        assert sw.get_auto_balance_config()["primeIdleWindows"] is False
+
+    def test_set_and_round_trip(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        sw.set_auto_balance_config(prime_idle_windows=True)
+        assert sw.get_auto_balance_config()["primeIdleWindows"] is True
+        sw.set_auto_balance_config(prime_idle_windows=False)
+        assert sw.get_auto_balance_config()["primeIdleWindows"] is False
+
+    def test_independent_of_enabled(self, temp_home: Path):
+        # Enabling the balancer must NOT turn priming on.
+        sw = ClaudeAccountSwitcher()
+        sw.set_auto_balance_config(enabled=True)
+        cfg = sw.get_auto_balance_config()
+        assert cfg["enabled"] is True
+        assert cfg["primeIdleWindows"] is False
+
 
 class TestEditPriorities:
     def _seed_account(self, switcher: ClaudeAccountSwitcher) -> None:

--- a/tests/test_auto_switch.py
+++ b/tests/test_auto_switch.py
@@ -16,6 +16,7 @@ from claude_swap import tui
 from claude_swap.exceptions import ValidationError
 from claude_swap.switcher import (
     DEFAULT_AUTO_SWITCH_THRESHOLD,
+    DEFAULT_QUICK_START_COMMAND,
     ClaudeAccountSwitcher,
     _max_usage_pct,
 )
@@ -233,3 +234,69 @@ class TestEditPriorities:
         with patch("claude_swap.tui.curses.curs_set"):
             tui._edit_priorities(screen, switcher)
         assert switcher.get_account_priority("1") == 7
+
+
+class TestQuickStartConfig:
+    """The Quick-start alias config is default-OFF, round-trips, and self-heals."""
+
+    def test_defaults_off_with_default_command(self, temp_home: Path):
+        cfg = ClaudeAccountSwitcher().get_quick_start_config()
+        assert cfg["enabled"] is False
+        assert cfg["command"] == DEFAULT_QUICK_START_COMMAND
+
+    def test_default_command_is_the_documented_one(self):
+        assert DEFAULT_QUICK_START_COMMAND == (
+            "cswap launch -- --dangerously-skip-permissions "
+            "--model claude-opus-4-8 "
+            "--settings '{\"ultracode\": true}'"
+        )
+
+    def test_enable_and_persist(self, temp_home: Path):
+        ClaudeAccountSwitcher().set_quick_start_config(enabled=True)
+        assert ClaudeAccountSwitcher().get_quick_start_config()["enabled"] is True
+
+    def test_set_custom_command_round_trips(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        sw.set_quick_start_config(command="cswap launch -- --model opus")
+        assert sw.get_quick_start_config()["command"] == "cswap launch -- --model opus"
+
+    def test_partial_update_keeps_other_field(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        sw.set_quick_start_config(enabled=True, command="cswap launch")
+        sw.set_quick_start_config(enabled=False)
+        cfg = sw.get_quick_start_config()
+        assert cfg == {"enabled": False, "command": "cswap launch"}
+
+    def test_blank_command_rejected(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        with pytest.raises(ValidationError):
+            sw.set_quick_start_config(command="   ")
+
+    def test_does_not_clobber_accounts(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._init_sequence_file()
+        data = sw._get_sequence_data()
+        data["accounts"]["1"] = {"email": "a@x.com"}
+        sw._write_json(sw.sequence_file, data)
+        sw.set_quick_start_config(enabled=True)
+        assert "1" in sw._get_sequence_data()["accounts"]
+
+
+class TestDoQuickStart:
+    def test_toggle_enables(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        # Enter on "Enable" (idx 0), then Esc to leave.
+        screen.getch.side_effect = [10, 27]
+        tui._do_quick_start(screen, switcher)
+        assert switcher.get_quick_start_config()["enabled"] is True
+
+    def test_reset_restores_default_command(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        switcher.set_quick_start_config(command="cswap launch")
+        screen = _stub_screen()
+        # Down to "Reset command to default" (idx 2) + Enter, then Esc.
+        screen.getch.side_effect = [tui.curses.KEY_DOWN, tui.curses.KEY_DOWN, 10, 27]
+        tui._do_quick_start(screen, switcher)
+        assert switcher.get_quick_start_config()["command"] == DEFAULT_QUICK_START_COMMAND

--- a/tests/test_auto_switch.py
+++ b/tests/test_auto_switch.py
@@ -146,44 +146,25 @@ class TestActiveUsagePct:
 
 
 # --------------------------------------------------------------------------- #
-# TUI decision helper                                                         #
+# Load balancer TUI sub-flows                                                 #
 # --------------------------------------------------------------------------- #
 
 
-class TestShouldAutoSwitch:
-    def test_below_threshold(self):
-        assert tui._should_auto_switch(94, 95) is False
-
-    def test_at_threshold(self):
-        assert tui._should_auto_switch(95, 95) is True
-
-    def test_above_threshold(self):
-        assert tui._should_auto_switch(99.5, 95) is True
-
-    def test_none_pct(self):
-        assert tui._should_auto_switch(None, 95) is False
-
-
-# --------------------------------------------------------------------------- #
-# TUI settings sub-flow                                                       #
-# --------------------------------------------------------------------------- #
-
-
-class TestDoAutoSwitch:
+class TestDoBalancer:
     def test_toggle_enables(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
         screen = _stub_screen()
         # Enter on "Enable" (idx 0), then Esc to leave the settings screen.
         screen.getch.side_effect = [10, 27]
-        tui._do_auto_switch(screen, switcher)
-        assert switcher.get_auto_switch_config()["enabled"] is True
+        tui._do_balancer(screen, switcher)
+        assert switcher.get_auto_balance_config()["enabled"] is True
 
     def test_back_does_nothing(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
         screen = _stub_screen()
         screen.getch.side_effect = [27]  # Esc immediately
-        tui._do_auto_switch(screen, switcher)
-        assert switcher.get_auto_switch_config()["enabled"] is False
+        tui._do_balancer(screen, switcher)
+        assert switcher.get_auto_balance_config()["enabled"] is False
 
     def test_set_threshold_via_prompt(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
@@ -194,34 +175,25 @@ class TestDoAutoSwitch:
         keys += [27]
         screen.getch.side_effect = keys
         with patch("claude_swap.tui.curses.curs_set"):
-            tui._do_auto_switch(screen, switcher)
-        assert switcher.get_auto_switch_config()["threshold"] == 80
+            tui._do_balancer(screen, switcher)
+        assert switcher.get_auto_balance_config()["threshold"] == 80
 
 
-# --------------------------------------------------------------------------- #
-# TUI monitor loop                                                            #
-# --------------------------------------------------------------------------- #
+class TestEditPriorities:
+    def _seed_account(self, switcher: ClaudeAccountSwitcher) -> None:
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["1"] = {"email": "a@x.com"}
+        data["sequence"] = [1]
+        switcher._write_json(switcher.sequence_file, data)
 
-
-class TestRunAutoMonitor:
-    def test_quits_without_switching_below_threshold(self, temp_home: Path):
+    def test_set_priority_via_prompt(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
+        self._seed_account(switcher)
         screen = _stub_screen()
-        screen.getch.side_effect = [ord("q")]
-        with patch.object(switcher, "get_active_usage_pct", return_value=10.0), \
-             patch("claude_swap.tui._auto_perform_switch") as mock_switch, \
-             patch("claude_swap.tui.curses.curs_set"):
-            tui._run_auto_monitor(screen, switcher, threshold=95)
-        mock_switch.assert_not_called()
-
-    def test_switches_when_threshold_reached(self, temp_home: Path):
-        switcher = ClaudeAccountSwitcher()
-        screen = _stub_screen()
-        screen.getch.side_effect = [ord("q")]
-        with patch.object(switcher, "get_active_usage_pct", return_value=96.0), \
-             patch(
-                 "claude_swap.tui._auto_perform_switch", return_value=True
-             ) as mock_switch, \
-             patch("claude_swap.tui.curses.curs_set"):
-            tui._run_auto_monitor(screen, switcher, threshold=95)
-        mock_switch.assert_called_once()
+        # Select account 1 (idx 0, Enter), type "7" + Enter, then Back.
+        screen.getch.side_effect = [10, ord("7"), 10, tui.curses.KEY_DOWN, 10]
+        with patch("claude_swap.tui.curses.curs_set"):
+            tui._edit_priorities(screen, switcher)
+        assert switcher.get_account_priority("1") == 7

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -13,17 +13,21 @@ from claude_swap.balancer import (
     BalancerConfig,
     AccountView,
     SessionView,
+    accounts_needing_prime,
     assign_new_session,
     config_from_dict,
     rebalance,
 )
 
-CFG = BalancerConfig()  # exhaust 95, target 90, band 3, cooldown 600
+CFG = BalancerConfig()  # exhaust 95, target 90, band 3 (no time cooldown)
 NOW = 10_000.0
 
 
-def AV(num, priority=0, max_pct=None, reset=None, signal="live"):
-    return AccountView(num=num, priority=priority, max_pct=max_pct, soonest_reset=reset, signal=signal)
+def AV(num, priority=0, max_pct=None, reset=None, signal="live", h5_pct=None, h5_reset=None):
+    return AccountView(
+        num=num, priority=priority, max_pct=max_pct, soonest_reset=reset, signal=signal,
+        five_hour_pct=h5_pct, five_hour_reset=h5_reset,
+    )
 
 
 def SV(sid, acct, ctx=0, last_seen=0.0, paused=None, migrated=0.0, pinned=None):
@@ -87,15 +91,26 @@ class TestRebalance:
         assert kinds == {"a": "PAUSE", "b": "PAUSE"}
         assert all(a.resume_at == 1500 for a in plan.actions)  # soonest
 
-    def test_new_high_priority_account_attracts_stranded_when_not_cooled(self):
+    def test_exhausted_session_migrates_to_open_account(self):
         accts = {"1": AV("1", priority=0, max_pct=96.0), "2": AV("2", priority=9, max_pct=5.0)}
         plan = rebalance(accts, [SV("s1", "1", migrated=NOW - 700)], NOW, CFG)
         assert _acts(plan) == [("MIGRATE", "s1", "2")]
 
-    def test_session_in_cooldown_is_not_stranded(self):
+    def test_recently_migrated_session_is_not_blocked_by_any_cooldown(self):
+        # A session that JUST migrated (last_migrated_at == now) and whose account
+        # is now exhausted must STILL be able to move — there is no time cooldown.
+        # last_migrated_at is telemetry only and gates nothing. This is the
+        # "stranded on a freshly-exhausted account" case the cooldown used to break.
         accts = {"1": AV("1", priority=0, max_pct=96.0), "2": AV("2", priority=9, max_pct=5.0)}
-        plan = rebalance(accts, [SV("s1", "1", migrated=NOW - 100)], NOW, CFG)
-        assert plan.actions == []  # cooldown: left alone (no bounce)
+        for elapsed in (0.0, 1.0, 100.0, 599.0):  # all well within the old 600s lockout
+            plan = rebalance(accts, [SV("s1", "1", migrated=NOW - elapsed)], NOW, CFG)
+            assert _acts(plan) == [("MIGRATE", "s1", "2")], f"blocked at elapsed={elapsed}"
+
+    def test_no_cooldown_field_on_config(self):
+        # The cooldown was removed entirely; nothing in the config gates on time.
+        assert not hasattr(CFG, "migration_cooldown")
+        assert not hasattr(balancer, "DEFAULT_MIGRATION_COOLDOWN")
+        assert not hasattr(balancer, "_in_cooldown")
 
     def test_paused_session_resumes_when_account_recovers(self):
         now = 1000.0
@@ -217,3 +232,198 @@ class TestAssignNewSession:
     def test_none_when_nothing_has_room(self):
         accts = {"1": AV("1", priority=9, max_pct=99.0)}
         assert assign_new_session(accts, 0, NOW, CFG) is None
+
+
+# --------------------------------------------------------------------------- #
+# Equal-priority EVEN USAGE — placement + migration spread (requirement #2)
+# --------------------------------------------------------------------------- #
+
+
+class TestEqualPriorityEvenUsage:
+    """Among accounts of the SAME priority, the least-used (most projected
+    headroom) is preferred so equal-priority accounts stay evenly used over time.
+
+    This is a tiebreak for WHERE a session goes, not WHETHER it moves: switch
+    minimization (only-switch-when-exhausted) is exercised separately below.
+    """
+
+    def _place_k_across_j(self, j: int, k: int, ctx: int = 0) -> dict[str, int]:
+        """Place K fresh sessions one-by-one across J equal-priority, equally-empty
+        accounts, threading the online reservation between placements (as a real
+        concurrent-launch pass does). Returns the per-account placement count.
+        """
+        accts = {str(n): AV(str(n), priority=5, max_pct=0.0) for n in range(1, j + 1)}
+        projected = {num: 0.0 for num in accts}
+        counts = {num: 0 for num in accts}
+        for _ in range(k):
+            chosen = assign_new_session(accts, ctx, NOW, CFG, projected=projected)
+            assert chosen is not None
+            counts[chosen] += 1
+            projected[chosen] += balancer._pct_cost(ctx)
+        return counts
+
+    def test_spreads_evenly_across_equal_priority_accounts(self):
+        # K = a multiple of J -> a perfectly even spread.
+        for j, k in ((2, 6), (3, 9), (4, 8), (5, 10)):
+            counts = self._place_k_across_j(j, k)
+            assert set(counts.values()) == {k // j}, (j, k, counts)
+
+    def test_spread_is_balanced_when_not_a_multiple(self):
+        # K not a multiple of J -> counts differ by at most one (round-robin).
+        for j, k in ((3, 7), (4, 10), (5, 13)):
+            counts = self._place_k_across_j(j, k)
+            assert max(counts.values()) - min(counts.values()) <= 1, (j, k, counts)
+            assert sum(counts.values()) == k
+
+    def test_first_placements_break_ties_by_account_number(self):
+        # Three equal-priority, equally-empty accounts: the first session goes to
+        # the lowest number, the second to the next, the third to the last — a
+        # deterministic, number-ordered round-robin (no dependence on dict order).
+        accts = {
+            "3": AV("3", priority=5, max_pct=0.0),
+            "1": AV("1", priority=5, max_pct=0.0),
+            "2": AV("2", priority=5, max_pct=0.0),
+        }
+        projected = {num: 0.0 for num in accts}
+        picks = []
+        for _ in range(3):
+            chosen = assign_new_session(accts, 0, NOW, CFG, projected=projected)
+            picks.append(chosen)
+            projected[chosen] += balancer._pct_cost(0)
+        assert picks == ["1", "2", "3"]
+
+    def test_prefers_least_used_within_priority_tier(self):
+        # Equal priority, different current usage -> the emptiest one wins.
+        accts = {
+            "1": AV("1", priority=5, max_pct=60.0),
+            "2": AV("2", priority=5, max_pct=10.0),
+            "3": AV("3", priority=5, max_pct=40.0),
+        }
+        assert assign_new_session(accts, 0, NOW, CFG) == "2"
+
+    def test_higher_priority_beats_emptier_lower_priority(self):
+        # Priority dominates the even-usage tiebreak: a near-empty low-priority
+        # account does NOT win over a higher-priority one with headroom.
+        accts = {
+            "1": AV("1", priority=9, max_pct=70.0),
+            "2": AV("2", priority=1, max_pct=2.0),
+        }
+        assert assign_new_session(accts, 0, NOW, CFG) == "1"
+
+    def test_migration_target_spreads_across_equal_priority(self):
+        # Two sessions stranded on an exhausted account, two equal-priority empty
+        # targets: each session lands on a DIFFERENT target (the online
+        # reservation makes the second pick the now-emptier sibling), so the
+        # exhausted account's load spreads evenly rather than stacking on one.
+        accts = {
+            "1": AV("1", priority=0, max_pct=97.0, reset=2000),
+            "2": AV("2", priority=5, max_pct=0.0),
+            "3": AV("3", priority=5, max_pct=0.0),
+        }
+        sessions = [SV("a", "1", ctx=0), SV("b", "1", ctx=0)]
+        plan = rebalance(accts, sessions, NOW, CFG)
+        targets = {a.session_id: a.to_account for a in plan.actions if a.kind == "MIGRATE"}
+        assert set(targets.values()) == {"2", "3"}, targets
+
+    def test_per_supervisor_migration_storm_spreads_via_reservation(self):
+        # The per-supervisor (independent build_world) path: each stranded session
+        # is migrated by its OWN supervisor in a SEPARATE pass with an empty
+        # in-pass `projected`. Cross-process spread therefore relies on the migrate
+        # path re-stamping reserved_at (BUG-003), which build_world folds into the
+        # target's max_pct. Simulate that here: fold each chosen target's
+        # reservation into av[tgt].max_pct between calls. The targets must spread
+        # across {'2','3'} rather than all stacking on the lowest-numbered '2'.
+        cost = balancer._pct_cost(0)
+        av = {
+            "1": AV("1", priority=0, max_pct=97.0, reset=2000),
+            "2": AV("2", priority=5, max_pct=0.0),
+            "3": AV("3", priority=5, max_pct=0.0),
+        }
+        picks = []
+        for sid in ("a", "b", "c", "d"):
+            tgt = balancer.choose_migration_target(SV(sid, "1", ctx=0), av, {}, CFG)
+            assert tgt is not None
+            picks.append(tgt)
+            # Mimic build_world folding this just-migrated session's reservation
+            # into the new account's apparent usage on the next supervisor's pass.
+            av[tgt] = AV(tgt, priority=5, max_pct=av[tgt].max_pct + cost)
+        # Round-robin spread across the two equal-priority empties, ties by number.
+        assert picks == ["2", "3", "2", "3"], picks
+        counts = {t: picks.count(t) for t in ("2", "3")}
+        assert counts == {"2": 2, "3": 2}, counts
+
+    def test_only_switches_when_exhausted_not_for_even_usage(self):
+        # WHETHER to switch is still governed by exhaustion: a session on a
+        # heavily-but-not-exhausted account is LEFT ALONE even though an
+        # equal-priority sibling is far emptier. Even-usage is a WHERE tiebreak,
+        # never a reason to migrate on its own.
+        accts = {
+            "1": AV("1", priority=5, max_pct=80.0),   # busy but below threshold
+            "2": AV("2", priority=5, max_pct=1.0),    # much emptier sibling
+        }
+        plan = rebalance(accts, [SV("s1", "1")], NOW, CFG)
+        assert plan.actions == []  # no churn purely to even out usage
+
+
+# --------------------------------------------------------------------------- #
+# Idle-5h-window prime detection (feature #3) — pure, table-driven
+# --------------------------------------------------------------------------- #
+
+
+class TestAccountsNeedingPrime:
+    """``accounts_needing_prime`` flags managed accounts whose 5h window is
+    UNSTARTED so the supervisor can prime them. Pure / I/O-free."""
+
+    def test_idle_unstarted_window_is_a_candidate(self):
+        # signal=cache, 5h pct ~0, no 5h reset, 7d not exhausted -> prime it.
+        accts = {"1": AV("1", max_pct=0.0, signal="cache", h5_pct=0.0, h5_reset=None)}
+        assert accounts_needing_prime(accts, CFG) == ["1"]
+
+    def test_started_window_is_not_a_candidate_by_pct(self):
+        # 5h pct above the epsilon => clock already running => leave alone.
+        accts = {"1": AV("1", max_pct=12.0, signal="cache", h5_pct=12.0, h5_reset=None)}
+        assert accounts_needing_prime(accts, CFG) == []
+
+    def test_started_window_is_not_a_candidate_by_reset(self):
+        # A concrete future 5h reset means the clock is running even if pct rounds
+        # to ~0 — don't burn a credit re-priming it.
+        accts = {"1": AV("1", max_pct=0.0, signal="cache", h5_pct=0.0, h5_reset=99999)}
+        assert accounts_needing_prime(accts, CFG) == []
+
+    def test_live_account_is_never_primed(self):
+        # A live (in-use) account already has a started clock; never prime it.
+        accts = {"1": AV("1", max_pct=0.0, signal="live", h5_pct=0.0, h5_reset=None)}
+        assert accounts_needing_prime(accts, CFG) == []
+
+    def test_unknown_usage_is_never_primed(self):
+        # signal=none => couldn't read usage => skip (don't blind-prime).
+        accts = {"1": AV("1", max_pct=None, signal="none", h5_pct=None, h5_reset=None)}
+        assert accounts_needing_prime(accts, CFG) == []
+
+    def test_seven_day_exhausted_account_is_not_primed(self):
+        # 5h unstarted but the WEEKLY cap is binding (max_pct over threshold from
+        # the 7d window) -> a fresh 5h window can't help, so don't waste a credit.
+        accts = {"1": AV("1", max_pct=99.0, signal="cache", h5_pct=0.0, h5_reset=None)}
+        assert accounts_needing_prime(accts, CFG) == []
+
+    def test_epsilon_tolerates_tiny_nonzero_pct(self):
+        accts = {"1": AV("1", max_pct=0.3, signal="cache", h5_pct=0.3, h5_reset=None)}
+        assert accounts_needing_prime(accts, CFG) == ["1"]
+
+    def test_candidates_returned_in_account_number_order(self):
+        accts = {
+            "10": AV("10", max_pct=0.0, signal="cache", h5_pct=0.0),
+            "2": AV("2", max_pct=0.0, signal="cache", h5_pct=0.0),
+            "1": AV("1", max_pct=0.0, signal="cache", h5_pct=0.0),
+        }
+        assert accounts_needing_prime(accts, CFG) == ["1", "2", "10"]
+
+    def test_mixed_pool_only_idle_cache_accounts(self):
+        accts = {
+            "1": AV("1", max_pct=0.0, signal="cache", h5_pct=0.0),     # candidate
+            "2": AV("2", max_pct=50.0, signal="live", h5_pct=50.0),    # live
+            "3": AV("3", max_pct=0.0, signal="cache", h5_pct=8.0),     # started (pct)
+            "4": AV("4", max_pct=None, signal="none"),                 # unknown
+            "5": AV("5", max_pct=0.0, signal="cache", h5_pct=0.0),     # candidate
+        }
+        assert accounts_needing_prime(accts, CFG) == ["1", "5"]

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -652,3 +652,14 @@ class TestProbeConfirmedAccount:
         # trigger a redundant prime double-bill.
         probe = AV("2", max_pct=PROBE_CONFIRMED_PCT, signal="probe", h5_pct=None, h5_reset=None)
         assert accounts_needing_prime({"2": probe}, CFG) == []
+
+    def test_probe_with_real_low_reading_fits_large_session(self):
+        # When build_world backs a probe view with a real near-idle reading (e.g. 27%
+        # — registry._probe_view uses min(80, real)), a large-context session that
+        # would NOT fit the flat-80 probe DOES fit, so it migrates instead of pausing
+        # for hours (the "auto-resuming in 2h55m while an account was available" bug).
+        cost = balancer._pct_cost(150_000)  # >100k ctx -> 6.0
+        real = AV("2", max_pct=27.0, signal="probe")
+        assert balancer._fits(real, {"2": 0.0}, cost, CFG) is True   # 27+6 <= 85
+        flat = AV("2", max_pct=PROBE_CONFIRMED_PCT, signal="probe")
+        assert balancer._fits(flat, {"2": 0.0}, cost, CFG) is False  # 80+6 > 85

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -24,10 +24,12 @@ CFG = BalancerConfig()  # exhaust 95, target 90, band 3 (no time cooldown)
 NOW = 10_000.0
 
 
-def AV(num, priority=0, max_pct=None, reset=None, signal="live", h5_pct=None, h5_reset=None):
+def AV(num, priority=0, max_pct=None, reset=None, signal="live", h5_pct=None, h5_reset=None,
+       extra_usage=False, spend_pct=None):
     return AccountView(
         num=num, priority=priority, max_pct=max_pct, soonest_reset=reset, signal=signal,
         five_hour_pct=h5_pct, five_hour_reset=h5_reset,
+        extra_usage=extra_usage, spend_pct=spend_pct,
     )
 
 
@@ -455,3 +457,90 @@ class TestFiveHourWarm:
         assert five_hour_warm(cold) is False
         assert accounts_needing_prime({"2": warm}, CFG) == []
         assert five_hour_warm(warm) is True
+
+
+# A config with the API-rate last-resort tier enabled (only_subscription off).
+CFG_API = BalancerConfig(only_subscription=False)
+
+
+class TestApiRateLastResort:
+    """Subscription accounts are always preferred; pay-as-you-go / API-rate
+    accounts (and exhausted-subscription-with-extra-usage) are a last resort,
+    gated behind ``only_subscription``."""
+
+    # -- default (only_subscription=True): API tier is never touched ---------
+
+    def test_default_never_places_new_session_on_api(self):
+        accts = {
+            "1": AV("1", max_pct=98.0),                                   # exhausted subscription
+            "2": AV("2", max_pct=None, extra_usage=True, spend_pct=0.0),  # API-capable
+        }
+        # Subscription-only: no headroom => None (caller starts paused), never a2.
+        assert assign_new_session(accts, 0, NOW, CFG) is None
+
+    def test_default_pauses_rather_than_spill_into_extra_usage(self):
+        accts = {"1": AV("1", max_pct=98.0, extra_usage=True, spend_pct=0.0)}
+        assert _kinds(rebalance(accts, [SV("s1", "1")], NOW, CFG)) == {"s1": "PAUSE"}
+
+    # -- API tier enabled: subscription STILL strictly preferred -------------
+
+    def test_subscription_preferred_over_api_even_at_lower_priority(self):
+        accts = {
+            "1": AV("1", priority=0, max_pct=50.0),                       # subscription headroom
+            "2": AV("2", priority=9, max_pct=None, extra_usage=True),     # API, higher priority
+        }
+        assert assign_new_session(accts, 0, NOW, CFG_API) == "1"
+
+    def test_api_used_only_when_no_subscription_headroom(self):
+        accts = {
+            "1": AV("1", max_pct=98.0),                                    # exhausted, no extra-usage
+            "2": AV("2", max_pct=None, extra_usage=True, spend_pct=10.0),  # API-capable
+        }
+        assert assign_new_session(accts, 0, NOW, CFG_API) == "2"
+
+    def test_migrate_exhausted_to_subscription_not_api(self):
+        accts = {
+            "1": AV("1", max_pct=98.0, extra_usage=True, spend_pct=0.0),   # current, exhausted, extra-usage
+            "2": AV("2", max_pct=40.0),                                    # subscription headroom
+            "3": AV("3", max_pct=None, extra_usage=True, spend_pct=0.0),   # API
+        }
+        # Migrating to the subscription account saves money — preferred over API/stay.
+        assert _acts(rebalance(accts, [SV("s1", "1")], NOW, CFG_API)) == [("MIGRATE", "s1", "2")]
+
+    def test_keep_on_current_extra_usage_when_no_subscription_left(self):
+        accts = {
+            "1": AV("1", max_pct=98.0, extra_usage=True, spend_pct=0.0),   # current, exhausted, extra-usage
+            "2": AV("2", max_pct=99.0),                                    # other subscription, exhausted, no extra-usage
+        }
+        # Keep working on the current account's pay-as-you-go capacity — don't pause,
+        # don't thrash to a different API account.
+        assert _kinds(rebalance(accts, [SV("s1", "1")], NOW, CFG_API)) == {"s1": "KEEP"}
+
+    def test_dead_current_migrates_to_api_elsewhere(self):
+        accts = {
+            "1": AV("1", max_pct=99.0),                                    # current exhausted, NO extra-usage
+            "2": AV("2", max_pct=None, extra_usage=True, spend_pct=0.0),   # API-capable elsewhere
+        }
+        assert _acts(rebalance(accts, [SV("s1", "1")], NOW, CFG_API)) == [("MIGRATE", "s1", "2")]
+
+    def test_pause_when_neither_subscription_nor_api_can_serve(self):
+        accts = {
+            "1": AV("1", max_pct=99.0),  # exhausted, no extra-usage
+            "2": AV("2", max_pct=99.0),  # exhausted, no extra-usage
+        }
+        assert _kinds(rebalance(accts, [SV("s1", "1")], NOW, CFG_API)) == {"s1": "PAUSE"}
+
+    def test_api_over_monthly_cap_is_not_usable(self):
+        accts = {
+            "1": AV("1", max_pct=98.0),                                      # exhausted subscription
+            "2": AV("2", max_pct=None, extra_usage=True, spend_pct=100.0),   # API maxed monthly budget
+        }
+        assert assign_new_session(accts, 0, NOW, CFG_API) is None
+
+    def test_api_least_monthly_spend_chosen_first(self):
+        accts = {
+            "1": AV("1", max_pct=98.0),                                     # exhausted subscription
+            "2": AV("2", max_pct=None, extra_usage=True, spend_pct=60.0),
+            "3": AV("3", max_pct=None, extra_usage=True, spend_pct=20.0),   # most budget left
+        }
+        assert assign_new_session(accts, 0, NOW, CFG_API) == "3"

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -1,0 +1,219 @@
+"""Tests for the pure load-balancer decision logic (``claude_swap.balancer``).
+
+The balancer is I/O-free, so these are fast, deterministic, table-driven unit
+tests over synthetic :class:`AccountView` / :class:`SessionView` snapshots — no
+filesystem, no network, no mocks.
+"""
+
+from __future__ import annotations
+
+from claude_swap import balancer
+from claude_swap.balancer import (
+    BASE_RESERVE,
+    BalancerConfig,
+    AccountView,
+    SessionView,
+    assign_new_session,
+    config_from_dict,
+    rebalance,
+)
+
+CFG = BalancerConfig()  # exhaust 95, target 90, band 3, cooldown 600
+NOW = 10_000.0
+
+
+def AV(num, priority=0, max_pct=None, reset=None, signal="live"):
+    return AccountView(num=num, priority=priority, max_pct=max_pct, soonest_reset=reset, signal=signal)
+
+
+def SV(sid, acct, ctx=0, last_seen=0.0, paused=None, migrated=0.0, pinned=None):
+    return SessionView(
+        sid, acct, ctx_tokens=ctx, last_seen=last_seen,
+        paused_until=paused, last_migrated_at=migrated, pinned_account=pinned,
+    )
+
+
+def _acts(plan):
+    return [(a.kind, a.session_id, a.to_account) for a in plan.actions]
+
+
+def _kinds(plan):
+    return {a.session_id: a.kind for a in plan.actions}
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+
+
+class TestConfig:
+    def test_safety_invariant_holds(self):
+        # The load-bearing margin: a freshly-placed session can't immediately
+        # re-exhaust its target.
+        assert CFG.exhaust_threshold - CFG.target_safety >= BASE_RESERVE
+
+    def test_from_dict_clamps_safety_below_threshold(self):
+        cfg = config_from_dict({"threshold": 80, "targetSafety": 95})
+        assert cfg.target_safety <= cfg.exhaust_threshold - int(BASE_RESERVE)
+
+    def test_from_dict_defaults_on_garbage(self):
+        cfg = config_from_dict({"threshold": "oops"})
+        assert cfg.exhaust_threshold == BalancerConfig().exhaust_threshold
+
+
+# --------------------------------------------------------------------------- #
+# rebalance — the core pass
+# --------------------------------------------------------------------------- #
+
+
+class TestRebalance:
+    def test_single_exhausted_migrates_to_highest_priority_target(self):
+        accts = {
+            "1": AV("1", priority=0, max_pct=96.0),
+            "2": AV("2", priority=1, max_pct=30.0),
+            "3": AV("3", priority=5, max_pct=30.0),
+        }
+        plan = rebalance(accts, [SV("s1", "1")], NOW, CFG)
+        assert _acts(plan) == [("MIGRATE", "s1", "3")]  # pri 5 wins
+
+    def test_all_exhausted_pause_until_soonest_reset(self):
+        now = 1000.0
+        accts = {
+            "1": AV("1", max_pct=96.0, reset=2000),
+            "2": AV("2", max_pct=97.0, reset=1500),
+        }
+        plan = rebalance(accts, [SV("a", "1"), SV("b", "2")], now, CFG)
+        kinds = _kinds(plan)
+        assert kinds == {"a": "PAUSE", "b": "PAUSE"}
+        assert all(a.resume_at == 1500 for a in plan.actions)  # soonest
+
+    def test_new_high_priority_account_attracts_stranded_when_not_cooled(self):
+        accts = {"1": AV("1", priority=0, max_pct=96.0), "2": AV("2", priority=9, max_pct=5.0)}
+        plan = rebalance(accts, [SV("s1", "1", migrated=NOW - 700)], NOW, CFG)
+        assert _acts(plan) == [("MIGRATE", "s1", "2")]
+
+    def test_session_in_cooldown_is_not_stranded(self):
+        accts = {"1": AV("1", priority=0, max_pct=96.0), "2": AV("2", priority=9, max_pct=5.0)}
+        plan = rebalance(accts, [SV("s1", "1", migrated=NOW - 100)], NOW, CFG)
+        assert plan.actions == []  # cooldown: left alone (no bounce)
+
+    def test_paused_session_resumes_when_account_recovers(self):
+        now = 1000.0
+        accts = {"1": AV("1", max_pct=20.0)}  # recovered (below band)
+        plan = rebalance(accts, [SV("s1", "1", paused=5000)], now, CFG)
+        assert _acts(plan) == [("RESUME", "s1", "1")]
+
+    def test_paused_session_stays_paused_while_account_capped(self):
+        # 7d window still over the limit (max_pct=96), so no early resume.
+        now = 1000.0
+        accts = {"1": AV("1", max_pct=96.0, reset=9000)}
+        plan = rebalance(accts, [SV("s1", "1", paused=5000)], now, CFG)
+        assert plan.actions == []
+
+    def test_expired_pause_still_capped_repauses_to_real_reset(self):
+        # Timer elapsed (now >= paused_until) but the account is still capped and
+        # there's nowhere to go -> re-pause until the real reset, NOT resume.
+        now = 6000.0
+        accts = {"1": AV("1", max_pct=96.0, reset=9000)}
+        plan = rebalance(accts, [SV("s1", "1", paused=5000)], now, CFG)
+        assert _kinds(plan) == {"s1": "PAUSE"}
+        assert plan.actions[0].resume_at == 9000
+
+    def test_expired_pause_migrates_when_another_account_opened_up(self):
+        # Timer elapsed; current account still capped but a sibling now has room.
+        now = 6000.0
+        accts = {
+            "1": AV("1", max_pct=96.0, reset=9000),
+            "2": AV("2", priority=3, max_pct=20.0),
+        }
+        plan = rebalance(accts, [SV("s1", "1", paused=5000)], now, CFG)
+        assert _acts(plan) == [("MIGRATE", "s1", "2")]
+
+    def test_move_then_exhaust_trap_pauses_instead(self):
+        # Only target at 88%; a big-context session would push it to ~98% > safety.
+        accts = {"1": AV("1", max_pct=96.0, reset=2000), "2": AV("2", max_pct=88.0)}
+        plan = rebalance(accts, [SV("s1", "1", ctx=400_000)], NOW, CFG)
+        assert _kinds(plan) == {"s1": "PAUSE"}
+
+    def test_co_exhaust_cheap_migrates_expensive_pauses(self):
+        # One target with room for one small session; the cheap one moves, the
+        # expensive one can't fit after the online reservation -> pauses.
+        accts = {
+            "1": AV("1", max_pct=96.0, reset=2000),
+            "2": AV("2", max_pct=86.0),
+        }
+        sessions = [SV("cheap", "1", ctx=0), SV("expensive", "1", ctx=300_000)]
+        plan = rebalance(accts, sessions, NOW, CFG)
+        kinds = _kinds(plan)
+        assert kinds["cheap"] == "MIGRATE"
+        assert kinds["expensive"] == "PAUSE"
+
+    def test_priority_tie_breaks_on_headroom_then_number(self):
+        accts = {
+            "1": AV("1", priority=0, max_pct=96.0),
+            "2": AV("2", priority=5, max_pct=50.0),
+            "3": AV("3", priority=5, max_pct=30.0),
+        }
+        plan = rebalance(accts, [SV("s1", "1")], NOW, CFG)
+        assert _acts(plan) == [("MIGRATE", "s1", "3")]  # more headroom wins
+
+        accts2 = {
+            "1": AV("1", priority=0, max_pct=96.0),
+            "2": AV("2", priority=5, max_pct=40.0),
+            "3": AV("3", priority=5, max_pct=40.0),
+        }
+        plan2 = rebalance(accts2, [SV("s1", "1")], NOW, CFG)
+        assert _acts(plan2) == [("MIGRATE", "s1", "2")]  # tie -> lowest num
+
+    def test_unknown_usage_account_is_never_a_target(self):
+        accts = {"1": AV("1", max_pct=96.0, reset=2000), "2": AV("2", max_pct=None)}
+        plan = rebalance(accts, [SV("s1", "1")], NOW, CFG)
+        assert _kinds(plan) == {"s1": "PAUSE"}
+
+    def test_pinned_session_never_moved_or_paused(self):
+        accts = {"1": AV("1", max_pct=96.0, reset=2000), "2": AV("2", max_pct=10.0)}
+        plan = rebalance(accts, [SV("s1", "1", pinned="1")], NOW, CFG)
+        assert plan.actions == []
+
+    def test_healthy_session_left_alone(self):
+        accts = {"1": AV("1", max_pct=40.0), "2": AV("2", max_pct=10.0)}
+        plan = rebalance(accts, [SV("s1", "1")], NOW, CFG)
+        assert plan.actions == []  # not exhausted -> no churn
+
+    def test_deterministic_regardless_of_input_order(self):
+        accts = {
+            "1": AV("1", priority=1, max_pct=96.0, reset=2000),
+            "2": AV("2", priority=5, max_pct=20.0),
+            "3": AV("3", priority=5, max_pct=21.0),
+        }
+        sessions = [SV("a", "1", ctx=10), SV("b", "1", ctx=20)]
+        plan1 = rebalance(accts, sessions, NOW, CFG)
+        # Reverse both the dict and the list order.
+        accts_rev = dict(reversed(list(accts.items())))
+        plan2 = rebalance(accts_rev, list(reversed(sessions)), NOW, CFG)
+        assert _acts(plan1) == _acts(plan2)
+
+
+# --------------------------------------------------------------------------- #
+# assign_new_session — initial placement
+# --------------------------------------------------------------------------- #
+
+
+class TestAssignNewSession:
+    def test_picks_highest_priority_with_headroom(self):
+        accts = {
+            "1": AV("1", priority=1, max_pct=10.0),
+            "2": AV("2", priority=9, max_pct=10.0),
+        }
+        assert assign_new_session(accts, 0, NOW, CFG) == "2"
+
+    def test_skips_exhausted_high_priority_for_next_tier(self):
+        accts = {
+            "1": AV("1", priority=9, max_pct=99.0),
+            "2": AV("2", priority=1, max_pct=10.0),
+        }
+        assert assign_new_session(accts, 0, NOW, CFG) == "2"
+
+    def test_none_when_nothing_has_room(self):
+        accts = {"1": AV("1", priority=9, max_pct=99.0)}
+        assert assign_new_session(accts, 0, NOW, CFG) is None

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -544,3 +544,47 @@ class TestApiRateLastResort:
             "3": AV("3", max_pct=None, extra_usage=True, spend_pct=20.0),   # most budget left
         }
         assert assign_new_session(accts, 0, NOW, CFG_API) == "3"
+
+    def test_pause_when_all_api_accounts_monthly_budget_exhausted(self):
+        # Every account is extra-usage-capable but all monthly budgets are maxed
+        # (spend_pct == cap) — nothing can serve, so the session pauses.
+        accts = {
+            "1": AV("1", max_pct=98.0, extra_usage=True, spend_pct=100.0),  # current, exhausted + maxed
+            "2": AV("2", max_pct=99.0, extra_usage=True, spend_pct=100.0),  # other, maxed
+        }
+        assert _kinds(rebalance(accts, [SV("s1", "1")], NOW, CFG_API)) == {"s1": "PAUSE"}
+
+    def test_expired_pause_keeps_on_current_extra_usage_when_api_enabled(self):
+        # A paused session whose timer has elapsed, stranded on an exhausted
+        # account that still has pay-as-you-go capacity, KEEPs (spills to API)
+        # rather than re-pausing — the resume path's API-tier interaction.
+        accts = {
+            "1": AV("1", max_pct=98.0, extra_usage=True, spend_pct=0.0),  # current, exhausted, extra-usage
+            "2": AV("2", max_pct=99.0),                                   # other subscription, exhausted
+        }
+        plan = rebalance(accts, [SV("s1", "1", paused=5000)], NOW, CFG_API)
+        assert _kinds(plan) == {"s1": "KEEP"}
+
+    def test_multiple_stranded_sessions_rank_api_by_budget(self):
+        # Two sessions stranded on an exhausted, non-extra-usage account both pick
+        # the lowest-spend API account. _rank_api_accounts ignores `projected` by
+        # design (spend_pct is server-side monthly tracking), so they may stack.
+        accts = {
+            "1": AV("1", max_pct=99.0),                                    # exhausted, no extra-usage
+            "2": AV("2", max_pct=None, extra_usage=True, spend_pct=60.0),
+            "3": AV("3", max_pct=None, extra_usage=True, spend_pct=20.0),  # most budget left
+        }
+        plan = rebalance(accts, [SV("s1", "1"), SV("s2", "1")], NOW, CFG_API)
+        targets = {a.session_id: a.to_account for a in plan.actions if a.kind == "MIGRATE"}
+        assert targets == {"s1": "3", "s2": "3"}
+
+    def test_fresh_config_defaults_to_subscription_only(self):
+        # The critical default-safe guarantee, end-to-end through config parsing:
+        # a fresh install (no autoBalance / empty dict) is subscription-only, so
+        # an exhausted account with extra-usage never spills to API rates.
+        for raw in (None, {}):
+            cfg = config_from_dict(raw)
+            assert cfg.only_subscription is True
+            accts = {"1": AV("1", max_pct=98.0, extra_usage=True, spend_pct=0.0)}
+            assert assign_new_session(accts, 0, NOW, cfg) is None
+            assert _kinds(rebalance(accts, [SV("s1", "1")], NOW, cfg)) == {"s1": "PAUSE"}

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -158,7 +158,7 @@ class TestRebalance:
         # expensive one can't fit after the online reservation -> pauses.
         accts = {
             "1": AV("1", max_pct=96.0, reset=2000),
-            "2": AV("2", max_pct=86.0),
+            "2": AV("2", max_pct=80.0),  # room for the cheap session, not both (target 85)
         }
         sessions = [SV("cheap", "1", ctx=0), SV("expensive", "1", ctx=300_000)]
         plan = rebalance(accts, sessions, NOW, CFG)

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -16,6 +16,7 @@ from claude_swap.balancer import (
     accounts_needing_prime,
     assign_new_session,
     config_from_dict,
+    five_hour_warm,
     rebalance,
 )
 
@@ -427,3 +428,30 @@ class TestAccountsNeedingPrime:
             "5": AV("5", max_pct=0.0, signal="cache", h5_pct=0.0),     # candidate
         }
         assert accounts_needing_prime(accts, CFG) == ["1", "5"]
+
+
+class TestFiveHourWarm:
+    """``five_hour_warm`` reports the dashboard's warm/cold/unknown 5h state —
+    the exact inverse of priming candidacy (a primeable window reads cold)."""
+
+    def test_running_reset_is_warm(self):
+        assert five_hour_warm(AV("1", h5_pct=0.0, h5_reset=99999)) is True
+
+    def test_pct_above_epsilon_is_warm(self):
+        assert five_hour_warm(AV("1", h5_pct=8.0, h5_reset=None)) is True
+
+    def test_zero_pct_no_reset_is_cold(self):
+        # The unstarted clock — exactly what idle-window priming targets.
+        assert five_hour_warm(AV("1", h5_pct=0.0, h5_reset=None)) is False
+
+    def test_unknown_usage_is_none(self):
+        assert five_hour_warm(AV("1", h5_pct=None, h5_reset=None)) is None
+
+    def test_inverse_of_prime_candidacy(self):
+        # An account flagged for priming must read cold; one left alone reads warm.
+        cold = AV("1", max_pct=0.0, signal="cache", h5_pct=0.0, h5_reset=None)
+        warm = AV("2", max_pct=12.0, signal="cache", h5_pct=12.0, h5_reset=None)
+        assert accounts_needing_prime({"1": cold}, CFG) == ["1"]
+        assert five_hour_warm(cold) is False
+        assert accounts_needing_prime({"2": warm}, CFG) == []
+        assert five_hour_warm(warm) is True

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from claude_swap import balancer
 from claude_swap.balancer import (
     BASE_RESERVE,
+    PROBE_CONFIRMED_PCT,
     BalancerConfig,
     AccountView,
     SessionView,
@@ -588,3 +589,66 @@ class TestApiRateLastResort:
             accts = {"1": AV("1", max_pct=98.0, extra_usage=True, spend_pct=0.0)}
             assert assign_new_session(accts, 0, NOW, cfg) is None
             assert _kinds(rebalance(accts, [SV("s1", "1")], NOW, cfg)) == {"s1": "PAUSE"}
+
+
+# --------------------------------------------------------------------------- #
+# Probe-confirmed accounts (signal="probe")
+# --------------------------------------------------------------------------- #
+
+
+class TestProbeConfirmedAccount:
+    """A messages-API headroom probe enters the pure model as a conservative
+    synthesized ``max_pct=PROBE_CONFIRMED_PCT`` with ``signal="probe"``. It must:
+    (a) be usable so a stranded session can resume onto it, (b) admit exactly one
+    zero-ctx session but reject a second (no co-exhaust), (c) rank below KNOWN
+    real headroom, and (d) never be a prime candidate.
+    """
+
+    def test_probe_value_respects_the_invariants(self):
+        # The numeric choice is defended against the default tunables.
+        assert PROBE_CONFIRMED_PCT < CFG.exhaust_threshold - CFG.hysteresis_band  # usable
+        assert PROBE_CONFIRMED_PCT + BASE_RESERVE <= CFG.target_safety            # one fits
+        assert PROBE_CONFIRMED_PCT + 2 * BASE_RESERVE > CFG.target_safety         # two don't
+
+    def test_probe_account_is_usable(self):
+        av = AV("2", max_pct=PROBE_CONFIRMED_PCT, signal="probe")
+        assert balancer._usable(av, CFG) is True
+
+    def test_one_session_fits_second_does_not(self):
+        av = AV("2", max_pct=PROBE_CONFIRMED_PCT, signal="probe")
+        projected: dict[str, float] = {"2": 0.0}
+        cost = balancer._pct_cost(0)  # zero-ctx session
+        # First zero-ctx session fits (80 + 3 <= 85).
+        assert balancer._fits(av, projected, cost, CFG) is True
+        # Debit the online reservation as Phase D would, then a second does NOT fit.
+        projected["2"] += cost
+        assert balancer._fits(av, projected, cost, CFG) is False
+
+    def test_two_stranded_sessions_do_not_co_stack(self):
+        # End-to-end through rebalance: both stranded on an exhausted account; only
+        # one lands on the probe-confirmed target, the other pauses (no co-exhaust).
+        accts = {
+            "1": AV("1", max_pct=99.0),                          # current, exhausted
+            "2": AV("2", max_pct=PROBE_CONFIRMED_PCT, signal="probe", reset=None),
+        }
+        plan = rebalance(accts, [SV("s1", "1"), SV("s2", "1")], NOW, CFG)
+        kinds = _kinds(plan)
+        migrated = [a for a in plan.actions if a.kind == "MIGRATE" and a.to_account == "2"]
+        assert len(migrated) == 1                                # exactly one moves to "2"
+        assert "PAUSE" in kinds.values()                         # the other can't co-stack
+
+    def test_real_headroom_outranks_probe(self):
+        # A real cache account at 50% (known headroom) is preferred over the
+        # synthesized probe at 80% (a guess) — KNOWN real headroom always wins.
+        accts = {
+            "real": AV("1", max_pct=50.0, signal="cache"),
+            "probe": AV("2", max_pct=PROBE_CONFIRMED_PCT, signal="probe"),
+        }
+        ranked = balancer._rank_accounts(accts, {"1": 0.0, "2": 0.0}, CFG)
+        assert [a.num for a in ranked] == ["1", "2"]
+
+    def test_probe_account_is_not_a_prime_candidate(self):
+        # accounts_needing_prime keys on signal == "cache"; a probe view must never
+        # trigger a redundant prime double-bill.
+        probe = AV("2", max_pct=PROBE_CONFIRMED_PCT, signal="probe", h5_pct=None, h5_reset=None)
+        assert accounts_needing_prime({"2": probe}, CFG) == []

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,6 +8,9 @@ import time
 from claude_swap.cache import (
     MISSING,
     PROBE_VERDICT_TTL_S,
+    is_real_usage,
+    last_known_usage,
+    merge_last_known,
     probe_ok,
     probe_recent,
     read_cache,
@@ -111,3 +114,51 @@ class TestWriteCache:
         result = read_cache(cache_file, ttl=60)
 
         assert result == data
+
+
+class TestIsRealUsage:
+    def test_true_for_usage_dict(self):
+        assert is_real_usage({"five_hour": {"pct": 40.0}}) is True
+
+    def test_false_for_markers_and_nondicts(self):
+        assert is_real_usage({"_unavailable": True}) is False
+        assert is_real_usage({"_probe_ok": True}) is False
+        assert is_real_usage(None) is False
+        assert is_real_usage("x") is False
+
+
+class TestLastKnownCarryForward:
+    """Failure markers remember the last healthy reading for the optimistic stale view."""
+
+    USAGE = {"five_hour": {"pct": 62.0, "resets_at": 1000}, "seven_day": {"pct": 30.0}}
+
+    def test_merge_snapshots_real_usage(self):
+        marker = merge_last_known({"_unavailable": True}, self.USAGE, now=500.0)
+        assert marker["_last_known"] == self.USAGE
+        assert marker["_last_known_at"] == 500.0
+
+    def test_merge_inherits_from_prior_marker(self):
+        prior = {"_unavailable": True, "_last_known": self.USAGE, "_last_known_at": 100.0}
+        marker = merge_last_known({"_unavailable": True, "retry_until": 9}, prior, now=999.0)
+        assert marker["_last_known"] == self.USAGE
+        assert marker["_last_known_at"] == 100.0  # inherited timestamp, not refreshed
+
+    def test_merge_noop_when_prev_has_nothing(self):
+        marker = merge_last_known({"_unavailable": True}, None, now=1.0)
+        assert "_last_known" not in marker
+        # A bare marker (no prior reading) carries nothing forward.
+        assert merge_last_known({"_unavailable": True}, {"_unavailable": True}, now=1.0) == {
+            "_unavailable": True
+        }
+
+    def test_last_known_usage_within_age(self):
+        marker = {"_last_known": self.USAGE, "_last_known_at": 100.0}
+        assert last_known_usage(marker, max_age=3600, now=200.0) == self.USAGE
+
+    def test_last_known_usage_too_old(self):
+        marker = {"_last_known": self.USAGE, "_last_known_at": 100.0}
+        assert last_known_usage(marker, max_age=3600, now=100.0 + 3600) is None
+
+    def test_last_known_usage_absent(self):
+        assert last_known_usage({"_unavailable": True}, max_age=3600, now=1.0) is None
+        assert last_known_usage(None, max_age=3600, now=1.0) is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,14 +6,18 @@ import json
 import time
 
 from claude_swap.cache import (
+    LOGGED_OUT_RECHECK_S,
     MISSING,
     PROBE_VERDICT_TTL_S,
     is_real_usage,
     last_known_usage,
+    logged_out,
+    logged_out_marker,
     merge_last_known,
     probe_ok,
     probe_recent,
     read_cache,
+    usage_backoff_active,
     write_cache,
 )
 
@@ -114,6 +118,43 @@ class TestWriteCache:
         result = read_cache(cache_file, ttl=60)
 
         assert result == data
+
+
+class TestLoggedOut:
+    """The logged-out marker: a dead refresh token, distinct from transient failures."""
+
+    def test_logged_out_true_only_for_logged_out_marker(self):
+        assert logged_out({"_unavailable": True, "_logged_out": True}) is True
+
+    def test_logged_out_false_otherwise(self):
+        assert logged_out({"_unavailable": True}) is False  # plain/429 marker
+        assert logged_out({"_unavailable": True, "retry_until": 9}) is False
+        assert logged_out({"_probe_ok": True}) is False
+        assert logged_out({"five_hour": {"pct": 5.0}}) is False
+        assert logged_out({}) is False
+        assert logged_out(None) is False
+
+    def test_marker_shape(self):
+        marker = logged_out_marker(now=1000.0)
+        assert marker["_unavailable"] is True
+        assert marker["_logged_out"] is True
+        assert marker["retry_until"] == 1000.0 + LOGGED_OUT_RECHECK_S
+
+    def test_marker_carries_no_last_known(self):
+        # A logged-out account must never resurrect as an optimistic stale target.
+        marker = logged_out_marker(now=1000.0)
+        assert "_last_known" not in marker
+        assert last_known_usage(marker, max_age=10**9, now=1000.0) is None
+
+    def test_marker_is_a_backoff_so_refetch_is_throttled(self):
+        # The retry_until gate reuses usage_backoff_active so the dead token is not
+        # re-POSTed every render/tick across concurrent processes.
+        marker = logged_out_marker(now=1000.0)
+        assert usage_backoff_active(marker, now=1000.0) is True
+        assert usage_backoff_active(marker, now=1000.0 + LOGGED_OUT_RECHECK_S + 1) is False
+
+    def test_marker_is_not_real_usage(self):
+        assert is_real_usage(logged_out_marker(now=1.0)) is False
 
 
 class TestIsRealUsage:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import json
 import time
 
-from claude_swap.cache import MISSING, read_cache, write_cache
+from claude_swap.cache import (
+    MISSING,
+    PROBE_VERDICT_TTL_S,
+    probe_ok,
+    probe_recent,
+    read_cache,
+    write_cache,
+)
 
 
 class TestReadCache:
@@ -50,6 +57,40 @@ class TestReadCache:
         result = read_cache(cache_file, ttl=60)
         assert result is None
         assert result is not MISSING
+
+
+class TestProbeRecent:
+    """The cross-process re-probe throttle gate."""
+
+    def test_recent_within_ttl(self):
+        now = 1000.0
+        entry = {"_probed_at": now - (PROBE_VERDICT_TTL_S - 1)}
+        assert probe_recent(entry, now=now) is True
+
+    def test_stale_past_ttl(self):
+        now = 1000.0
+        entry = {"_probed_at": now - (PROBE_VERDICT_TTL_S + 1)}
+        assert probe_recent(entry, now=now) is False
+
+    def test_false_for_missing_stamp_and_non_dicts(self):
+        assert probe_recent({"five_hour": {"pct": 5.0}}) is False  # plain usage entry
+        assert probe_recent({}) is False                            # no _probed_at
+        assert probe_recent(None) is False
+        assert probe_recent("nope") is False
+
+
+class TestProbeOk:
+    """Distinguishes a confirmed-OK verdict from a no-signal marker."""
+
+    def test_true_only_for_probe_ok_marker(self):
+        assert probe_ok({"_probe_ok": True, "_probed_at": 1.0}) is True
+
+    def test_false_otherwise(self):
+        assert probe_ok({"_probe_ok": False}) is False
+        assert probe_ok({"_unavailable": True, "_probed_at": 1.0}) is False
+        assert probe_ok({"five_hour": {"pct": 5.0}}) is False
+        assert probe_ok({}) is False
+        assert probe_ok(None) is False
 
 
 class TestWriteCache:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ import pytest
 
 from claude_swap import __version__
 from claude_swap import cli
+from claude_swap.switcher import ClaudeAccountSwitcher
 
 # src layout: ensure subprocess can find claude_swap
 _SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
@@ -460,3 +461,93 @@ class TestRunCommand:
 
         assert excinfo.value.code == 1
         assert "boom" in capsys.readouterr().err
+
+
+class TestQuickStart:
+    """The configurable bare-`cswap` alias (quickStart): default OFF, alias-with-args."""
+
+    def _run_launch(self, argv: list[str]) -> dict:
+        """Invoke main() and capture the argv that reaches the launch handler."""
+        captured: dict = {}
+
+        def fake_launch(a):
+            captured["argv"] = list(a)
+
+        with patch("claude_swap.cli._launch_command", side_effect=fake_launch), \
+             patch.object(sys, "argv", ["claude-swap", *argv]):
+            cli.main()
+        return captured
+
+    def test_disabled_by_default_bare_cswap_errors(self, temp_home, capsys):
+        # No quickStart config => bare `cswap` falls through to argparse's
+        # required-argument error, exactly as before the feature existed.
+        with patch.object(sys, "argv", ["claude-swap"]):
+            with pytest.raises(SystemExit) as e:
+                cli.main()
+        assert e.value.code == 2
+
+    def test_bare_runs_default_command_when_enabled(self, temp_home):
+        ClaudeAccountSwitcher().set_quick_start_config(enabled=True)
+        cap = self._run_launch([])
+        # `cswap launch -- <claude args>` => launch handler sees everything after
+        # the subcommand, i.e. starting at the `--` separator.
+        assert cap["argv"][0] == "--"
+        assert "--dangerously-skip-permissions" in cap["argv"]
+        assert cap["argv"][-2:] == ["--settings", '{"ultracode": true}']
+
+    def test_extra_args_are_appended(self, temp_home):
+        ClaudeAccountSwitcher().set_quick_start_config(enabled=True)
+        cap = self._run_launch(["--resume", "abc123"])
+        assert "--dangerously-skip-permissions" in cap["argv"]
+        assert cap["argv"][-2:] == ["--resume", "abc123"]
+
+    def test_reserved_flag_is_not_hijacked(self, temp_home):
+        ClaudeAccountSwitcher().set_quick_start_config(enabled=True)
+        with patch("claude_swap.cli._launch_command") as launch, \
+             patch("claude_swap.switcher.ClaudeAccountSwitcher.status") as status, \
+             patch("os.geteuid", return_value=1000), \
+             patch.object(sys, "argv", ["claude-swap", "--status"]):
+            cli.main()
+        launch.assert_not_called()
+        status.assert_called_once()
+
+    def test_custom_command_can_target_another_subcommand(self, temp_home):
+        calls: list = []
+
+        class FakeSessionManager:
+            def __init__(self, switcher):
+                pass
+
+            def run(self, identifier, claude_args, share=True):
+                calls.append((identifier, claude_args, share))
+
+        sw = ClaudeAccountSwitcher()
+        sw.set_quick_start_config(enabled=True, command="cswap run 2")
+        with patch("claude_swap.session.SessionManager", FakeSessionManager), \
+             patch("os.geteuid", return_value=1000), \
+             patch.object(sys, "argv", ["claude-swap"]):
+            cli.main()
+        assert calls == [("2", [], True)]
+
+    def test_double_dash_separator_is_stripped(self, temp_home):
+        # `cswap -- <args>` means "everything after -- is extra" — it must NOT
+        # leave a stray `--` on top of the default command's own separator (which
+        # would make claude treat --resume as a positional prompt).
+        ClaudeAccountSwitcher().set_quick_start_config(enabled=True)
+        cap = self._run_launch(["--", "--resume", "abc123"])
+        assert cap["argv"][-2:] == ["--resume", "abc123"]
+        # Only the configured command's own leading `--` survives (no stray one).
+        assert cap["argv"].count("--") == 1
+
+    def test_abbreviated_flag_is_rejected_not_silently_expanded(self, temp_home):
+        # allow_abbrev=False keeps argparse's matching in lockstep with the
+        # exact-match reserved set: an abbreviated flag is no longer silently
+        # expanded (and so can never mean one thing with quick-start off and
+        # another with it on). Quick-start is OFF here (the default).
+        with patch("claude_swap.cli._launch_command") as launch, \
+             patch("os.geteuid", return_value=1000), \
+             patch.object(sys, "argv", ["claude-swap", "--lis"]):
+            with pytest.raises(SystemExit) as e:
+                cli.main()
+        assert e.value.code == 2
+        launch.assert_not_called()

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -1,0 +1,348 @@
+"""Tests for the cmux integration (pure parts; no real cmux is ever invoked)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap import cmux
+from claude_swap.models import Platform
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+# --------------------------------------------------------------------------- #
+# build_surface / command resolution
+# --------------------------------------------------------------------------- #
+
+
+class TestSurface:
+    def test_build_surface_shape(self):
+        s = cmux.build_surface()
+        assert s["name"] == cmux.SURFACE_NAME
+        assert s["type"] == "terminal"
+        assert "launch" in s["command"]
+        assert s["cwd"] == "."
+        # The preserve-key env MUST include CLAUDE_CONFIG_DIR so the wrapper keeps
+        # cswap's per-session profile pin.
+        env = s["env"]
+        assert cmux.CLAUDE_CONFIG_DIR_KEY in env[cmux.PRESERVE_KEYS_ENV]
+
+    def test_launch_command_prefers_path(self, monkeypatch):
+        monkeypatch.setattr(cmux.shutil, "which", lambda name: "/usr/local/bin/cswap")
+        assert cmux.cswap_launch_command() == "cswap launch"
+
+    def test_launch_command_interpreter_fallback(self, monkeypatch):
+        monkeypatch.setattr(cmux.shutil, "which", lambda name: None)
+        cmd = cmux.cswap_launch_command()
+        assert "-m claude_swap launch" in cmd
+
+
+# --------------------------------------------------------------------------- #
+# preserve-key merge logic (shared with the supervisor)
+# --------------------------------------------------------------------------- #
+
+
+class TestPreserveKeys:
+    def test_empty_adds_our_key(self):
+        assert cmux.merge_preserve_keys(None) == "CLAUDE_CONFIG_DIR"
+        assert cmux.merge_preserve_keys("") == "CLAUDE_CONFIG_DIR"
+
+    def test_appends_without_clobbering(self):
+        out = cmux.merge_preserve_keys("FOO,BAR")
+        assert out.split(",") == ["FOO", "BAR", "CLAUDE_CONFIG_DIR"]
+
+    def test_idempotent_when_already_present(self):
+        assert cmux.merge_preserve_keys("CLAUDE_CONFIG_DIR") == "CLAUDE_CONFIG_DIR"
+        assert (
+            cmux.merge_preserve_keys("FOO CLAUDE_CONFIG_DIR")
+            == "FOO,CLAUDE_CONFIG_DIR"
+        )
+
+    def test_space_separated_input(self):
+        out = cmux.merge_preserve_keys("FOO BAR")
+        assert out.split(",") == ["FOO", "BAR", "CLAUDE_CONFIG_DIR"]
+
+
+# --------------------------------------------------------------------------- #
+# find_cmux / availability
+# --------------------------------------------------------------------------- #
+
+
+class TestDiscovery:
+    def test_find_cmux_prefers_path(self, monkeypatch):
+        monkeypatch.setattr(cmux.shutil, "which", lambda name: "/opt/bin/cmux")
+        assert cmux.find_cmux() == "/opt/bin/cmux"
+
+    def test_find_cmux_app_bundle_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(cmux.shutil, "which", lambda name: None)
+        fake_cli = tmp_path / "cmux"
+        fake_cli.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(cmux, "_APP_BUNDLE_CLI", fake_cli)
+        assert cmux.find_cmux() == str(fake_cli)
+
+    def test_find_cmux_absent(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(cmux.shutil, "which", lambda name: None)
+        monkeypatch.setattr(cmux, "_APP_BUNDLE_CLI", tmp_path / "nope")
+        assert cmux.find_cmux() is None
+
+    def test_is_available_requires_macos(self, monkeypatch):
+        monkeypatch.setattr(cmux, "find_cmux", lambda: "/opt/bin/cmux")
+        monkeypatch.setattr(Platform, "detect", classmethod(lambda cls: Platform.LINUX))
+        assert cmux.is_available() is False
+        monkeypatch.setattr(Platform, "detect", classmethod(lambda cls: Platform.MACOS))
+        assert cmux.is_available() is True
+
+    def test_require_macos_cmux_raises_off_macos(self, monkeypatch):
+        from claude_swap.exceptions import SessionError
+
+        monkeypatch.setattr(Platform, "detect", classmethod(lambda cls: Platform.LINUX))
+        with pytest.raises(SessionError, match="macOS-only"):
+            cmux._require_macos_cmux()
+
+    def test_require_macos_cmux_raises_when_missing(self, monkeypatch):
+        from claude_swap.exceptions import SessionError
+
+        monkeypatch.setattr(Platform, "detect", classmethod(lambda cls: Platform.MACOS))
+        monkeypatch.setattr(cmux, "find_cmux", lambda: None)
+        with pytest.raises(SessionError, match="cmux was not found"):
+            cmux._require_macos_cmux()
+
+
+# --------------------------------------------------------------------------- #
+# JSONC parsing + merge idempotency / user-content preservation
+# --------------------------------------------------------------------------- #
+
+
+class TestConfigMerge:
+    def test_load_jsonc_with_comments(self, tmp_path):
+        p = tmp_path / "cmux.json"
+        p.write_text(
+            """{
+  // a line comment
+  "schemaVersion": 1, /* block */
+  "app": {"minimalMode": false},
+}"""
+        )
+        data = cmux.load_config(p)
+        assert data["schemaVersion"] == 1
+        assert data["app"]["minimalMode"] is False
+
+    def test_load_missing_returns_empty(self, tmp_path):
+        assert cmux.load_config(tmp_path / "absent.json") == {}
+
+    def test_load_empty_returns_empty(self, tmp_path):
+        p = tmp_path / "cmux.json"
+        p.write_text("")
+        assert cmux.load_config(p) == {}
+
+    def test_load_corrupt_returns_empty(self, tmp_path):
+        p = tmp_path / "cmux.json"
+        p.write_text("{ not json ]]")
+        assert cmux.load_config(p) == {}
+
+    def test_comment_marker_inside_string_preserved(self, tmp_path):
+        p = tmp_path / "cmux.json"
+        p.write_text('{"x": "http://example.com//path"}')
+        assert cmux.load_config(p)["x"] == "http://example.com//path"
+
+    def test_merge_into_empty(self):
+        merged, changed = cmux.merge_surface({})
+        assert changed is True
+        assert any(c["name"] == cmux.SURFACE_NAME for c in merged["commands"])
+        assert "$schema" in merged and merged["schemaVersion"] == 1
+
+    def test_merge_preserves_user_content(self):
+        config = {
+            "schemaVersion": 1,
+            "app": {"minimalMode": True},
+            "commands": [{"name": "My Custom", "command": "echo hi"}],
+            "shortcuts": {"bindings": {"quit": "cmd+q"}},
+        }
+        merged, changed = cmux.merge_surface(config)
+        assert changed is True
+        # Every pre-existing key + command survives.
+        assert merged["app"] == {"minimalMode": True}
+        assert merged["shortcuts"]["bindings"]["quit"] == "cmd+q"
+        names = [c["name"] for c in merged["commands"]]
+        assert "My Custom" in names and cmux.SURFACE_NAME in names
+
+    def test_merge_is_idempotent(self):
+        merged1, changed1 = cmux.merge_surface({})
+        assert changed1 is True
+        merged2, changed2 = cmux.merge_surface(merged1)
+        assert changed2 is False
+        assert merged2["commands"] == merged1["commands"]
+
+    def test_merge_does_not_duplicate_on_rerun(self):
+        merged, _ = cmux.merge_surface({})
+        merged, _ = cmux.merge_surface(merged)
+        merged, _ = cmux.merge_surface(merged)
+        ours = [c for c in merged["commands"] if c["name"] == cmux.SURFACE_NAME]
+        assert len(ours) == 1
+
+    def test_merge_updates_stale_entry(self):
+        # A pre-existing entry with our name but a different command is refreshed.
+        config = {
+            "commands": [{"name": cmux.SURFACE_NAME, "command": "old", "cwd": "/x"}]
+        }
+        merged, changed = cmux.merge_surface(config)
+        assert changed is True
+        ours = [c for c in merged["commands"] if c["name"] == cmux.SURFACE_NAME]
+        assert len(ours) == 1
+        assert ours[0] == cmux.build_surface()
+
+    def test_merge_does_not_mutate_caller(self):
+        config = {"commands": [{"name": "Keep", "command": "x"}]}
+        original = json.loads(json.dumps(config))
+        cmux.merge_surface(config)
+        assert config == original  # caller's dict/list untouched
+
+
+# --------------------------------------------------------------------------- #
+# fanout command construction (pure)
+# --------------------------------------------------------------------------- #
+
+
+class TestFanoutCommand:
+    def test_no_args(self, monkeypatch):
+        monkeypatch.setattr(cmux.shutil, "which", lambda name: "/bin/cswap")
+        assert cmux._build_launch_command([]) == "cswap launch"
+
+    def test_with_claude_args_quoted(self, monkeypatch):
+        monkeypatch.setattr(cmux.shutil, "which", lambda name: "/bin/cswap")
+        cmd = cmux._build_launch_command(["--resume", "my session"])
+        assert cmd == "cswap launch -- '--resume' 'my session'"
+
+    def test_quote_escapes_single_quote(self):
+        assert cmux._shell_quote("a'b") == "'a'\\''b'"
+
+
+# --------------------------------------------------------------------------- #
+# config_path
+# --------------------------------------------------------------------------- #
+
+
+class TestConfigPath:
+    def test_config_path_under_home(self, temp_home: Path):
+        p = cmux.config_path()
+        assert p == temp_home / ".config" / "cmux" / "cmux.json"
+
+
+# --------------------------------------------------------------------------- #
+# setup() end-to-end with the cmux CLI mocked (no real cmux)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeCLI:
+    """Records cmux CLI calls; reports validate/reload success."""
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def run(self, args, **kwargs):
+        import subprocess
+
+        self.calls.append(args)
+        sub = args[1] if len(args) > 1 else ""
+        if args[1:3] == ["config", "validate"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="JSONC syntax is valid\n", stderr=""
+            )
+        if sub == "reload-config":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if sub == "list-workspaces":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+@pytest.fixture
+def _macos_with_fake_cmux(monkeypatch):
+    """Force macOS + a fake cmux CLI, capturing every subprocess invocation."""
+    monkeypatch.setattr(Platform, "detect", classmethod(lambda cls: Platform.MACOS))
+    monkeypatch.setattr(cmux, "find_cmux", lambda: "/fake/cmux")
+    fake = _FakeCLI()
+    monkeypatch.setattr(cmux.subprocess, "run", fake.run)
+    return fake
+
+
+class TestSetup:
+    def test_setup_writes_surface_and_validates(self, temp_home, _macos_with_fake_cmux):
+        sw = ClaudeAccountSwitcher()
+        status = cmux.setup(sw)
+        assert status["ok"] is True
+        assert status["changed"] is True
+        assert status["validated"] is True
+        assert status["reloaded"] is True
+        # cmux.json now contains our surface and is strict, parseable JSON.
+        cfg = json.loads(Path(status["config_path"]).read_text())
+        assert any(c["name"] == cmux.SURFACE_NAME for c in cfg["commands"])
+
+    def test_setup_idempotent_no_backup_first_run(self, temp_home, _macos_with_fake_cmux):
+        sw = ClaudeAccountSwitcher()
+        first = cmux.setup(sw)
+        # No prior cmux.json -> nothing to back up.
+        assert first["backup_path"] is None
+        second = cmux.setup(sw)
+        assert second["changed"] is False  # already current
+        assert second["backup_path"] is not None  # now there IS a file to back up
+
+    def test_setup_preserves_existing_user_config(self, temp_home, _macos_with_fake_cmux):
+        cfg_path = cmux.config_path()
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text(
+            '{\n  // user comment\n  "app": {"minimalMode": true},\n'
+            '  "commands": [{"name": "Mine", "command": "x"}]\n}'
+        )
+        sw = ClaudeAccountSwitcher()
+        status = cmux.setup(sw)
+        assert status["ok"] is True
+        assert status["backup_path"] is not None
+        assert Path(status["backup_path"]).exists()
+        cfg = json.loads(cfg_path.read_text())
+        assert cfg["app"]["minimalMode"] is True
+        names = [c["name"] for c in cfg["commands"]]
+        assert "Mine" in names and cmux.SURFACE_NAME in names
+
+    def test_setup_off_macos_raises(self, temp_home, monkeypatch):
+        from claude_swap.exceptions import SessionError
+
+        monkeypatch.setattr(Platform, "detect", classmethod(lambda cls: Platform.LINUX))
+        sw = ClaudeAccountSwitcher()
+        with pytest.raises(SessionError, match="macOS-only"):
+            cmux.setup(sw)
+
+
+# --------------------------------------------------------------------------- #
+# supervisor env: CMUX preserve-key wiring
+# --------------------------------------------------------------------------- #
+
+
+class TestSupervisorEnv:
+    def test_preserve_key_added_under_cmux(self, temp_home, monkeypatch):
+        from claude_swap.supervisor import Supervisor
+
+        sw = ClaudeAccountSwitcher()
+        sup = Supervisor(
+            sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False
+        )
+        monkeypatch.setenv("CMUX_SURFACE_ID", "surface:1")
+        monkeypatch.setenv(cmux.PRESERVE_KEYS_ENV, "EXISTING")
+        env = sup._session_env()
+        keys = env[cmux.PRESERVE_KEYS_ENV].split(",")
+        assert "EXISTING" in keys
+        assert cmux.CLAUDE_CONFIG_DIR_KEY in keys
+        assert env["CLAUDE_CONFIG_DIR"] == str(temp_home / "p")
+
+    def test_no_preserve_key_outside_cmux(self, temp_home, monkeypatch):
+        from claude_swap.supervisor import Supervisor
+
+        sw = ClaudeAccountSwitcher()
+        sup = Supervisor(
+            sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False
+        )
+        monkeypatch.delenv("CMUX_SURFACE_ID", raising=False)
+        monkeypatch.delenv(cmux.PRESERVE_KEYS_ENV, raising=False)
+        env = sup._session_env()
+        assert cmux.PRESERVE_KEYS_ENV not in env

--- a/tests/test_cmux.py
+++ b/tests/test_cmux.py
@@ -313,6 +313,80 @@ class TestSetup:
         with pytest.raises(SessionError, match="macOS-only"):
             cmux.setup(sw)
 
+    def test_two_setups_same_second_keep_distinct_backups(
+        self, temp_home, _macos_with_fake_cmux, monkeypatch
+    ):
+        """BUG 013: same-second backups must not overwrite each other."""
+        # Freeze the 1-second-resolution timestamp so both backups would collide
+        # under the old naming scheme.
+        monkeypatch.setattr(cmux.time, "strftime", lambda fmt: "20240101-120000")
+
+        cfg_path = cmux.config_path()
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text('{"commands": [{"name": "Mine", "command": "v1"}]}')
+
+        sw = ClaudeAccountSwitcher()
+        first = cmux.setup(sw)
+        assert first["backup_path"] is not None
+
+        # Mutate the live config so the second backup captures different bytes,
+        # then run setup again within the same (frozen) second.
+        cfg_path.write_text('{"commands": [{"name": "Mine", "command": "v2"}]}')
+        second = cmux.setup(sw)
+        assert second["backup_path"] is not None
+
+        # Distinct backup paths, both still on disk (the original is preserved).
+        assert first["backup_path"] != second["backup_path"]
+        assert Path(first["backup_path"]).exists()
+        assert Path(second["backup_path"]).exists()
+
+
+# --------------------------------------------------------------------------- #
+# _open_one_workspace — rc==0 is authoritative (no duplicate creates)
+# --------------------------------------------------------------------------- #
+
+
+class TestOpenWorkspace:
+    def test_rc_zero_returns_true_without_re_creating(self, monkeypatch):
+        """BUG 010: a single rc==0 new-workspace must not trigger a re-create."""
+        calls: list[tuple] = []
+
+        def fake_run_cli(cli, *args, **kwargs):
+            import subprocess
+
+            calls.append(args)
+            return subprocess.CompletedProcess(list(args), 0, stdout="", stderr="")
+
+        monkeypatch.setattr(cmux, "_run_cli", fake_run_cli)
+        ok = cmux._open_one_workspace("/fake/cmux", "/cwd", "cmd", "ws")
+        assert ok is True
+        # Exactly ONE new-workspace call — no verify-by-count re-create even if
+        # a list-workspaces read would have lagged.
+        new_ws_calls = [a for a in calls if a and a[0] == "new-workspace"]
+        assert len(new_ws_calls) == 1
+
+    def test_retries_on_nonzero_then_succeeds(self, monkeypatch):
+        rcs = iter([1, 0])
+
+        def fake_run_cli(cli, *args, **kwargs):
+            import subprocess
+
+            return subprocess.CompletedProcess(list(args), next(rcs), stdout="", stderr="")
+
+        monkeypatch.setattr(cmux, "_run_cli", fake_run_cli)
+        monkeypatch.setattr(cmux.time, "sleep", lambda *_: None)
+        assert cmux._open_one_workspace("/fake/cmux", "/cwd", "cmd", "ws") is True
+
+    def test_gives_up_after_all_nonzero(self, monkeypatch):
+        def fake_run_cli(cli, *args, **kwargs):
+            import subprocess
+
+            return subprocess.CompletedProcess(list(args), 2, stdout="", stderr="")
+
+        monkeypatch.setattr(cmux, "_run_cli", fake_run_cli)
+        monkeypatch.setattr(cmux.time, "sleep", lambda *_: None)
+        assert cmux._open_one_workspace("/fake/cmux", "/cwd", "cmd", "ws") is False
+
 
 # --------------------------------------------------------------------------- #
 # supervisor env: CMUX preserve-key wiring

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,69 @@
+"""Tests for embedding cswap into Claude Code (managed-session settings)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_swap import embed
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class TestManagedSettings:
+    def test_build_managed_settings_shape(self):
+        s = embed.build_managed_settings()
+        assert s["statusLine"]["type"] == "command"
+        assert s["statusLine"]["command"]  # non-empty
+        assert s["effortLevel"] == embed.EFFORT_LEVEL == "xhigh"
+
+    def test_statusline_command_is_a_string(self):
+        cmd = embed.cswap_statusline_command()
+        assert isinstance(cmd, str) and "statusline" in cmd
+
+
+class TestTemplate:
+    def test_write_template_then_idempotent(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        assert embed.write_managed_template(sw) is True
+        # Second call: already current -> no rewrite.
+        assert embed.write_managed_template(sw) is False
+        path = embed.managed_template_path(sw)
+        data = json.loads(path.read_text())
+        assert data["effortLevel"] == "xhigh"
+
+    def test_install_into_profile_writes_real_settings(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        profile = sw.managed_dir / "abc123"
+        embed.install_into_profile(sw, profile)
+        settings = profile / "settings.json"
+        assert settings.exists()
+        # Must be a real file, never a symlink into ~/.claude.
+        assert not settings.is_symlink()
+        data = json.loads(settings.read_text())
+        assert "statusLine" in data and data["effortLevel"] == "xhigh"
+
+
+class TestEmbedHealth:
+    def test_unhealthy_before_install(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        health = embed.embed_health(sw)
+        assert health["ok"] is False
+        assert health["template_ok"] is False
+        assert health["issues"]
+
+    def test_healthy_after_install(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        health = embed.install(sw)
+        assert health["ok"] is True
+        assert health["template_ok"] is True
+        assert health["issues"] == []
+
+    def test_health_flags_tampered_template(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        embed.install(sw)
+        # Corrupt the template's effort level.
+        path = embed.managed_template_path(sw)
+        data = json.loads(path.read_text())
+        data["effortLevel"] = "low"
+        path.write_text(json.dumps(data))
+        assert embed.embed_health(sw)["ok"] is False

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -20,6 +20,48 @@ class TestManagedSettings:
         cmd = embed.cswap_statusline_command()
         assert isinstance(cmd, str) and "statusline" in cmd
 
+    def test_statusfailure_command_is_a_string(self):
+        cmd = embed.cswap_statusfailure_command()
+        assert isinstance(cmd, str) and "statusfailure" in cmd
+
+    def test_build_managed_settings_carries_stopfailure_hook(self):
+        s = embed.build_managed_settings()
+        groups = s["hooks"]["StopFailure"]
+        cmd = groups[0]["hooks"][0]["command"]
+        assert groups[0]["hooks"][0]["type"] == "command"
+        assert "statusfailure" in cmd
+
+    def test_install_into_profile_keeps_user_hooks_and_adds_stopfailure(
+        self, temp_home: Path
+    ):
+        # A user with their own hooks (incl. a StopFailure hook) must keep them,
+        # with cswap's StopFailure safety net added alongside (not clobbering).
+        user_settings = Path.home() / ".claude" / "settings.json"
+        user_settings.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [{"hooks": [{"type": "command", "command": "mine"}]}],
+                        "StopFailure": [{"hooks": [{"type": "command", "command": "theirs"}]}],
+                    }
+                }
+            )
+        )
+        sw = ClaudeAccountSwitcher()
+        profile = sw.managed_dir / "abc123"
+        embed.install_into_profile(sw, profile)
+        data = json.loads((profile / "settings.json").read_text())
+        # User's unrelated hook survives.
+        assert data["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "mine"
+        # User's StopFailure hook survives AND ours is appended.
+        cmds = [
+            h["command"]
+            for g in data["hooks"]["StopFailure"]
+            for h in g["hooks"]
+        ]
+        assert "theirs" in cmds
+        assert any("statusfailure" in c for c in cmds)
+
 
 class TestTemplate:
     def test_write_template_then_idempotent(self, temp_home: Path):
@@ -65,5 +107,16 @@ class TestEmbedHealth:
         path = embed.managed_template_path(sw)
         data = json.loads(path.read_text())
         data["effortLevel"] = "low"
+        path.write_text(json.dumps(data))
+        assert embed.embed_health(sw)["ok"] is False
+
+    def test_health_flags_template_missing_stopfailure_hook(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        embed.install(sw)
+        # An older template (no StopFailure hook) must read as unhealthy so the
+        # upgrade migration refreshes it.
+        path = embed.managed_template_path(sw)
+        data = json.loads(path.read_text())
+        data.pop("hooks", None)
         path.write_text(json.dumps(data))
         assert embed.embed_health(sw)["ok"] is False

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -88,6 +88,19 @@ def _patch_keyring(fake: FakeKeyring):
     return patch.dict(sys.modules, {"keyring": fake})
 
 
+def _applied_migrations(switcher: ClaudeAccountSwitcher) -> dict:
+    """Return the recorded {migration_id: ts} map, {} if the state file is absent.
+
+    Used instead of asserting the state file's *absence*: an unrelated migration
+    (e.g. install_balancer_v1) may legitimately complete and create the file, so
+    a precise check is "this specific migration is not marked".
+    """
+    path = switcher.backup_dir / ".migrations.json"
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text()).get("applied", {})
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
@@ -294,7 +307,7 @@ class TestFailures:
         # Source entry preserved, migration not recorded → retried next run.
         assert (KEYRING_SERVICE, "account-1-a@example.com") in fake.store
         assert fake.deleted == []
-        assert not (switcher.backup_dir / ".migrations.json").exists()
+        assert "windows_keyring_to_files" not in _applied_migrations(switcher)
         # The bad/partial file must not shadow the intact keyring entry.
         assert not (
             switcher.credentials_dir / ".creds-1-a@example.com.enc"
@@ -323,7 +336,7 @@ class TestFailures:
         # The healthy account migrated; the failed one is untouched + unmarked.
         assert switcher._read_account_credentials("1", "ok@example.com") == "good"
         assert (KEYRING_SERVICE, "account-2-bad@example.com") in fake.store
-        assert not (switcher.backup_dir / ".migrations.json").exists()
+        assert "windows_keyring_to_files" not in _applied_migrations(switcher)
 
     def test_partial_failure_raises_from_migration_fn(self, temp_home):
         switcher = _make_windows_switcher(temp_home)
@@ -344,7 +357,7 @@ class TestFailures:
         # Runner swallows it and leaves it unmarked.
         with patch.dict(sys.modules, {"keyring": None}):
             run_migrations(switcher)
-        assert not (switcher.backup_dir / ".migrations.json").exists()
+        assert "windows_keyring_to_files" not in _applied_migrations(switcher)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -619,3 +619,53 @@ class TestFetchUsageForAccount:
         output = capsys.readouterr().out
         assert "failed to save refreshed token" in output
         assert "cswap --add-account" in output
+
+
+class TestPrimeAccount:
+    """The minimal credit-consuming call that starts an idle 5h window.
+
+    Every test MOCKS urllib — NO real prime call is ever made.
+    """
+
+    @staticmethod
+    def _resp(status: int):
+        resp = MagicMock()
+        resp.status = status
+        resp.read.return_value = b"{}"
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_2xx_starts_clock_returns_true(self):
+        with patch("claude_swap.oauth.urllib.request.urlopen", return_value=self._resp(200)) as m:
+            assert oauth.prime_account("tok-abc") is True
+        # Verify the request shape: POST /v1/messages with the OAuth beta header.
+        req = m.call_args[0][0]
+        assert req.full_url == "https://api.anthropic.com/v1/messages"
+        assert req.get_method() == "POST"
+        assert req.get_header("Authorization") == "Bearer tok-abc"
+        assert req.get_header("Anthropic-beta") == oauth.OAUTH_BETA_HEADER
+        body = json.loads(req.data.decode())
+        assert body["model"] == oauth.PRIME_MODEL
+        assert body["max_tokens"] == 1
+        assert body["messages"] == [{"role": "user", "content": "hi"}]
+
+    def test_429_is_treated_as_already_started(self):
+        err = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=429, msg="Too Many Requests", hdrs=None, fp=None,
+        )
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            assert oauth.prime_account("tok-abc") is True  # window already running
+
+    def test_401_returns_false(self):
+        err = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=401, msg="Unauthorized", hdrs=None, fp=None,
+        )
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            assert oauth.prime_account("tok-abc") is False
+
+    def test_network_error_returns_false_never_raises(self):
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=OSError("boom")):
+            assert oauth.prime_account("tok-abc") is False

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -465,6 +465,78 @@ class TestFetchUsageForAccount:
         assert result is not None
         assert result["five_hour"]["pct"] == 10.0
 
+    def test_429_populates_failure_out_with_retry_after(self):
+        """A usage-endpoint 429 surfaces the server's Retry-After for backoff.
+
+        The endpoint rate-limits the whole client (not a specific token); honoring
+        Retry-After is what stops the 'usage unavailable' refetch-every-TTL loop.
+        """
+        credentials = self._make_credentials()  # fresh token -> no refresh attempt
+
+        def mock_urlopen(req, timeout=0):
+            if "oauth/usage" in req.full_url:
+                raise urllib.error.HTTPError(
+                    req.full_url, 429, "Too Many Requests",
+                    hdrs={"Retry-After": "1800"}, fp=None,
+                )
+            raise AssertionError(f"Unexpected URL: {req.full_url}")
+
+        failure: dict = {}
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=mock_urlopen):
+            result = oauth.fetch_usage_for_account(
+                "1", "test@example.com", credentials,
+                is_active=False, failure_out=failure,
+            )
+
+        assert result is None
+        assert failure.get("retry_after") == 1800
+
+    def test_retry_after_is_clamped_to_a_sane_max(self):
+        """A huge/buggy Retry-After can't blackhole an account for hours."""
+        from claude_swap.oauth import _MAX_USAGE_BACKOFF_S
+
+        credentials = self._make_credentials()
+
+        def mock_urlopen(req, timeout=0):
+            if "oauth/usage" in req.full_url:
+                raise urllib.error.HTTPError(
+                    req.full_url, 429, "Too Many Requests",
+                    hdrs={"Retry-After": "999999999"}, fp=None,
+                )
+            raise AssertionError(f"Unexpected URL: {req.full_url}")
+
+        failure: dict = {}
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=mock_urlopen):
+            oauth.fetch_usage_for_account(
+                "1", "test@example.com", credentials,
+                is_active=False, failure_out=failure,
+            )
+        assert failure.get("retry_after") == _MAX_USAGE_BACKOFF_S
+
+    def test_active_account_is_never_refreshed(self):
+        """is_active=True (active default / live session) must skip refresh entirely,
+        even with an expired token — refreshing rotates the live login's token out."""
+        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+        credentials = self._make_credentials(expires_at=now_ms - 1_000)  # expired
+
+        usage_resp = self._make_usage_response(h5_pct=5.0, d7_pct=6.0)
+
+        def mock_urlopen(req, timeout=0):
+            if "oauth/token" in req.full_url:
+                raise AssertionError("active account must NOT refresh its token")
+            if "oauth/usage" in req.full_url:
+                return usage_resp
+            raise AssertionError(f"Unexpected URL: {req.full_url}")
+
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=mock_urlopen), \
+             patch("claude_swap.oauth.refresh_oauth_credentials") as refresh_mock:
+            result = oauth.fetch_usage_for_account(
+                "1", "test@example.com", credentials, is_active=True,
+            )
+
+        refresh_mock.assert_not_called()
+        assert result is not None
+
     def test_refresh_failure_returns_none_gracefully(self):
         """If token refresh fails (e.g. revoked), usage returns None."""
         now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
@@ -669,6 +741,84 @@ class TestPrimeAccount:
     def test_network_error_returns_false_never_raises(self):
         with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=OSError("boom")):
             assert oauth.prime_account("tok-abc") is False
+
+
+class TestProbeMessagesHeadroom:
+    """The messages-API headroom probe — the backup signal when the usage endpoint
+    is 429-backed-off. Every test MOCKS urllib — NO real call is ever made.
+    """
+
+    @staticmethod
+    def _resp(status: int):
+        resp = MagicMock()
+        resp.status = status
+        resp.read.return_value = b"{}"
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_2xx_returns_true_and_sends_correct_shape(self):
+        with patch("claude_swap.oauth.urllib.request.urlopen", return_value=self._resp(200)) as m:
+            assert oauth.probe_messages_headroom("tok-abc") is True
+        # Same request shape as a prime call: POST /v1/messages with the OAuth beta.
+        req = m.call_args[0][0]
+        assert req.full_url == "https://api.anthropic.com/v1/messages"
+        assert req.get_method() == "POST"
+        assert req.get_header("Authorization") == "Bearer tok-abc"
+        assert req.get_header("Anthropic-beta") == oauth.OAUTH_BETA_HEADER
+        assert req.get_header("Anthropic-version") == "2023-06-01"
+        body = json.loads(req.data.decode())
+        assert body["model"] == oauth.PRIME_MODEL
+        assert body["max_tokens"] == 1
+        assert body["messages"] == [{"role": "user", "content": "hi"}]
+
+    def test_429_returns_false_and_records_retry_after(self):
+        err = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=429, msg="Too Many Requests",
+            hdrs={"Retry-After": "1800"}, fp=None,
+        )
+        failure: dict = {}
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            assert oauth.probe_messages_headroom("tok-abc", failure_out=failure) is False
+        assert failure["retry_after"] == 1800
+
+    def test_429_retry_after_is_clamped(self):
+        from claude_swap.oauth import _MAX_USAGE_BACKOFF_S
+
+        err = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=429, msg="Too Many Requests",
+            hdrs={"Retry-After": "999999999"}, fp=None,
+        )
+        failure: dict = {}
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            assert oauth.probe_messages_headroom("tok-abc", failure_out=failure) is False
+        assert failure["retry_after"] == _MAX_USAGE_BACKOFF_S
+
+    def test_429_without_header_returns_false_no_retry_after(self):
+        err = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=429, msg="Too Many Requests", hdrs=None, fp=None,
+        )
+        failure: dict = {}
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            assert oauth.probe_messages_headroom("tok-abc", failure_out=failure) is False
+        assert "retry_after" not in failure
+
+    def test_401_returns_none_not_false(self):
+        # Logged out is UNKNOWN, not "capped" — the caller must not cache a false
+        # capped verdict for a transient/auth failure.
+        err = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages",
+            code=401, msg="Unauthorized", hdrs=None, fp=None,
+        )
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            assert oauth.probe_messages_headroom("tok-abc") is None
+
+    def test_network_error_returns_none_never_raises(self):
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=OSError("boom")):
+            assert oauth.probe_messages_headroom("tok-abc") is None
 
 
 class TestSubscriptionType:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import urllib.error
 from datetime import datetime, timezone
@@ -283,6 +284,32 @@ class TestRefreshOAuthCredentials:
         assert seen_body["refresh_token"] == "old-refresh"
         assert seen_body["client_id"] == oauth.OAUTH_CLIENT_ID
         assert "scope" not in seen_body
+
+    def test_invalid_grant_sets_failure_flag(self):
+        """A dead refresh token (400 invalid_grant) is reported as logged-out, not transient."""
+        err = urllib.error.HTTPError(
+            url=oauth.OAUTH_TOKEN_URL, code=400, msg="Bad Request", hdrs=None,
+            fp=io.BytesIO(b'{"error": "invalid_grant", "error_description": "Refresh token not found or invalid"}'),
+        )
+        fail: dict = {}
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            refreshed = oauth.refresh_oauth_credentials(self._make_credentials(), failure_out=fail)
+
+        assert refreshed is None
+        assert fail.get("invalid_grant") is True
+
+    def test_transient_failure_does_not_set_invalid_grant(self):
+        """A 5xx / network blip is NOT a logged-out verdict — failure_out stays clean."""
+        err = urllib.error.HTTPError(
+            url=oauth.OAUTH_TOKEN_URL, code=503, msg="Service Unavailable", hdrs=None,
+            fp=io.BytesIO(b"upstream timeout"),
+        )
+        fail: dict = {}
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            refreshed = oauth.refresh_oauth_credentials(self._make_credentials(), failure_out=fail)
+
+        assert refreshed is None
+        assert "invalid_grant" not in fail
 
 
 class TestBuildTokenStatus:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -669,3 +669,33 @@ class TestPrimeAccount:
     def test_network_error_returns_false_never_raises(self):
         with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=OSError("boom")):
             assert oauth.prime_account("tok-abc") is False
+
+
+class TestSubscriptionType:
+    """Subscription-tier detection gates idle-window priming away from API accounts."""
+
+    def test_extracts_lowercased_type(self):
+        creds = json.dumps({"claudeAiOauth": {"subscriptionType": "Max"}})
+        assert oauth.extract_subscription_type(creds) == "max"
+
+    def test_none_when_absent(self):
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "t"}})
+        assert oauth.extract_subscription_type(creds) is None
+
+    def test_none_when_no_oauth_payload(self):
+        # An API-key / console account carries no claudeAiOauth block.
+        assert oauth.extract_subscription_type(json.dumps({"apiKey": "sk-x"})) is None
+        assert oauth.extract_subscription_type("not json") is None
+
+    def test_blank_type_is_none(self):
+        creds = json.dumps({"claudeAiOauth": {"subscriptionType": "   "}})
+        assert oauth.extract_subscription_type(creds) is None
+
+    def test_primable_subscription_tiers(self):
+        for sub in ("pro", "max", "team", "enterprise", "MAX", "Team"):
+            assert oauth.is_primable_subscription(sub) is True, sub
+
+    def test_non_primable_types(self):
+        # None / blank / API / console / unrecognized must never be primed.
+        for sub in (None, "", "api", "console", "free", "unknown"):
+            assert oauth.is_primable_subscription(sub) is False, sub

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -22,6 +22,7 @@ from claude_swap.paths import (
     get_credentials_path,
     get_global_config_path,
     get_legacy_backup_root,
+    mark_cwd_trusted,
     migrate_legacy_backup_dir,
 )
 
@@ -314,3 +315,48 @@ class TestMigrateLegacyBackupDir:
         moved = target / "credentials" / ".creds-1-user@example.com.enc"
         assert moved.stat().st_mode & 0o777 == 0o600
         assert (target / "credentials").stat().st_mode & 0o777 == 0o700
+
+
+class TestMarkCwdTrusted:
+    def test_falsy_cwd_is_noop(self):
+        config: dict = {}
+        assert mark_cwd_trusted(config, None) is False
+        assert mark_cwd_trusted(config, "") is False
+        assert config == {}
+
+    def test_marks_abspath_trusted(self, tmp_path: Path):
+        config: dict = {}
+        assert mark_cwd_trusted(config, str(tmp_path)) is True
+        key = os.path.realpath(tmp_path)
+        assert config["projects"][key]["hasTrustDialogAccepted"] is True
+
+    def test_normalizes_relative_and_dotdot(self):
+        config: dict = {}
+        mark_cwd_trusted(config, "/tmp/foo/../bar")
+        assert os.path.abspath("/tmp/foo/../bar") in config["projects"]
+
+    def test_seeds_realpath_variant_for_symlinked_cwd(self, tmp_path: Path):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+        config: dict = {}
+        mark_cwd_trusted(config, str(link))
+        # claude keys the map by the child's resolved process.cwd(), so the
+        # realpath MUST be present even though we were handed the symlink.
+        assert config["projects"][str(real)]["hasTrustDialogAccepted"] is True
+
+    def test_preserves_existing_entry_metadata(self):
+        key = os.path.abspath("/x/y")
+        config = {"projects": {key: {"allowedTools": ["Bash"], "history": [1]}}}
+        mark_cwd_trusted(config, "/x/y")
+        entry = config["projects"][key]
+        assert entry["hasTrustDialogAccepted"] is True
+        assert entry["allowedTools"] == ["Bash"]
+        assert entry["history"] == [1]
+
+    def test_replaces_malformed_projects_map(self):
+        config = {"projects": "corrupt"}
+        mark_cwd_trusted(config, "/a/b")
+        assert isinstance(config["projects"], dict)
+        assert config["projects"][os.path.abspath("/a/b")]["hasTrustDialogAccepted"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -198,34 +198,51 @@ class TestBuildWorld:
         registry.write_registry(sw, reg)
         return reg
 
-    def test_live_account_fetches_spend_on_cold_cache(self, temp_home: Path):
-        # Regression: a LIVE account's pay-as-you-go capability must NOT be lost
-        # when the usage cache is cold. build_world fetches it once; the live
-        # signal still wins for the rate-limit numbers.
+    def test_live_account_reads_spend_from_cache_no_fetch(self, temp_home: Path):
+        # A live account reads pay-as-you-go info from the cache when present and
+        # NEVER triggers a usage fetch (avoids extra usage-API load + token churn).
         sw = ClaudeAccountSwitcher()
         _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        write_cache(sw.backup_dir / "cache" / "usage.json",
+                    {"1": {"extra_usage_enabled": True, "spend": {"pct": 12.0}}})
         reg = self._seed_live_session(sw)
-        fetched = {"extra_usage_enabled": True, "spend": {"pct": 12.0},
-                   "five_hour": {"pct": 5.0}}  # usage-API view; live signal wins for limits
-        with patch("claude_swap.registry._fetch_idle_usage", return_value=fetched) as m:
+        with patch("claude_swap.registry._fetch_idle_usage") as m:
             acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
         av = acct_views["1"]
         assert av.signal == "live"
-        assert av.max_pct == 98.0           # from the LIVE signal, not the fetch
-        assert av.extra_usage is True       # recovered from the cold-cache fetch
-        assert av.spend_pct == 12.0
-        m.assert_called_once()
+        assert av.max_pct == 98.0                       # from the live signal
+        assert (av.extra_usage, av.spend_pct) == (True, 12.0)  # from cache
+        m.assert_not_called()                           # never fetch for a live acct
 
-    def test_live_account_no_fetch_when_idle_disabled(self, temp_home: Path):
-        # With fetch_idle=False the cold-cache live account stays best-effort: no
-        # network, extra_usage unknown (False).
+    def test_live_account_cold_cache_extra_usage_unknown_no_fetch(self, temp_home: Path):
+        # Cold cache: a live account's extra-usage is simply unknown (False); we
+        # still never fetch for it.
         sw = ClaudeAccountSwitcher()
         _seed_accounts(sw, {"1": ("a@x.com", 5)})
         reg = self._seed_live_session(sw)
         with patch("claude_swap.registry._fetch_idle_usage") as m:
-            acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
         assert acct_views["1"].extra_usage is False
         m.assert_not_called()
+
+    def test_failed_idle_fetch_is_cached_to_throttle_retries(self, temp_home: Path):
+        # A failed idle fetch (e.g. usage-API 429 -> None) is recorded as an
+        # "_unavailable" marker so the cache TTL throttles retries instead of
+        # refetching every pass — the fix for the all-accounts 429 feedback loop.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = registry.read_registry(sw)
+        with patch("claude_swap.registry._fetch_idle_usage", return_value=None) as m:
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
+            assert acct_views["2"].signal == "none"
+            assert m.call_count == 1
+            # The marker is now cached -> a second pass does NOT refetch.
+            acct_views2, _ = registry.build_world(sw, reg, fetch_idle=True)
+            assert acct_views2["2"].signal == "none"
+            assert m.call_count == 1
+        from claude_swap.cache import read_cache
+        cp = sw.backup_dir / "cache" / "usage.json"
+        assert read_cache(cp, 10**9).get("2", {}).get("_unavailable") is True
 
 
 class TestPlacementReservation:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -374,6 +374,30 @@ class TestProbeUnavailable:
         entry = read_cache(sw.backup_dir / "cache" / "usage.json", 10**9).get("2")
         assert probe_ok(entry) is True
 
+    def test_probe_ok_verdict_carries_last_known_forward(self, temp_home: Path):
+        # A probe-OK verdict must thread _last_known forward (like every other marker
+        # write) so a later 429 can inherit it instead of collapsing to zero headroom.
+        from claude_swap.cache import probe_ok, read_cache
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        last_known = {"five_hour": {"pct": 55}}
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {
+                "_unavailable": True,
+                "retry_until": time.time() + 3600,
+                "_last_known": last_known,
+                "_last_known_at": time.time(),
+            }},
+        )
+        reg = registry.read_registry(sw)
+        with patch("claude_swap.registry._probe_idle_headroom", return_value=True):
+            registry.build_world(sw, reg, fetch_idle=True, probe_unavailable=True)
+        entry = read_cache(sw.backup_dir / "cache" / "usage.json", 10**9).get("2")
+        assert probe_ok(entry) is True
+        assert entry["_last_known"] == last_known  # snapshot survives the OK verdict
+
     def test_probe_ok_verdict_reused_on_second_pass_without_reprobing(self, temp_home: Path):
         # Regression for the resume-path blocker: a cached probe-OK verdict carries no
         # _unavailable/retry_until, so without an explicit reuse branch the SECOND
@@ -726,3 +750,101 @@ class TestPrimeGuards:
         assert changed is True
         assert "1" in reg["primed"]
         assert "2" not in reg["primed"]
+
+
+class TestStaleOptimisticView:
+    """A usage-backed-off account that was healthy when last read enters the model
+    with an optimistic ``signal="stale"`` view (its last-known usage), so a stranded
+    session can migrate onto it WITHOUT spending a probe credit."""
+
+    LAST_KNOWN = {
+        "five_hour": {"pct": 62.0, "resets_at": 9_999_999_999},
+        "seven_day": {"pct": 30.0, "resets_at": 9_999_999_999},
+    }
+
+    def test_fresh_last_known_yields_stale_view(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {
+                "_unavailable": True,
+                "retry_until": time.time() + 3600,
+                "_last_known": self.LAST_KNOWN,
+                "_last_known_at": time.time(),
+            }},
+        )
+        reg = registry.read_registry(sw)
+        # Backoff is active -> must NOT fetch; the stale reading backs the view.
+        with patch("claude_swap.registry._fetch_idle_usage") as m:
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
+        m.assert_not_called()
+        av = acct_views["2"]
+        assert av.signal == "stale"
+        assert av.max_pct == 62.0  # max(5h=62, 7d=30), no reserve
+        assert av.five_hour_pct == 62.0
+
+    def test_fresh_negative_probe_suppresses_stale_view(self, temp_home: Path):
+        # A live probe just confirmed the account is capped/unknown NOW (a recent
+        # _probed_at, no _probe_ok). That authoritative verdict must trump the older
+        # last-known reading -> NO stale view (else migrate->limit->migrate).
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {
+                "_unavailable": True,
+                "retry_until": time.time() + 3600,
+                "_probed_at": time.time(),  # fresh negative probe verdict
+                "_last_known": self.LAST_KNOWN,
+                "_last_known_at": time.time(),
+            }},
+        )
+        reg = registry.read_registry(sw)
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
+        av = acct_views["2"]
+        assert av.signal == "none"  # not "stale" — the probe said capped
+        assert av.max_pct is None
+
+    def test_old_last_known_falls_back_to_none(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {
+                "_unavailable": True,
+                "retry_until": time.time() + 3600,
+                "_last_known": self.LAST_KNOWN,
+                "_last_known_at": time.time() - registry.STALE_USAGE_MAX_AGE_S - 1,
+            }},
+        )
+        reg = registry.read_registry(sw)
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
+        av = acct_views["2"]
+        assert av.signal == "none"
+        assert av.max_pct is None
+
+    def test_fresh_fetch_failure_records_last_known_from_prior_usage(self, temp_home: Path):
+        # Prior cache holds REAL usage that has aged out of the fresh TTL; a fetch
+        # that then 429s must snapshot that reading into the new backoff marker so
+        # the next pass can serve a stale view.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(sw.backup_dir / "cache" / "usage.json", {"2": self.LAST_KNOWN})
+        reg = registry.read_registry(sw)
+
+        def fake_fetch(switcher, num, email, *, is_active=False, failure_out=None):
+            if failure_out is not None:
+                failure_out["retry_after"] = 1800
+            return None
+
+        # TTL=0 forces the prior real usage to be "stale" so build_world refetches.
+        with patch("claude_swap.registry._usage_ttl", return_value=0), \
+             patch("claude_swap.registry._fetch_idle_usage", side_effect=fake_fetch):
+            registry.build_world(sw, reg, fetch_idle=True)
+
+        from claude_swap.cache import read_cache
+        entry = read_cache(sw.backup_dir / "cache" / "usage.json", 10**9).get("2")
+        assert entry["_unavailable"] is True
+        assert entry["_last_known"] == self.LAST_KNOWN
+        assert isinstance(entry["_last_known_at"], (int, float))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 from claude_swap import registry
 from claude_swap.cache import write_cache
@@ -186,6 +187,45 @@ class TestBuildWorld:
         with FileLock(sw.lock_file):
             acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
         assert "1" in acct_views
+
+    def _seed_live_session(self, sw):
+        reg = registry.read_registry(sw)
+        registry.upsert_session(
+            reg, "m1", account_num="1", supervisor_pid=os.getpid(),
+            rate_limits={"five_hour": {"used_percentage": 98.0, "resets_at": 2000}},
+            last_seen=time.time(),
+        )
+        registry.write_registry(sw, reg)
+        return reg
+
+    def test_live_account_fetches_spend_on_cold_cache(self, temp_home: Path):
+        # Regression: a LIVE account's pay-as-you-go capability must NOT be lost
+        # when the usage cache is cold. build_world fetches it once; the live
+        # signal still wins for the rate-limit numbers.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        reg = self._seed_live_session(sw)
+        fetched = {"extra_usage_enabled": True, "spend": {"pct": 12.0},
+                   "five_hour": {"pct": 5.0}}  # usage-API view; live signal wins for limits
+        with patch("claude_swap.registry._fetch_idle_usage", return_value=fetched) as m:
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
+        av = acct_views["1"]
+        assert av.signal == "live"
+        assert av.max_pct == 98.0           # from the LIVE signal, not the fetch
+        assert av.extra_usage is True       # recovered from the cold-cache fetch
+        assert av.spend_pct == 12.0
+        m.assert_called_once()
+
+    def test_live_account_no_fetch_when_idle_disabled(self, temp_home: Path):
+        # With fetch_idle=False the cold-cache live account stays best-effort: no
+        # network, extra_usage unknown (False).
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        reg = self._seed_live_session(sw)
+        with patch("claude_swap.registry._fetch_idle_usage") as m:
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["1"].extra_usage is False
+        m.assert_not_called()
 
 
 class TestPlacementReservation:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
-from claude_swap import registry
+from claude_swap import balancer, registry
 from claude_swap.cache import write_cache
 from claude_swap.locking import FileLock
 from claude_swap.switcher import ClaudeAccountSwitcher
@@ -334,6 +334,67 @@ class TestBuildWorld:
         assert usage_backoff_active(entry) is True
 
 
+class TestLoggedOut:
+    """build_world surfaces a dead-refresh-token account as a distinct logged-out
+    signal + persisted marker (not a generic 'unavailable'), and never as a usable
+    or stale migration target."""
+
+    def test_build_world_marks_logged_out(self, temp_home: Path):
+        from claude_swap.cache import logged_out, read_cache
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = registry.read_registry(sw)
+
+        def fake_fetch(switcher, num, email, *, is_active=False, failure_out=None):
+            if failure_out is not None:
+                failure_out["logged_out"] = True
+            return None
+
+        with patch("claude_swap.registry._fetch_idle_usage", side_effect=fake_fetch):
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
+
+        av = acct_views["2"]
+        assert av.signal == "logged_out"
+        assert av.max_pct is None  # unknown headroom -> never a migration target
+        entry = read_cache(sw.backup_dir / "cache" / "usage.json", 10**9).get("2")
+        assert logged_out(entry) is True
+
+    def test_logged_out_marker_throttles_refetch(self, temp_home: Path):
+        # A persisted logged-out marker is a backoff (retry_until): the next pass must
+        # NOT re-POST the dead token (no _fetch_idle_usage call).
+        from claude_swap.cache import logged_out_marker
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(sw.backup_dir / "cache" / "usage.json", {"2": logged_out_marker()})
+        reg = registry.read_registry(sw)
+        with patch("claude_swap.registry._fetch_idle_usage") as m:
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
+        m.assert_not_called()
+        assert acct_views["2"].signal == "logged_out"
+
+    def test_logged_out_never_probed_on_resume_path(self, temp_home: Path):
+        # The resume/strand path (probe_unavailable=True) must NOT re-probe a
+        # logged-out account: a dead token can't refresh and the messages probe only
+        # 401s, so re-POSTing it every ~30s pass is pure waste (and token-reuse risk).
+        from claude_swap.cache import logged_out, logged_out_marker, read_cache
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(sw.backup_dir / "cache" / "usage.json", {"2": logged_out_marker()})
+        reg = registry.read_registry(sw)
+        with patch("claude_swap.registry._probe_idle_headroom") as probe:
+            acct_views, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+        probe.assert_not_called()
+        assert acct_views["2"].signal == "logged_out"
+        # The logged-out marker (and its throttle) survives the pass intact.
+        entry = read_cache(sw.backup_dir / "cache" / "usage.json", 10**9).get("2")
+        assert logged_out(entry) is True
+
+
 class TestProbeUnavailable:
     """The messages-API headroom probe fallback (default OFF). A usage-429-backed-off
     idle account is probed only when ``probe_unavailable=True``; a 2xx synthesizes a
@@ -598,6 +659,67 @@ class TestProbeUnavailable:
             )
         assert acct_views["2"].signal == "probe"
         assert acct_views["2"].max_pct == balancer.PROBE_CONFIRMED_PCT
+
+
+class TestProbeViewUsesRealReading:
+    """A probe view uses min(PROBE_CONFIRMED_PCT, real last-known) so a near-idle
+    account confirmed runnable isn't pinned at the pessimistic 80 — the fix for the
+    "auto-resuming in 2h55m while an account was available" pause. The online
+    reservation still stacks on top, so co-exhaust protection is unchanged."""
+
+    def _marker(self, h5, d7, age_s=0.0):
+        return {
+            "_unavailable": True,
+            "retry_until": time.time() + 3600,
+            "_last_known": {
+                "five_hour": {"pct": h5, "resets_at": 9_999_999_999},
+                "seven_day": {"pct": d7, "resets_at": 9_999_999_999},
+            },
+            "_last_known_at": time.time() - age_s,
+        }
+
+    def test_uses_real_low_reading_instead_of_80(self):
+        # last-known max(14, 27) = 27 -> base 27, not 80.
+        av = registry._probe_view("2", 0, 0.0, self._marker(14.0, 27.0))
+        assert av.signal == "probe"
+        assert av.max_pct == 27.0
+
+    def test_no_last_known_stays_conservative_80(self):
+        # No real reading on the marker -> byte-for-byte the prior behaviour.
+        av = registry._probe_view("2", 0, 0.0, {"_unavailable": True})
+        assert av.max_pct == balancer.PROBE_CONFIRMED_PCT
+
+    def test_clamps_high_reading_to_80(self):
+        # A stale reading near the cap must never make the probe MORE optimistic than
+        # the conservative 80 (the probe only proves "a turn works now").
+        av = registry._probe_view("2", 0, 0.0, self._marker(92.0, 50.0))
+        assert av.max_pct == balancer.PROBE_CONFIRMED_PCT
+
+    def test_old_last_known_falls_back_to_80(self):
+        # An aged-out last-known reading is not trusted -> conservative 80.
+        av = registry._probe_view(
+            "2", 0, 0.0, self._marker(14.0, 27.0, age_s=registry.STALE_USAGE_MAX_AGE_S + 1)
+        )
+        assert av.max_pct == balancer.PROBE_CONFIRMED_PCT
+
+    def test_online_reservation_still_stacks_on_real_reading(self):
+        # The co-exhaust guard is the reservation, not the 80: a real 27% reading with
+        # a one-session reserve (BASE_RESERVE=3) projects to 30, exactly as it would
+        # for any real-cache account at 27%.
+        resv = balancer._pct_cost(0)  # 3.0
+        av = registry._probe_view("2", 0, resv, self._marker(27.0, 10.0))
+        assert av.max_pct == 30.0
+
+    def test_large_session_fits_probe_with_real_reading(self):
+        # The end the fix exists for: a >100k-context session that could NOT fit a
+        # flat-80 probe target (80+6 > 85) DOES fit when the real reading (27%) backs
+        # the probe view (27+6 <= 85) -> it migrates instead of pausing for hours.
+        cfg = balancer.config_from_dict(None)
+        cost = balancer._pct_cost(150_000)  # 6.0 -> 80+6=86 > 85, but 27+6=33 <= 85
+        real_av = registry._probe_view("2", 0, 0.0, self._marker(14.0, 27.0))
+        assert balancer._fits(real_av, {"2": 0.0}, cost, cfg) is True
+        flat_av = registry._probe_view("2", 0, 0.0, {"_unavailable": True})
+        assert balancer._fits(flat_av, {"2": 0.0}, cost, cfg) is False
 
 
 class TestPlacementReservation:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,180 @@
+"""Tests for the managed-session registry + world-building.
+
+Covers the usage-signal normalization seam, PID-based liveness, intent
+round-trips, atomic persistence, and that ``build_world`` does not require the
+write lock (it must be safe to call before acquiring it).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from claude_swap import registry
+from claude_swap.cache import write_cache
+from claude_swap.locking import FileLock
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+DEAD_PID = 2_147_483_646  # almost certainly not a live process
+
+
+def _seed_accounts(switcher, accounts: dict) -> None:
+    """accounts: {num: (email, priority)}."""
+    switcher._setup_directories()
+    switcher._init_sequence_file()
+    data = switcher._get_sequence_data()
+    for num, (email, pri) in accounts.items():
+        data["accounts"][num] = {
+            "email": email,
+            "uuid": "",
+            "organizationUuid": "",
+            "organizationName": "",
+            "priority": pri,
+            "added": "2024-01-01T00:00:00Z",
+        }
+    data["sequence"] = sorted(int(n) for n in accounts)
+    switcher._write_json(switcher.sequence_file, data)
+
+
+# --------------------------------------------------------------------------- #
+# Schema normalization
+# --------------------------------------------------------------------------- #
+
+
+class TestNormalization:
+    def test_rl_to_usage_maps_used_percentage_to_pct(self):
+        rl = {
+            "five_hour": {"used_percentage": 88.0, "resets_at": 2000},
+            "seven_day": {"used_percentage": 41.0, "resets_at": 9000},
+        }
+        usage = registry._rl_to_usage(rl)
+        assert usage["five_hour"] == {"pct": 88.0, "resets_at": 2000}
+        assert usage["seven_day"] == {"pct": 41.0, "resets_at": 9000}
+
+    def test_rl_to_usage_none_and_empty(self):
+        assert registry._rl_to_usage(None) is None
+        assert registry._rl_to_usage({}) is None
+        assert registry._rl_to_usage({"five_hour": {}}) is None
+
+    def test_soonest_blocking_reset_picks_max_pct_window(self):
+        # 7d is the capping window -> its reset is the blocking one.
+        usage = {
+            "five_hour": {"pct": 30.0, "resets_at": 1000},
+            "seven_day": {"pct": 96.0, "resets_at": 5000},
+        }
+        assert registry.soonest_blocking_reset(usage) == 5000
+
+    def test_soonest_blocking_reset_none(self):
+        assert registry.soonest_blocking_reset(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# State store
+# --------------------------------------------------------------------------- #
+
+
+class TestStateStore:
+    def test_read_missing_returns_skeleton(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        reg = registry.read_registry(sw)
+        assert reg["sessions"] == {}
+        assert reg["version"] == registry.REGISTRY_VERSION
+
+    def test_upsert_round_trip_and_persist(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        reg = registry.read_registry(sw)
+        registry.upsert_session(reg, "m1", account_num="2", supervisor_pid=os.getpid())
+        registry.write_registry(sw, reg)
+        reg2 = registry.read_registry(sw)
+        assert reg2["sessions"]["m1"]["account_num"] == "2"
+
+    def test_upsert_skips_none_and_stamps_started_at_once(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        reg = registry.read_registry(sw)
+        row = registry.upsert_session(reg, "m1", account_num="1", cwd="/a")
+        started = row["started_at"]
+        # A later heartbeat omits cwd (None) -> keeps the old value, started_at stable.
+        row2 = registry.upsert_session(reg, "m1", account_num="1", cwd=None)
+        assert row2["cwd"] == "/a"
+        assert row2["started_at"] == started
+
+    def test_reap_dead_drops_dead_keeps_alive(self, temp_home: Path):
+        reg = {"version": 1, "sessions": {}}
+        registry.upsert_session(reg, "alive", supervisor_pid=os.getpid())
+        registry.upsert_session(reg, "dead", supervisor_pid=DEAD_PID)
+        registry.upsert_session(reg, "nopid")  # no pid yet -> kept
+        changed = registry.reap_dead(reg)
+        assert changed is True
+        assert set(reg["sessions"]) == {"alive", "nopid"}
+
+    def test_intent_round_trip(self, temp_home: Path):
+        reg = {"version": 1, "sessions": {}}
+        registry.upsert_session(reg, "m1", account_num="1")
+        registry.set_intent(reg, "m1", "3", now=100.0)
+        assert reg["sessions"]["m1"]["migration"] == {"to": "3", "decided_at": 100.0}
+        registry.clear_intent(reg, "m1")
+        assert reg["sessions"]["m1"]["migration"] is None
+
+    def test_expire_intents(self, temp_home: Path):
+        reg = {"version": 1, "sessions": {}}
+        registry.upsert_session(reg, "m1", account_num="1")
+        registry.set_intent(reg, "m1", "3", now=0.0)
+        assert registry.expire_intents(reg, now=registry._INTENT_TTL_S + 1) is True
+        assert reg["sessions"]["m1"]["migration"] is None
+
+
+# --------------------------------------------------------------------------- #
+# World building
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildWorld:
+    def test_live_account_uses_session_rate_limits(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        reg = registry.read_registry(sw)
+        registry.upsert_session(
+            reg, "m1", account_num="1", supervisor_pid=os.getpid(),
+            rate_limits={
+                "five_hour": {"used_percentage": 88.0, "resets_at": 2000},
+                "seven_day": {"used_percentage": 40.0, "resets_at": 9000},
+            },
+            last_seen=time.time(),
+        )
+        registry.write_registry(sw, reg)
+        acct_views, sess_views = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["1"].max_pct == 88.0
+        assert acct_views["1"].signal == "live"
+        assert acct_views["1"].priority == 5
+        assert [s.session_id for s in sess_views] == ["m1"]
+
+    def test_idle_account_uses_cache(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {"five_hour": {"pct": 40.0}, "seven_day": {"pct": 10.0}}},
+        )
+        reg = registry.read_registry(sw)
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["2"].max_pct == 40.0
+        assert acct_views["2"].signal == "cache"
+
+    def test_unknown_account_has_no_usage(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"3": ("c@x.com", 0)})
+        reg = registry.read_registry(sw)
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["3"].max_pct is None
+        assert acct_views["3"].signal == "none"
+
+    def test_build_world_does_not_need_the_write_lock(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 0)})
+        reg = registry.read_registry(sw)
+        # Hold the switcher lock; build_world must still return (it never locks).
+        with FileLock(sw.lock_file):
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert "1" in acct_views

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -145,9 +145,13 @@ class TestBuildWorld:
         )
         registry.write_registry(sw, reg)
         acct_views, sess_views = registry.build_world(sw, reg, fetch_idle=False)
-        assert acct_views["1"].max_pct == 88.0
-        assert acct_views["1"].signal == "live"
-        assert acct_views["1"].priority == 5
+        av = acct_views["1"]
+        assert av.max_pct == 88.0
+        assert av.signal == "live"
+        assert av.priority == 5
+        # Per-window breakdown carried for the dashboard (max_pct is only the max).
+        assert (av.five_hour_pct, av.five_hour_reset) == (88.0, 2000)
+        assert (av.seven_day_pct, av.seven_day_reset) == (40.0, 9000)
         assert [s.session_id for s in sess_views] == ["m1"]
 
     def test_idle_account_uses_cache(self, temp_home: Path):
@@ -159,8 +163,12 @@ class TestBuildWorld:
         )
         reg = registry.read_registry(sw)
         acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
-        assert acct_views["2"].max_pct == 40.0
-        assert acct_views["2"].signal == "cache"
+        av = acct_views["2"]
+        assert av.max_pct == 40.0
+        assert av.signal == "cache"
+        # Both windows surface; no resets_at in this cache entry -> resets None.
+        assert (av.five_hour_pct, av.five_hour_reset) == (40.0, None)
+        assert (av.seven_day_pct, av.seven_day_reset) == (10.0, None)
 
     def test_unknown_account_has_no_usage(self, temp_home: Path):
         sw = ClaudeAccountSwitcher()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -178,3 +178,74 @@ class TestBuildWorld:
         with FileLock(sw.lock_file):
             acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
         assert "1" in acct_views
+
+
+class TestPlacementReservation:
+    """BUG 003: a just-placed session not yet reporting usage counts as load."""
+
+    def test_reservation_raises_max_pct_for_fresh_session(self, temp_home: Path):
+        from claude_swap import balancer
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        now = time.time()
+        reg = registry.read_registry(sw)
+        # A reporting session establishes account "1" at 20%.
+        registry.upsert_session(
+            reg, "reporting", account_num="1", supervisor_pid=os.getpid(),
+            rate_limits={
+                "five_hour": {"used_percentage": 20.0, "resets_at": 2000},
+                "seven_day": {"used_percentage": 5.0, "resets_at": 9000},
+            },
+            last_seen=now,
+        )
+        # A freshly-placed session: no rate_limits yet, reserved just now, with a
+        # non-trivial context so _pct_cost is strictly positive.
+        registry.upsert_session(
+            reg, "fresh", account_num="1", supervisor_pid=os.getpid(),
+            reserved_at=now, ctx_tokens=100_000, last_seen=now,
+        )
+        registry.write_registry(sw, reg)
+
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        expected_reserve = balancer._pct_cost(100_000)
+        assert expected_reserve > 0
+        # max_pct of "1" is the live 20% raised by the reservation load.
+        assert acct_views["1"].max_pct == 20.0 + expected_reserve
+        assert acct_views["1"].signal == "live"
+
+    def test_reservation_expires_after_ttl(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        now = time.time()
+        reg = registry.read_registry(sw)
+        registry.upsert_session(
+            reg, "reporting", account_num="1", supervisor_pid=os.getpid(),
+            rate_limits={"five_hour": {"used_percentage": 20.0, "resets_at": 2000}},
+            last_seen=now,
+        )
+        # reserved_at is older than the TTL -> no synthetic load is added.
+        registry.upsert_session(
+            reg, "stale", account_num="1", supervisor_pid=os.getpid(),
+            reserved_at=now - registry._RESERVE_TTL_S - 1, ctx_tokens=100_000,
+            last_seen=now,
+        )
+        registry.write_registry(sw, reg)
+
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["1"].max_pct == 20.0  # unchanged
+
+    def test_reservation_left_alone_when_usage_unknown(self, temp_home: Path):
+        # An account with no usage signal stays max_pct=None even with a reserve.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        now = time.time()
+        reg = registry.read_registry(sw)
+        registry.upsert_session(
+            reg, "fresh", account_num="1", supervisor_pid=os.getpid(),
+            reserved_at=now, ctx_tokens=100_000, last_seen=now,
+        )
+        registry.write_registry(sw, reg)
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["1"].max_pct is None
+        assert acct_views["1"].signal == "none"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -249,3 +249,84 @@ class TestPlacementReservation:
         acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
         assert acct_views["1"].max_pct is None
         assert acct_views["1"].signal == "none"
+
+
+class TestFiveHourSignal:
+    """build_world populates the 5h-specific fields the prime detection needs."""
+
+    def test_live_account_carries_five_hour_fields(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        reg = registry.read_registry(sw)
+        registry.upsert_session(
+            reg, "m1", account_num="1", supervisor_pid=os.getpid(),
+            rate_limits={
+                "five_hour": {"used_percentage": 12.0, "resets_at": 2000},
+                "seven_day": {"used_percentage": 40.0, "resets_at": 9000},
+            },
+            last_seen=time.time(),
+        )
+        registry.write_registry(sw, reg)
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["1"].five_hour_pct == 12.0
+        assert acct_views["1"].five_hour_reset == 2000
+
+    def test_idle_cache_account_unstarted_window(self, temp_home: Path):
+        # Cached usage with a 0% five_hour and no resets_at -> unstarted clock.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 10.0}}},
+        )
+        reg = registry.read_registry(sw)
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["2"].five_hour_pct == 0.0
+        assert acct_views["2"].five_hour_reset is None  # no reset => unstarted
+        assert acct_views["2"].signal == "cache"
+
+    def test_unknown_account_has_no_five_hour_fields(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"3": ("c@x.com", 0)})
+        reg = registry.read_registry(sw)
+        acct_views, _ = registry.build_world(sw, reg, fetch_idle=False)
+        assert acct_views["3"].five_hour_pct is None
+        assert acct_views["3"].five_hour_reset is None
+
+    def test_five_hour_signal_helper(self):
+        assert registry._five_hour_signal(None) == (None, None)
+        assert registry._five_hour_signal({}) == (None, None)
+        assert registry._five_hour_signal({"five_hour": {"pct": 5.0}}) == (5.0, None)
+        assert registry._five_hour_signal(
+            {"five_hour": {"pct": 5.0, "resets_at": 1234}}
+        ) == (5.0, 1234)
+
+
+class TestPrimeGuards:
+    """The registry-side prime sweep + per-account guards (feature #3)."""
+
+    def test_claim_prime_sweep_once_per_interval(self):
+        reg = registry._skeleton()
+        now = 1000.0
+        assert registry.claim_prime_sweep(reg, now) is True   # first claim wins
+        assert registry.claim_prime_sweep(reg, now + 1) is False  # too soon
+        later = now + registry._PRIME_SWEEP_INTERVAL_S + 1
+        assert registry.claim_prime_sweep(reg, later) is True  # interval elapsed
+
+    def test_prime_guard_blocks_recent_then_clears(self):
+        reg = registry._skeleton()
+        now = 1000.0
+        assert registry.prime_guarded(reg, "1", now) is False  # never primed
+        registry.stamp_primed(reg, "1", now)
+        assert registry.prime_guarded(reg, "1", now + 1) is True
+        assert registry.prime_guarded(reg, "1", now + registry._PRIME_ACCOUNT_GUARD_S + 1) is False
+
+    def test_prune_primed_drops_stale_stamps(self):
+        reg = registry._skeleton()
+        now = 1000.0
+        registry.stamp_primed(reg, "1", now)
+        registry.stamp_primed(reg, "2", now - registry._PRIME_ACCOUNT_GUARD_S - 1)
+        changed = registry.prune_primed(reg, now)
+        assert changed is True
+        assert "1" in reg["primed"]
+        assert "2" not in reg["primed"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -244,6 +244,337 @@ class TestBuildWorld:
         cp = sw.backup_dir / "cache" / "usage.json"
         assert read_cache(cp, 10**9).get("2", {}).get("_unavailable") is True
 
+    def test_active_default_account_is_never_refreshed(self, temp_home: Path):
+        # Credential-invalidation fix: the idle usage path MUST mark the active
+        # default login (the account Claude Code owns right now) is_active=True so
+        # it is never refreshed/rotated out from under the live login — the bug
+        # that forced spontaneous re-logins. A genuinely-idle account still may.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 0), "2": ("b@x.com", 0)})
+        reg = registry.read_registry(sw)
+        seen: dict[str, bool] = {}
+
+        def fake_fetch(switcher, num, email, *, is_active=False, failure_out=None):
+            seen[num] = is_active
+            return None
+
+        with patch("claude_swap.registry._fetch_idle_usage", side_effect=fake_fetch), \
+             patch.object(ClaudeAccountSwitcher, "active_account_num", return_value="1"):
+            registry.build_world(sw, reg, fetch_idle=True)
+
+        assert seen == {"1": True, "2": False}
+
+    def test_live_session_account_is_never_refreshed(self, temp_home: Path):
+        # An account with a live (cswap run / vanilla) session is also is_active=True
+        # — refreshing it would rotate the token out from under that live session.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 0), "2": ("b@x.com", 0)})
+        reg = registry.read_registry(sw)
+        seen: dict[str, bool] = {}
+
+        def fake_fetch(switcher, num, email, *, is_active=False, failure_out=None):
+            seen[num] = is_active
+            return None
+
+        with patch("claude_swap.registry._fetch_idle_usage", side_effect=fake_fetch), \
+             patch.object(ClaudeAccountSwitcher, "active_account_num", return_value=None), \
+             patch.object(ClaudeAccountSwitcher, "has_live_session",
+                          side_effect=lambda num, email: num == "2"):
+            registry.build_world(sw, reg, fetch_idle=True)
+
+        assert seen == {"1": False, "2": True}
+
+    def test_retry_after_backoff_marker_suppresses_refetch_past_ttl(self, temp_home: Path):
+        # A 429 backoff marker (retry_until in the future) suppresses refetch even
+        # after the freshness TTL elapses (here TTL=0), so a rate-limited usage
+        # endpoint is not re-hit every TTL — the persistent "usage unavailable" loop.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {"_unavailable": True, "retry_until": time.time() + 3600}},
+        )
+        reg = registry.read_registry(sw)
+        with patch("claude_swap.registry._usage_ttl", return_value=0), \
+             patch("claude_swap.registry._fetch_idle_usage") as m:
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)
+        assert acct_views["2"].signal == "none"
+        m.assert_not_called()
+
+    def test_expired_backoff_marker_allows_refetch(self, temp_home: Path):
+        # Once the server's Retry-After window elapses, the account is refetched.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {"_unavailable": True, "retry_until": time.time() - 10}},
+        )
+        reg = registry.read_registry(sw)
+        with patch("claude_swap.registry._usage_ttl", return_value=0), \
+             patch("claude_swap.registry._fetch_idle_usage", return_value=None) as m:
+            registry.build_world(sw, reg, fetch_idle=True)
+        m.assert_called_once()
+
+    def test_429_retry_after_is_recorded_as_backoff_marker(self, temp_home: Path):
+        # A usage-endpoint 429 records a backoff marker carrying the server's
+        # Retry-After so subsequent passes honor it (see the suppress test above).
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = registry.read_registry(sw)
+
+        def fake_fetch(switcher, num, email, *, is_active=False, failure_out=None):
+            if failure_out is not None:
+                failure_out["retry_after"] = 1800
+            return None
+
+        with patch("claude_swap.registry._fetch_idle_usage", side_effect=fake_fetch):
+            registry.build_world(sw, reg, fetch_idle=True)
+        from claude_swap.cache import read_cache, usage_backoff_active
+        entry = read_cache(sw.backup_dir / "cache" / "usage.json", 10**9).get("2")
+        assert usage_backoff_active(entry) is True
+
+
+class TestProbeUnavailable:
+    """The messages-API headroom probe fallback (default OFF). A usage-429-backed-off
+    idle account is probed only when ``probe_unavailable=True``; a 2xx synthesizes a
+    ``signal="probe"`` view so a stranded session can resume onto it."""
+
+    def _backed_off(self, sw):
+        # Account "2" has a usage-429 backoff marker active (retry_until future).
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {"_unavailable": True, "retry_until": time.time() + 3600}},
+        )
+        return registry.read_registry(sw)
+
+    def test_probe_default_off_never_probes(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+        with patch("claude_swap.registry._probe_idle_headroom") as m:
+            acct_views, _ = registry.build_world(sw, reg, fetch_idle=True)  # default off
+        assert acct_views["2"].signal == "none"
+        m.assert_not_called()
+
+    def test_probe_confirms_headroom(self, temp_home: Path):
+        from claude_swap import balancer
+        from claude_swap.cache import probe_ok, read_cache
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+        with patch("claude_swap.registry._probe_idle_headroom", return_value=True):
+            acct_views, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+        av = acct_views["2"]
+        assert av.signal == "probe"
+        assert av.max_pct == balancer.PROBE_CONFIRMED_PCT
+        # The OK verdict is cached so the next pass reuses it without re-probing.
+        entry = read_cache(sw.backup_dir / "cache" / "usage.json", 10**9).get("2")
+        assert probe_ok(entry) is True
+
+    def test_probe_ok_verdict_reused_on_second_pass_without_reprobing(self, temp_home: Path):
+        # Regression for the resume-path blocker: a cached probe-OK verdict carries no
+        # _unavailable/retry_until, so without an explicit reuse branch the SECOND
+        # build_world pass (the one _reassign_for_resume runs) would fall through to
+        # signal="cache"/max_pct=None — a zero-headroom account that is never a
+        # migration target — silently un-pausing the stranded session onto its still-
+        # exhausted account. Drive build_world TWICE in-process and assert the second
+        # pass STILL yields signal="probe" with NO second network probe.
+        from claude_swap import balancer
+        from claude_swap.cache import PROBE_VERDICT_TTL_S
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+        with patch("claude_swap.registry._probe_idle_headroom", return_value=True) as m:
+            first, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+            assert first["2"].signal == "probe"
+            assert m.call_count == 1
+
+            # Second pass: reuse the cached _probe_ok verdict WITHOUT re-probing.
+            second, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+            assert second["2"].signal == "probe"
+            assert second["2"].max_pct == balancer.PROBE_CONFIRMED_PCT
+            assert m.call_count == 1  # NOT re-probed
+
+        # The verdict is read off the persisted (inf-TTL) slot, so it survives the
+        # 60s freshness TTL through the full PROBE_VERDICT_TTL_S cadence. Confirm the
+        # cadence helper still considers it fresh well past the freshness window.
+        assert PROBE_VERDICT_TTL_S > 60
+
+    def test_probe_429_refreshes_backoff(self, temp_home: Path):
+        from claude_swap.cache import read_cache, usage_backoff_active
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+
+        def fake_probe(switcher, num, email, *, is_active=False, failure_out=None):
+            if failure_out is not None:
+                failure_out["retry_after"] = 1800
+            return False
+
+        with patch("claude_swap.registry._probe_idle_headroom", side_effect=fake_probe):
+            acct_views, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+        assert acct_views["2"].signal == "none"
+        entry = read_cache(sw.backup_dir / "cache" / "usage.json", 10**9).get("2")
+        assert usage_backoff_active(entry) is True          # retry_until in the future
+        assert isinstance(entry.get("_probed_at"), (int, float))  # probe stamped
+
+    def test_probe_unknown_throttles_then_reprobes_when_stale(self, temp_home: Path):
+        from claude_swap.cache import PROBE_VERDICT_TTL_S, read_cache
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+
+        cp = sw.backup_dir / "cache" / "usage.json"
+        with patch("claude_swap.registry._probe_idle_headroom", return_value=None) as m:
+            acct_views, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+            assert acct_views["2"].signal == "none"
+            assert m.call_count == 1
+            # Marker stamped, NO retry_until (elapses on the usage TTL normally).
+            entry = read_cache(cp, 10**9).get("2")
+            assert entry.get("_unavailable") is True
+            assert "retry_until" not in entry
+            assert isinstance(entry.get("_probed_at"), (int, float))
+
+            # A SECOND pass within the cadence does NOT re-probe (probe_recent gate).
+            registry.build_world(sw, reg, fetch_idle=True, probe_unavailable=True)
+            assert m.call_count == 1
+
+            # Backdate the stamp past the cadence -> the next pass DOES re-probe.
+            stale = dict(read_cache(cp, 10**9))
+            stale["2"] = dict(stale["2"])
+            stale["2"]["_probed_at"] = time.time() - (PROBE_VERDICT_TTL_S + 1)
+            write_cache(cp, stale)
+            registry.build_world(sw, reg, fetch_idle=True, probe_unavailable=True)
+            assert m.call_count == 2
+
+    def test_probe_stamps_claim_under_lock_before_network(self, temp_home: Path):
+        # Cross-process herd guard (finding #4): before the (out-of-lock) network
+        # probe fires, build_world must compare-and-set a provisional claim stamp
+        # under the lock so a concurrently-waking supervisor that re-reads the slot
+        # sees a fresh verdict and bows out instead of also probing. We assert the
+        # slot is stamped fresh AT THE MOMENT the probe runs (inside the patched
+        # _probe_idle_headroom), proving the claim landed before the network call.
+        from claude_swap.cache import probe_recent, read_cache
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+        cp = sw.backup_dir / "cache" / "usage.json"
+        observed: dict = {}
+
+        def fake_probe(switcher, num, email, *, is_active=False, failure_out=None):
+            # At this point the claim must already be persisted: a second supervisor
+            # re-reading now would see a fresh stamp and skip its own probe.
+            entry = read_cache(cp, 10**9).get(num)
+            observed["claim_recent"] = probe_recent(entry)
+            return True
+
+        with patch("claude_swap.registry._probe_idle_headroom", side_effect=fake_probe):
+            registry.build_world(sw, reg, fetch_idle=True, probe_unavailable=True)
+        assert observed.get("claim_recent") is True
+
+    def test_probe_never_touches_active_account(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+        with patch("claude_swap.registry._probe_idle_headroom") as m, \
+             patch.object(ClaudeAccountSwitcher, "active_account_num", return_value="2"):
+            acct_views, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+        # The active default's creds are owned by Claude Code -> never probed.
+        assert acct_views["2"].signal == "none"
+        m.assert_not_called()
+
+    def test_probe_never_touches_live_session_account(self, temp_home: Path):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+        with patch("claude_swap.registry._probe_idle_headroom") as m, \
+             patch.object(ClaudeAccountSwitcher, "active_account_num", return_value=None), \
+             patch.object(ClaudeAccountSwitcher, "has_live_session",
+                          side_effect=lambda num, email: num == "2"):
+            acct_views, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+        assert acct_views["2"].signal == "none"
+        m.assert_not_called()
+
+    def test_probe_skips_non_subscription_account(self, temp_home: Path):
+        # Credential-safety: the probe sends the same billable /v1/messages turn as
+        # priming, so it MUST carry priming's subscription-tier gate. A pay-as-you-go
+        # / API / console account (no primeable subscriptionType) must NOT be probed —
+        # a billed 2xx there would be misread as ~80% subscription headroom and charge
+        # real dollars, defeating onlySubscriptionTokens. The network probe must never
+        # be reached; the verdict is "unknown" (None) -> signal stays "none".
+        import json
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        reg = self._backed_off(sw)
+        # API/console-style creds: no subscriptionType (is_primable_subscription False).
+        api_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok-api"}})
+        with patch.object(
+            ClaudeAccountSwitcher, "read_account_credentials", return_value=api_creds
+        ), patch.object(
+            ClaudeAccountSwitcher, "active_account_num", return_value=None
+        ), patch.object(
+            ClaudeAccountSwitcher, "has_live_session", return_value=False
+        ), patch("claude_swap.oauth.probe_messages_headroom") as net:
+            acct_views, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+        assert acct_views["2"].signal == "none"   # never a target -> no billing
+        net.assert_not_called()                    # the billable turn never fired
+
+    def test_probe_idle_headroom_gates_non_subscription(self, temp_home: Path):
+        # Unit-level: the real _probe_idle_headroom returns None (unknown) for a
+        # non-subscription account and never calls the billable messages endpoint.
+        import json
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        api_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok-api"}})
+        with patch.object(
+            ClaudeAccountSwitcher, "read_account_credentials", return_value=api_creds
+        ), patch("claude_swap.oauth.probe_messages_headroom") as net:
+            verdict = registry._probe_idle_headroom(sw, "2", "b@x.com")
+        assert verdict is None
+        net.assert_not_called()
+
+    def test_probe_on_within_ttl_failure_marker(self, temp_home: Path):
+        # A plain (non-429) "_unavailable" marker within the freshness TTL is also a
+        # probe candidate when probe_unavailable=True.
+        from claude_swap import balancer
+
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"2": ("b@x.com", 0)})
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {"_unavailable": True}},  # no retry_until -> within-TTL failure
+        )
+        reg = registry.read_registry(sw)
+        with patch("claude_swap.registry._probe_idle_headroom", return_value=True):
+            acct_views, _ = registry.build_world(
+                sw, reg, fetch_idle=True, probe_unavailable=True
+            )
+        assert acct_views["2"].signal == "probe"
+        assert acct_views["2"].max_pct == balancer.PROBE_CONFIRMED_PCT
+
 
 class TestPlacementReservation:
     """BUG 003: a just-placed session not yet reporting usage counts as load."""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,6 +9,7 @@ import sys
 import unicodedata
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -303,6 +304,35 @@ class TestBootstrap:
         session_dir, _, _ = manager.setup_session("2", share=False)
         assert (session_dir / ".credentials.json").read_text() == CREDS
         assert "Could not refresh" in capsys.readouterr().out
+
+    def test_bootstrap_serializes_refresh_on_per_account_lock(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        # The bootstrap's single-use-token refresh must take the PER-ACCOUNT refresh
+        # lock BEFORE the global lock (the same lock+ordering the idle path uses), so
+        # it can't race a concurrent idle build_world refresh of the same token.
+        from claude_swap.locking import FileLock as RealLock
+
+        seen: list[str] = []
+
+        class SpyLock:
+            def __init__(self, path, timeout=10.0):
+                seen.append(path.name)
+                self._inner = RealLock(path, timeout)
+
+            def __enter__(self):
+                return self._inner.__enter__()
+
+            def __exit__(self, *a):
+                return self._inner.__exit__(*a)
+
+        with patch("claude_swap.session.FileLock", SpyLock):
+            manager.setup_session("2", share=False)
+
+        assert f".refresh-{ACCOUNT_NUM}.lock" in seen
+        assert ".lock" in seen
+        # per-account refresh lock acquired before the global lock (consistent order)
+        assert seen.index(f".refresh-{ACCOUNT_NUM}.lock") < seen.index(".lock")
 
     def test_setup_token_account_skips_refresh_silently(
         self, manager, seeded_switcher, auth_status_tracks_seed, monkeypatch, capsys

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -261,6 +261,14 @@ class TestBootstrap:
         assert config["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
         assert config["hasCompletedOnboarding"] is True
         assert config["theme"] == "light"  # carried over from backup config
+        # The directory `cswap run` execs claude in (inherited cwd) is
+        # pre-trusted so claude skips the folder trust dialog.
+        assert (
+            config["projects"][os.path.realpath(os.getcwd())][
+                "hasTrustDialogAccepted"
+            ]
+            is True
+        )
 
         # Rotated refresh token persisted back to backup storage.
         assert (
@@ -423,7 +431,12 @@ class TestBootstrap:
         manager.setup_session("2", share=False)
 
         merged = json.loads((session_dir / ".claude.json").read_text())
-        assert merged["projects"] == {"/some/project": {"history": ["x"]}}
+        # Existing per-project history survives the re-bootstrap...
+        assert merged["projects"]["/some/project"] == {"history": ["x"]}
+        # ...alongside the launch cwd's pre-seeded folder-trust entry.
+        assert merged["projects"][os.path.realpath(os.getcwd())][
+            "hasTrustDialogAccepted"
+        ]
         assert merged["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -902,7 +902,8 @@ class TestGuards:
         make_live(session_dir)
         seen: dict[str, bool] = {}
 
-        def fake_fetch(num, email, creds, is_active=False, persist_credentials=None):
+        def fake_fetch(num, email, creds, is_active=False, persist_credentials=None,
+                       failure_out=None):
             seen[num] = is_active
             return None
 

--- a/tests/test_statusfailure.py
+++ b/tests/test_statusfailure.py
@@ -89,6 +89,11 @@ def _intent(sw, managed_id: str):
     return (reg["sessions"][managed_id].get("migration") or {}).get("to")
 
 
+def _auth_recover(sw, managed_id: str):
+    reg = registry.read_registry(sw)
+    return reg["sessions"][managed_id].get("auth_recover")
+
+
 class TestStopFailureSafetyNet:
     def test_rate_limit_over_threshold_with_target_writes_intent(
         self, temp_home, monkeypatch
@@ -102,6 +107,37 @@ class TestStopFailureSafetyNet:
         statusline.run_statusfailure(sw, _stdin("rate_limit"))
 
         assert _intent(sw, managed_id) == "2"
+
+    def test_authentication_failed_sets_auth_recover_not_intent_under_threshold(
+        self, temp_home, monkeypatch
+    ):
+        # A 401 auth failure flags ``auth_recover`` on the row and records NO
+        # migration intent — even when the account is comfortably UNDER the
+        # exhaust threshold (auth isn't usage-driven).
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "auth-under"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=20.0, target_headroom=True)
+
+        statusline.run_statusfailure(sw, _stdin("authentication_failed"))
+
+        assert isinstance(_auth_recover(sw, managed_id), (int, float))
+        assert _intent(sw, managed_id) is None
+
+    def test_auth_variant_casing_sets_auth_recover(self, temp_home, monkeypatch):
+        # Tolerant matching: any error_type CONTAINING "auth" (any casing) flags
+        # an auth recovery, not a migration intent.
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "auth-variant"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=97.0, target_headroom=True)
+
+        statusline.run_statusfailure(sw, _stdin("Authentication_Error"))
+
+        assert isinstance(_auth_recover(sw, managed_id), (int, float))
+        assert _intent(sw, managed_id) is None
 
     def test_overloaded_writes_no_intent_even_over_threshold(
         self, temp_home, monkeypatch

--- a/tests/test_statusfailure.py
+++ b/tests/test_statusfailure.py
@@ -39,8 +39,10 @@ def _seed_accounts(switcher, accounts: dict) -> None:
     switcher._write_json(switcher.sequence_file, data)
 
 
-def _stdin(error_type: str | None, sid: str = "claude-sid") -> str:
-    """A StopFailure stdin payload with the given ``error_type``."""
+def _stdin(
+    error_type: str | None, sid: str = "claude-sid", *, message: str | None = None
+) -> str:
+    """A StopFailure stdin payload with the given ``error_type`` (+ optional message)."""
     payload = {
         "session_id": sid,
         "cwd": "/work",
@@ -48,6 +50,8 @@ def _stdin(error_type: str | None, sid: str = "claude-sid") -> str:
     }
     if error_type is not None:
         payload["error_type"] = error_type
+    if message is not None:
+        payload["message"] = message
     return json.dumps(payload)
 
 
@@ -107,6 +111,46 @@ class TestStopFailureSafetyNet:
         statusline.run_statusfailure(sw, _stdin("rate_limit"))
 
         assert _intent(sw, managed_id) == "2"
+
+    def test_transient_socket_message_is_a_no_op_even_with_auth_error_type(
+        self, temp_home, monkeypatch
+    ):
+        # The headline failure mode: error_type says "authentication_failed" but
+        # the message reveals it's a closed socket ("API Error: 401 The socket
+        # connection was closed unexpectedly"). Transient wins over auth -> NO
+        # auth_recover flag and NO migration intent. Even over threshold.
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "transient-auth"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=97.0, target_headroom=True)
+
+        rc = statusline.run_statusfailure(
+            sw,
+            _stdin(
+                "authentication_failed",
+                message="API Error: 401 The socket connection was closed unexpectedly",
+            ),
+        )
+
+        assert rc == 0
+        assert _auth_recover(sw, managed_id) is None
+        assert _intent(sw, managed_id) is None
+
+    def test_pure_connection_error_type_is_a_no_op(self, temp_home, monkeypatch):
+        # A plain connection error_type (no message) over threshold -> no-op:
+        # neither migration nor auth recovery, exits 0.
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "transient-conn"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=97.0, target_headroom=True)
+
+        rc = statusline.run_statusfailure(sw, _stdin("connection_error"))
+
+        assert rc == 0
+        assert _auth_recover(sw, managed_id) is None
+        assert _intent(sw, managed_id) is None
 
     def test_authentication_failed_sets_auth_recover_not_intent_under_threshold(
         self, temp_home, monkeypatch

--- a/tests/test_statusfailure.py
+++ b/tests/test_statusfailure.py
@@ -1,0 +1,192 @@
+"""Tests for the ``cswap statusfailure`` StopFailure safety net.
+
+The hook fires when a managed turn fails after claude exhausts its API retries
+(a hard rate limit). When the session's account is genuinely at/over the exhaust
+threshold AND the failure isn't a plainly-not-account-specific kind (overload /
+server error), the handler records a migration *intent* so the owning supervisor
+re-points the session and the NEXT turn lands on a fresh account. It never writes
+credentials and always exits 0.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from claude_swap import registry, statusline
+from claude_swap.cache import write_cache
+from claude_swap.locking import FileLock
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+def _seed_accounts(switcher, accounts: dict) -> None:
+    """accounts: {num: (email, priority)}."""
+    switcher._setup_directories()
+    switcher._init_sequence_file()
+    data = switcher._get_sequence_data()
+    for num, (email, pri) in accounts.items():
+        data["accounts"][num] = {
+            "email": email,
+            "uuid": "",
+            "organizationUuid": "",
+            "organizationName": "",
+            "priority": pri,
+            "added": "2024-01-01T00:00:00Z",
+        }
+    data["sequence"] = sorted(int(n) for n in accounts)
+    switcher._write_json(switcher.sequence_file, data)
+
+
+def _stdin(error_type: str | None, sid: str = "claude-sid") -> str:
+    """A StopFailure stdin payload with the given ``error_type``."""
+    payload = {
+        "session_id": sid,
+        "cwd": "/work",
+        "hook_event_name": "StopFailure",
+    }
+    if error_type is not None:
+        payload["error_type"] = error_type
+    return json.dumps(payload)
+
+
+def _setup(sw, profile_dir: Path, *, own_pct: float, target_headroom: bool):
+    """Seed a managed session on Account-1 with ``own_pct`` utilization.
+
+    Account-1's live usage is set via the registry heartbeat; Account-2 gets a
+    cache signal (with or without headroom) to control whether a target exists.
+    Returns the managed id.
+    """
+    _seed_accounts(sw, {"1": ("a@x.com", 0), "2": ("b@x.com", 5)})
+    sw.set_auto_balance_config(enabled=True, threshold=95)
+    write_cache(
+        sw.backup_dir / "cache" / "usage.json",
+        {"2": {"five_hour": {"pct": (10.0 if target_headroom else 99.0)}, "seven_day": {"pct": 5.0}}},
+    )
+    managed_id = profile_dir.name
+    reg = registry.read_registry(sw)
+    registry.upsert_session(
+        reg,
+        managed_id,
+        account_num="1",
+        supervisor_pid=os.getpid(),
+        profile_dir=str(profile_dir),
+        ctx_tokens=1000,
+        last_seen=time.time(),
+        rate_limits={
+            "five_hour": {"used_percentage": own_pct, "resets_at": int(time.time()) + 3600},
+            "seven_day": {"used_percentage": 10.0, "resets_at": int(time.time()) + 9000},
+        },
+    )
+    with FileLock(sw.lock_file):
+        registry.write_registry(sw, reg)
+    return managed_id
+
+
+def _intent(sw, managed_id: str):
+    reg = registry.read_registry(sw)
+    return (reg["sessions"][managed_id].get("migration") or {}).get("to")
+
+
+class TestStopFailureSafetyNet:
+    def test_rate_limit_over_threshold_with_target_writes_intent(
+        self, temp_home, monkeypatch
+    ):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "rl-over"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=97.0, target_headroom=True)
+
+        statusline.run_statusfailure(sw, _stdin("rate_limit"))
+
+        assert _intent(sw, managed_id) == "2"
+
+    def test_overloaded_writes_no_intent_even_over_threshold(
+        self, temp_home, monkeypatch
+    ):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "ovl"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=97.0, target_headroom=True)
+
+        statusline.run_statusfailure(sw, _stdin("overloaded"))
+
+        assert _intent(sw, managed_id) is None
+
+    def test_server_error_writes_no_intent_even_over_threshold(
+        self, temp_home, monkeypatch
+    ):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "srv"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=97.0, target_headroom=True)
+
+        statusline.run_statusfailure(sw, _stdin("server_error"))
+
+        assert _intent(sw, managed_id) is None
+
+    def test_under_threshold_writes_no_intent(self, temp_home, monkeypatch):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "under"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=50.0, target_headroom=True)
+
+        statusline.run_statusfailure(sw, _stdin("rate_limit"))
+
+        assert _intent(sw, managed_id) is None
+
+    def test_unknown_error_type_relies_on_usage_check(self, temp_home, monkeypatch):
+        # An absent/unknown error_type still migrates when the account is over
+        # threshold (usage check alone), since (a) is sufficient.
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "unk"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=97.0, target_headroom=True)
+
+        statusline.run_statusfailure(sw, _stdin(None))
+
+        assert _intent(sw, managed_id) == "2"
+
+    def test_over_threshold_but_no_target_headroom_writes_no_intent(
+        self, temp_home, monkeypatch
+    ):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "no-target"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup(sw, profile_dir, own_pct=97.0, target_headroom=False)
+
+        statusline.run_statusfailure(sw, _stdin("rate_limit"))
+
+        assert _intent(sw, managed_id) is None
+
+    def test_malformed_stdin_exits_zero_no_crash(self, temp_home, monkeypatch):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "bad"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+
+        assert statusline.run_statusfailure(sw, "not json{{{") == 0
+        assert statusline.run_statusfailure(sw, "") == 0
+        assert statusline.run_statusfailure(sw, "[1, 2, 3]") == 0
+
+    def test_no_managed_id_exits_zero(self, temp_home, monkeypatch):
+        sw = ClaudeAccountSwitcher()
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        assert statusline.run_statusfailure(sw, _stdin("rate_limit")) == 0
+
+    def test_no_registry_row_exits_zero(self, temp_home, monkeypatch):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "orphan"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        _seed_accounts(sw, {"1": ("a@x.com", 0)})
+        sw.set_auto_balance_config(enabled=True, threshold=95)
+        # No registry row for this session -> bail.
+        assert statusline.run_statusfailure(sw, _stdin("rate_limit")) == 0

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,120 @@
+"""Tests for the ``cswap statusline`` balancer trigger (planning re-arm).
+
+Focus: BUG 012 — once an account is at/over threshold, ``_prev_max_pct`` stays
+over threshold every tick, so a rising-EDGE-only trigger would never re-fire if a
+migration intent failed to consume. The level-based re-arm must re-plan whenever
+the account is over threshold with NO pending intent, while still NOT re-planning
+when an intent is already pending (no churn).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from claude_swap import registry, statusline
+from claude_swap.cache import write_cache
+from claude_swap.locking import FileLock
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+def _seed_accounts(switcher, accounts: dict) -> None:
+    """accounts: {num: (email, priority)}."""
+    switcher._setup_directories()
+    switcher._init_sequence_file()
+    data = switcher._get_sequence_data()
+    for num, (email, pri) in accounts.items():
+        data["accounts"][num] = {
+            "email": email,
+            "uuid": "",
+            "organizationUuid": "",
+            "organizationName": "",
+            "priority": pri,
+            "added": "2024-01-01T00:00:00Z",
+        }
+    data["sequence"] = sorted(int(n) for n in accounts)
+    switcher._write_json(switcher.sequence_file, data)
+
+
+def _stdin(pct: float, sid: str = "claude-sid") -> str:
+    """A statusline stdin payload putting the session's account at ``pct``."""
+    return json.dumps(
+        {
+            "rate_limits": {
+                "five_hour": {"used_percentage": pct, "resets_at": int(time.time()) + 3600},
+                "seven_day": {"used_percentage": 10.0, "resets_at": int(time.time()) + 9000},
+            },
+            "context_window": {"total_input_tokens": 1000},
+            "model": {"id": "claude-opus"},
+            "cwd": "/work",
+            "session_id": sid,
+        }
+    )
+
+
+def _setup_over_threshold(sw, profile_dir: Path, *, with_intent: bool):
+    """Seed a managed session already at/over threshold with prev>=threshold.
+
+    A second account ("2") is given cache usage with plenty of headroom so the
+    balancer has a real migration target. Returns the managed id.
+    """
+    _seed_accounts(sw, {"1": ("a@x.com", 0), "2": ("b@x.com", 5)})
+    sw.set_auto_balance_config(enabled=True, threshold=95)
+    # Account 2 has headroom (cache signal) so a MIGRATE target exists.
+    write_cache(
+        sw.backup_dir / "cache" / "usage.json",
+        {"2": {"five_hour": {"pct": 10.0}, "seven_day": {"pct": 5.0}}},
+    )
+    managed_id = profile_dir.name
+    reg = registry.read_registry(sw)
+    registry.upsert_session(
+        reg, managed_id, account_num="1", supervisor_pid=os.getpid(),
+        profile_dir=str(profile_dir), last_seen=time.time(),
+    )
+    # Already crossed: prev_max is over the threshold (so it's NOT a rising edge).
+    reg["sessions"][managed_id]["_prev_max_pct"] = 96.0
+    if with_intent:
+        # A distinctly-old decided_at (still within the 1800s TTL) so a re-plan
+        # would be detectable as an overwrite, but it won't be expired.
+        registry.set_intent(reg, managed_id, "2", time.time() - 100.0)
+    with FileLock(sw.lock_file):
+        registry.write_registry(sw, reg)
+    return managed_id
+
+
+class TestPlanningReArm:
+    def test_re_fires_when_over_threshold_and_no_intent(self, temp_home, monkeypatch):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "abc123managed"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup_over_threshold(sw, profile_dir, with_intent=False)
+
+        # No rising edge (prev=96 >= 95), no pending intent -> level re-arm fires.
+        statusline.run_statusline(sw, _stdin(96.0))
+
+        reg = registry.read_registry(sw)
+        intent = reg["sessions"][managed_id].get("migration")
+        assert isinstance(intent, dict) and intent.get("to") == "2"
+
+    def test_does_not_re_fire_when_intent_already_pending(self, temp_home, monkeypatch):
+        sw = ClaudeAccountSwitcher()
+        profile_dir = sw.managed_dir / "def456managed"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile_dir))
+        managed_id = _setup_over_threshold(sw, profile_dir, with_intent=True)
+
+        # The intent is recorded with a sentinel decided_at; re-planning would
+        # overwrite it with ``now``. Capture the original to detect a re-fire.
+        reg_before = registry.read_registry(sw)
+        before = reg_before["sessions"][managed_id]["migration"]["decided_at"]
+
+        statusline.run_statusline(sw, _stdin(96.0))
+
+        reg_after = registry.read_registry(sw)
+        intent = reg_after["sessions"][managed_id].get("migration")
+        # Intent is still present and unchanged (no re-plan happened this tick).
+        assert isinstance(intent, dict) and intent.get("to") == "2"
+        assert intent["decided_at"] == before

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -374,6 +374,132 @@ class TestProbeWiring:
         assert all(kw.get("probe_unavailable", False) is False for kw in seen_kwargs)
 
 
+class TestWaitForResetUX:
+    """The pause screen: a per-account usage block beside the countdown, and an
+    Enter shortcut to force an immediate re-check instead of waiting out the tick."""
+
+    def _sup(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5), "2": ("b@x.com", 5), "3": ("c@x.com", 5)})
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        sup._pending_resume_at = int(time.time()) + 100  # remaining > 0
+        return sup
+
+    def test_enter_short_circuits_the_wait(self, temp_home, monkeypatch):
+        # Enter (stdin readable) forces an immediate re-check: build_world runs again
+        # without sleeping out the up-to-30s tick.
+        sup = self._sup(temp_home)
+        calls = {"n": 0}
+
+        def fake_build_world(switcher, reg, **kwargs):
+            calls["n"] += 1
+            return ({}, [])
+
+        # Not resumable on the first pass, resumable on the second.
+        monkeypatch.setattr(sup, "_resumable", lambda av, sv, cfg: calls["n"] >= 2)
+        monkeypatch.setattr(sup, "_pause_status_lines", lambda av, cfg: [])
+        # Force the select path on (pytest stdin isn't a tty) and report Enter ready.
+        monkeypatch.setattr(Supervisor, "_safe_isatty", staticmethod(lambda s: True))
+        monkeypatch.setattr(sup, "_consume_stdin_line", lambda: "\n")
+        sleep = patch("claude_swap.supervisor.time.sleep")
+        with patch("claude_swap.supervisor.registry.build_world", side_effect=fake_build_world), \
+             patch("claude_swap.supervisor.select.select", return_value=([1], [], [])), \
+             sleep as sleep_mock:
+            sup._wait_for_reset()
+        assert calls["n"] == 2          # re-checked immediately after Enter
+        sleep_mock.assert_not_called()  # Enter path never sleeps
+
+    def test_eof_disables_select_to_avoid_busy_loop(self, temp_home, monkeypatch):
+        # EOF on stdin (readline -> "") must disable the select path so the loop
+        # falls back to sleeping instead of spinning (select would report EOF
+        # readable forever).
+        sup = self._sup(temp_home)
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            "claude_swap.supervisor.registry.build_world",
+            lambda switcher, reg, **kw: ({}, []),
+        )
+        monkeypatch.setattr(sup, "_resumable", lambda av, sv, cfg: calls["n"] >= 2)
+        monkeypatch.setattr(sup, "_pause_status_lines", lambda av, cfg: [])
+        monkeypatch.setattr(Supervisor, "_safe_isatty", staticmethod(lambda s: True))
+        monkeypatch.setattr(sup, "_consume_stdin_line", lambda: "")  # EOF
+
+        def count_and_resume(*a, **k):
+            calls["n"] += 1
+
+        with patch("claude_swap.supervisor.select.select", return_value=([1], [], [])) as sel, \
+             patch("claude_swap.supervisor.time.sleep", side_effect=count_and_resume) as slp:
+            sup._wait_for_reset()
+        # First tick: select fires, hits EOF, disables select. Second tick: sleeps.
+        assert sel.call_count == 1
+        assert slp.called
+
+    def test_non_tty_falls_back_to_sleep_never_selects(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            "claude_swap.supervisor.registry.build_world",
+            lambda switcher, reg, **kw: ({}, []),
+        )
+        monkeypatch.setattr(sup, "_resumable", lambda av, sv, cfg: calls["n"] >= 2)
+        monkeypatch.setattr(sup, "_pause_status_lines", lambda av, cfg: [])
+        monkeypatch.setattr(Supervisor, "_safe_isatty", staticmethod(lambda s: False))
+
+        def count(*a, **k):
+            calls["n"] += 1
+
+        with patch("claude_swap.supervisor.select.select") as sel, \
+             patch("claude_swap.supervisor.time.sleep", side_effect=count) as slp:
+            sup._wait_for_reset()
+        sel.assert_not_called()  # stdin not a tty -> never poll it
+        assert slp.called
+
+    def test_renders_account_block_with_tags(self, temp_home, monkeypatch, capsys):
+        from claude_swap.cache import write_cache
+
+        sup = self._sup(temp_home)
+        _seed_accounts(sup.switcher, {"4": ("d@x.com", 5)})  # extra no-signal account
+        # A no-signal (429-backed-off) account with a recent last-known reading: the
+        # render must fall back to the cached number, NOT show "unknown" (exercises
+        # the cache-fallback branch — the one the STALE_USAGE_MAX_AGE_S import bug hid).
+        write_cache(
+            sup.switcher.backup_dir / "cache" / "usage.json",
+            {"4": {
+                "_unavailable": True,
+                "retry_until": time.time() + 3600,
+                "_last_known": {"five_hour": {"pct": 33.0}, "seven_day": {"pct": 12.0}},
+                "_last_known_at": time.time(),
+            }},
+        )
+        # Current account "1" exhausted, "2" usable target, "3" logged out, "4" cached.
+        world = {
+            "1": balancer.AccountView(num="1", priority=5, max_pct=99.0, signal="live",
+                                      five_hour_pct=99.0, seven_day_pct=40.0),
+            "2": balancer.AccountView(num="2", priority=5, max_pct=20.0, signal="cache",
+                                      five_hour_pct=20.0, seven_day_pct=10.0),
+            "3": balancer.AccountView(num="3", priority=5, max_pct=None, signal="logged_out"),
+            "4": balancer.AccountView(num="4", priority=5, max_pct=None, signal="none"),
+        }
+        calls = {"n": 0}
+
+        def fake_build_world(switcher, reg, **kwargs):
+            calls["n"] += 1
+            return (world, [])
+
+        monkeypatch.setattr(sup, "_resumable", lambda av, sv, cfg: calls["n"] >= 2)
+        monkeypatch.setattr(Supervisor, "_safe_isatty", staticmethod(lambda s: False))
+        with patch("claude_swap.supervisor.registry.build_world", side_effect=fake_build_world), \
+             patch("claude_swap.supervisor.time.sleep"):
+            sup._wait_for_reset()
+        out = capsys.readouterr().out
+        assert "auto-resuming in" in out
+        assert "a@x.com" in out and "b@x.com" in out and "c@x.com" in out
+        assert "(current)" in out      # the session's own account
+        assert "available" in out      # the usable target
+        assert "logged out" in out     # the dead account
+        assert "33% (cached)" in out   # no-signal account -> last-known fallback
+
+
 class TestMigrateReservation:
     """BUG 003 (migrate path): _migrate must re-arm the cross-process headroom
     reservation on the NEW account so a second, independently-stranded session's

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,135 @@
+"""Tests for the managed-session supervisor's recovery + resume wiring.
+
+These exercise the pure decision-feeding seams of ``Supervisor`` (the parts the
+ultrareview flagged) without spawning a real ``claude`` or touching credentials:
+``subprocess.Popen`` and the recovery side-effects are mocked, and the registry
+is driven directly so we can assert what the supervisor reads/writes.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from claude_swap import balancer, registry
+from claude_swap.supervisor import Supervisor
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+def _seed_accounts(switcher, accounts: dict) -> None:
+    """accounts: {num: (email, priority)}."""
+    switcher._setup_directories()
+    switcher._init_sequence_file()
+    data = switcher._get_sequence_data()
+    for num, (email, pri) in accounts.items():
+        data["accounts"][num] = {
+            "email": email,
+            "uuid": "",
+            "organizationUuid": "",
+            "organizationName": "",
+            "priority": pri,
+            "added": "2024-01-01T00:00:00Z",
+        }
+    data["sequence"] = sorted(int(n) for n in accounts)
+    switcher._write_json(switcher.sequence_file, data)
+
+
+class _FakeProc:
+    def __init__(self, pid=4321):
+        self.pid = pid
+
+    def poll(self):
+        return 0
+
+
+class TestAutoResumeSessionId:
+    """BUG 007: auto-resume must read claude's CURRENT session id pre-Popen."""
+
+    def test_resume_reads_session_id_from_registry_row(self, temp_home, monkeypatch):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+
+        # Register the row, then seed claude's own session id as the statusline
+        # would once claude has rendered — the authoritative value for --resume.
+        sup._register()
+        reg = registry.read_registry(sw)
+        reg["sessions"]["mid"]["claude_session_id"] = "sid-1"
+        from claude_swap.locking import FileLock
+
+        with FileLock(sw.lock_file):
+            registry.write_registry(sw, reg)
+
+        # Capture every Popen arg list; never actually spawn a process.
+        popen_calls: list[list[str]] = []
+
+        def fake_popen(cmd, **kwargs):
+            popen_calls.append(list(cmd))
+            return _FakeProc()
+
+        monkeypatch.setattr("claude_swap.supervisor.subprocess.Popen", fake_popen)
+        # Neutralise the heavy / side-effecting steps so we drive only the loop.
+        monkeypatch.setattr(sup, "_bootstrap_profile", lambda: None)
+        monkeypatch.setattr(sup, "_register", lambda: None)
+        monkeypatch.setattr(sup, "_set_pids", lambda pid: None)
+        monkeypatch.setattr(sup, "_pause_and_resume", lambda: None)
+
+        # First iteration: limit exit -> recover (resume armed). Second
+        # iteration: clean exit on a healthy account -> deregister + return.
+        outcomes = iter([("exit", 1), ("exit", 0)])
+        limit_flags = iter([True, False])
+        monkeypatch.setattr(sup, "_supervise", lambda proc: next(outcomes))
+        monkeypatch.setattr(
+            sup, "_should_handle_limit_exit", lambda: next(limit_flags)
+        )
+
+        rc = sup.run([], "/usr/bin/claude")
+        assert rc == 0
+
+        # Two launches: first fresh, second resumes with the row's session id.
+        assert len(popen_calls) == 2
+        first_args = popen_calls[0][1:]  # strip the claude binary
+        second_args = popen_calls[1][1:]
+        assert "--resume" not in first_args  # fresh start, no stale resume
+        assert second_args == ["--resume", "sid-1"]
+
+    def test_current_session_id_empty_when_row_missing(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        sup = Supervisor(sw, "absent", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        assert sup._current_claude_session_id() == ""
+
+
+class TestSelfSessionView:
+    """BUG 009: recovery paths must size the view with this session's ctx_tokens."""
+
+    def test_view_reflects_ctx_tokens_so_cost_is_not_undersized(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        sup._register()
+
+        # No ctx yet -> bare-view cost is the base reserve only.
+        bare = sup._self_session_view()
+        assert bare.ctx_tokens == 0
+        assert balancer._pct_cost(bare.ctx_tokens) == balancer.BASE_RESERVE
+
+        # Record a large context (as the statusline heartbeat would).
+        reg = registry.read_registry(sw)
+        reg["sessions"]["mid"]["ctx_tokens"] = 300_000
+        reg["sessions"]["mid"]["paused_until"] = 12345
+        reg["sessions"]["mid"]["last_migrated_at"] = 99.0
+        reg["sessions"]["mid"]["pinned_account"] = "2"
+        from claude_swap.locking import FileLock
+
+        with FileLock(sw.lock_file):
+            registry.write_registry(sw, reg)
+
+        sv = sup._self_session_view()
+        assert sv.ctx_tokens == 300_000
+        # The cost is strictly larger than the bare/base reserve now.
+        assert balancer._pct_cost(sv.ctx_tokens) > balancer.BASE_RESERVE
+        # The other fields are carried through from the row, not defaulted.
+        assert sv.paused_until == 12345
+        assert sv.last_migrated_at == 99.0
+        assert sv.pinned_account == "2"

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from claude_swap import balancer, registry
-from claude_swap.supervisor import Supervisor
+from claude_swap.supervisor import _MAX_AUTH_RECOVER_ATTEMPTS, Supervisor
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -214,6 +214,22 @@ class TestSessionEnv:
         env = sup._session_env()
         assert env["CLAUDE_CODE_MAX_RETRIES"] == "3"
 
+    def test_forces_session_persistence_by_default(self, temp_home, monkeypatch):
+        # cmux sets CLAUDE_CODE_CHILD_SESSION=1, which makes Claude Code skip writing
+        # the main <sessionId>.jsonl transcript; a managed session must force it on so
+        # auto-resume / `cswap launch -- --resume <id>` works and no history is lost.
+        monkeypatch.delenv("CLAUDE_CODE_FORCE_SESSION_PERSISTENCE", raising=False)
+        sup = self._sup(temp_home)
+        env = sup._session_env()
+        assert env["CLAUDE_CODE_FORCE_SESSION_PERSISTENCE"] == "1"
+
+    def test_respects_user_set_session_persistence(self, temp_home, monkeypatch):
+        # An explicit user override is never clobbered.
+        monkeypatch.setenv("CLAUDE_CODE_FORCE_SESSION_PERSISTENCE", "0")
+        sup = self._sup(temp_home)
+        env = sup._session_env()
+        assert env["CLAUDE_CODE_FORCE_SESSION_PERSISTENCE"] == "0"
+
 
 class TestSelfSessionView:
     """BUG 009: recovery paths must size the view with this session's ctx_tokens."""
@@ -248,6 +264,103 @@ class TestSelfSessionView:
         assert sv.paused_until == 12345
         assert sv.last_migrated_at == 99.0
         assert sv.pinned_account == "2"
+
+
+class TestProbeWiring:
+    """The strand/resume paths opt into the messages-API headroom probe
+    (``probe_unavailable=True``); render/limit-detection paths NEVER do."""
+
+    def _sup(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5), "2": ("b@x.com", 5)})
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        sup._register()
+        return sup
+
+    def test_pause_and_resume_probes_and_migrates(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        # Current account "1" exhausted; "2" is a probe-confirmed runnable target.
+        world = (
+            {
+                "1": balancer.AccountView(num="1", priority=5, max_pct=99.0, signal="cache"),
+                "2": balancer.AccountView(
+                    num="2", priority=5, max_pct=balancer.PROBE_CONFIRMED_PCT, signal="probe"
+                ),
+            },
+            [],
+        )
+        seen_kwargs: list[dict] = []
+
+        def fake_build_world(switcher, reg, **kwargs):
+            seen_kwargs.append(kwargs)
+            return world
+
+        migrated: list[str] = []
+        monkeypatch.setattr(sup, "_migrate", lambda to: migrated.append(to))
+        monkeypatch.setattr(sup, "_mark_paused", lambda until: None)
+        with patch("claude_swap.supervisor.registry.build_world", side_effect=fake_build_world):
+            sup._pause_and_resume()
+
+        # The pause/resume decision path opted into probing, and the probe-confirmed
+        # account is migrated onto instead of pausing an hour.
+        assert all(kw.get("probe_unavailable") is True for kw in seen_kwargs)
+        assert migrated == ["2"]
+
+    def test_pause_and_resume_migrates_via_real_build_world(self, temp_home, monkeypatch):
+        # End-to-end over the REAL build_world (NOT a static stub), so the multi-pass
+        # cache-reuse seam that the resume-path blocker lived in is actually exercised:
+        # _pause_and_resume's gate pass probes account "2" and confirms headroom; the
+        # immediately-following _reassign_for_resume pass must REUSE that cached
+        # probe-OK verdict (signal="probe") and migrate onto "2" — not see it as
+        # signal="cache"/max_pct=None and un-pause the session onto exhausted "1".
+        from claude_swap.cache import write_cache
+        from claude_swap.locking import FileLock
+
+        sup = self._sup(temp_home)
+        # Current account "1" is exhausted via this session's live rate_limits (99%).
+        reg = registry.read_registry(sup.switcher)
+        reg["sessions"]["mid"]["rate_limits"] = {
+            "five_hour": {"used_percentage": 99.0, "resets_at": int(time.time()) + 3600},
+        }
+        reg["sessions"]["mid"]["last_seen"] = time.time()
+        with FileLock(sup.switcher.lock_file):
+            registry.write_registry(sup.switcher, reg)
+        # Account "2" is usage-429-backed-off -> a probe candidate.
+        write_cache(
+            sup.switcher.backup_dir / "cache" / "usage.json",
+            {"2": {"_unavailable": True, "retry_until": time.time() + 3600}},
+        )
+        reg = registry.read_registry(sup.switcher)
+
+        migrated: list[str] = []
+        monkeypatch.setattr(sup, "_migrate", lambda to: migrated.append(to))
+        monkeypatch.setattr(sup, "_mark_paused", lambda until: None)
+        # The probe confirms account "2" can serve a turn now (no real network).
+        with patch("claude_swap.registry._probe_idle_headroom", return_value=True):
+            sup._pause_and_resume()
+
+        # The stranded session resumes onto the probe-confirmed account.
+        assert migrated == ["2"]
+
+    def test_render_and_limit_detection_paths_do_not_probe(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        seen_kwargs: list[dict] = []
+
+        def fake_build_world(switcher, reg, **kwargs):
+            seen_kwargs.append(kwargs)
+            return ({"1": balancer.AccountView(num="1", priority=5, max_pct=10.0, signal="cache")}, [])
+
+        monkeypatch.setattr(
+            sup.switcher, "get_auto_balance_config",
+            lambda: {"enabled": True, "model": "sonnet", "effortLevel": "",
+                     "threshold": 90, "targetSafety": 85},
+        )
+        with patch("claude_swap.supervisor.registry.build_world", side_effect=fake_build_world):
+            sup._account_view()            # render of current account's pct
+            sup._should_handle_limit_exit()  # limit-exit detection
+        # Neither path requests a probe (default OFF) — no accidental billing.
+        assert seen_kwargs  # build_world was called
+        assert all(kw.get("probe_unavailable", False) is False for kw in seen_kwargs)
 
 
 class TestMigrateReservation:
@@ -400,6 +513,239 @@ class TestRecoverAuth:
         assert calls == []
         reg2 = registry.read_registry(sup.switcher)
         assert reg2["sessions"]["mid"].get("auth_recover") is None
+
+
+class TestAuthExitRecovery:
+    """A child that hard-exits on invalid credentials recovers, bounded — instead
+    of the exit being mistaken for a clean quit and the session silently ending."""
+
+    def _sup(self, temp_home, share=False):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5), "2": ("b@x.com", 5)})
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=share)
+        sup._register()
+        return sup
+
+    def _set_row(self, sup, **fields):
+        from claude_swap.locking import FileLock
+
+        reg = registry.read_registry(sup.switcher)
+        reg["sessions"]["mid"].update(fields)
+        with FileLock(sup.switcher.lock_file):
+            registry.write_registry(sup.switcher, reg)
+
+    def test_clean_exit_is_never_an_auth_exit(self, temp_home):
+        sup = self._sup(temp_home)
+        with patch.object(sup, "_profile_auth_invalid") as probe:
+            assert sup._should_recover_auth_exit(0) is False  # rc 0 -> clean quit
+        probe.assert_not_called()  # clean quits pay no probe cost
+
+    def test_recent_auth_flag_triggers_recovery_and_is_cleared(self, temp_home):
+        sup = self._sup(temp_home)
+        self._set_row(sup, auth_recover=time.time())
+        with patch.object(sup, "_profile_auth_invalid") as probe:
+            assert sup._should_recover_auth_exit(1) is True
+            probe.assert_not_called()  # the flag is enough; no probe needed
+        reg = registry.read_registry(sup.switcher)
+        assert reg["sessions"]["mid"].get("auth_recover") is None  # cleared
+
+    def test_probe_runs_only_on_launch_time_failure(self, temp_home):
+        # No flag, no recorded session id => claude exited before rendering =>
+        # the credit-free auth probe decides.
+        sup = self._sup(temp_home)
+        with patch.object(sup, "_profile_auth_invalid", return_value=True) as probe:
+            assert sup._should_recover_auth_exit(1) is True
+            probe.assert_called_once()
+
+    def test_no_probe_once_session_rendered(self, temp_home):
+        # A non-zero exit AFTER claude rendered (has a session id) is a quit/crash,
+        # not a launch-time auth failure -> no probe, not treated as an auth exit.
+        sup = self._sup(temp_home)
+        self._set_row(sup, claude_session_id="sid-1")
+        with patch.object(sup, "_profile_auth_invalid", return_value=True) as probe:
+            assert sup._should_recover_auth_exit(1) is False
+            probe.assert_not_called()
+
+    def test_signal_killed_child_is_not_an_auth_exit(self, temp_home):
+        # A negative rc means claude was killed by a signal (e.g. -11 SIGSEGV),
+        # not an authentication problem -> never enter auth recovery.
+        sup = self._sup(temp_home)
+        with patch.object(sup, "_profile_auth_invalid", return_value=True) as probe:
+            assert sup._should_recover_auth_exit(-11) is False
+            probe.assert_not_called()
+
+    def test_run_stops_after_cap_exhausted(self, temp_home, monkeypatch):
+        # Repeated auth-failure exits are bounded: once the per-launch cap is hit
+        # the supervisor stops relaunching (no spin) and returns the child's code.
+        sup = self._sup(temp_home)
+        sup._auth_recover_attempts = _MAX_AUTH_RECOVER_ATTEMPTS  # already exhausted
+        popen_calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "claude_swap.supervisor.subprocess.Popen",
+            lambda cmd, **kw: (popen_calls.append(list(cmd)) or _FakeProc()),
+        )
+        monkeypatch.setattr(sup, "_bootstrap_profile", lambda: None)
+        monkeypatch.setattr(sup, "_register", lambda: None)
+        monkeypatch.setattr(sup, "_set_pids", lambda pid: None)
+        monkeypatch.setattr(sup, "_should_handle_limit_exit", lambda: False)
+        monkeypatch.setattr(sup, "_should_recover_auth_exit", lambda rc: True)
+        recovered: list[int] = []
+        monkeypatch.setattr(sup, "_recover_auth", lambda: recovered.append(1) or True)
+        monkeypatch.setattr(sup, "_supervise", lambda proc: ("exit", 1))
+
+        rc = sup.run([], "/usr/bin/claude")
+        assert rc == 1
+        assert recovered == []        # cap already hit -> never attempts recovery
+        assert len(popen_calls) == 1  # no relaunch / spin
+
+    def test_run_recovers_then_relaunches(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        popen_calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "claude_swap.supervisor.subprocess.Popen",
+            lambda cmd, **kw: (popen_calls.append(list(cmd)) or _FakeProc()),
+        )
+        monkeypatch.setattr(sup, "_bootstrap_profile", lambda: None)
+        monkeypatch.setattr(sup, "_register", lambda: None)
+        monkeypatch.setattr(sup, "_set_pids", lambda pid: None)
+        monkeypatch.setattr(sup, "_should_handle_limit_exit", lambda: False)
+        auth_flags = iter([True, False])
+        monkeypatch.setattr(sup, "_should_recover_auth_exit", lambda rc: next(auth_flags))
+        recovered: list[int] = []
+        monkeypatch.setattr(sup, "_recover_auth", lambda: (recovered.append(1) or True))
+        outcomes = iter([("exit", 1), ("exit", 0)])
+        monkeypatch.setattr(sup, "_supervise", lambda proc: next(outcomes))
+
+        rc = sup.run([], "/usr/bin/claude")
+        assert rc == 0
+        assert recovered == [1]        # recovered once
+        assert len(popen_calls) == 2   # relaunched after recovery
+
+    def test_run_gives_up_when_recovery_fails(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        popen_calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "claude_swap.supervisor.subprocess.Popen",
+            lambda cmd, **kw: (popen_calls.append(list(cmd)) or _FakeProc()),
+        )
+        monkeypatch.setattr(sup, "_bootstrap_profile", lambda: None)
+        monkeypatch.setattr(sup, "_register", lambda: None)
+        monkeypatch.setattr(sup, "_set_pids", lambda pid: None)
+        monkeypatch.setattr(sup, "_should_handle_limit_exit", lambda: False)
+        monkeypatch.setattr(sup, "_should_recover_auth_exit", lambda rc: True)
+        monkeypatch.setattr(sup, "_recover_auth", lambda: False)  # logged out, no target
+        monkeypatch.setattr(sup, "_supervise", lambda proc: ("exit", 7))
+        deregistered: list[int] = []
+        monkeypatch.setattr(sup, "_deregister", lambda: deregistered.append(1))
+
+        rc = sup.run([], "/usr/bin/claude")
+        assert rc == 7                 # returns the child's code, no spin
+        assert len(popen_calls) == 1   # did NOT relaunch into dead creds
+        assert deregistered == [1]
+
+
+class TestSignalAndResumeHint:
+    """Ctrl-C must reach claude (so it prints its own resume hint), and the
+    supervisor prints a balancer-aware resume hint on a clean quit."""
+
+    def _sup(self, temp_home, share=True):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=share)
+        sup._register()
+        return sup
+
+    def _set_session_id(self, sup, sid):
+        from claude_swap.locking import FileLock
+
+        reg = registry.read_registry(sup.switcher)
+        reg["sessions"]["mid"]["claude_session_id"] = sid
+        with FileLock(sup.switcher.lock_file):
+            registry.write_registry(sup.switcher, reg)
+
+    def test_passive_sigint_installs_noop_and_restores(self, temp_home):
+        import signal
+
+        sup = self._sup(temp_home)
+        original = signal.getsignal(signal.SIGINT)
+        prev = sup._install_passive_sigint()
+        try:
+            installed = signal.getsignal(signal.SIGINT)
+            assert callable(installed) and installed is not original
+        finally:
+            sup._restore_sigint(prev)
+        assert signal.getsignal(signal.SIGINT) is original
+
+    def test_resume_hint_printed_with_share_and_session_id(self, temp_home, capsys):
+        sup = self._sup(temp_home, share=True)
+        self._set_session_id(sup, "sess-123")
+        sup._print_resume_hint()
+        assert "cswap launch -- --resume sess-123" in capsys.readouterr().out
+
+    def test_resume_hint_suppressed_without_share(self, temp_home, capsys):
+        sup = self._sup(temp_home, share=False)
+        self._set_session_id(sup, "sess-123")
+        sup._print_resume_hint()
+        assert capsys.readouterr().out == ""
+
+    def test_sigint_restored_before_pause_wait(self, temp_home, monkeypatch):
+        # Regression: the passive (no-op) SIGINT handler must be installed ONLY
+        # while claude is the live foreground process. During the child-less
+        # pause/auto-resume countdown the original handler must be back so Ctrl-C
+        # stays interruptible (otherwise a user is stuck in the countdown).
+        import signal
+
+        sup = self._sup(temp_home, share=False)
+        monkeypatch.setattr(
+            "claude_swap.supervisor.subprocess.Popen", lambda cmd, **kw: _FakeProc()
+        )
+        monkeypatch.setattr(sup, "_bootstrap_profile", lambda: None)
+        monkeypatch.setattr(sup, "_register", lambda: None)
+        monkeypatch.setattr(sup, "_set_pids", lambda pid: None)
+
+        seen: dict[str, object] = {}
+
+        def fake_pause():
+            seen["handler"] = signal.getsignal(signal.SIGINT)
+
+        monkeypatch.setattr(sup, "_pause_and_resume", fake_pause)
+        limit_flags = iter([True, False])
+        monkeypatch.setattr(sup, "_should_handle_limit_exit", lambda: next(limit_flags))
+        outcomes = iter([("exit", 1), ("exit", 0)])
+        monkeypatch.setattr(sup, "_supervise", lambda proc: next(outcomes))
+
+        original = signal.getsignal(signal.SIGINT)
+        sup.run([], "/usr/bin/claude")
+        # The handler active during the (child-less) pause wait is the ORIGINAL,
+        # not the supervisor's passive no-op installed around the live child.
+        assert seen["handler"] is original
+
+    def test_keyboardinterrupt_reaps_not_kills_and_prints_hint(
+        self, temp_home, monkeypatch, capsys
+    ):
+        sup = self._sup(temp_home, share=True)
+        self._set_session_id(sup, "sess-9")
+        monkeypatch.setattr(sup, "_bootstrap_profile", lambda: None)
+        monkeypatch.setattr(sup, "_register", lambda: None)  # keep the seeded row
+        monkeypatch.setattr(sup, "_set_pids", lambda pid: None)
+        monkeypatch.setattr(
+            "claude_swap.supervisor.subprocess.Popen", lambda cmd, **kw: _FakeProc()
+        )
+
+        def boom(proc):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(sup, "_supervise", boom)
+        reaped: list[int] = []
+        terminated: list[int] = []
+        monkeypatch.setattr(sup, "_reap_or_terminate", lambda proc: reaped.append(1))
+        monkeypatch.setattr(sup, "_terminate", lambda proc: terminated.append(1))
+
+        rc = sup.run([], "/usr/bin/claude")
+        assert rc == 130
+        assert reaped == [1]       # reaped (let claude finish its quit), not killed
+        assert terminated == []
+        assert "cswap launch -- --resume sess-9" in capsys.readouterr().out
 
 
 class TestPrimeIdleWindows:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 from claude_swap import balancer, registry
 from claude_swap.supervisor import Supervisor
@@ -223,3 +224,97 @@ class TestSelfSessionView:
         assert sv.paused_until == 12345
         assert sv.last_migrated_at == 99.0
         assert sv.pinned_account == "2"
+
+
+class TestRecoverAuth:
+    """401 auto-recovery: refresh+re-seed the same account, else migrate."""
+
+    def _sup(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5), "2": ("b@x.com", 5)})
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        sup._register()
+        return sup
+
+    def test_refresh_success_does_not_migrate(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        monkeypatch.setattr(
+            sup.switcher, "refresh_account_and_reseed", lambda acct, pdir: True
+        )
+        migrated: list[str] = []
+        monkeypatch.setattr(sup, "_migrate", lambda to: migrated.append(to))
+
+        sup._recover_auth()
+
+        assert migrated == []  # same-account refresh worked -> no migration
+
+    def test_refresh_fail_with_target_migrates(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        monkeypatch.setattr(
+            sup.switcher, "refresh_account_and_reseed", lambda acct, pdir: False
+        )
+        migrated: list[str] = []
+        monkeypatch.setattr(sup, "_migrate", lambda to: migrated.append(to))
+        with patch("claude_swap.supervisor.registry.build_world", return_value=({}, {})), \
+             patch("claude_swap.supervisor.balancer.choose_migration_target", return_value="2"):
+            sup._recover_auth()
+
+        assert migrated == ["2"]  # account logged out -> migrate to healthy target
+
+    def test_refresh_fail_no_target_does_not_crash(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        monkeypatch.setattr(
+            sup.switcher, "refresh_account_and_reseed", lambda acct, pdir: False
+        )
+        migrated: list[str] = []
+        monkeypatch.setattr(sup, "_migrate", lambda to: migrated.append(to))
+        with patch("claude_swap.supervisor.registry.build_world", return_value=({}, {})), \
+             patch("claude_swap.supervisor.balancer.choose_migration_target", return_value=None):
+            # No target anywhere -> warn the user, no migration, no crash.
+            sup._recover_auth()
+
+        assert migrated == []
+
+    def test_consume_state_routes_recent_auth_flag_and_clears_it(
+        self, temp_home, monkeypatch
+    ):
+        import time
+        from claude_swap.locking import FileLock
+
+        sup = self._sup(temp_home)
+        reg = registry.read_registry(sup.switcher)
+        reg["sessions"]["mid"]["auth_recover"] = time.time()
+        with FileLock(sup.switcher.lock_file):
+            registry.write_registry(sup.switcher, reg)
+
+        calls: list[int] = []
+        monkeypatch.setattr(sup, "_recover_auth", lambda: calls.append(1))
+
+        decision = sup._consume_own_state()
+
+        assert decision == "auth"
+        assert calls == [1]
+        # The flag is cleared so the next tick doesn't re-recover.
+        reg2 = registry.read_registry(sup.switcher)
+        assert reg2["sessions"]["mid"].get("auth_recover") is None
+
+    def test_consume_state_ignores_stale_auth_flag(self, temp_home, monkeypatch):
+        import time
+        from claude_swap.locking import FileLock
+
+        sup = self._sup(temp_home)
+        reg = registry.read_registry(sup.switcher)
+        # A flag older than the TTL was left by a crash -> cleared, not acted on.
+        reg["sessions"]["mid"]["auth_recover"] = time.time() - 10_000
+        with FileLock(sup.switcher.lock_file):
+            registry.write_registry(sup.switcher, reg)
+
+        calls: list[int] = []
+        monkeypatch.setattr(sup, "_recover_auth", lambda: calls.append(1))
+
+        decision = sup._consume_own_state()
+
+        assert decision is None
+        assert calls == []
+        reg2 = registry.read_registry(sup.switcher)
+        assert reg2["sessions"]["mid"].get("auth_recover") is None

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -551,6 +551,7 @@ class TestPrimeOneAccount:
                 "accessToken": "tok-2",
                 "refreshToken": "ref-2",
                 "expiresAt": int((_time.time() + 3600) * 1000),
+                "subscriptionType": "max",
             }
         })
         with FileLock(sw.lock_file):
@@ -564,6 +565,30 @@ class TestPrimeOneAccount:
             ok = sup._prime_one_account("2")
         assert ok is True
         m.assert_called_once_with("tok-2")
+
+    def test_skips_api_credit_account_without_billing_it(self, temp_home):
+        # An account authenticated without a recognized subscription tier (e.g.
+        # API / console billing) must never be primed — no prime POST at all.
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5), "2": ("b@x.com", 5)})
+        import json as _json
+        import time as _time
+        from claude_swap.locking import FileLock
+        creds = _json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "tok-2",
+                "refreshToken": "ref-2",
+                "expiresAt": int((_time.time() + 3600) * 1000),
+                # No subscriptionType -> treated as a non-subscription account.
+            }
+        })
+        with FileLock(sw.lock_file):
+            sw.write_account_credentials("2", "b@x.com", creds)
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        with patch("claude_swap.supervisor.oauth.prime_account", return_value=True) as m:
+            ok = sup._prime_one_account("2")
+        assert ok is False
+        m.assert_not_called()
 
     def test_missing_credentials_returns_false_without_calling(self, temp_home):
         sup = self._sup_with_creds(temp_home)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -14,7 +14,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 from claude_swap import balancer, registry
-from claude_swap.supervisor import _MAX_AUTH_RECOVER_ATTEMPTS, Supervisor
+from claude_swap.supervisor import (
+    _MAX_AUTH_RECOVER_ATTEMPTS,
+    _RECOVERY_PROMPT,
+    Supervisor,
+    _resume_launch_args,
+    _strip_trailing_prompt,
+)
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -93,7 +99,12 @@ class TestAutoResumeSessionId:
         first_args = popen_calls[0][1:]  # strip the claude binary
         second_args = popen_calls[1][1:]
         assert "--resume" not in first_args  # fresh start, no stale resume
-        assert second_args == ["--resume", "sid-1"]
+        # The resume reads the CURRENT session id (BUG 007) and, since this is an
+        # auto-recovery, re-passes the launch flags and injects the recovery prompt.
+        assert second_args[:2] == ["--resume", "sid-1"]
+        assert second_args.count("--resume") == 1
+        assert second_args[-1] == _RECOVERY_PROMPT
+        assert "--dangerously-skip-permissions" in second_args  # QoL flag preserved
 
     def test_current_session_id_empty_when_row_missing(self, temp_home):
         sw = ClaudeAccountSwitcher()
@@ -943,3 +954,101 @@ class TestPrimeOneAccount:
             ok = sup._prime_one_account("1")
         assert ok is False
         m.assert_not_called()
+
+
+class TestStripTrailingPrompt:
+    """The pure argv splitter that finds (and drops) a trailing positional prompt."""
+
+    def test_flags_only_unchanged(self):
+        # The managed-launch norm (quickStart): all flags + flag values, no prompt.
+        args = [
+            "--fallback-model", "sonnet", "--dangerously-skip-permissions",
+            "--model", "claude-opus-4-8", "--settings", '{"ultracode": true}',
+        ]
+        assert _strip_trailing_prompt(args) == args
+
+    def test_drops_bare_trailing_prompt(self):
+        assert _strip_trailing_prompt(["--model", "opus", "do the task"]) == ["--model", "opus"]
+
+    def test_value_flag_value_is_not_a_prompt(self):
+        # The settings JSON does not start with '-' but is --settings' value.
+        args = ["--settings", '{"ultracode": true}']
+        assert _strip_trailing_prompt(args) == args
+
+    def test_boolean_flag_then_prompt(self):
+        assert _strip_trailing_prompt(
+            ["--dangerously-skip-permissions", "fix the bug"]
+        ) == ["--dangerously-skip-permissions"]
+
+    def test_variadic_consumes_then_stops_at_flag(self):
+        args = ["--add-dir", "/a", "/b", "--model", "opus"]
+        assert _strip_trailing_prompt(args) == args
+
+    def test_inline_equals_value(self):
+        assert _strip_trailing_prompt(["--model=opus", "go"]) == ["--model=opus"]
+
+    def test_empty(self):
+        assert _strip_trailing_prompt([]) == []
+
+    def test_bare_prompt_first(self):
+        assert _strip_trailing_prompt(["just a prompt"]) == []
+
+
+class TestResumeLaunchArgs:
+    """Building the auto-resume argv: --resume + preserved flags + recovery prompt."""
+
+    def test_quickstart_flags_preserved_and_prompt_injected(self):
+        base = [
+            "--fallback-model", "sonnet", "--dangerously-skip-permissions",
+            "--model", "claude-opus-4-8", "--settings", '{"ultracode": true}',
+        ]
+        out = _resume_launch_args(base, "sid-123", _RECOVERY_PROMPT)
+        assert out[:2] == ["--resume", "sid-123"]
+        # prompt is the final positional, fenced from the flags by ``--``
+        assert out[-2:] == ["--", _RECOVERY_PROMPT]
+        for tok in base:
+            assert tok in out
+        assert out.count("--resume") == 1
+
+    def test_original_positional_prompt_dropped(self):
+        base = ["--model", "opus", "original task"]
+        out = _resume_launch_args(base, "sid", _RECOVERY_PROMPT)
+        assert "original task" not in out
+        assert out == ["--resume", "sid", "--model", "opus", "--", _RECOVERY_PROMPT]
+
+    def test_user_resume_flag_dropped_no_double_resume(self):
+        base = ["--resume", "old-sid", "--model", "opus"]
+        out = _resume_launch_args(base, "new-sid", _RECOVERY_PROMPT)
+        assert out.count("--resume") == 1
+        assert "old-sid" not in out
+        assert out == ["--resume", "new-sid", "--model", "opus", "--", _RECOVERY_PROMPT]
+
+    def test_continue_fork_print_dropped(self):
+        base = ["--continue", "--fork-session", "-p", "--model", "opus"]
+        out = _resume_launch_args(base, "sid", _RECOVERY_PROMPT)
+        for dropped in ("--continue", "--fork-session", "-p"):
+            assert dropped not in out  # resume is interactive, never headless
+        assert out == ["--resume", "sid", "--model", "opus", "--", _RECOVERY_PROMPT]
+
+    def test_session_id_flag_and_value_dropped(self):
+        base = ["--session-id", "abc", "--settings", '{"x": 1}']
+        out = _resume_launch_args(base, "sid", _RECOVERY_PROMPT)
+        assert "--session-id" not in out and "abc" not in out
+        assert out == ["--resume", "sid", "--settings", '{"x": 1}', "--", _RECOVERY_PROMPT]
+
+    def test_trailing_variadic_does_not_swallow_prompt(self):
+        # The bug the review caught: a trailing variadic flag (--add-dir) would
+        # eat a bare final prompt. The ``--`` terminator keeps the prompt positional.
+        base = ["--dangerously-skip-permissions", "--add-dir", "/a", "/b"]
+        out = _resume_launch_args(base, "sid", _RECOVERY_PROMPT)
+        assert out == [
+            "--resume", "sid", "--dangerously-skip-permissions",
+            "--add-dir", "/a", "/b", "--", _RECOVERY_PROMPT,
+        ]
+        # ``--`` sits immediately before the prompt, after the variadic value-run.
+        assert out.index("--") == len(out) - 2
+
+    def test_trailing_optvalue_debug_does_not_swallow_prompt(self):
+        base = ["--model", "opus", "-d"]
+        out = _resume_launch_args(base, "sid", _RECOVERY_PROMPT)
+        assert out == ["--resume", "sid", "--model", "opus", "-d", "--", _RECOVERY_PROMPT]

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -191,6 +191,29 @@ class TestQolArgs:
         assert args[args.index("--fallback-model") + 1] == "haiku"
 
 
+class TestSessionEnv:
+    """The managed-session env: transient-resilience retry knob."""
+
+    def _sup(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        return Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+
+    def test_sets_default_max_retries(self, temp_home, monkeypatch):
+        # Extra in-turn retries so transient errors self-heal before failing a turn.
+        monkeypatch.delenv("CLAUDE_CODE_MAX_RETRIES", raising=False)
+        sup = self._sup(temp_home)
+        env = sup._session_env()
+        assert env["CLAUDE_CODE_MAX_RETRIES"] == "20"
+
+    def test_respects_user_set_max_retries(self, temp_home, monkeypatch):
+        # An explicit user override is never clobbered.
+        monkeypatch.setenv("CLAUDE_CODE_MAX_RETRIES", "3")
+        sup = self._sup(temp_home)
+        env = sup._session_env()
+        assert env["CLAUDE_CODE_MAX_RETRIES"] == "3"
+
+
 class TestSelfSessionView:
     """BUG 009: recovery paths must size the view with this session's ctx_tokens."""
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -165,6 +165,31 @@ class TestShareHistory:
         assert not (real_dest / "from_home.txt").exists()
 
 
+class TestQolArgs:
+    """QoL launch flags: model, skip-permissions, and the 529 fallback model."""
+
+    def _sup(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        return Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+
+    def test_default_launch_adds_fallback_model_sonnet(self, temp_home):
+        sup = self._sup(temp_home)
+        args = sup._qol_args([])
+        assert "--fallback-model" in args
+        assert args[args.index("--fallback-model") + 1] == "sonnet"
+        # Sanity: the other QoL defaults are still there.
+        assert "--model" in args
+        assert "--dangerously-skip-permissions" in args
+
+    def test_user_fallback_model_wins_no_double_add(self, temp_home):
+        sup = self._sup(temp_home)
+        args = sup._qol_args(["--fallback-model", "haiku"])
+        # Exactly one occurrence, and it's the user's value.
+        assert args.count("--fallback-model") == 1
+        assert args[args.index("--fallback-model") + 1] == "haiku"
+
+
 class TestSelfSessionView:
     """BUG 009: recovery paths must size the view with this session's ctx_tokens."""
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -100,6 +100,71 @@ class TestAutoResumeSessionId:
         assert sup._current_claude_session_id() == ""
 
 
+class TestShareHistory:
+    """A shared balanced profile symlinks ~/.claude session history so
+    --resume/--continue can reach sessions started with plain ``claude``."""
+
+    def _make_sup(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5)})
+        profile = temp_home / "managed_profile"
+        profile.mkdir()
+        return Supervisor(
+            sw, "mid", profile, "1", cwd=str(temp_home), share=True
+        )
+
+    def test_symlinks_existing_history_items(self, temp_home):
+        claude = temp_home / ".claude"
+        # Seed each shared item in the default ~/.claude with a sentinel inside.
+        for name in Supervisor._SHARED_HISTORY:
+            src = claude / name
+            src.mkdir()
+            (src / "marker.txt").write_text(name)
+
+        sup = self._make_sup(temp_home)
+        sup._share_history()
+
+        for name in Supervisor._SHARED_HISTORY:
+            dest = sup.profile_dir / name
+            assert dest.is_symlink(), f"{name} should be a symlink"
+            assert dest.resolve() == (claude / name).resolve()
+            # The shared content is reachable through the symlink.
+            assert (dest / "marker.txt").read_text() == name
+
+    def test_missing_source_items_are_skipped(self, temp_home):
+        claude = temp_home / ".claude"
+        # Only "projects" exists in the default home; the others are absent.
+        (claude / "projects").mkdir()
+
+        sup = self._make_sup(temp_home)
+        sup._share_history()
+
+        assert (sup.profile_dir / "projects").is_symlink()
+        for name in ("todos", "shell-snapshots"):
+            dest = sup.profile_dir / name
+            assert not dest.exists()
+            assert not dest.is_symlink()
+
+    def test_existing_real_dest_is_not_clobbered(self, temp_home):
+        claude = temp_home / ".claude"
+        (claude / "projects").mkdir()
+        (claude / "projects" / "from_home.txt").write_text("home")
+
+        sup = self._make_sup(temp_home)
+        # A real (non-symlink) dir already lives in the managed profile.
+        real_dest = sup.profile_dir / "projects"
+        real_dest.mkdir()
+        (real_dest / "local.txt").write_text("local")
+
+        sup._share_history()
+
+        # Left untouched: still a real directory, still holds its own content,
+        # and was not replaced by a symlink to ~/.claude.
+        assert real_dest.is_dir() and not real_dest.is_symlink()
+        assert (real_dest / "local.txt").read_text() == "local"
+        assert not (real_dest / "from_home.txt").exists()
+
+
 class TestSelfSessionView:
     """BUG 009: recovery paths must size the view with this session's ctx_tokens."""
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -9,6 +9,7 @@ is driven directly so we can assert what the supervisor reads/writes.
 from __future__ import annotations
 
 import os
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -249,6 +250,64 @@ class TestSelfSessionView:
         assert sv.pinned_account == "2"
 
 
+class TestMigrateReservation:
+    """BUG 003 (migrate path): _migrate must re-arm the cross-process headroom
+    reservation on the NEW account so a second, independently-stranded session's
+    separate build_world pass sees the target as non-empty and does not stack."""
+
+    def _sup(self, temp_home, monkeypatch):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5), "2": ("b@x.com", 5), "3": ("c@x.com", 5)})
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        sup._register()
+        # Give this session a real context so its reservation cost is positive.
+        reg = registry.read_registry(sw)
+        reg["sessions"]["mid"]["ctx_tokens"] = 100_000
+        from claude_swap.locking import FileLock
+        with FileLock(sw.lock_file):
+            registry.write_registry(sw, reg)
+        # Migration only re-points credentials; stub the disk seed so the test is
+        # filesystem-light and never touches a real keychain/profile.
+        monkeypatch.setattr(sup.switcher, "seed_profile_credentials",
+                            lambda *a, **k: None)
+        return sup
+
+    def test_migrate_restamps_reserved_at_and_clears_rate_limits(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home, monkeypatch)
+        before = time.time()
+        sup._migrate("2")
+
+        reg = registry.read_registry(sup.switcher)
+        row = reg["sessions"]["mid"]
+        assert row["account_num"] == "2"            # re-pointed to the target
+        assert row["rate_limits"] is None           # don't judge by old numbers
+        assert row["paused_until"] is None
+        assert row["_prev_max_pct"] is None          # fresh rising-edge basis
+        # The reservation stamp is fresh (the load-bearing BUG-003 fix).
+        assert isinstance(row.get("reserved_at"), (int, float))
+        assert row["reserved_at"] >= before
+
+    def test_migrated_session_counts_as_load_on_new_account(self, temp_home, monkeypatch):
+        # After the migrate, build_world must attribute _pct_cost(ctx) of synthetic
+        # load to the NEW account so a separate stranded session does not co-stack.
+        sup = self._sup(temp_home, monkeypatch)
+        # Seed a cached usage so account "2" is otherwise idle at a known pct
+        # (use write_cache so it lands inside the TTL envelope build_world reads).
+        from claude_swap.cache import write_cache
+        write_cache(
+            sup.switcher.backup_dir / "cache" / "usage.json",
+            {"2": {"five_hour": {"pct": 80.0, "resets_at": 2000}}},
+        )
+        sup._migrate("2")
+
+        reg = registry.read_registry(sup.switcher)
+        acct_views, _ = registry.build_world(sup.switcher, reg, fetch_idle=False)
+        expected = balancer._pct_cost(100_000)
+        assert expected > 0
+        # Account 2's cached 80% is raised by the migrated session's reservation.
+        assert acct_views["2"].max_pct == 80.0 + expected
+
+
 class TestRecoverAuth:
     """401 auto-recovery: refresh+re-seed the same account, else migrate."""
 
@@ -341,3 +400,175 @@ class TestRecoverAuth:
         assert calls == []
         reg2 = registry.read_registry(sup.switcher)
         assert reg2["sessions"]["mid"].get("auth_recover") is None
+
+
+class TestPrimeIdleWindows:
+    """The resident supervisor's idle-5h-window prime sweep (feature #3).
+
+    Every test MOCKS oauth.prime_account — NO real prime call is ever made.
+    """
+
+    def _sup(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5), "2": ("b@x.com", 5), "3": ("c@x.com", 5)})
+        # Priming requires BOTH the balancer being enabled AND the dedicated,
+        # default-OFF primeIdleWindows opt-in (feature #3).
+        sw.set_auto_balance_config(enabled=True, prime_idle_windows=True)
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        sup._register()
+        return sup
+
+    def _idle_world(self):
+        # Account 1 hosts this session (live); 2 and 3 are idle with unstarted
+        # 5h windows -> prime candidates; choose only those != self.account.
+        return (
+            {
+                "1": balancer.AccountView("1", priority=5, max_pct=10.0, signal="live",
+                                          five_hour_pct=10.0),
+                "2": balancer.AccountView("2", priority=5, max_pct=0.0, signal="cache",
+                                          five_hour_pct=0.0, five_hour_reset=None),
+                "3": balancer.AccountView("3", priority=5, max_pct=0.0, signal="cache",
+                                          five_hour_pct=0.0, five_hour_reset=None),
+            },
+            [],
+        )
+
+    def test_primes_idle_candidates_and_stamps_them(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        primed: list[str] = []
+        monkeypatch.setattr(sup, "_prime_one_account",
+                            lambda num: primed.append(num) or True)
+        with patch("claude_swap.supervisor.registry.build_world", return_value=self._idle_world()):
+            sup._maybe_prime_idle_windows()
+
+        # Account 1 is self (skipped); 2 and 3 are idle candidates and get primed.
+        assert sorted(primed) == ["2", "3"]
+        reg = registry.read_registry(sup.switcher)
+        assert set(reg.get("primed", {})) == {"2", "3"}
+
+    def test_local_interval_gate_skips_repeated_calls(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        calls = {"n": 0}
+        monkeypatch.setattr(sup, "_prime_one_account",
+                            lambda num: calls.__setitem__("n", calls["n"] + 1) or True)
+        with patch("claude_swap.supervisor.registry.build_world", return_value=self._idle_world()):
+            sup._maybe_prime_idle_windows()
+            first = calls["n"]
+            sup._maybe_prime_idle_windows()  # immediate second call -> local gate
+        assert first == 2
+        assert calls["n"] == 2  # no additional primes on the gated second tick
+
+    def test_disabled_balancer_never_primes(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        sup.switcher.set_auto_balance_config(enabled=False)
+        primed: list[str] = []
+        monkeypatch.setattr(sup, "_prime_one_account",
+                            lambda num: primed.append(num) or True)
+        with patch("claude_swap.supervisor.registry.build_world", return_value=self._idle_world()):
+            sup._maybe_prime_idle_windows()
+        assert primed == []
+
+    def test_enabled_but_prime_flag_off_never_primes(self, temp_home, monkeypatch):
+        # primeIdleWindows is a dedicated, default-OFF opt-in (review fix #3): even
+        # with the balancer enabled, priming must NOT fire unless it is set, because
+        # it spends real credits on the unverified fixed-from-first-use premise.
+        sup = self._sup(temp_home)
+        sup.switcher.set_auto_balance_config(enabled=True, prime_idle_windows=False)
+        primed: list[str] = []
+        monkeypatch.setattr(sup, "_prime_one_account",
+                            lambda num: primed.append(num) or True)
+        with patch("claude_swap.supervisor.registry.build_world", return_value=self._idle_world()):
+            sup._maybe_prime_idle_windows()
+        assert primed == []
+
+    def test_prime_fires_only_when_both_flags_on(self, temp_home, monkeypatch):
+        # Mirror of the above: with BOTH enabled and primeIdleWindows on, the sweep
+        # fires. (The default new-config state has primeIdleWindows False.)
+        sup = self._sup(temp_home)
+        sup.switcher.set_auto_balance_config(enabled=True, prime_idle_windows=True)
+        primed: list[str] = []
+        monkeypatch.setattr(sup, "_prime_one_account",
+                            lambda num: primed.append(num) or True)
+        with patch("claude_swap.supervisor.registry.build_world", return_value=self._idle_world()):
+            sup._maybe_prime_idle_windows()
+        assert sorted(primed) == ["2", "3"]
+
+    def test_cross_process_claim_blocks_second_supervisor(self, temp_home, monkeypatch):
+        # A second supervisor in the same interval must NOT re-sweep (the registry
+        # claim is shared); only one fires the (mocked) prime calls.
+        sup1 = self._sup(temp_home)
+        sup2 = Supervisor(sup1.switcher, "mid2", temp_home / "p2", "1",
+                          cwd=str(temp_home), share=False)
+        sup2._register()
+        primed: list[str] = []
+        for s in (sup1, sup2):
+            monkeypatch.setattr(s, "_prime_one_account",
+                                lambda num: primed.append(num) or True)
+        with patch("claude_swap.supervisor.registry.build_world", return_value=self._idle_world()):
+            sup1._maybe_prime_idle_windows()
+            sup2._maybe_prime_idle_windows()
+        assert sorted(primed) == ["2", "3"]  # exactly one sweep happened
+
+    def test_guard_skips_recently_primed_account(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        # Pre-stamp account 2 as just-primed so it is guarded out this sweep.
+        from claude_swap.locking import FileLock
+        with FileLock(sup.switcher.lock_file):
+            reg = registry.read_registry(sup.switcher)
+            registry.stamp_primed(reg, "2", __import__("time").time())
+            registry.write_registry(sup.switcher, reg)
+        primed: list[str] = []
+        monkeypatch.setattr(sup, "_prime_one_account",
+                            lambda num: primed.append(num) or True)
+        with patch("claude_swap.supervisor.registry.build_world", return_value=self._idle_world()):
+            sup._maybe_prime_idle_windows()
+        assert primed == ["3"]  # 2 guarded, 1 is self
+
+    def test_prime_failure_is_not_stamped(self, temp_home, monkeypatch):
+        sup = self._sup(temp_home)
+        monkeypatch.setattr(sup, "_prime_one_account", lambda num: False)  # all fail
+        with patch("claude_swap.supervisor.registry.build_world", return_value=self._idle_world()):
+            sup._maybe_prime_idle_windows()
+        reg = registry.read_registry(sup.switcher)
+        assert reg.get("primed", {}) == {}  # nothing stamped on failure
+
+
+class TestPrimeOneAccount:
+    """`_prime_one_account` reads inactive-account creds and calls oauth.prime_account.
+
+    oauth.prime_account is MOCKED — NO real network call is made.
+    """
+
+    def _sup_with_creds(self, temp_home):
+        sw = ClaudeAccountSwitcher()
+        _seed_accounts(sw, {"1": ("a@x.com", 5), "2": ("b@x.com", 5)})
+        # Seed a fresh (unexpired) token for account 2 so no refresh path runs.
+        import json as _json
+        import time as _time
+        from claude_swap.locking import FileLock
+        creds = _json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "tok-2",
+                "refreshToken": "ref-2",
+                "expiresAt": int((_time.time() + 3600) * 1000),
+            }
+        })
+        with FileLock(sw.lock_file):
+            sw.write_account_credentials("2", "b@x.com", creds)
+        sup = Supervisor(sw, "mid", temp_home / "p", "1", cwd=str(temp_home), share=False)
+        return sup
+
+    def test_calls_prime_with_extracted_token(self, temp_home):
+        sup = self._sup_with_creds(temp_home)
+        with patch("claude_swap.supervisor.oauth.prime_account", return_value=True) as m:
+            ok = sup._prime_one_account("2")
+        assert ok is True
+        m.assert_called_once_with("tok-2")
+
+    def test_missing_credentials_returns_false_without_calling(self, temp_home):
+        sup = self._sup_with_creds(temp_home)
+        # Account "1" has no stored creds in this fixture.
+        with patch("claude_swap.supervisor.oauth.prime_account", return_value=True) as m:
+            ok = sup._prime_one_account("1")
+        assert ok is False
+        m.assert_not_called()

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2533,3 +2533,123 @@ class TestSeedProfileCredentialsAtomic:
         assert (profile_dir / ".credentials.json").exists()
         # No leftover temp files in the profile dir.
         assert not list(profile_dir.glob("*.tmp"))
+
+
+class TestRefreshAccountAndReseed:
+    """401 auto-recovery: refresh an account's token + re-seed a managed profile.
+
+    Exercises ``refresh_account_and_reseed`` without real network I/O — the OAuth
+    refresh + expiry helpers are mocked and ``seed_profile_credentials`` is spied.
+    """
+
+    def _switcher(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.LINUX  # file-backed backup creds (no Keychain)
+        s._setup_directories()
+        s._init_sequence_file()
+        return s
+
+    def _seed_account(
+        self, s: ClaudeAccountSwitcher, num: int, email: str, *, expires_at: int
+    ) -> None:
+        s._write_account_credentials(
+            str(num),
+            email,
+            json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": f"sk-{num}",
+                    "refreshToken": f"rt-{num}",
+                    "expiresAt": expires_at,
+                },
+            }),
+        )
+        s._write_account_config(
+            str(num),
+            email,
+            json.dumps({"oauthAccount": {"emailAddress": email, "accountUuid": f"uuid-{num}"}}),
+        )
+        data = s._get_sequence_data()
+        data["accounts"][str(num)] = {
+            "email": email,
+            "uuid": f"uuid-{num}",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+            data["sequence"].sort()
+        s._write_json(s.sequence_file, data)
+
+    def test_fresh_token_reseeds_without_refreshing(self, temp_home: Path):
+        s = self._switcher(temp_home)
+        self._seed_account(s, 1, "a@x.com", expires_at=0)
+        profile_dir = s.managed_dir / "m1"
+
+        with patch("claude_swap.switcher.oauth.is_oauth_token_expired", return_value=False), \
+             patch("claude_swap.switcher.oauth.refresh_oauth_credentials") as refresh, \
+             patch.object(s, "seed_profile_credentials") as seed:
+            ok = s.refresh_account_and_reseed("1", profile_dir)
+
+        assert ok is True
+        refresh.assert_not_called()  # token already fresh -> no network refresh
+        seed.assert_called_once_with(profile_dir, "1", "a@x.com")
+
+    def test_expired_token_refreshes_persists_and_reseeds(self, temp_home: Path):
+        s = self._switcher(temp_home)
+        self._seed_account(s, 1, "a@x.com", expires_at=0)
+        profile_dir = s.managed_dir / "m1"
+        refreshed = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-new",
+                "refreshToken": "rt-new",
+                "expiresAt": 9_999_999_999_000,
+            }
+        })
+
+        with patch("claude_swap.switcher.oauth.is_oauth_token_expired", return_value=True), \
+             patch("claude_swap.switcher.oauth.refresh_oauth_credentials", return_value=refreshed), \
+             patch.object(s, "_write_account_credentials") as write_creds, \
+             patch.object(s, "seed_profile_credentials") as seed:
+            ok = s.refresh_account_and_reseed("1", profile_dir)
+
+        assert ok is True
+        # Fresh creds persisted to the canonical backup, then profile re-seeded.
+        write_creds.assert_called_once_with("1", "a@x.com", refreshed)
+        seed.assert_called_once_with(profile_dir, "1", "a@x.com")
+
+    def test_refresh_returns_none_returns_false_no_reseed(self, temp_home: Path):
+        s = self._switcher(temp_home)
+        self._seed_account(s, 1, "a@x.com", expires_at=0)
+        profile_dir = s.managed_dir / "m1"
+
+        with patch("claude_swap.switcher.oauth.is_oauth_token_expired", return_value=True), \
+             patch("claude_swap.switcher.oauth.refresh_oauth_credentials", return_value=None), \
+             patch.object(s, "_write_account_credentials") as write_creds, \
+             patch.object(s, "seed_profile_credentials") as seed:
+            ok = s.refresh_account_and_reseed("1", profile_dir)
+
+        assert ok is False  # refresh token dead -> account logged out
+        write_creds.assert_not_called()
+        seed.assert_not_called()
+
+    def test_no_backup_creds_returns_false(self, temp_home: Path):
+        s = self._switcher(temp_home)
+        # Register the account in sequence.json but write NO backup credentials.
+        data = s._get_sequence_data()
+        data["accounts"]["1"] = {
+            "email": "a@x.com",
+            "uuid": "uuid-1",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [1]
+        s._write_json(s.sequence_file, data)
+        profile_dir = s.managed_dir / "m1"
+
+        with patch.object(s, "seed_profile_credentials") as seed:
+            ok = s.refresh_account_and_reseed("1", profile_dir)
+
+        assert ok is False
+        seed.assert_not_called()

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2507,6 +2507,64 @@ class TestSeedProfileCredentialsAtomic:
             assert (creds_path.stat().st_mode & 0o777) == 0o600
             assert (config_path.stat().st_mode & 0o777) == 0o600
 
+    def test_seed_trusts_launch_cwd(self, temp_home: Path):
+        """Passing ``cwd`` pre-accepts the folder trust dialog for that dir so
+        the spawned claude doesn't stop on the workspace-trust prompt."""
+        sw = self._switcher()
+        creds_json = json.dumps({"accessToken": "tok"})
+        config_json = json.dumps({"oauthAccount": {"emailAddress": "a@x.com"}})
+        profile_dir = temp_home / "managed" / "m3"
+        workspace = temp_home / "Projects" / "IAMBot"
+        workspace.mkdir(parents=True)
+        with patch.object(sw, "_read_account_credentials", return_value=creds_json), \
+             patch.object(sw, "_read_account_config", return_value=config_json):
+            sw.seed_profile_credentials(
+                profile_dir, "1", "a@x.com", cwd=str(workspace)
+            )
+        cfg = json.loads((profile_dir / ".claude.json").read_text(encoding="utf-8"))
+        projects = cfg["projects"]
+        # The directory claude will run in is marked trusted (under its
+        # realpath — what the child's process.cwd() resolves to).
+        assert projects[os.path.realpath(workspace)]["hasTrustDialogAccepted"] is True
+
+    def test_seed_without_cwd_adds_no_projects(self, temp_home: Path):
+        """Backward compat: no cwd → no projects map is fabricated."""
+        sw = self._switcher()
+        creds_json = json.dumps({"accessToken": "tok"})
+        config_json = json.dumps({"oauthAccount": {"emailAddress": "a@x.com"}})
+        profile_dir = temp_home / "managed" / "m4"
+        with patch.object(sw, "_read_account_credentials", return_value=creds_json), \
+             patch.object(sw, "_read_account_config", return_value=config_json):
+            sw.seed_profile_credentials(profile_dir, "1", "a@x.com")
+        cfg = json.loads((profile_dir / ".claude.json").read_text(encoding="utf-8"))
+        assert "projects" not in cfg
+
+    def test_seed_trust_preserves_existing_project_metadata(self, temp_home: Path):
+        """Re-seeding keeps a project's existing history/allowedTools intact and
+        only flips trust on — projects/history survive a re-point."""
+        sw = self._switcher()
+        creds_json = json.dumps({"accessToken": "tok"})
+        config_json = json.dumps({"oauthAccount": {"emailAddress": "a@x.com"}})
+        profile_dir = temp_home / "managed" / "m5"
+        workspace = temp_home / "ws"
+        workspace.mkdir()
+        key = os.path.realpath(workspace)
+        profile_dir.mkdir(parents=True)
+        (profile_dir / ".claude.json").write_text(
+            json.dumps({"projects": {key: {"allowedTools": ["Bash"]}}}),
+            encoding="utf-8",
+        )
+        with patch.object(sw, "_read_account_credentials", return_value=creds_json), \
+             patch.object(sw, "_read_account_config", return_value=config_json):
+            sw.seed_profile_credentials(
+                profile_dir, "1", "a@x.com", cwd=str(workspace)
+            )
+        entry = json.loads(
+            (profile_dir / ".claude.json").read_text(encoding="utf-8")
+        )["projects"][key]
+        assert entry["hasTrustDialogAccepted"] is True
+        assert entry["allowedTools"] == ["Bash"]
+
     def test_seed_uses_atomic_rename_not_truncating_write(self, temp_home: Path):
         """The credential write must go through os.replace (a rename), never a
         plain truncate+write that a live reader could observe mid-write."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -452,6 +452,176 @@ class TestStatusCache:
         assert cached["2"] == {"five_hour": {"pct": 80}}
 
 
+class TestEnsureFreshInactiveCredentials:
+    """The locked, double-checked refresh chokepoint that stops the single-use
+    refresh-token reuse race (concurrent processes revoking the token family ->
+    idle accounts silently logging out)."""
+
+    @staticmethod
+    def _creds(access="acc", refresh="rt", expires_at=1000):
+        payload = {"claudeAiOauth": {"accessToken": access, "refreshToken": refresh}}
+        if expires_at is not None:
+            payload["claudeAiOauth"]["expiresAt"] = expires_at
+        return json.dumps(payload)
+
+    def _switcher(self):
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        return sw
+
+    def test_fresh_token_returns_unchanged_without_refresh(self, temp_home: Path):
+        sw = self._switcher()
+        future = int((__import__("time").time() + 3600) * 1000)
+        creds = self._creds(expires_at=future)
+        with patch("claude_swap.oauth.refresh_oauth_credentials") as rmock:
+            out = sw.ensure_fresh_inactive_credentials("2", "a@b.com", creds)
+        assert out == creds
+        rmock.assert_not_called()
+
+    def test_no_refresh_token_returns_unchanged(self, temp_home: Path):
+        # A --add-token account (no refresh token) must never hit the network.
+        sw = self._switcher()
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "acc", "expiresAt": 1000}})
+        with patch("claude_swap.oauth.refresh_oauth_credentials") as rmock:
+            out = sw.ensure_fresh_inactive_credentials("2", "a@b.com", creds)
+        assert out == creds
+        rmock.assert_not_called()
+
+    def test_expired_token_refreshes_and_persists_to_backup(self, temp_home: Path):
+        sw = self._switcher()
+        expired = self._creds(access="old", expires_at=1000)
+        refreshed = self._creds(access="new", refresh="rt-new", expires_at=None)
+        with patch.object(sw, "_read_account_credentials", return_value=expired), \
+             patch.object(sw, "_write_account_credentials") as wb, \
+             patch("claude_swap.oauth.refresh_oauth_credentials", return_value=refreshed):
+            out = sw.ensure_fresh_inactive_credentials("2", "a@b.com", expired)
+        assert out == refreshed
+        wb.assert_called_once_with("2", "a@b.com", refreshed)
+
+    def test_double_check_reuses_winner_token_without_posting(self, temp_home: Path):
+        # A concurrent winner already refreshed + persisted: the loser must reuse the
+        # fresh on-disk token and NOT POST the (now consumed) refresh token again.
+        sw = self._switcher()
+        caller_expired = self._creds(access="old", expires_at=1000)
+        future = int((__import__("time").time() + 3600) * 1000)
+        disk_fresh = self._creds(access="winner", refresh="rt-new", expires_at=future)
+        with patch.object(sw, "_read_account_credentials", return_value=disk_fresh), \
+             patch.object(sw, "_write_account_credentials") as wb, \
+             patch("claude_swap.oauth.refresh_oauth_credentials") as rmock:
+            out = sw.ensure_fresh_inactive_credentials("2", "a@b.com", caller_expired)
+        assert out == disk_fresh
+        rmock.assert_not_called()
+        wb.assert_not_called()
+
+    def test_invalid_grant_flags_logged_out(self, temp_home: Path):
+        sw = self._switcher()
+        expired = self._creds(access="old", expires_at=1000)
+
+        def fake_refresh(base, failure_out=None):
+            if failure_out is not None:
+                failure_out["invalid_grant"] = True
+            return None
+
+        fail: dict = {}
+        with patch.object(sw, "_read_account_credentials", return_value=expired), \
+             patch.object(sw, "_write_account_credentials") as wb, \
+             patch("claude_swap.oauth.refresh_oauth_credentials", side_effect=fake_refresh):
+            out = sw.ensure_fresh_inactive_credentials("2", "a@b.com", expired, failure_out=fail)
+        assert fail.get("logged_out") is True
+        assert out == expired  # unchanged base, never live creds
+        wb.assert_not_called()
+
+
+class TestRefreshAccountAndReseedSerialization:
+    """The managed-session 401 recovery must serialize its single-use-token POST on
+    the per-account refresh lock (before the global lock) so it can't race an idle
+    build_world refresh of the same account's token."""
+
+    def test_acquires_per_account_refresh_lock_before_global(self, temp_home: Path):
+        from claude_swap.locking import FileLock as RealLock
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._init_sequence_file()
+        data = sw._get_sequence_data()
+        data["accounts"]["2"] = {
+            "email": "b@x.com", "uuid": "", "organizationUuid": "",
+            "organizationName": "", "priority": 0, "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [2]
+        sw._write_json(sw.sequence_file, data)
+
+        expired = json.dumps({"claudeAiOauth": {
+            "accessToken": "old", "refreshToken": "rt", "expiresAt": 1000}})
+        refreshed = json.dumps({"claudeAiOauth": {
+            "accessToken": "new", "refreshToken": "rt2"}})
+
+        seen: list[str] = []
+
+        class SpyLock:
+            def __init__(self, path, timeout=10.0):
+                seen.append(path.name)
+                self._inner = RealLock(path, timeout)
+
+            def __enter__(self):
+                return self._inner.__enter__()
+
+            def __exit__(self, *a):
+                return self._inner.__exit__(*a)
+
+        with patch("claude_swap.switcher.FileLock", SpyLock), \
+             patch.object(sw, "_read_account_credentials", return_value=expired), \
+             patch.object(sw, "_write_account_credentials"), \
+             patch.object(sw, "seed_profile_credentials"), \
+             patch("claude_swap.oauth.refresh_oauth_credentials", return_value=refreshed):
+            ok = sw.refresh_account_and_reseed("2", temp_home / "profile")
+
+        assert ok is True
+        assert ".refresh-2.lock" in seen
+        assert ".lock" in seen
+        assert seen.index(".refresh-2.lock") < seen.index(".lock")
+
+
+class TestClearLoggedOutMarkerOnRelogin:
+    """Writing fresh backup credentials drops a stale logged-out usage marker so a
+    re-login shows real usage immediately, not 'logged out' for LOGGED_OUT_RECHECK_S."""
+
+    def test_cred_write_clears_logged_out_marker(self, temp_home: Path):
+        from claude_swap.cache import logged_out_marker, read_cache, write_cache
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        path = sw.backup_dir / "cache" / "usage.json"
+        write_cache(path, {"2": logged_out_marker(), "3": {"five_hour": {"pct": 5}}})
+
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+        with patch.object(sw, "_live_session_pids", return_value=[]), \
+             patch.object(sw, "_invalidate_session_credentials"):
+            sw._write_account_credentials("2", "b@x.com", creds)
+
+        cached = read_cache(path, 10**9)
+        assert "2" not in cached  # logged-out marker dropped
+        assert cached["3"] == {"five_hour": {"pct": 5}}  # other accounts untouched
+
+    def test_cred_write_preserves_real_usage_marker(self, temp_home: Path):
+        # A routine refresh-token rotation also lands in _write_account_credentials;
+        # it must NOT wipe good cached usage (only logged-out markers are cleared).
+        from claude_swap.cache import read_cache, write_cache
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        path = sw.backup_dir / "cache" / "usage.json"
+        real = {"five_hour": {"pct": 42}}
+        write_cache(path, {"2": real})
+
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "rotated"}})
+        with patch.object(sw, "_live_session_pids", return_value=[]), \
+             patch.object(sw, "_invalidate_session_credentials"):
+            sw._write_account_credentials("2", "b@x.com", creds)
+
+        assert read_cache(path, 10**9)["2"] == real
+
+
 class TestListAccountsUsage:
     """Test list_accounts shows usage info."""
 
@@ -544,12 +714,19 @@ class TestListAccountsUsage:
         to rewrite live credentials for the active account. Per
         OAUTH_REFRESH_REDESIGN.md, cswap must never write to live creds — that
         would race with Claude Code's own refresh (which coordinates via a
-        ~/.claude/ lockfile cswap doesn't honor).
+        ~/.claude/ lockfile cswap doesn't honor). The inactive-account refresh now
+        runs through ``ensure_fresh_inactive_credentials`` (the locked, double-checked
+        chokepoint), which persists via ``_write_account_credentials`` (backup only).
         """
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
         active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        # Backup token is EXPIRED so the chokepoint actually refreshes it.
         backup_creds = json.dumps({
-            "claudeAiOauth": {"accessToken": "sk-backup", "refreshToken": "rt-orig"},
+            "claudeAiOauth": {
+                "accessToken": "sk-backup",
+                "refreshToken": "rt-orig",
+                "expiresAt": 1000,
+            },
         })
         refreshed_creds = json.dumps({
             "claudeAiOauth": {"accessToken": "sk-new", "refreshToken": "rt-new"},
@@ -559,18 +736,12 @@ class TestListAccountsUsage:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        def mock_fetch(account_num, email, credentials, is_active, persist_credentials,
-                       failure_out=None):
-            # Simulate a refresh on the inactive account only.
-            if not is_active:
-                persist_credentials(account_num, email, refreshed_creds)
-            return None
-
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
              patch.object(switcher, "_write_credentials") as write_live, \
              patch.object(switcher, "_write_account_credentials") as write_backup, \
-             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+             patch("claude_swap.oauth.refresh_oauth_credentials", return_value=refreshed_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
             switcher.list_accounts()
 
         # Live creds must never be written from list_accounts()
@@ -666,6 +837,225 @@ class TestListAccountsUsage:
         output = capsys.readouterr().out
         # Should show live data (10%), not cached data (25%)
         assert "10%" in output
+
+
+class TestLiveSignalDisplay:
+    """The display/poll paths reuse the registry's free, never-rate-limited live
+    ``rate_limits`` signal for any account hosting a live managed session.
+
+    Root cause of the recurring "usage rate-limited — retry in ~Nm": ``list_accounts``
+    / ``status`` / ``get_active_usage_pct`` hit the (per-client-rate-limited) usage
+    API even for an account the registry already has a fresh live reading for — so
+    the active account showed "rate-limited" while a perfectly good reading sat in
+    the registry, and the redundant calls fed the 429 loop. These tests pin the fix:
+    live reading wins, NO usage-API call, and live-derived values are never persisted
+    to the shared cache (they lack the API's spend/extra-usage)."""
+
+    def _seed_live_session(self, sw, account_num, h5=88.0, d7=40.0):
+        import os
+        import time
+
+        from claude_swap import registry
+
+        reg = registry.read_registry(sw)
+        registry.upsert_session(
+            reg,
+            f"m{account_num}",
+            account_num=str(account_num),
+            supervisor_pid=os.getpid(),
+            rate_limits={
+                "five_hour": {"used_percentage": h5, "resets_at": int(time.time()) + 3600},
+                "seven_day": {"used_percentage": d7, "resets_at": int(time.time()) + 100000},
+            },
+            last_seen=time.time(),
+        )
+        registry.write_registry(sw, reg)
+
+    def test_list_prefers_live_signal_no_fetch_for_live_account(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        import time
+
+        from claude_swap.cache import write_cache
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"  # active
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)
+
+        # Live managed session on the INACTIVE account 2, reporting fresh usage.
+        self._seed_live_session(sw, "2", h5=88.0, d7=40.0)
+        # The usage endpoint is 429-backed-off for account 2: WITHOUT the live path
+        # this renders "usage rate-limited" for it.
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"2": {"_unavailable": True, "retry_until": time.time() + 3000}},
+        )
+
+        def fake_fetch(num, *a, **k):
+            # account 1 (active, no live session) still fetches normally.
+            return {"five_hour": {"pct": 12.0}, "seven_day": {"pct": 20.0}}
+
+        with patch.object(sw, "_read_credentials", return_value=active_creds), \
+             patch.object(sw, "_read_account_credentials", return_value=backup_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=fake_fetch) as mock_fetch:
+            sw.list_accounts()
+
+        out = capsys.readouterr().out
+        assert "88%" in out  # live reading shown for the live account
+        assert "rate-limited" not in out  # never the backoff line for a live account
+        called_nums = [c.args[0] for c in mock_fetch.call_args_list]
+        assert "2" not in called_nums  # the live account never hit the usage API
+
+    def test_list_does_not_persist_live_derived_usage(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        import time
+
+        from claude_swap.cache import read_cache, write_cache
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)
+        self._seed_live_session(sw, "2", h5=88.0)
+        path = sw.backup_dir / "cache" / "usage.json"
+        write_cache(path, {"2": {"_unavailable": True, "retry_until": time.time() + 3000}})
+
+        with patch.object(sw, "_read_credentials", return_value=active_creds), \
+             patch.object(sw, "_read_account_credentials", return_value=backup_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account",
+                   return_value={"five_hour": {"pct": 12.0}}):
+            sw.list_accounts()
+
+        # The cache must keep account 2's marker — NOT the live-derived reading (it
+        # lacks spend/extra-usage and would mislead build_world / other readers).
+        entry = read_cache(path, 10**9)["2"]
+        assert entry.get("_unavailable") is True
+        assert "five_hour" not in entry  # the live 88% was not written through
+
+    def test_list_merges_spend_from_cache_onto_live_reading(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        from claude_swap.cache import write_cache
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)
+        self._seed_live_session(sw, "2", h5=88.0)
+        # Fresh, complete cache (both keys) -> cache-fast-path, no fetch. Account 2's
+        # cached entry is a REAL reading carrying spend; the live overlay must keep
+        # the live 5h/7d but merge the pay-as-you-go line the live signal lacks.
+        write_cache(sw.backup_dir / "cache" / "usage.json", {
+            "1": {"five_hour": {"pct": 5}},
+            "2": {
+                "five_hour": {"pct": 3},
+                "extra_usage_enabled": True,
+                "spend": {"used": 1.0, "limit": 10.0, "pct": 10.0, "currency": "USD"},
+            },
+        })
+
+        with patch.object(sw, "_read_credentials", return_value=active_creds), \
+             patch.object(sw, "_read_account_credentials", return_value=backup_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
+            sw.list_accounts()
+
+        out = capsys.readouterr().out
+        mock_fetch.assert_not_called()  # fresh complete cache -> no API hit
+        assert "88%" in out  # live 5h (not the cached 3%)
+        assert "$1.00" in out  # spend merged from the cached real reading
+
+    def test_status_prefers_live_signal_over_backoff(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        import time
+
+        from claude_swap.cache import write_cache
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        sample_sequence_data["accounts"]["1"]["organizationUuid"] = ""
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)
+        self._seed_live_session(sw, "1", h5=88.0, d7=40.0)
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"1": {"_unavailable": True, "retry_until": time.time() + 3000}},
+        )
+
+        with patch.object(sw, "_get_current_account", return_value=("test@example.com", "")), \
+             patch.object(sw, "_read_credentials", return_value=creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
+            sw.status()
+
+        out = capsys.readouterr().out
+        mock_fetch.assert_not_called()  # live signal -> no usage-API call
+        assert "88%" in out
+        assert "rate-limited" not in out
+
+    def test_get_active_usage_pct_prefers_live_signal(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        import time
+
+        from claude_swap.cache import write_cache
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        sample_sequence_data["accounts"]["1"]["organizationUuid"] = ""
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)
+        self._seed_live_session(sw, "1", h5=88.0, d7=40.0)
+        # Backed off: WITHOUT the live path get_active_usage_pct returns None (the
+        # auto-switch monitor then can't act). With it, the live max (88) is returned.
+        write_cache(
+            sw.backup_dir / "cache" / "usage.json",
+            {"1": {"_unavailable": True, "retry_until": time.time() + 3000}},
+        )
+
+        with patch.object(sw, "_get_current_account", return_value=("test@example.com", "")), \
+             patch.object(sw, "_read_credentials", return_value=creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
+            pct = sw.get_active_usage_pct()
+
+        mock_fetch.assert_not_called()
+        assert pct == 88.0
+
+    def test_no_live_session_falls_back_to_usage_api(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        """No live managed session -> the live map is empty and the usage API is
+        used exactly as before (regression guard that idle accounts still fetch)."""
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)  # no registry sessions
+
+        with patch.object(sw, "_read_credentials", return_value=active_creds), \
+             patch.object(sw, "_read_account_credentials", return_value=backup_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account",
+                   return_value={"five_hour": {"pct": 33.0}}) as mock_fetch:
+            sw.list_accounts()
+
+        assert mock_fetch.called  # idle accounts still fetch via the usage API
+        assert "33%" in capsys.readouterr().out
 
 
 class TestPerformSwitchPostDisplay:
@@ -2797,6 +3187,49 @@ class TestUsageBackoffThrottle:
         assert pct is None
         entry = read_cache(path, 10**9)["1"]
         assert usage_backoff_active(entry) is True
+
+
+class TestLoggedOutRender:
+    """A logged-out account (dead refresh token) shows an actionable re-login hint,
+    never the ambiguous 'usage unavailable' nor optimistic stale numbers."""
+
+    def test_list_shows_logged_out_hint(
+        self, temp_home, mock_claude_config, sample_sequence_data, capsys
+    ):
+        from claude_swap.cache import logged_out_marker, write_cache
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)
+        seq = sw._get_sequence_data()
+        out_num = str(seq["sequence"][0])
+        # Full cache (all sequence keys) -> cache-hit path, no fetch/creds needed.
+        cache = {str(n): {"five_hour": {"pct": 5}} for n in seq["sequence"]}
+        cache[out_num] = logged_out_marker()
+        write_cache(sw.backup_dir / "cache" / "usage.json", cache)
+        with patch.object(sw, "_read_credentials", return_value=""), \
+             patch.object(sw, "_read_account_credentials", return_value=""):
+            sw.list_accounts()
+        out = capsys.readouterr().out
+        assert "logged out" in out
+        assert "re-login" in out
+        # Never the generic line for a logged-out account.
+        assert "usage unavailable" not in out
+
+    def test_logged_out_marker_does_not_render_stale_numbers(self):
+        # Even if a logged-out marker somehow carried a last-known reading, it must
+        # never be shown as optimistic usage (the account can't authenticate).
+        from claude_swap.switcher import _stale_usage_render, _usage_status_line
+
+        marker = {
+            "_unavailable": True,
+            "_logged_out": True,
+            "retry_until": __import__("time").time() + 300,
+            "_last_known": {"five_hour": {"pct": 62}},
+            "_last_known_at": __import__("time").time(),
+        }
+        assert _stale_usage_render(marker) is None
+        assert "re-login" in _usage_status_line(marker)
 
 
 class TestStaleUsageRender:

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -559,7 +559,8 @@ class TestListAccountsUsage:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
+        def mock_fetch(account_num, email, credentials, is_active, persist_credentials,
+                       failure_out=None):
             # Simulate a refresh on the inactive account only.
             if not is_active:
                 persist_credentials(account_num, email, refreshed_creds)

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2475,3 +2475,61 @@ class TestSwitchSkipsBrokenSlots:
 
         with pytest.raises(ConfigError, match="No managed accounts have valid"):
             s.switch()
+
+
+class TestSeedProfileCredentialsAtomic:
+    """BUG 015: profile seeds must be atomic (no truncate+write race)."""
+
+    def _switcher(self):
+        return ClaudeAccountSwitcher()
+
+    def test_seed_writes_both_files_atomically(self, temp_home: Path):
+        sw = self._switcher()
+        creds_json = json.dumps({"accessToken": "tok", "refreshToken": "ref"})
+        config_json = json.dumps(
+            {"oauthAccount": {"emailAddress": "a@x.com"}, "theme": "light"}
+        )
+        profile_dir = temp_home / "managed" / "m1"
+        with patch.object(sw, "_read_account_credentials", return_value=creds_json), \
+             patch.object(sw, "_read_account_config", return_value=config_json):
+            sw.seed_profile_credentials(profile_dir, "1", "a@x.com")
+
+        creds_path = profile_dir / ".credentials.json"
+        config_path = profile_dir / ".claude.json"
+        # Contents are correct and verbatim for credentials.
+        assert creds_path.read_text(encoding="utf-8") == creds_json
+        cfg = json.loads(config_path.read_text(encoding="utf-8"))
+        assert cfg["oauthAccount"] == {"emailAddress": "a@x.com"}
+        assert cfg["hasCompletedOnboarding"] is True
+        assert cfg["theme"] == "light"
+        # 0600 perms on both (skip the perm check on Windows).
+        if sys.platform != "win32":
+            assert (creds_path.stat().st_mode & 0o777) == 0o600
+            assert (config_path.stat().st_mode & 0o777) == 0o600
+
+    def test_seed_uses_atomic_rename_not_truncating_write(self, temp_home: Path):
+        """The credential write must go through os.replace (a rename), never a
+        plain truncate+write that a live reader could observe mid-write."""
+        sw = self._switcher()
+        profile_dir = temp_home / "managed" / "m2"
+        creds_json = json.dumps({"accessToken": "tok"})
+        config_json = json.dumps({"oauthAccount": {"emailAddress": "a@x.com"}})
+
+        replaces: list[tuple[str, str]] = []
+        real_replace = os.replace
+
+        def spy_replace(src, dst):
+            replaces.append((str(src), str(dst)))
+            return real_replace(src, dst)
+
+        with patch.object(sw, "_read_account_credentials", return_value=creds_json), \
+             patch.object(sw, "_read_account_config", return_value=config_json), \
+             patch("claude_swap.switcher.os.replace", side_effect=spy_replace):
+            sw.seed_profile_credentials(profile_dir, "1", "a@x.com")
+
+        # .credentials.json was committed via an atomic rename onto its final path.
+        creds_path = str(profile_dir / ".credentials.json")
+        assert any(dst == creds_path for _, dst in replaces)
+        assert (profile_dir / ".credentials.json").exists()
+        # No leftover temp files in the profile dir.
+        assert not list(profile_dir.glob("*.tmp"))

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2712,3 +2712,127 @@ class TestRefreshAccountAndReseed:
 
         assert ok is False
         seed.assert_not_called()
+
+
+class TestUsageBackoffThrottle:
+    """status() and get_active_usage_pct honor the shared 429 backoff marker rather
+    than re-hitting a rate-limited usage endpoint once the freshness cache lapses."""
+
+    def _setup(self, sample_sequence_data):
+        import time
+
+        from claude_swap.cache import write_cache
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        sample_sequence_data["accounts"]["1"]["organizationUuid"] = "org-1"
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        path = sw.backup_dir / "cache" / "usage.json"
+        return sw, creds, path, time, write_cache
+
+    def test_status_honors_active_backoff_marker(
+        self, temp_home, mock_claude_config, sample_sequence_data, capsys
+    ):
+        sw, creds, path, time, write_cache = self._setup(sample_sequence_data)
+        write_cache(path, {"1": {"_unavailable": True, "retry_until": time.time() + 3600}})
+        with patch("claude_swap.switcher._USAGE_CACHE_TTL", 0), \
+             patch.object(sw, "_get_current_account", return_value=("test@example.com", "org-1")), \
+             patch.object(sw, "_read_credentials", return_value=creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account") as m:
+            sw.status()
+        m.assert_not_called()  # backoff active -> no refetch
+        assert "rate-limited" in capsys.readouterr().out
+
+    def test_status_429_caches_backoff_marker(
+        self, temp_home, mock_claude_config, sample_sequence_data
+    ):
+        from claude_swap.cache import read_cache, usage_backoff_active
+
+        sw, creds, path, time, write_cache = self._setup(sample_sequence_data)
+
+        def fake_fetch(*a, failure_out=None, **k):
+            if failure_out is not None:
+                failure_out["retry_after"] = 1800
+            return None
+
+        with patch("claude_swap.switcher._USAGE_CACHE_TTL", 0), \
+             patch.object(sw, "_get_current_account", return_value=("test@example.com", "org-1")), \
+             patch.object(sw, "_read_credentials", return_value=creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=fake_fetch):
+            sw.status()
+        entry = read_cache(path, 10**9)["1"]
+        assert usage_backoff_active(entry) is True  # marker persisted, not a bare None
+
+    def test_get_active_usage_pct_honors_backoff(
+        self, temp_home, mock_claude_config, sample_sequence_data
+    ):
+        sw, creds, path, time, write_cache = self._setup(sample_sequence_data)
+        write_cache(path, {"1": {"_unavailable": True, "retry_until": time.time() + 3600}})
+        with patch("claude_swap.switcher._USAGE_CACHE_TTL", 0), \
+             patch.object(sw, "_get_current_account", return_value=("test@example.com", "org-1")), \
+             patch.object(sw, "_read_credentials", return_value=creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account") as m:
+            pct = sw.get_active_usage_pct()
+        m.assert_not_called()
+        assert pct is None  # unknown during backoff -> auto-switch won't act on a guess
+
+    def test_get_active_usage_pct_429_caches_marker(
+        self, temp_home, mock_claude_config, sample_sequence_data
+    ):
+        from claude_swap.cache import read_cache, usage_backoff_active
+
+        sw, creds, path, time, write_cache = self._setup(sample_sequence_data)
+
+        def fake_fetch(*a, failure_out=None, **k):
+            if failure_out is not None:
+                failure_out["retry_after"] = 1800
+            return None
+
+        with patch.object(sw, "_get_current_account", return_value=("test@example.com", "org-1")), \
+             patch.object(sw, "_read_credentials", return_value=creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=fake_fetch):
+            pct = sw.get_active_usage_pct()
+        assert pct is None
+        entry = read_cache(path, 10**9)["1"]
+        assert usage_backoff_active(entry) is True
+
+
+class TestStaleUsageRender:
+    """A backed-off account with a recent last-known reading renders the cached
+    numbers (flagged) instead of a bare "usage unavailable"."""
+
+    def test_list_shows_last_known_instead_of_unavailable(
+        self, temp_home, mock_claude_config, sample_sequence_data, capsys
+    ):
+        import time
+
+        from claude_swap.cache import write_cache
+
+        sw = ClaudeAccountSwitcher()
+        sw._setup_directories()
+        sw._write_json(sw.sequence_file, sample_sequence_data)
+        seq = sw._get_sequence_data()
+        stale_num = str(seq["sequence"][0])
+        # Seed a full cache (all sequence keys) so list_accounts takes the cache-hit
+        # path (no fetch, no creds needed): the first account is 429-backed-off with
+        # a recent last-known reading; the rest get a trivial usage entry.
+        cache = {
+            str(n): {"five_hour": {"pct": 5}}
+            for n in seq["sequence"]
+        }
+        cache[stale_num] = {
+            "_unavailable": True,
+            "retry_until": time.time() + 1800,
+            "_last_known": {"five_hour": {"pct": 62}, "seven_day": {"pct": 30}},
+            "_last_known_at": time.time(),
+        }
+        write_cache(sw.backup_dir / "cache" / "usage.json", cache)
+        with patch.object(sw, "_read_credentials", return_value=""), \
+             patch.object(sw, "_read_account_credentials", return_value=""):
+            sw.list_accounts()
+        out = capsys.readouterr().out
+        assert "last-known" in out and "cached" in out
+        assert "62%" in out
+        assert "usage unavailable" not in out

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -29,6 +29,38 @@ def _stub_screen(rows: int = 30, cols: int = 100) -> MagicMock:
     return screen
 
 
+def _capture_screen(rows: int = 30, cols: int = 100):
+    """A curses-window mock that records ``addstr`` output into a line buffer.
+
+    Returns ``(screen, lines)`` where ``lines`` maps row -> rendered text, so a
+    test can assert on what ``_draw_dashboard`` actually painted.
+    """
+    screen = MagicMock()
+    screen.getmaxyx.return_value = (rows, cols)
+    lines: dict[int, str] = {}
+
+    def _addstr(y, x, s, *_a):
+        s = str(s)
+        cur = lines.get(y, "")
+        if len(cur) < x:
+            cur = cur.ljust(x)
+        lines[y] = cur[:x] + s + cur[x + len(s):]
+
+    screen.addstr.side_effect = _addstr
+    return screen, lines
+
+
+def _all_text(lines: dict[int, str]) -> str:
+    return "\n".join(lines[y] for y in sorted(lines))
+
+
+def _line_with(lines: dict[int, str], needle: str) -> str:
+    for y in sorted(lines):
+        if needle in lines[y]:
+            return lines[y]
+    return ""
+
+
 def _make_seq(temp_home: Path, accounts: list[tuple[str, str]] | None = None) -> Path:
     """Write a sequence.json to the backup directory.
 
@@ -296,6 +328,168 @@ class TestDoRemove:
 # --------------------------------------------------------------------------- #
 # CLI integration                                                              #
 # --------------------------------------------------------------------------- #
+
+
+class TestDashboard:
+    """``_draw_dashboard`` renders per-account usage for every account (5h + 7d
+    consumption/resets, session count, and warm/cold when warming is enabled)."""
+
+    NOW = 1_000_000.0
+
+    def _accts(self):
+        from claude_swap.balancer import AccountView
+
+        n = self.NOW
+        return {
+            # live, in-use, 5h running
+            "1": AccountView(
+                num="1", priority=3, max_pct=45.0, signal="live",
+                five_hour_pct=45.0, five_hour_reset=int(n + 8000),
+                seven_day_pct=30.0, seven_day_reset=int(n + 360000),
+            ),
+            # idle (cache), 5h unstarted -> cold
+            "2": AccountView(
+                num="2", priority=3, max_pct=12.0, signal="cache",
+                five_hour_pct=0.0, five_hour_reset=None,
+                seven_day_pct=12.0, seven_day_reset=int(n + 430000),
+            ),
+            # unknown usage (logged out / failed read)
+            "9": AccountView(num="9", priority=1, signal="none"),
+        }
+
+    def _sessions(self):
+        return [
+            {"session_id": "s1", "account_num": "1", "cwd": "/a", "last_seen": self.NOW},
+            {"session_id": "s2", "account_num": "1", "cwd": "/b", "last_seen": self.NOW},
+        ]
+
+    def _switcher(self, prime: bool = True) -> MagicMock:
+        sw = MagicMock()
+        sw.get_auto_balance_config.return_value = {
+            "enabled": True, "threshold": 95, "targetSafety": 90,
+            "primeIdleWindows": prime,
+        }
+        return sw
+
+    def _draw(self, prime: bool = True):
+        screen, lines = _capture_screen()
+        with patch("claude_swap.tui.time.time", return_value=self.NOW):
+            tui._draw_dashboard(screen, self._switcher(prime), self._sessions(), self._accts())
+        return lines
+
+    def test_per_account_session_count_including_idle(self):
+        lines = self._draw()
+        # Two sessions land on a1; idle accounts still render with a 0 count.
+        assert "P3  2 sess" in _line_with(lines, "a1   P3")
+        assert "P3  0 sess" in _line_with(lines, "a2   P3")
+
+    def test_idle_account_shows_both_windows_with_usage(self):
+        # The whole point: usage is shown even for an account hosting NO session.
+        row = _line_with(self._draw(), "a2   P3")
+        assert "5h   0% (no reset)" in row      # unstarted 5h window
+        assert "7d  12% (resets" in row          # weekly consumption + reset
+
+    def test_live_account_shows_5h_and_7d_resets(self):
+        row = _line_with(self._draw(), "a1   P3")
+        assert "5h  45% (resets 2h13m)" in row
+        assert "7d  30% (resets 4d04h)" in row
+
+    def test_warm_column_present_only_when_warming_enabled(self):
+        on = self._draw(prime=True)
+        assert "warming ON" in _all_text(on)
+        assert _line_with(on, "a1   P3").rstrip().endswith("warm")   # 5h running
+        assert _line_with(on, "a2   P3").rstrip().endswith("cold")   # 5h unstarted
+
+        off = self._draw(prime=False)
+        assert "warming OFF" in _all_text(off)
+        # No per-account warm/cold token when warming is disabled.
+        assert not _line_with(off, "a1   P3").rstrip().endswith("warm")
+        assert not _line_with(off, "a2   P3").rstrip().endswith("cold")
+
+    def test_unknown_usage_account_marked_unavailable(self):
+        assert "usage unavailable" in _line_with(self._draw(), "a9   P1")
+
+    def test_ui_loop_never_hits_the_network(self):
+        # The render loop must only read the worker-warmed cache + live signals
+        # (fetch_idle=False) so a slow account can never block rendering/quit.
+        screen = _stub_screen()
+        screen.getch.side_effect = [-1, -1, ord("q")]
+        calls: list[bool] = []
+
+        def fake_build_world(switcher, reg, *, fetch_idle):
+            calls.append(fetch_idle)
+            return ({}, [])
+
+        with patch("claude_swap.tui.threading.Thread") as thread_cls, \
+             patch("claude_swap.tui.registry.read_registry", return_value={}), \
+             patch("claude_swap.tui.registry.live_sessions", return_value=[]), \
+             patch("claude_swap.tui.registry.build_world", side_effect=fake_build_world), \
+             patch("claude_swap.tui.curses.curs_set"):
+            tui._balancer_dashboard(screen, self._switcher())
+
+        assert calls and all(c is False for c in calls)
+        # A background refresher thread is started and stopped on exit.
+        thread_cls.assert_called_once()
+        assert thread_cls.call_args.kwargs.get("daemon") is True
+        thread_cls.return_value.start.assert_called_once()
+
+    def test_idle_refresher_warms_cache_with_fetch_then_stops(self):
+        # The worker fetches idle usage (fetch_idle=True) and exits when stopped.
+        stop = tui.threading.Event()
+        calls: list[bool] = []
+
+        def fake_build_world(switcher, reg, *, fetch_idle):
+            calls.append(fetch_idle)
+            stop.set()  # one pass, then unblock stop.wait and exit the loop
+            return ({}, [])
+
+        with patch("claude_swap.tui.registry.read_registry", return_value={}), \
+             patch("claude_swap.tui.registry.build_world", side_effect=fake_build_world):
+            tui._idle_usage_refresher(MagicMock(), stop)
+
+        assert calls == [True]
+
+    def test_idle_refresher_survives_a_failed_pass(self):
+        # A raising build_world must not kill the worker mid-loop; it logs and stops.
+        stop = tui.threading.Event()
+        sw = MagicMock()
+
+        def boom(switcher, reg, *, fetch_idle):
+            stop.set()
+            raise RuntimeError("usage API down")
+
+        with patch("claude_swap.tui.registry.read_registry", return_value={}), \
+             patch("claude_swap.tui.registry.build_world", side_effect=boom):
+            tui._idle_usage_refresher(sw, stop)  # must not raise
+
+        sw._logger.debug.assert_called()
+
+
+class TestDashboardFormatters:
+    def test_short_countdown_days_hours_minutes(self):
+        assert tui._short_countdown(4 * 86400 + 5 * 3600) == "4d05h"
+        assert tui._short_countdown(2 * 3600 + 13 * 60) == "2h13m"
+        assert tui._short_countdown(42 * 60) == "42m"
+        assert tui._short_countdown(-5) == "0m"
+
+    def test_fmt_reset(self):
+        assert tui._fmt_reset(1000 + 8000, 1000) == "(resets 2h13m)"
+        # "(no reset)" is reserved for a truly unstarted (cold) window...
+        assert tui._fmt_reset(None, 1000) == "(no reset)"
+        # ...an elapsed reset epoch is a window rolling over, not "no reset", so it
+        # can't contradict a `warm` token derived from the same timestamp.
+        assert tui._fmt_reset(500, 1000) == "(resetting)"
+
+    def test_fmt_pct(self):
+        assert tui._fmt_pct(45.0).strip() == "45%"
+        assert tui._fmt_pct(0.0).strip() == "0%"
+        assert "%" not in tui._fmt_pct(None)
+
+    def test_account_row_unavailable_signal(self):
+        from claude_swap.balancer import AccountView
+
+        av = AccountView(num="9", priority=1, signal="none")
+        assert "usage unavailable" in tui._account_row(av, 0, 0.0, show_warm=True)
 
 
 class TestCliIntegration:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -558,6 +558,18 @@ class TestDashboardFormatters:
         # warm/cold suppressed when usage is unknown (no bare "· ?").
         assert "· warm" not in flat and "· cold" not in flat and "· ?" not in flat
 
+    def test_account_block_logged_out_signal(self):
+        from claude_swap.balancer import AccountView
+
+        av = AccountView(num="9", priority=1, signal="logged_out")
+        flat = self._flatten(
+            tui._account_block(av, "c@x.com", "personal", False, 0, 0.0, show_warm=True)
+        )
+        assert "logged out — re-login" in flat
+        # Distinct from a transient no-signal read.
+        assert "usage unavailable" not in flat
+        assert "0 sessions" in flat
+
     def test_account_block_session_pluralization(self):
         from claude_swap.balancer import AccountView
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -369,6 +369,17 @@ class TestDashboard:
             "enabled": True, "threshold": 95, "targetSafety": 90,
             "primeIdleWindows": prime,
         }
+        # Identity data the account headers read (email/org/active marker). Mirrors
+        # `cswap --list`: account 1 is the current login => marked (active).
+        sw._get_sequence_data_migrated.return_value = {
+            "accounts": {
+                "1": {"email": "a@x.com", "organizationName": "", "organizationUuid": ""},
+                "2": {"email": "b@x.com", "organizationName": "", "organizationUuid": ""},
+                "9": {"email": "c@x.com", "organizationName": "", "organizationUuid": ""},
+            }
+        }
+        sw._get_current_account.return_value = ("a@x.com", "")
+        sw._get_display_tag = lambda email, org_name, org_uuid: org_name or "personal"
         return sw
 
     def _draw(self, prime: bool = True):
@@ -378,36 +389,71 @@ class TestDashboard:
         return lines
 
     def test_per_account_session_count_including_idle(self):
+        text = _all_text(self._draw())
+        # Two sessions land on a1 (only account with sessions, so unambiguous);
+        # idle accounts still render their own session-count row at 0.
+        assert "2 sessions" in text
+        assert "0 sessions" in text
+
+    def test_account_header_matches_list_format(self):
+        # The header reads like a `cswap --list` row: "num: email [tag] (active)".
         lines = self._draw()
-        # Two sessions land on a1; idle accounts still render with a 0 count.
-        assert "P3  2 sess" in _line_with(lines, "a1   P3")
-        assert "P3  0 sess" in _line_with(lines, "a2   P3")
+        assert "1: a@x.com [personal] (active)" in _line_with(lines, "a@x.com")
+        # The active marker only lands on the current-login account.
+        assert "(active)" not in _line_with(lines, "b@x.com")
 
     def test_idle_account_shows_both_windows_with_usage(self):
         # The whole point: usage is shown even for an account hosting NO session.
-        row = _line_with(self._draw(), "a2   P3")
-        assert "5h   0% (no reset)" in row      # unstarted 5h window
-        assert "7d  12% (resets" in row          # weekly consumption + reset
+        text = _all_text(self._draw())
+        assert "5h:   0%   not started" in text     # unstarted 5h window (cold)
+        assert "7d:  12%   resets" in text           # weekly consumption + reset
 
     def test_live_account_shows_5h_and_7d_resets(self):
-        row = _line_with(self._draw(), "a1   P3")
-        assert "5h  45% (resets 2h13m)" in row
-        assert "7d  30% (resets 4d04h)" in row
+        text = _all_text(self._draw())
+        # `--list`-style: usage% then "resets <clock>  in <countdown>".
+        assert "5h:  45%   resets" in text and "in 2h 13m" in text
+        assert "7d:  30%   resets" in text and "in 4d 4h" in text
 
     def test_warm_column_present_only_when_warming_enabled(self):
-        on = self._draw(prime=True)
-        assert "warming ON" in _all_text(on)
-        assert _line_with(on, "a1   P3").rstrip().endswith("warm")   # 5h running
-        assert _line_with(on, "a2   P3").rstrip().endswith("cold")   # 5h unstarted
+        on = _all_text(self._draw(prime=True))
+        assert "warming ON" in on
+        # warm/cold annotates the session-count row of accounts with a signal.
+        assert "2 sessions  · warm" in on   # a1: 5h running
+        assert "0 sessions  · cold" in on   # a2: 5h unstarted
 
-        off = self._draw(prime=False)
-        assert "warming OFF" in _all_text(off)
-        # No per-account warm/cold token when warming is disabled.
-        assert not _line_with(off, "a1   P3").rstrip().endswith("warm")
-        assert not _line_with(off, "a2   P3").rstrip().endswith("cold")
+        off = _all_text(self._draw(prime=False))
+        assert "warming OFF" in off
+        # No per-account warm/cold token on the session rows when warming is off
+        # (match the session-row form so the header's "· warming OFF" can't alias).
+        assert "sessions  · warm" not in off
+        assert "sessions  · cold" not in off
 
     def test_unknown_usage_account_marked_unavailable(self):
-        assert "usage unavailable" in _line_with(self._draw(), "a9   P1")
+        text = _all_text(self._draw())
+        assert "usage unavailable" in text
+        # warm/cold is meaningless without a usage signal -> not annotated.
+        assert "· ?" not in text
+
+    def test_short_terminal_never_leaves_dangling_header(self):
+        # Block-fit guard: on a short screen whole accounts are dropped rather
+        # than painting a header with no tree rows beneath it.
+        import re
+
+        for rows in range(tui._MIN_ROWS, 30):
+            screen, lines = _capture_screen(rows=rows, cols=100)
+            with patch("claude_swap.tui.time.time", return_value=self.NOW):
+                tui._draw_dashboard(
+                    screen, self._switcher(), self._sessions(), self._accts()
+                )
+            ys = sorted(lines)
+            for i, y in enumerate(ys):
+                if re.match(r"\s*\d+: \S+@", lines[y]):  # an account header line
+                    nxt = next(
+                        (lines[y2] for y2 in ys if y2 > y and lines[y2].strip()), ""
+                    )
+                    assert "├" in nxt or "└" in nxt, (
+                        f"dangling header at rows={rows}: {lines[y]!r} -> {nxt!r}"
+                    )
 
     def test_ui_loop_never_hits_the_network(self):
         # The render loop must only read the worker-warmed cache + live signals
@@ -472,24 +518,90 @@ class TestDashboardFormatters:
         assert tui._short_countdown(42 * 60) == "42m"
         assert tui._short_countdown(-5) == "0m"
 
-    def test_fmt_reset(self):
-        assert tui._fmt_reset(1000 + 8000, 1000) == "(resets 2h13m)"
-        # "(no reset)" is reserved for a truly unstarted (cold) window...
-        assert tui._fmt_reset(None, 1000) == "(no reset)"
-        # ...an elapsed reset epoch is a window rolling over, not "no reset", so it
-        # can't contradict a `warm` token derived from the same timestamp.
-        assert tui._fmt_reset(500, 1000) == "(resetting)"
+    def test_list_countdown(self):
+        # `--list`-style spacing (distinct from the compact _short_countdown).
+        assert tui._list_countdown(2 * 86400 + 11 * 3600) == "2d 11h"
+        assert tui._list_countdown(2 * 3600 + 58 * 60) == "2h 58m"
+        assert tui._list_countdown(42 * 60) == "42m"
+        assert tui._list_countdown(-5) == "0m"
+
+    def test_reset_clause(self):
+        clause = tui._reset_clause(1000 + 8000, 1000)
+        assert clause.startswith("resets ")
+        assert clause.endswith("in 2h 13m")
+        # "not started" is reserved for a truly unstarted (cold) window...
+        assert tui._reset_clause(None, 1000) == "not started"
+        # ...an elapsed reset epoch is a window rolling over, not "not started", so
+        # it can't contradict a `warm` token derived from the same timestamp.
+        assert tui._reset_clause(500, 1000) == "resetting"
 
     def test_fmt_pct(self):
         assert tui._fmt_pct(45.0).strip() == "45%"
         assert tui._fmt_pct(0.0).strip() == "0%"
         assert "%" not in tui._fmt_pct(None)
 
-    def test_account_row_unavailable_signal(self):
+    @staticmethod
+    def _flatten(block) -> str:
+        """Join an _account_block's (text, attr) segments into plain rows."""
+        return "\n".join("".join(text for text, _attr in row) for row in block)
+
+    def test_account_block_unavailable_signal(self):
         from claude_swap.balancer import AccountView
 
         av = AccountView(num="9", priority=1, signal="none")
-        assert "usage unavailable" in tui._account_row(av, 0, 0.0, show_warm=True)
+        flat = self._flatten(
+            tui._account_block(av, "c@x.com", "personal", False, 0, 0.0, show_warm=True)
+        )
+        assert "9: c@x.com [personal]" in flat
+        assert "usage unavailable" in flat
+        assert "0 sessions" in flat
+        # warm/cold suppressed when usage is unknown (no bare "· ?").
+        assert "· warm" not in flat and "· cold" not in flat and "· ?" not in flat
+
+    def test_account_block_session_pluralization(self):
+        from claude_swap.balancer import AccountView
+
+        av = AccountView(
+            num="1", priority=0, signal="cache",
+            five_hour_pct=10.0, seven_day_pct=5.0,
+        )
+        one = self._flatten(
+            tui._account_block(av, "e@x.com", "personal", False, 1, 0.0, show_warm=False)
+        )
+        assert "1 session" in one and "1 sessions" not in one
+
+    def test_account_block_omits_window_without_pct(self):
+        # A live/cache signal can carry only one window's pct (the usage API emits
+        # a window only once it is running). Mirror `cswap --list`: render the
+        # window that has data and OMIT the absent one — never a faked
+        # "5h:   —   not started" row.
+        from claude_swap.balancer import AccountView
+
+        av = AccountView(
+            num="3", priority=0, signal="cache",
+            five_hour_pct=None, five_hour_reset=None,
+            seven_day_pct=12.0, seven_day_reset=None,
+        )
+        flat = self._flatten(
+            tui._account_block(av, "p@x.com", "personal", False, 0, 0.0, show_warm=False)
+        )
+        assert "7d:  12%" in flat       # the window with data is shown
+        assert "5h:" not in flat        # the absent window is omitted, not faked
+
+    def test_account_block_unknown_5h_has_no_warm_token(self):
+        # five_hour_warm is tri-state: None (unknown 5h usage) must NOT render a
+        # bare "· ?" — leave the session row unannotated.
+        from claude_swap.balancer import AccountView
+
+        av = AccountView(
+            num="3", priority=0, signal="cache",
+            five_hour_pct=None, seven_day_pct=20.0,
+        )
+        flat = self._flatten(
+            tui._account_block(av, "p@x.com", "personal", False, 0, 0.0, show_warm=True)
+        )
+        assert "· ?" not in flat
+        assert "· warm" not in flat and "· cold" not in flat
 
 
 class TestCliIntegration:


### PR DESCRIPTION
## Supersedes #50 — auto-switch + an event-driven load balancer + cmux

This builds on **#50 (Add auto-switch at usage limit, by @7GMA)** and supersedes it: it includes that work (with the README conflict resolved) and grows it into a full multi-account **load balancer**. Credit to @7GMA for the original auto-switch feature — its threshold/usage model is carried forward.

### What's new

**Event-driven load balancer (Beta).** Run multiple Claude Code sessions across multiple accounts. When a session's account nears its usage limit, cswap migrates that session to a **higher-priority account with headroom** (concentrating load on top accounts, spilling to the next tier only when one fills), while **minimizing migrations** (each re-bills the context window). Single-subscription users instead get **pause + auto-resume** via `claude --resume` when the window resets, so in-flight workflows survive the limit.

- **Fully event-driven** — the in-session statusline reports usage on each message and triggers a churn-minimizing rebalance. No polling loop, no background daemon (the prior 60s auto-switch monitor is removed).
- **Credential-safe** — the statusline only writes registry *intents*; each session's supervisor owns its own profile and re-points only its own credentials (verbatim seed, no refresh side-effects); managed profiles live under a separate root from `cswap run`.
- New: `cswap launch`, `cswap --install` (also runs on upgrade via a migration), `cswap --status` embed-health, `cswap --balance` dashboard, per-account `cswap --set-priority`. QoL defaults for managed sessions (latest model, `--dangerously-skip-permissions`, high effort).

**cmux integration (Beta, macOS).** `cswap cmux setup` adds a "Balanced Claude (cswap)" command to manaflow-ai/cmux; `cswap cmux <N>` fans out N panes, each landing on a different account. `cswap launch` is cmux-wrapper-aware (preserves `CLAUDE_CONFIG_DIR`). No fork — CLI + config only.

### Testing
- **586 unit tests** (pure balancer is table-driven; registry/statusline/supervisor/embed/cmux covered).
- **Live E2E** on real accounts: managed launch authenticates on the right subscription account, statusline populates the registry, migration intent + per-account re-point verified, vanilla isolation held (`~/.claude/settings.json` byte-identical).
- **Two adversarial review rounds** (a local multi-agent pass + a cloud ultrareview): every confirmed finding fixed, each with a regression test — including the auto-resume session-id, the cross-process account-spread reservation, atomic credential writes, and the pause/resume livelock.

### Notes
- Beta. The cmux fanout's live multi-pane spawn needs cmux socket control enabled (`Settings → Automation`); the config surface + the balancer spread work regardless.
- "ultracode" effort is session-only, so managed sessions use the persistable `xhigh` level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
