### PR TITLE
Soften post-switch messaging with platform-aware activation guidance

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1846,7 +1846,7 @@ class ClaudeAccountSwitcher:
                     f"{accent('Activated')} Account-{target_account} ({target_email})"
                 )
                 print()
-                warning("Please restart Claude Code to use the new authentication.")
+                self._print_switch_followup()
                 print()
                 return
 
@@ -1953,8 +1953,25 @@ class ClaudeAccountSwitcher:
             self._logger.warning(f"Post-switch usage display failed: {e!r}")
             print(dimmed("  (usage display unavailable — run `cswap --list` to retry)"))
         print()
-        warning("Please restart Claude Code to use the new authentication.")
+        self._print_switch_followup()
         print()
+
+    def _print_switch_followup(self) -> None:
+        """Print the platform-appropriate note after a successful switch.
+
+        A restart is never required: Claude Code clears its cached OAuth token
+        when ``.credentials.json`` changes (Linux/WSL/Windows — effective on the
+        next message) or when the macOS Keychain cache TTL (~30s) expires. Both
+        lines are therefore dim informational hints, not warnings; macOS adds
+        that a restart skips the ~30s wait.
+        """
+        if self.platform == Platform.MACOS:
+            print(dimmed(
+                "Switch takes effect within about 30 seconds — "
+                "restart Claude Code to apply immediately."
+            ))
+        else:
+            print(dimmed("Active on your next message — no restart needed."))
 
     def purge(self) -> None:
         """Remove all traces of claude-swap from the system.

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -924,6 +924,10 @@ class TestPerformSwitchPostDisplay:
             switcher, creds_store, configs_store, live_state,
         )
 
+        # Pin platform so the post-switch followup message is deterministic
+        # across hosts (macOS prints a different note).
+        switcher.platform = Platform.LINUX
+
         try:
             with patch.object(
                 switcher,
@@ -944,7 +948,31 @@ class TestPerformSwitchPostDisplay:
         output = capsys.readouterr().out
         assert "Switched to" in output
         assert "usage display unavailable" in output
-        assert "restart Claude Code" in output
+        assert "no restart needed" in output
+
+    def test_switch_followup_macos(self, temp_home: Path, capsys):
+        """macOS shows the ~30s cache note; a restart applies it instantly."""
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.MACOS
+
+        switcher._print_switch_followup()
+
+        out = capsys.readouterr().out
+        assert "within about 30 seconds" in out
+        assert "apply immediately" in out
+        assert "no restart needed" not in out
+
+    def test_switch_followup_non_macos(self, temp_home: Path, capsys):
+        """Linux/WSL/Windows show the immediate, no-restart note."""
+        for plat in (Platform.LINUX, Platform.WSL, Platform.WINDOWS):
+            switcher = ClaudeAccountSwitcher()
+            switcher.platform = plat
+
+            switcher._print_switch_followup()
+
+            out = capsys.readouterr().out
+            assert "no restart needed" in out, plat
+            assert "30 seconds" not in out, plat
 
     def test_switch_with_unset_active_account_does_not_write_none_backup(
         self,


### PR DESCRIPTION
The post-switch message previously printed a yellow warning to restart Claude Code on every platform. A restart is never actually required — Claude Code re-reads file-based credentials on the next message (Linux/Windows/WSL) and auto-expires its macOS Keychain cache (~30s).

Replaces it with a calm, dim, platform-aware note:
- Linux/Windows/WSL: `Active on your next message — no restart needed.`
- macOS: `Switch takes effect within about 30 seconds — restart Claude Code to apply immediately.`

Updates the affected test assertion and adds coverage for both branches.