### PR TITLE
feat: usage-aware account switching (--switch --strategy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ cswap --switch-to user@example.com
 Let claude-swap pick the account for you based on how much quota is left, instead of rotating blindly:
 
 ```bash
-cswap --switch --best              # jump to the account with the most 5h/7d quota left
-cswap --switch --skip-exhausted    # rotate to the next account, skipping any at their limit
+cswap --switch --strategy best             # jump to the account with the most 5h/7d quota left
+cswap --switch --strategy next-available   # rotate to the next account, skipping any at their limit
 ```
 
 These use the same 5-hour and 7-day usage windows shown by `--list` (pay-as-you-go spend is ignored). They never move you onto an account that's worse than the one you're on: if you already hold the most quota, or every other account is at its limit, claude-swap stays put and tells you. If usage can't be fetched at all, it falls back to plain rotation. They apply when you have an active Claude login; right after a fresh `--import` (no login yet) they're ignored.
@@ -108,8 +108,8 @@ This will update the stored credentials without creating a duplicate.
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
 cswap --list                    # Show all accounts with 5h/7d usage and reset times
-cswap --switch --best           # Switch to the account with the most quota left
-cswap --switch --skip-exhausted # Rotate to the next account, skipping rate-limited ones
+cswap --switch --strategy best           # Switch to the account with the most quota left
+cswap --switch --strategy next-available # Rotate to the next account, skipping rate-limited ones
 cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
 cswap --remove-account 2        # Remove an account

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ cswap --switch-to 2
 cswap --switch-to user@example.com
 ```
 
+### Switch by remaining usage
+
+Let claude-swap pick the account for you based on how much quota is left, instead of rotating blindly:
+
+```bash
+cswap --switch --best              # jump to the account with the most 5h/7d quota left
+cswap --switch --skip-exhausted    # rotate to the next account, skipping any at their limit
+```
+
+These use the same 5-hour and 7-day usage windows shown by `--list` (pay-as-you-go spend is ignored). They never move you onto an account that's worse than the one you're on: if you already hold the most quota, or every other account is at its limit, claude-swap stays put and tells you. If usage can't be fetched at all, it falls back to plain rotation. They apply when you have an active Claude login; right after a fresh `--import` (no login yet) they're ignored.
+
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.
 
 ### Run multiple accounts at the same time (session mode)
@@ -97,6 +108,8 @@ This will update the stored credentials without creating a duplicate.
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
 cswap --list                    # Show all accounts with 5h/7d usage and reset times
+cswap --switch --best           # Switch to the account with the most quota left
+cswap --switch --skip-exhausted # Rotate to the next account, skipping rate-limited ones
 cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
 cswap --remove-account 2        # Remove an account

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -106,8 +106,8 @@ Examples:
   %(prog)s --add-token - --slot 3
   %(prog)s --list
   %(prog)s --switch
-  %(prog)s --switch --best                  # switch to the account with most quota left
-  %(prog)s --switch --skip-exhausted        # rotate, skipping rate-limited accounts
+  %(prog)s --switch --strategy best             # switch to the account with most quota left
+  %(prog)s --switch --strategy next-available   # rotate, skipping rate-limited accounts
   %(prog)s --switch-to 2
   %(prog)s --switch-to user@example.com
   %(prog)s run 2                            # run account 2 in this terminal only
@@ -139,15 +139,14 @@ Examples:
         help="Show OAuth token expiry state (use with --list)",
     )
     parser.add_argument(
-        "--best",
-        action="store_true",
-        help="With --switch: switch to the account with the most remaining 5h/7d quota",
-    )
-    parser.add_argument(
-        "--skip-exhausted",
-        dest="skip_exhausted",
-        action="store_true",
-        help="With --switch: rotate to the next account, skipping any at their 5h/7d limit",
+        "--strategy",
+        choices=["best", "next-available"],
+        metavar="{best,next-available}",
+        help=(
+            "With --switch: pick the target by remaining 5h/7d quota. "
+            "'best' jumps to the account with the most headroom; "
+            "'next-available' rotates to the next account, skipping any at their limit"
+        ),
     )
     parser.add_argument(
         "--slot",
@@ -253,8 +252,8 @@ Examples:
     if args.token_status and not args.list:
         parser.error("--token-status can only be used with --list")
 
-    if (args.best or args.skip_exhausted) and not args.switch:
-        parser.error("--best and --skip-exhausted can only be used with --switch")
+    if args.strategy is not None and not args.switch:
+        parser.error("--strategy can only be used with --switch")
 
     if args.slot is not None and not (args.add_account or args.add_token is not None):
         parser.error("--slot can only be used with --add-account or --add-token")
@@ -310,7 +309,7 @@ Examples:
                 show_token_status=args.token_status,
             )
         elif args.switch:
-            switcher.switch(best=args.best, skip_exhausted=args.skip_exhausted)
+            switcher.switch(strategy=args.strategy)
         elif args.switch_to:
             switcher.switch_to(args.switch_to)
         elif args.status:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -106,6 +106,8 @@ Examples:
   %(prog)s --add-token - --slot 3
   %(prog)s --list
   %(prog)s --switch
+  %(prog)s --switch --best                  # switch to the account with most quota left
+  %(prog)s --switch --skip-exhausted        # rotate, skipping rate-limited accounts
   %(prog)s --switch-to 2
   %(prog)s --switch-to user@example.com
   %(prog)s run 2                            # run account 2 in this terminal only
@@ -135,6 +137,17 @@ Examples:
         "--token-status",
         action="store_true",
         help="Show OAuth token expiry state (use with --list)",
+    )
+    parser.add_argument(
+        "--best",
+        action="store_true",
+        help="With --switch: switch to the account with the most remaining 5h/7d quota",
+    )
+    parser.add_argument(
+        "--skip-exhausted",
+        dest="skip_exhausted",
+        action="store_true",
+        help="With --switch: rotate to the next account, skipping any at their 5h/7d limit",
     )
     parser.add_argument(
         "--slot",
@@ -240,6 +253,9 @@ Examples:
     if args.token_status and not args.list:
         parser.error("--token-status can only be used with --list")
 
+    if (args.best or args.skip_exhausted) and not args.switch:
+        parser.error("--best and --skip-exhausted can only be used with --switch")
+
     if args.slot is not None and not (args.add_account or args.add_token is not None):
         parser.error("--slot can only be used with --add-account or --add-token")
 
@@ -294,7 +310,7 @@ Examples:
                 show_token_status=args.token_status,
             )
         elif args.switch:
-            switcher.switch()
+            switcher.switch(best=args.best, skip_exhausted=args.skip_exhausted)
         elif args.switch_to:
             switcher.switch_to(args.switch_to)
         elif args.status:

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -204,6 +204,28 @@ def build_usage_result(data: dict) -> dict | None:
     return result if result else None
 
 
+def account_headroom(usage: dict | None) -> float | None:
+    """Remaining percentage before this account hits a rate-limit window.
+
+    Considers only the 5-hour and 7-day utilization windows — the two that
+    actually gate requests. ``spend`` (pay-as-you-go extra-usage credits) is a
+    separate axis and is deliberately ignored. Returns the headroom of the
+    *binding* window (``100 - max(pct)``), so ``<= 0`` means the account is at
+    or over a limit. Returns ``None`` when usage is unavailable or carries no
+    window data, which callers treat as "unknown" (never auto-skipped).
+    """
+    if not isinstance(usage, dict):
+        return None
+    pcts = [
+        window["pct"]
+        for window in (usage.get("five_hour"), usage.get("seven_day"))
+        if isinstance(window, dict) and isinstance(window.get("pct"), (int, float))
+    ]
+    if not pcts:
+        return None
+    return 100.0 - max(pcts)
+
+
 def fetch_usage(access_token: str) -> dict | None:
     """Fetch 5-hour and 7-day utilization from the Anthropic usage API."""
     try:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1285,7 +1285,7 @@ class ClaudeAccountSwitcher:
     def _select_best_switchable(
         self, current_num: str | None
     ) -> tuple[str | None, str]:
-        """Decide the ``--best`` target relative to the current account.
+        """Decide the ``best`` strategy target relative to the current account.
 
         Compares the rate-limit headroom of every *other* switchable account
         against the current one and only recommends a switch that lands on
@@ -1483,19 +1483,20 @@ class ClaudeAccountSwitcher:
 
         self.add_account()
 
-    def switch(self, best: bool = False, skip_exhausted: bool = False) -> None:
+    def switch(self, strategy: str | None = None) -> None:
         """Switch to next account in sequence.
 
         Args:
-            best: Jump to the switchable account with the most remaining 5h/7d
-                  quota instead of advancing the rotation.
-            skip_exhausted: While rotating, skip any account currently at its
-                  5h/7d limit.
+            strategy: Usage-aware target selection. ``"best"`` jumps to the
+                  switchable account with the most remaining 5h/7d quota instead
+                  of advancing the rotation; ``"next-available"`` rotates to the
+                  next account, skipping any currently at its 5h/7d limit. ``None``
+                  (the default) performs a plain rotation.
 
-        Both options are usage-aware and never block: if usage data can't be
-        fetched, or every candidate is exhausted, the switch falls back to plain
-        rotation. They apply to the normal path (a live Claude login present);
-        the fresh-machine path (no live login, e.g. right after --import) ignores
+        The usage-aware strategies never block: if usage data can't be fetched,
+        or every candidate is exhausted, the switch falls back to plain rotation.
+        They apply to the normal path (a live Claude login present); the
+        fresh-machine path (no live login, e.g. right after --import) ignores
         them.
         """
         if not self.sequence_file.exists():
@@ -1574,7 +1575,7 @@ class ClaudeAccountSwitcher:
         # Usage-aware "jump to most headroom". Only switches to strictly more
         # headroom than the current account; otherwise stays put or (when usage
         # is unavailable) falls through to plain rotation.
-        if best:
+        if strategy == "best":
             target, note = self._select_best_switchable(current_num)
             if target is not None:
                 self._perform_switch(target)
@@ -1606,7 +1607,7 @@ class ClaudeAccountSwitcher:
 
         # Only fetch usage when needed; an empty map means the headroom check
         # below is always None (skipped), preserving the non-usage-aware path.
-        usage = self._usage_by_account() if skip_exhausted else {}
+        usage = self._usage_by_account() if strategy == "next-available" else {}
 
         next_account: str | None = None
         skipped_exhausted: list[str] = []
@@ -1619,7 +1620,7 @@ class ClaudeAccountSwitcher:
                     f"cswap --add-account --slot {candidate})"
                 )
                 continue
-            if skip_exhausted:
+            if strategy == "next-available":
                 headroom = oauth.account_headroom(usage.get(candidate))
                 if headroom is not None and headroom <= 0:
                     skipped_exhausted.append(candidate)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1188,17 +1188,15 @@ class ClaudeAccountSwitcher:
         self._logger.info(f"Removed account {account_num}: {email}")
         print(f"{accent('Removed')} Account-{account_num} ({email})")
 
-    def list_accounts(
-        self,
-        show_token_status: bool = False,
-    ) -> None:
-        """List all managed accounts."""
-        if not self.sequence_file.exists():
-            print(dimmed("No accounts are managed yet."))
-            self._first_run_setup()
-            return
+    def _build_accounts_info(self) -> list[tuple[int, str, str, str, bool, str]]:
+        """Build per-account (num, email, org_name, org_uuid, is_active, creds).
 
-        data = self._get_sequence_data_migrated()
+        Shared by list_accounts and the usage-aware switch helpers so the active
+        slot is detected and credentials are read in exactly one place. The
+        active account's credentials come from Claude Code's live store; every
+        other slot reads its backup copy.
+        """
+        data = self._get_sequence_data_migrated() or {}
         current_identity = self._get_current_account()
 
         # Find active account number by (email, organizationUuid) composite key
@@ -1211,7 +1209,7 @@ class ClaudeAccountSwitcher:
                     active_num = num
                     break
 
-        accounts_info = []
+        accounts_info: list[tuple[int, str, str, str, bool, str]] = []
         for num in data.get("sequence", []):
             account = data.get("accounts", {}).get(str(num), {})
             email = account.get("email", "unknown")
@@ -1225,7 +1223,18 @@ class ClaudeAccountSwitcher:
                 creds = self._read_account_credentials(str(num), email)
 
             accounts_info.append((num, email, org_name, org_uuid, is_active, creds))
+        return accounts_info
 
+    def _collect_usage(
+        self, accounts_info: list[tuple[int, str, str, str, bool, str]]
+    ) -> list[dict | str | None]:
+        """Fetch usage for each account (cache-first), returning one entry per row.
+
+        Each entry is a usage dict, the string ``"no credentials"``, or ``None``
+        when the API call failed. Results are cached under
+        ``<backup_dir>/cache/usage.json`` for ``_USAGE_CACHE_TTL`` seconds and
+        reused only when the cache covers exactly the same set of accounts.
+        """
         def fetch(
             account_info: tuple[int, str, str, str, bool, str]
         ) -> dict | str | None:
@@ -1255,14 +1264,90 @@ class ClaudeAccountSwitcher:
         cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
         account_keys = {str(info[0]) for info in accounts_info}
         if cached is not MISSING and isinstance(cached, dict) and cached.keys() == account_keys:
-            usages = [cached.get(str(info[0])) for info in accounts_info]
-        else:
-            with ThreadPoolExecutor() as executor:
-                usages = list(executor.map(fetch, accounts_info))
-            write_cache(usage_cache_path, {
-                str(info[0]): usage
-                for info, usage in zip(accounts_info, usages)
-            })
+            return [cached.get(str(info[0])) for info in accounts_info]
+
+        with ThreadPoolExecutor() as executor:
+            usages = list(executor.map(fetch, accounts_info))
+        write_cache(usage_cache_path, {
+            str(info[0]): usage
+            for info, usage in zip(accounts_info, usages)
+        })
+        return usages
+
+    def _usage_by_account(self) -> dict[str, dict | str | None]:
+        """Map account number → usage entry (cache-first) for managed accounts."""
+        accounts_info = self._build_accounts_info()
+        usages = self._collect_usage(accounts_info)
+        return {
+            str(info[0]): usage for info, usage in zip(accounts_info, usages)
+        }
+
+    def _select_best_switchable(
+        self, current_num: str | None
+    ) -> tuple[str | None, str]:
+        """Decide the ``--best`` target relative to the current account.
+
+        Compares the rate-limit headroom of every *other* switchable account
+        against the current one and only recommends a switch that lands on
+        *strictly more* headroom — never onto an account worse than where the
+        user already is. Returns ``(target, note)``:
+
+        - ``(num, "")`` — switch to ``num`` (strictly more headroom than current)
+        - ``(None, "stay")`` — current account already has the most headroom
+        - ``(None, "exhausted")`` — current is the best but everything is at its
+          limit (switching would not help)
+        - ``(None, "unavailable")`` — no other account has usage data; caller
+          falls back to plain rotation
+        - ``(None, "none")`` — no other switchable account exists
+
+        Ties (including current-vs-other) resolve in favour of staying put.
+        Never raises on network failure.
+        """
+        data = self._get_sequence_data() or {}
+        others = [
+            str(n) for n in data.get("sequence", [])
+            if str(n) != str(current_num) and self._account_is_switchable(str(n))
+        ]
+        if not others:
+            return None, "none"
+
+        usage = self._usage_by_account()
+        scored = [
+            (h, num)
+            for num in others
+            if (h := oauth.account_headroom(usage.get(num))) is not None
+        ]
+        if not scored:
+            return None, "unavailable"
+
+        # max() keeps the first maximal element; `scored` preserves rotation
+        # order, so ties resolve to the earliest slot.
+        best_headroom, best_num = max(scored, key=lambda t: t[0])
+        current_headroom = oauth.account_headroom(usage.get(str(current_num)))
+
+        if current_headroom is None:
+            # Can't compare to the current account — switch only if the best
+            # other account still has room; otherwise everything is exhausted.
+            return (best_num, "") if best_headroom > 0 else (None, "exhausted")
+
+        if best_headroom > current_headroom:
+            return best_num, ""
+        # Current account is the best (or tied). Stay; distinguish the all-maxed
+        # case so the caller can word it accurately.
+        return None, ("exhausted" if current_headroom <= 0 else "stay")
+
+    def list_accounts(
+        self,
+        show_token_status: bool = False,
+    ) -> None:
+        """List all managed accounts."""
+        if not self.sequence_file.exists():
+            print(dimmed("No accounts are managed yet."))
+            self._first_run_setup()
+            return
+
+        accounts_info = self._build_accounts_info()
+        usages = self._collect_usage(accounts_info)
 
         print(bolded("Accounts:"))
         for i, ((num, email, org_name, org_uuid, is_active, _), usage) in enumerate(zip(accounts_info, usages)):
@@ -1398,8 +1483,21 @@ class ClaudeAccountSwitcher:
 
         self.add_account()
 
-    def switch(self) -> None:
-        """Switch to next account in sequence."""
+    def switch(self, best: bool = False, skip_exhausted: bool = False) -> None:
+        """Switch to next account in sequence.
+
+        Args:
+            best: Jump to the switchable account with the most remaining 5h/7d
+                  quota instead of advancing the rotation.
+            skip_exhausted: While rotating, skip any account currently at its
+                  5h/7d limit.
+
+        Both options are usage-aware and never block: if usage data can't be
+        fetched, or every candidate is exhausted, the switch falls back to plain
+        rotation. They apply to the normal path (a live Claude login present);
+        the fresh-machine path (no live login, e.g. right after --import) ignores
+        them.
+        """
         if not self.sequence_file.exists():
             raise ConfigError("No accounts are managed yet")
 
@@ -1463,6 +1561,39 @@ class ClaudeAccountSwitcher:
             return
 
         active_account = data.get("activeAccountNumber")
+        # Where the user actually is right now (live identity), falling back to
+        # the recorded active slot. Used so usage-aware switching never moves
+        # them onto an account worse than their current one.
+        current_num = next(
+            (num for num, acc in data.get("accounts", {}).items()
+             if acc.get("email") == current_email
+             and acc.get("organizationUuid", "") == current_org_uuid),
+            str(active_account) if active_account is not None else None,
+        )
+
+        # Usage-aware "jump to most headroom". Only switches to strictly more
+        # headroom than the current account; otherwise stays put or (when usage
+        # is unavailable) falls through to plain rotation.
+        if best:
+            target, note = self._select_best_switchable(current_num)
+            if target is not None:
+                self._perform_switch(target)
+                return
+            if note == "stay":
+                print(
+                    f"{accent('Already on the account with the most remaining quota')} "
+                    f"(Account-{current_num})."
+                )
+                return
+            if note == "exhausted":
+                warning(
+                    f"All accounts are at their 5h/7d limit — staying on "
+                    f"Account-{current_num}."
+                )
+                return
+            if note == "unavailable":
+                print(dimmed("Usage data unavailable — rotating to the next account."))
+            # note == "none": fall through; rotation reports the lack of targets.
 
         # Find current index and get next, skipping broken candidates.
         # The active slot is never checked here — _perform_switch captures
@@ -1473,17 +1604,38 @@ class ClaudeAccountSwitcher:
         except ValueError:
             current_index = 0
 
+        # Only fetch usage when needed; an empty map means the headroom check
+        # below is always None (skipped), preserving the non-usage-aware path.
+        usage = self._usage_by_account() if skip_exhausted else {}
+
         next_account: str | None = None
+        skipped_exhausted: list[str] = []
         for offset in range(1, len(sequence)):
             candidate = str(sequence[(current_index + offset) % len(sequence)])
-            if self._account_is_switchable(candidate):
-                next_account = candidate
-                break
-            print(
-                f"{accent('Skipping')} Account-{candidate} "
-                f"(no stored credentials/config, re-add with "
-                f"cswap --add-account --slot {candidate})"
+            if not self._account_is_switchable(candidate):
+                print(
+                    f"{accent('Skipping')} Account-{candidate} "
+                    f"(no stored credentials/config, re-add with "
+                    f"cswap --add-account --slot {candidate})"
+                )
+                continue
+            if skip_exhausted:
+                headroom = oauth.account_headroom(usage.get(candidate))
+                if headroom is not None and headroom <= 0:
+                    skipped_exhausted.append(candidate)
+                    print(f"{accent('Skipping')} Account-{candidate} (at 5h/7d limit)")
+                    continue
+            next_account = candidate
+            break
+
+        # Every rotation target is at its limit. Switching onto an exhausted
+        # account would not help, so stay on the current one instead.
+        if next_account is None and skipped_exhausted:
+            warning(
+                f"All other accounts are at their 5h/7d limit — staying on "
+                f"Account-{current_num}."
             )
+            return
 
         if next_account is None:
             print(dimmed(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,47 +134,51 @@ class TestCLI:
             show_token_status=True,
         )
 
-    def test_best_flag_requires_switch(self, capsys):
-        """--best should only be accepted alongside --switch."""
-        with patch.object(sys, "argv", ["claude-swap", "--best", "--list"]):
+    def test_strategy_best_requires_switch(self, capsys):
+        """--strategy should only be accepted alongside --switch."""
+        with patch.object(sys, "argv", ["claude-swap", "--strategy", "best", "--list"]):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
 
         assert excinfo.value.code == 2
-        assert "--best and --skip-exhausted can only be used with --switch" in capsys.readouterr().err
+        assert "--strategy can only be used with --switch" in capsys.readouterr().err
 
-    def test_skip_exhausted_flag_requires_switch(self, capsys):
-        """--skip-exhausted should only be accepted alongside --switch."""
-        with patch.object(sys, "argv", ["claude-swap", "--skip-exhausted", "--list"]):
+    def test_strategy_next_available_requires_switch(self, capsys):
+        """--strategy next-available should only be accepted alongside --switch."""
+        with patch.object(sys, "argv", ["claude-swap", "--strategy", "next-available", "--list"]):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
 
         assert excinfo.value.code == 2
-        assert "--best and --skip-exhausted can only be used with --switch" in capsys.readouterr().err
+        assert "--strategy can only be used with --switch" in capsys.readouterr().err
 
-    def test_switch_flags_forwarded(self):
-        """--switch --best --skip-exhausted forwards both flags to switch()."""
+    def test_strategy_rejects_unknown_value(self, capsys):
+        """argparse rejects strategies outside the known choices."""
+        with patch.object(sys, "argv", ["claude-swap", "--switch", "--strategy", "bogus"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 2
+
+    def test_switch_strategy_forwarded(self):
+        """--switch --strategy best forwards the strategy to switch()."""
         with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--switch", "--best", "--skip-exhausted"]), \
+             patch.object(sys, "argv", ["claude-swap", "--switch", "--strategy", "best"]), \
              patch("os.geteuid", return_value=1000), \
              patch("claude_swap.update_check.check_for_update", return_value=None):
             cli.main()
 
-        switcher_cls.return_value.switch.assert_called_once_with(
-            best=True, skip_exhausted=True,
-        )
+        switcher_cls.return_value.switch.assert_called_once_with(strategy="best")
 
-    def test_plain_switch_passes_false_flags(self):
-        """Bare --switch forwards best=False, skip_exhausted=False."""
+    def test_plain_switch_passes_no_strategy(self):
+        """Bare --switch forwards strategy=None."""
         with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
              patch.object(sys, "argv", ["claude-swap", "--switch"]), \
              patch("os.geteuid", return_value=1000), \
              patch("claude_swap.update_check.check_for_update", return_value=None):
             cli.main()
 
-        switcher_cls.return_value.switch.assert_called_once_with(
-            best=False, skip_exhausted=False,
-        )
+        switcher_cls.return_value.switch.assert_called_once_with(strategy=None)
 
     def test_slot_flag_requires_add_account(self, capsys):
         """--slot should only be accepted alongside --add-account or --add-token."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,6 +134,48 @@ class TestCLI:
             show_token_status=True,
         )
 
+    def test_best_flag_requires_switch(self, capsys):
+        """--best should only be accepted alongside --switch."""
+        with patch.object(sys, "argv", ["claude-swap", "--best", "--list"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 2
+        assert "--best and --skip-exhausted can only be used with --switch" in capsys.readouterr().err
+
+    def test_skip_exhausted_flag_requires_switch(self, capsys):
+        """--skip-exhausted should only be accepted alongside --switch."""
+        with patch.object(sys, "argv", ["claude-swap", "--skip-exhausted", "--list"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 2
+        assert "--best and --skip-exhausted can only be used with --switch" in capsys.readouterr().err
+
+    def test_switch_flags_forwarded(self):
+        """--switch --best --skip-exhausted forwards both flags to switch()."""
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "--switch", "--best", "--skip-exhausted"]), \
+             patch("os.geteuid", return_value=1000), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.switch.assert_called_once_with(
+            best=True, skip_exhausted=True,
+        )
+
+    def test_plain_switch_passes_false_flags(self):
+        """Bare --switch forwards best=False, skip_exhausted=False."""
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "--switch"]), \
+             patch("os.geteuid", return_value=1000), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.switch.assert_called_once_with(
+            best=False, skip_exhausted=False,
+        )
+
     def test_slot_flag_requires_add_account(self, capsys):
         """--slot should only be accepted alongside --add-account or --add-token."""
         with patch.object(sys, "argv", ["claude-swap", "--list", "--slot", "3"]):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -28,6 +28,40 @@ class TestExtractAccessToken:
         assert oauth.extract_access_token("") is None
 
 
+class TestAccountHeadroom:
+    """Test account_headroom."""
+
+    def test_binding_window_is_the_higher_utilization(self):
+        usage = {"five_hour": {"pct": 80.0}, "seven_day": {"pct": 20.0}}
+        assert oauth.account_headroom(usage) == 20.0  # 100 - max(80, 20)
+
+    def test_seven_day_can_be_the_binding_window(self):
+        usage = {"five_hour": {"pct": 10.0}, "seven_day": {"pct": 95.0}}
+        assert oauth.account_headroom(usage) == 5.0
+
+    def test_single_window(self):
+        assert oauth.account_headroom({"five_hour": {"pct": 40.0}}) == 60.0
+
+    def test_at_limit_is_zero_headroom(self):
+        assert oauth.account_headroom({"five_hour": {"pct": 100.0}}) == 0.0
+
+    def test_spend_is_ignored(self):
+        # Pay-as-you-go credits must not drive rate-limit headroom.
+        usage = {"spend": {"pct": 99.0}, "five_hour": {"pct": 10.0}}
+        assert oauth.account_headroom(usage) == 90.0
+
+    def test_no_window_data_is_unknown(self):
+        assert oauth.account_headroom({"spend": {"pct": 50.0}}) is None
+        assert oauth.account_headroom({}) is None
+
+    def test_none_and_non_dict_are_unknown(self):
+        assert oauth.account_headroom(None) is None
+        assert oauth.account_headroom("no credentials") is None
+
+    def test_malformed_pct_is_ignored(self):
+        assert oauth.account_headroom({"five_hour": {"pct": None}}) is None
+
+
 class TestFormatReset:
     """Test format_reset."""
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2478,8 +2478,8 @@ class TestSwitchSkipsBrokenSlots:
 
 
 class TestUsageAwareSwitch:
-    """--switch --best / --skip-exhausted pick targets by remaining 5h/7d quota,
-    and always fall back to plain rotation rather than blocking."""
+    """--switch --strategy best / next-available pick targets by remaining 5h/7d
+    quota, and always fall back to plain rotation rather than blocking."""
 
     def _setup(self, temp_home: Path) -> ClaudeAccountSwitcher:
         s = ClaudeAccountSwitcher()
@@ -2545,12 +2545,12 @@ class TestUsageAwareSwitch:
         usage = {"1": self._usage(50), "2": self._usage(90), "3": self._usage(20)}
         with patch.object(s, "_usage_by_account", return_value=usage), \
              patch.object(s, "list_accounts"):
-            s.switch(best=True)
+            s.switch(strategy="best")
 
         assert s._get_sequence_data()["activeAccountNumber"] == 3
 
     def test_best_stays_when_current_is_already_best(self, temp_home: Path, capsys):
-        """Regression: --best must NOT move you onto a worse account when you
+        """Regression: strategy "best" must NOT move you onto a worse account when you
         already hold the most headroom (real-world bug: 89% current vs 100% other)."""
         s = self._setup(temp_home)
         self._seed(s, 1, "a@example.com")
@@ -2561,7 +2561,7 @@ class TestUsageAwareSwitch:
         usage = {"1": self._usage(89), "2": self._usage(100)}
         with patch.object(s, "_usage_by_account", return_value=usage), \
              patch.object(s, "list_accounts") as mock_list:
-            s.switch(best=True)
+            s.switch(strategy="best")
 
         assert "Already on the account with the most remaining quota" in capsys.readouterr().out
         assert s._get_sequence_data()["activeAccountNumber"] == 1  # unchanged
@@ -2577,7 +2577,7 @@ class TestUsageAwareSwitch:
         usage = {"1": self._usage(100), "2": self._usage(100), "3": self._usage(100)}
         with patch.object(s, "_usage_by_account", return_value=usage), \
              patch.object(s, "list_accounts"):
-            s.switch(best=True)
+            s.switch(strategy="best")
 
         out = capsys.readouterr().out
         assert "All accounts are at their 5h/7d limit" in out
@@ -2593,7 +2593,7 @@ class TestUsageAwareSwitch:
         # No usage data for any account → unknown → fall back to rotation.
         with patch.object(s, "_usage_by_account", return_value={"1": None, "2": None}), \
              patch.object(s, "list_accounts"):
-            s.switch(best=True)
+            s.switch(strategy="best")
 
         assert "Usage data unavailable" in capsys.readouterr().out
         assert s._get_sequence_data()["activeAccountNumber"] == 2
@@ -2608,7 +2608,7 @@ class TestUsageAwareSwitch:
         usage = {"1": self._usage(0), "2": self._usage(100), "3": self._usage(20)}
         with patch.object(s, "_usage_by_account", return_value=usage), \
              patch.object(s, "list_accounts"):
-            s.switch(skip_exhausted=True)
+            s.switch(strategy="next-available")
 
         out = capsys.readouterr().out
         assert "Skipping Account-2 (at 5h/7d limit)" in out
@@ -2624,7 +2624,7 @@ class TestUsageAwareSwitch:
         usage = {"1": self._usage(0), "2": self._usage(100), "3": self._usage(100)}
         with patch.object(s, "_usage_by_account", return_value=usage), \
              patch.object(s, "list_accounts") as mock_list:
-            s.switch(skip_exhausted=True)
+            s.switch(strategy="next-available")
 
         out = capsys.readouterr().out
         assert "staying on Account-1" in out
@@ -2641,6 +2641,6 @@ class TestUsageAwareSwitch:
         # Usage unknown for account 2 → must NOT be skipped (give it a chance).
         with patch.object(s, "_usage_by_account", return_value={"1": None, "2": None}), \
              patch.object(s, "list_accounts"):
-            s.switch(skip_exhausted=True)
+            s.switch(strategy="next-available")
 
         assert s._get_sequence_data()["activeAccountNumber"] == 2

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2475,3 +2475,172 @@ class TestSwitchSkipsBrokenSlots:
 
         with pytest.raises(ConfigError, match="No managed accounts have valid"):
             s.switch()
+
+
+class TestUsageAwareSwitch:
+    """--switch --best / --skip-exhausted pick targets by remaining 5h/7d quota,
+    and always fall back to plain rotation rather than blocking."""
+
+    def _setup(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.LINUX
+        s._setup_directories()
+        s._init_sequence_file()
+        return s
+
+    def _seed(self, s: ClaudeAccountSwitcher, num: int, email: str) -> None:
+        s._write_account_credentials(
+            str(num),
+            email,
+            json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": f"sk-{num}",
+                    "refreshToken": f"rt-{num}",
+                },
+            }),
+        )
+        s._write_account_config(
+            str(num),
+            email,
+            json.dumps({
+                "oauthAccount": {"emailAddress": email, "accountUuid": f"uuid-{num}"},
+            }),
+        )
+        data = s._get_sequence_data()
+        data["accounts"][str(num)] = {
+            "email": email,
+            "uuid": f"uuid-{num}",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+            data["sequence"].sort()
+        if data["activeAccountNumber"] is None:
+            data["activeAccountNumber"] = num
+        s._write_json(s.sequence_file, data)
+
+    def _make_live(self, temp_home: Path, email: str, num: int) -> None:
+        """Make account `num` the live (active) Claude login."""
+        (temp_home / ".claude" / ".credentials.json").write_text(json.dumps({
+            "claudeAiOauth": {"accessToken": "sk-live", "refreshToken": "rt-live"},
+        }))
+        (temp_home / ".claude.json").write_text(json.dumps({
+            "oauthAccount": {"emailAddress": email, "accountUuid": f"uuid-{num}"},
+        }))
+
+    @staticmethod
+    def _usage(pct: float) -> dict:
+        return {"five_hour": {"pct": pct}, "seven_day": {"pct": 0.0}}
+
+    def test_best_switches_to_more_headroom(self, temp_home: Path):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._seed(s, 3, "c@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        # Current (1) has 50% headroom; 3 has 80% (best), 2 has 10%.
+        usage = {"1": self._usage(50), "2": self._usage(90), "3": self._usage(20)}
+        with patch.object(s, "_usage_by_account", return_value=usage), \
+             patch.object(s, "list_accounts"):
+            s.switch(best=True)
+
+        assert s._get_sequence_data()["activeAccountNumber"] == 3
+
+    def test_best_stays_when_current_is_already_best(self, temp_home: Path, capsys):
+        """Regression: --best must NOT move you onto a worse account when you
+        already hold the most headroom (real-world bug: 89% current vs 100% other)."""
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        # Current (1) has 11% headroom; the only other (2) is maxed out.
+        usage = {"1": self._usage(89), "2": self._usage(100)}
+        with patch.object(s, "_usage_by_account", return_value=usage), \
+             patch.object(s, "list_accounts") as mock_list:
+            s.switch(best=True)
+
+        assert "Already on the account with the most remaining quota" in capsys.readouterr().out
+        assert s._get_sequence_data()["activeAccountNumber"] == 1  # unchanged
+        mock_list.assert_not_called()  # no switch happened
+
+    def test_best_all_exhausted_stays_put(self, temp_home: Path, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._seed(s, 3, "c@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        usage = {"1": self._usage(100), "2": self._usage(100), "3": self._usage(100)}
+        with patch.object(s, "_usage_by_account", return_value=usage), \
+             patch.object(s, "list_accounts"):
+            s.switch(best=True)
+
+        out = capsys.readouterr().out
+        assert "All accounts are at their 5h/7d limit" in out
+        assert "staying on Account-1" in out
+        assert s._get_sequence_data()["activeAccountNumber"] == 1  # unchanged
+
+    def test_best_usage_unavailable_rotates_normally(self, temp_home: Path, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        # No usage data for any account → unknown → fall back to rotation.
+        with patch.object(s, "_usage_by_account", return_value={"1": None, "2": None}), \
+             patch.object(s, "list_accounts"):
+            s.switch(best=True)
+
+        assert "Usage data unavailable" in capsys.readouterr().out
+        assert s._get_sequence_data()["activeAccountNumber"] == 2
+
+    def test_skip_exhausted_skips_limited_account(self, temp_home: Path, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._seed(s, 3, "c@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        usage = {"1": self._usage(0), "2": self._usage(100), "3": self._usage(20)}
+        with patch.object(s, "_usage_by_account", return_value=usage), \
+             patch.object(s, "list_accounts"):
+            s.switch(skip_exhausted=True)
+
+        out = capsys.readouterr().out
+        assert "Skipping Account-2 (at 5h/7d limit)" in out
+        assert s._get_sequence_data()["activeAccountNumber"] == 3
+
+    def test_skip_exhausted_all_limited_stays_put(self, temp_home: Path, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._seed(s, 3, "c@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        usage = {"1": self._usage(0), "2": self._usage(100), "3": self._usage(100)}
+        with patch.object(s, "_usage_by_account", return_value=usage), \
+             patch.object(s, "list_accounts") as mock_list:
+            s.switch(skip_exhausted=True)
+
+        out = capsys.readouterr().out
+        assert "staying on Account-1" in out
+        # No switch onto an exhausted account; stays on the current one.
+        assert s._get_sequence_data()["activeAccountNumber"] == 1
+        mock_list.assert_not_called()
+
+    def test_skip_exhausted_unknown_usage_is_not_skipped(self, temp_home: Path):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        # Usage unknown for account 2 → must NOT be skipped (give it a chance).
+        with patch.object(s, "_usage_by_account", return_value={"1": None, "2": None}), \
+             patch.object(s, "list_accounts"):
+            s.switch(skip_exhausted=True)
+
+        assert s._get_sequence_data()["activeAccountNumber"] == 2


### PR DESCRIPTION

 ## Summary

  Adds two opt-in modifiers to `cswap --switch` that pick the target account by **remaining rate-limit quota** instead of rotating blindly:

  - **`--switch --best`** — switch to the account with the most remaining 5h/7d headroom. Never moves you onto an account worse than your current one: if you already hold the most quota (or every other
  account is at its limit), it stays put and says so.
  - **`--switch --skip-exhausted`** — rotate to the next account, skipping any at their 5h/7d limit; if all rotation targets are exhausted, it stays on the current account rather than switching onto a
  maxed-out one.

  Headroom is derived from the 5-hour and 7-day utilization windows already fetched for `--list` (pay-as-you-go spend is ignored). Decisions use the live login identity and fall back to plain rotation when
  usage data can't be fetched, so the feature **never blocks a switch**. Both modifiers apply to the normal path with an active login; the fresh-machine path (no login yet, e.g. right after `--import`) is
  unchanged.

  ## Examples

  ```bash
  # Jump to the account with the most remaining 5h/7d quota
  cswap --switch --best

  # Rotate to the next account, skipping any at their 5h/7d limit
  cswap --switch --skip-exhausted
  ```

  ### `--best`

  Switches when another account has strictly more headroom:

  ```text
  $ cswap --switch --best
  Switched to Account-3 (dev@example.com)
  Accounts:
    1: a@example.com   ├ 5h: 92%  └ 7d: 71%
    3: dev@example.com ├ 5h: 12%  └ 7d: 40%  (active)
  ```

  Stays put when you already hold the most quota (does **not** move you onto a worse account):

  ```text
  $ cswap --switch --best
  Already on the account with the most remaining quota (Account-2).
  ```

  When every account is maxed out, switching wouldn't help — it stays put:

  ```text
  $ cswap --switch --best
  All accounts are at their 5h/7d limit — staying on Account-2.
  ```

  If usage can't be fetched (e.g. offline), it falls back to plain rotation so the switch is never blocked:

  ```text
  $ cswap --switch --best
  Usage data unavailable — rotating to the next account.
  Switched to Account-2 (b@example.com)
  ```

  ### `--skip-exhausted`

  Skips rate-limited accounts during rotation:

  ```text
  $ cswap --switch --skip-exhausted
  Skipping Account-1 (at 5h/7d limit)
  Switched to Account-3 (dev@example.com)
  ```

  If every other account is exhausted, it stays on the current one instead of switching onto a maxed-out account:

  ```text
  $ cswap --switch --skip-exhausted
  All other accounts are at their 5h/7d limit — staying on Account-2.
  ```

  ### Validation

  The modifiers only make sense with `--switch`:

  ```text
  $ cswap --best --list
  cswap: error: --best and --skip-exhausted can only be used with --switch
  ```

  ## Implementation

  - **`oauth.account_headroom()`** — pure helper returning the binding window's remaining percentage (`100 - max(5h%, 7d%)`), or `None` when usage is unavailable / has no window data. `spend` is
  deliberately ignored.
  - **`switcher`** — extract `_build_accounts_info()` / `_collect_usage()` / `_usage_by_account()` out of `list_accounts` so usage fetching has a single cache-first path (reuses the existing `usage.json`
  15s TTL cache). Add `_select_best_switchable()` (compares against the current account's headroom; recommends a switch only when it lands on strictly more) and wire `best` / `skip_exhausted` into
  `switch()`.
  - **`cli`** — add `--best` / `--skip-exhausted` flags, validation requiring `--switch`, and help/epilog examples.
  - **`README`** — new "Switch by remaining usage" section.

  ## Behavior guarantees (all covered by tests)

  - Never switches you onto an account with less headroom than your current one.
  - Usage unavailable for all accounts → falls back to plain rotation (never blocks).
  - Every account at its limit → stays put with a clear message.
  - `--skip-exhausted` does **not** skip accounts whose usage is unknown (gives them a chance).
  - `skip_exhausted=False` path is byte-for-byte the existing rotation behavior.

  ## Testing

  - `oauth.account_headroom` unit tests (binding window, single window, at-limit, spend-ignored, malformed/None).
  - `switch()` selection + stay-put fallbacks for both `--best` and `--skip-exhausted`.
  - CLI flag validation and forwarding.
