### PR TITLE
feat(macos): opt into file-based credential storage via CSWAP_FILE_STORAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,30 @@ cswap --purge                   # Remove all claude-swap data
 | Platform | Credentials | Config backups |
 |----------|-------------|----------------|
 | Windows | File-based (inside the backup directory, under `credentials/`) | `~/.claude-swap-backup/` |
-| macOS | macOS Keychain | `~/.claude-swap-backup/` |
+| macOS | macOS Keychain (or file-based with `CSWAP_FILE_STORAGE`) | `~/.claude-swap-backup/` |
 | Linux / WSL | File-based (inside the backup directory, under `credentials/`) | `${XDG_DATA_HOME:-~/.local/share}/claude-swap/` |
 
 Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`.
 
 On Linux/WSL, set `XDG_DATA_HOME` to override the default location. Data from older installs under `~/.claude-swap-backup/` is migrated automatically on first run.
+
+### macOS file-based storage (`CSWAP_FILE_STORAGE`)
+
+macOS stores credentials in the login Keychain by default. On a headless or remote
+macOS host (SSH/mosh, CI, a detached daemon) the Keychain is often locked or
+unreachable, so the `security` CLI prompts for an unlock that never gets answered —
+or fails outright. Claude Code itself falls back to `~/.claude/.credentials.json`
+there, so set `CSWAP_FILE_STORAGE=1` to make cswap store credentials (active and
+`.enc` backups) as files too, staying in lockstep with Claude Code:
+
+```bash
+export CSWAP_FILE_STORAGE=1   # e.g. in ~/.zshrc on the remote host
+```
+
+This is opt-in; the Keychain remains the macOS default. Set it from the start (or
+re-add your accounts afterwards), since file-stored and Keychain-stored credentials
+live in different places. Linux/WSL/Windows always use file storage and ignore the
+variable.
 
 ## Advanced
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -238,17 +238,37 @@ class ClaudeAccountSwitcher:
         if sys.platform != "win32":
             os.chmod(path, 0o600)
 
+    def _prefer_file_storage(self) -> bool:
+        """Whether credentials should live in files rather than the macOS Keychain.
+
+        Linux/WSL/Windows always use files. macOS uses the Keychain by default,
+        but a headless or remote session (SSH/mosh, CI, a detached daemon) often
+        cannot reach the login Keychain: ``security`` then prompts for an unlock
+        that never gets answered, or fails outright. Claude Code itself falls
+        back to ``~/.claude/.credentials.json`` in that situation, so setting
+        ``CSWAP_FILE_STORAGE=1`` makes cswap store and read credentials as files
+        on macOS too, staying in lockstep with Claude Code.
+
+        Opt-in only: the Keychain remains the macOS default. Switch the variable
+        on from the start (or re-add accounts afterwards), since file-stored and
+        Keychain-stored credentials live in different places.
+        """
+        if self.platform in (Platform.LINUX, Platform.WSL, Platform.WINDOWS):
+            return True
+        return bool(os.environ.get("CSWAP_FILE_STORAGE"))
+
     def _read_credentials(self) -> str | None:
         """Read credentials from Claude Code's storage.
 
         Claude Code stores credentials in:
         - macOS: Keychain with service "Claude Code-credentials"
-        - Linux/WSL/Windows: File at ~/.claude/.credentials.json
+        - Linux/WSL/Windows (or macOS with ``CSWAP_FILE_STORAGE``): File at
+          ~/.claude/.credentials.json
 
         Returns:
             Credentials string if found, empty string if not found, None on error.
         """
-        if self.platform == Platform.MACOS:
+        if not self._prefer_file_storage():
             try:
                 val = macos_keychain.get_password(
                     CLAUDE_CODE_KEYCHAIN_SERVICE, os.environ.get("USER", "user")
@@ -274,12 +294,13 @@ class ClaudeAccountSwitcher:
 
         Claude Code stores credentials in:
         - macOS: Keychain with service "Claude Code-credentials"
-        - Linux/WSL/Windows: File at ~/.claude/.credentials.json
+        - Linux/WSL/Windows (or macOS with ``CSWAP_FILE_STORAGE``): File at
+          ~/.claude/.credentials.json
 
         Raises:
             CredentialWriteError: If writing credentials fails.
         """
-        if self.platform == Platform.MACOS:
+        if not self._prefer_file_storage():
             try:
                 macos_keychain.set_password(
                     CLAUDE_CODE_KEYCHAIN_SERVICE,
@@ -318,11 +339,12 @@ class ClaudeAccountSwitcher:
 
         Linux/WSL/Windows store them as base64 files under ``credentials_dir``;
         macOS (and any UNKNOWN platform) use the macOS Keychain (via the
-        ``security`` CLI). Windows moved to files because the Windows Credential
-        Manager rejects entries over ~2,500 bytes, which Claude Code session
-        credentials can exceed (#45).
+        ``security`` CLI), unless ``CSWAP_FILE_STORAGE`` opts macOS into files
+        too (see ``_prefer_file_storage``). Windows moved to files because the
+        Windows Credential Manager rejects entries over ~2,500 bytes, which
+        Claude Code session credentials can exceed (#45).
         """
-        return self.platform in (Platform.LINUX, Platform.WSL, Platform.WINDOWS)
+        return self._prefer_file_storage()
 
     def _read_account_credentials(self, account_num: str, email: str) -> str:
         """Read account credentials from backup.
@@ -1960,12 +1982,13 @@ class ClaudeAccountSwitcher:
         """Print the platform-appropriate note after a successful switch.
 
         A restart is never required: Claude Code clears its cached OAuth token
-        when ``.credentials.json`` changes (Linux/WSL/Windows — effective on the
+        when ``.credentials.json`` changes (file storage — effective on the
         next message) or when the macOS Keychain cache TTL (~30s) expires. Both
-        lines are therefore dim informational hints, not warnings; macOS adds
-        that a restart skips the ~30s wait.
+        lines are therefore dim informational hints, not warnings; the Keychain
+        path adds that a restart skips the ~30s wait. The file-storage note also
+        covers macOS under ``CSWAP_FILE_STORAGE``.
         """
-        if self.platform == Platform.MACOS:
+        if not self._prefer_file_storage():
             print(dimmed(
                 "Switch takes effect within about 30 seconds — "
                 "restart Claude Code to apply immediately."

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2821,3 +2821,82 @@ class TestUsageAwareSwitch:
 
         # Anchored on the live account (2) → next is 3, not 2 (a no-op).
         assert s._get_sequence_data()["activeAccountNumber"] == 3
+
+
+class TestMacosFileStorageOptIn:
+    """macOS file-storage opt-in via ``CSWAP_FILE_STORAGE``.
+
+    Lets a headless/remote macOS host (SSH/mosh, CI) store credentials in
+    ``~/.claude/.credentials.json`` and ``.enc`` backup files instead of the
+    login Keychain, matching Claude Code's own fallback. Keychain stays the
+    macOS default; the variable is strictly opt-in.
+    """
+
+    def test_macos_defaults_to_keychain(self, temp_home: Path, monkeypatch):
+        monkeypatch.delenv("CSWAP_FILE_STORAGE", raising=False)
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.MACOS
+        assert s._prefer_file_storage() is False
+        assert s._uses_file_backup_backend() is False
+
+    def test_macos_opts_into_file_storage(self, temp_home: Path, monkeypatch):
+        monkeypatch.setenv("CSWAP_FILE_STORAGE", "1")
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.MACOS
+        assert s._prefer_file_storage() is True
+        assert s._uses_file_backup_backend() is True
+
+    def test_non_macos_always_uses_files_regardless_of_env(
+        self, temp_home: Path, monkeypatch
+    ):
+        monkeypatch.delenv("CSWAP_FILE_STORAGE", raising=False)
+        for plat in (Platform.LINUX, Platform.WSL, Platform.WINDOWS):
+            s = ClaudeAccountSwitcher()
+            s.platform = plat
+            assert s._prefer_file_storage() is True, plat
+
+    def test_macos_active_credentials_roundtrip_via_file(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        monkeypatch.setenv("CSWAP_FILE_STORAGE", "1")
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.MACOS
+
+        creds = '{"claudeAiOauth": {"accessToken": "tok"}}'
+        s._write_credentials(creds)
+
+        cred_file = temp_home / ".claude" / ".credentials.json"
+        assert cred_file.exists()
+        assert s._read_credentials() == creds
+        # File storage must bypass the Keychain entirely.
+        assert block_real_keychain.data == {}
+
+    def test_macos_backup_credentials_use_enc_files(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        monkeypatch.setenv("CSWAP_FILE_STORAGE", "1")
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.MACOS
+        s._setup_directories()
+
+        with patch.object(s, "_live_session_pids", return_value=[]), \
+             patch.object(s, "_invalidate_session_credentials"):
+            s._write_account_credentials("2", "user@example.com", "secret-creds")
+
+        enc = s.credentials_dir / ".creds-2-user@example.com.enc"
+        assert enc.exists()
+        assert s._read_account_credentials("2", "user@example.com") == "secret-creds"
+        assert block_real_keychain.data == {}
+
+    def test_macos_followup_message_under_file_storage(
+        self, temp_home: Path, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("CSWAP_FILE_STORAGE", "1")
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.MACOS
+
+        s._print_switch_followup()
+
+        out = capsys.readouterr().out
+        assert "no restart needed" in out
+        assert "30 seconds" not in out


### PR DESCRIPTION
## Problem

On a headless or remote **macOS** host (SSH/mosh, CI, a detached daemon), the login Keychain is often locked or unreachable. The `security` CLI then prompts for an unlock that never gets answered — or fails outright — so cswap can report `no stored credentials/config` even when backups exist, and switches don't take effect.

Claude Code itself already falls back to `~/.claude/.credentials.json` in that situation, so cswap and Claude Code can end up reading from different stores on the same machine.

## Change

Add a `_prefer_file_storage()` gate. Setting `CSWAP_FILE_STORAGE=1` makes macOS use **file storage** — active credentials (`~/.claude/.credentials.json`) and `.enc` per-account backups — exactly like Linux/WSL/Windows, keeping cswap in lockstep with Claude Code.

Routed through the gate:
- `_read_credentials` / `_write_credentials` (active credential)
- `_uses_file_backup_backend` (per-account backup backend)
- `_print_switch_followup` (the file-storage "no restart needed" note now applies on macOS too)

**Opt-in only** — the Keychain remains the macOS default, so the carefully engineered silent-`security` path is untouched for everyone who doesn't set the variable. Linux/WSL/Windows always use files and ignore the variable.

## Notes / caveats

- File-stored and Keychain-stored credentials live in different places, so the variable should be set from the start (or accounts re-added afterwards). Documented in the README.
- No default behavior changes.

## Tests

Added `TestMacosFileStorageOptIn` covering the gate (default off, opt-in on, non-macOS always-on), file round-trips for active + backup credentials, Keychain bypass, and the followup message. Full suite: **512 passed, 3 skipped**.