### PR TITLE
macOS: auto-fall back to file credentials when the Keychain is unavailable

### DIFF
--- a/src/claude_swap/macos_keychain.py
+++ b/src/claude_swap/macos_keychain.py
@@ -35,6 +35,7 @@ its functions are only meaningful on macOS.
 
 from __future__ import annotations
 
+import os
 import subprocess
 
 # ``security -i`` reads stdin with a 4096-byte fgets() buffer (BUFSIZ on darwin).
@@ -45,6 +46,13 @@ SECURITY_STDIN_LINE_LIMIT = 4096 - 64
 
 _NOT_FOUND_RC = 44  # errSecItemNotFound surfaced by find/delete-generic-password
 
+# Bound every ``security`` spawn so a wedged Keychain (a locked login keychain
+# prompting for an unlock that never comes on a headless/SSH host) can't hang the
+# CLI. 5s, deliberately short: a credential op that has to fall back to the file
+# may be followed by a best-effort cleanup spawn, so the per-op budget doubles in
+# the worst case. A healthy Keychain answers in well under 100ms.
+_TIMEOUT = 5.0
+
 # Pin the absolute path to Apple's system binary rather than resolving via PATH:
 # this is a credential tool, so an attacker-controlled ``security`` earlier on
 # PATH must not be able to intercept secrets. ``/usr/bin/security`` is present on
@@ -54,6 +62,35 @@ _SECURITY = "/usr/bin/security"
 
 class KeychainError(Exception):
     """A ``security`` invocation failed for a reason other than "not found"."""
+
+
+# The exceptions a Keychain operation may raise that callers should treat as
+# "Keychain unusable" (→ fall back to file storage) rather than a programming
+# bug: a wrapper failure (KeychainError, incl. a converted timeout), a raw
+# subprocess timeout, or a missing ``security`` binary (OSError). Catching this
+# tuple — never bare ``Exception`` — keeps a real bug loud instead of silently
+# routing to the file backend mid-invocation.
+KEYCHAIN_ERRORS = (KeychainError, subprocess.TimeoutExpired, OSError)
+
+
+def keychain_account_name() -> str:
+    """Account name for the active-credential Keychain item, mirroring Claude
+    Code's ``getUsername()`` (``utils/secureStorage/macOsKeychainHelpers.ts``).
+
+    ``$USER`` first, then the OS username, then a stable final fallback. Matching
+    this exactly matters on headless/launchd/cron hosts where ``$USER`` is unset:
+    a divergent default (e.g. ``"user"``) would key a *different* Keychain item
+    than Claude Code, so the two could not see each other's active credential.
+    """
+    user = os.environ.get("USER")
+    if user:
+        return user
+    try:
+        import pwd  # POSIX-only; the account-name call sites are macOS-only
+
+        return pwd.getpwuid(os.geteuid()).pw_name
+    except Exception:
+        return "claude-code-user"
 
 
 def _quote(value: str) -> str:
@@ -71,13 +108,20 @@ def get_password(service: str, account: str) -> str | None:
     """Return the stored password, or ``None`` if no such item exists (rc 44).
 
     Raises :class:`KeychainError` on any other non-zero exit (locked / denied /
-    unavailable), so a genuine miss is not confused with a transient failure.
+    unavailable) or a timeout, so a genuine miss is not confused with a transient
+    failure.
     """
-    result = subprocess.run(
-        [_SECURITY, "find-generic-password", "-a", account, "-w", "-s", service],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [_SECURITY, "find-generic-password", "-a", account, "-w", "-s", service],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise KeychainError(
+            f"security find-generic-password timed out after {_TIMEOUT}s"
+        ) from e
     if result.returncode == 0:
         # `-w` prints the value followed by one newline; strip exactly that so
         # values with meaningful leading/trailing whitespace survive intact.
@@ -95,14 +139,20 @@ def item_exists(service: str, account: str) -> bool:
 
     Attribute-only lookup (no ``-w``): nothing is decrypted, so this can never
     trigger a Keychain prompt, even for items owned by another app. Returns
-    ``True`` only on rc 0; "not found" (rc 44) and error exits both return
-    ``False`` — callers use this for cleanup verification, not access decisions.
+    ``True`` only on rc 0; "not found" (rc 44), error exits, a timeout, and a
+    missing binary all return ``False``. Deliberately **non-raising**: callers use
+    it for cleanup verification, not access decisions, so it must never feed the
+    capability cache (a timeout here means "couldn't tell", not "Keychain works").
     """
-    result = subprocess.run(
-        [_SECURITY, "find-generic-password", "-a", account, "-s", service],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [_SECURITY, "find-generic-password", "-a", account, "-s", service],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
     return result.returncode == 0
 
 
@@ -111,7 +161,7 @@ def set_password(service: str, account: str, password: str) -> None:
 
     Prefers ``security -i`` stdin so the secret stays out of argv; falls back to
     argv only for payloads that would overflow the stdin line buffer. Raises
-    :class:`KeychainError` on a non-zero exit.
+    :class:`KeychainError` on a non-zero exit or a timeout.
     """
     hex_value = password.encode("utf-8").hex()
     # `-X` passes the value as hex, avoiding any escaping issues for the secret.
@@ -119,25 +169,32 @@ def set_password(service: str, account: str, password: str) -> None:
         f"add-generic-password -U -a {_quote(account)} -s {_quote(service)} "
         f"-X {hex_value}\n"
     )
-    if len(command.encode("utf-8")) <= SECURITY_STDIN_LINE_LIMIT:
-        result = subprocess.run(
-            [_SECURITY, "-i"],
-            input=command,
-            capture_output=True,
-            text=True,
-        )
-    else:
-        # Overflows the stdin line buffer; fall back to argv. Hex in argv is
-        # recoverable by a determined observer but defeats naive plaintext-grep
-        # rules, and the alternative — silent corruption — is strictly worse.
-        result = subprocess.run(
-            [
-                _SECURITY, "add-generic-password", "-U",
-                "-a", account, "-s", service, "-X", hex_value,
-            ],
-            capture_output=True,
-            text=True,
-        )
+    try:
+        if len(command.encode("utf-8")) <= SECURITY_STDIN_LINE_LIMIT:
+            result = subprocess.run(
+                [_SECURITY, "-i"],
+                input=command,
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT,
+            )
+        else:
+            # Overflows the stdin line buffer; fall back to argv. Hex in argv is
+            # recoverable by a determined observer but defeats naive plaintext-grep
+            # rules, and the alternative — silent corruption — is strictly worse.
+            result = subprocess.run(
+                [
+                    _SECURITY, "add-generic-password", "-U",
+                    "-a", account, "-s", service, "-X", hex_value,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT,
+            )
+    except subprocess.TimeoutExpired as e:
+        raise KeychainError(
+            f"security add-generic-password timed out after {_TIMEOUT}s"
+        ) from e
     if result.returncode != 0:
         raise KeychainError(
             f"security add-generic-password failed (rc={result.returncode}): "
@@ -148,13 +205,19 @@ def set_password(service: str, account: str, password: str) -> None:
 def delete_password(service: str, account: str) -> None:
     """Delete a generic-password item. rc 44 (already absent) counts as success.
 
-    Raises :class:`KeychainError` on any other non-zero exit.
+    Raises :class:`KeychainError` on any other non-zero exit or a timeout.
     """
-    result = subprocess.run(
-        [_SECURITY, "delete-generic-password", "-a", account, "-s", service],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [_SECURITY, "delete-generic-password", "-a", account, "-s", service],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise KeychainError(
+            f"security delete-generic-password timed out after {_TIMEOUT}s"
+        ) from e
     if result.returncode in (0, _NOT_FOUND_RC):
         return
     raise KeychainError(

--- a/src/claude_swap/migrations.py
+++ b/src/claude_swap/migrations.py
@@ -330,11 +330,23 @@ def migrate_macos_keyring_to_security(switcher: "ClaudeAccountSwitcher") -> bool
     # and already-migrated users have every account here, so they never touch
     # keyring at all. Only the still-missing accounts proceed below; on a retry
     # this also narrows work to the accounts that actually failed last time.
-    pending = {
-        account_num: info
-        for account_num, info in accounts.items()
-        if not switcher._read_account_credentials(account_num, info.get("email", ""))
-    }
+    #
+    # Read the security service *directly* (not the transparent .enc-wins backup
+    # methods): this migration's job is the Keychain specifically, so a fallback
+    # .enc must not be mistaken for "already migrated". A down Keychain here is not
+    # "nothing to migrate" — defer and retry rather than skip real entries.
+    try:
+        pending = {
+            account_num: info
+            for account_num, info in accounts.items()
+            if not switcher._kc_read_backup(account_num, info.get("email", ""))
+        }
+    except macos_keychain.KEYCHAIN_ERRORS as e:
+        # Keychain unusable (locked/denied/missing) — defer, don't skip real
+        # entries. A programming error is NOT caught here; it propagates.
+        raise MigrationIncomplete(
+            f"Keychain unavailable, deferring macOS keyring migration: {e}"
+        ) from e
     if not pending:
         return True  # All accounts already in the security service.
 
@@ -425,16 +437,18 @@ def migrate_macos_keyring_to_security(switcher: "ClaudeAccountSwitcher") -> bool
             continue
 
         # --- write + verify before deleting the source ------------------------
+        # Keychain-only helpers: this migration targets the security service, so
+        # it must not be diverted to .enc files by the transparent backup methods.
         try:
-            switcher._write_account_credentials(account_num, email, creds)
-            readback = switcher._read_account_credentials(account_num, email)
+            switcher._kc_write_backup(account_num, email, creds)
+            readback = switcher._kc_read_backup(account_num, email)
         except Exception as e:  # noqa: BLE001
             switcher._logger.warning(
                 f"macos_keyring_to_security: write/read-back for {canonical} failed: {e}"
             )
             # A partial/garbage security item must not shadow the still-intact
             # keyring entry. Drop it; the retry rewrites it.
-            switcher._delete_account_credentials(account_num, email)
+            switcher._delete_backup_keychain_quiet(account_num, email)
             failed += 1
             continue
 
@@ -443,7 +457,7 @@ def migrate_macos_keyring_to_security(switcher: "ClaudeAccountSwitcher") -> bool
                 f"macos_keyring_to_security: read-back mismatch for {canonical}; "
                 "discarding the security item and leaving the keyring entry in place"
             )
-            switcher._delete_account_credentials(account_num, email)
+            switcher._delete_backup_keychain_quiet(account_num, email)
             failed += 1
             continue
 

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -141,16 +141,12 @@ def keychain_service_name(session_dir: Path) -> str:
 
 
 def _keychain_account_name() -> str:
-    """Keychain account name, mirroring Claude's ``getUsername()``."""
-    user = os.environ.get("USER")
-    if user:
-        return user
-    try:
-        import pwd  # POSIX-only; matches the macOS-only call sites
+    """Keychain account name, mirroring Claude's ``getUsername()``.
 
-        return pwd.getpwuid(os.geteuid()).pw_name
-    except Exception:
-        return "claude-code-user"
+    Delegates to :func:`macos_keychain.keychain_account_name` so session profiles
+    and the active store derive the account name identically.
+    """
+    return macos_keychain.keychain_account_name()
 
 
 def delete_macos_keychain_entry(session_dir: Path) -> None:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -145,6 +145,15 @@ class ClaudeAccountSwitcher:
         self.lock_file = self.backup_dir / ".lock"
         self._logger = setup_logging(self.backup_dir, debug=debug)
 
+        # macOS Keychain usability, learned per-process from real `security`
+        # calls (see _kc_call / _use_keychain). None = not yet probed; True/False
+        # once an op has run. Must be set BEFORE run_migrations(), which performs
+        # Keychain ops on macOS. _last_active_credentials_backend records where the
+        # most recent active-credential write landed ("keychain" | "file"), for the
+        # post-switch follow-up message.
+        self._keychain_usable_cache: bool | None = None
+        self._last_active_credentials_backend: str | None = None
+
         # Run any pending one-time data migrations (e.g. relocating Windows
         # backup credentials out of Credential Manager into files). Imported
         # lazily to avoid a circular import, and self-contained so it never
@@ -238,154 +247,284 @@ class ClaudeAccountSwitcher:
         if sys.platform != "win32":
             os.chmod(path, 0o600)
 
-    def _read_credentials(self) -> str | None:
-        """Read credentials from Claude Code's storage.
+    def _kc_call(self, fn, *args):
+        """Run a ``macos_keychain`` wrapper call, learning Keychain usability.
 
-        Claude Code stores credentials in:
-        - macOS: Keychain with service "Claude Code-credentials"
-        - Linux/WSL/Windows: File at ~/.claude/.credentials.json
+        A success (including ``get_password`` returning ``None`` for a missing
+        item) marks the Keychain usable — but only flips the cache ``None -> True``,
+        never ``False -> True``: once a call has failed this run we stay in file
+        mode so one invocation can't split-brain between backends. A
+        ``KeychainError`` / ``TimeoutExpired`` / ``OSError`` (binary missing) marks
+        it unusable and re-raises so the caller can fall back. Only those three are
+        caught — a programming error propagates.
+
+        Do NOT route ``item_exists`` through here: it returns ``False`` for both
+        "absent" and "failed", so a timeout would be misread as a usable Keychain.
+        """
+        try:
+            result = fn(*args)
+        except macos_keychain.KEYCHAIN_ERRORS:
+            self._keychain_usable_cache = False
+            raise
+        if self._keychain_usable_cache is None:
+            self._keychain_usable_cache = True
+        return result
+
+    def _use_keychain(self) -> bool:
+        """Whether credential *writes* should target the macOS Keychain this run.
+
+        ``False`` off macOS. On macOS, ``True`` until a Keychain op has failed this
+        process (the cache flips to ``False`` and sticks). Unknown (``None``) is
+        optimistic — the first real op tries the Keychain and records the outcome.
+        """
+        if self.platform != Platform.MACOS:
+            return False
+        return self._keychain_usable_cache is not False
+
+    def _read_credentials(self) -> str | None:
+        """Read Claude Code's active credentials.
+
+        macOS reads the Keychain (service "Claude Code-credentials") when it's
+        usable — mirroring Claude Code's keychain-first read — and an empty or
+        failed Keychain falls through to the plaintext file
+        ``~/.claude/.credentials.json`` (where Claude Code itself falls back).
+        Linux/WSL/Windows always read the file. Non-mutating.
 
         Returns:
-            Credentials string if found, empty string if not found, None on error.
+            Credentials string if found, "" if not found, None on a file read error.
         """
-        if self.platform == Platform.MACOS:
+        if self._use_keychain():
             try:
-                val = macos_keychain.get_password(
-                    CLAUDE_CODE_KEYCHAIN_SERVICE, os.environ.get("USER", "user")
+                val = self._kc_call(
+                    macos_keychain.get_password,
+                    CLAUDE_CODE_KEYCHAIN_SERVICE,
+                    macos_keychain.keychain_account_name(),
                 )
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                # Locked / denied / unavailable Keychain (rc-44 "not found" comes
+                # back as None, not raised). _kc_call has flipped routing to file
+                # mode; fall through to the plaintext file Claude Code uses too.
+                # (A programming error is NOT caught here — it propagates.)
+                self._logger.warning(f"Keychain read failed, trying file: {e}")
+                val = None
+            if val:
+                return val
+            # Keychain empty (rc-44) or failed → read the plaintext fallback file.
+
+        cred_file = get_credentials_path()
+        if cred_file.exists():
+            try:
+                return cred_file.read_text(encoding="utf-8")
             except Exception as e:
-                # rc-44 (not found) is returned as None by the wrapper, not raised;
-                # anything raised here is a genuine error (locked / denied / etc.).
-                self._logger.error(f"Failed to read credentials: {e}")
+                self._logger.error(f"Failed to read credentials file: {e}")
                 return None
-            return val if val is not None else ""
-        else:  # Linux/WSL/Windows - credentials stored in file
-            cred_file = get_credentials_path()
-            if cred_file.exists():
-                try:
-                    return cred_file.read_text(encoding="utf-8")
-                except Exception as e:
-                    self._logger.error(f"Failed to read credentials file: {e}")
-                    return None
-            return ""
+        return ""
+
+    def _write_active_credentials_file(self, credentials: str) -> None:
+        """Atomically write Claude Code's plaintext active-credentials file."""
+        cred_dir = get_claude_config_home()
+        cred_dir.mkdir(parents=True, exist_ok=True)
+        cred_file = cred_dir / ".credentials.json"
+        import tempfile
+        fd, tmp_path = tempfile.mkstemp(dir=str(cred_dir), suffix=".tmp")
+        try:
+            os.write(fd, credentials.encode("utf-8"))
+            os.close(fd)
+            fd = -1
+            os.replace(tmp_path, str(cred_file))
+            if sys.platform != "win32":
+                os.chmod(str(cred_file), 0o600)
+        except BaseException:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def _delete_active_keychain_entry(self) -> None:
+        """Best-effort removal of the active-credential Keychain item (macOS only).
+
+        Claude Code reads the Keychain before the plaintext file, so once we fall
+        back to the file we must clear any stale Keychain entry or Claude Code would
+        resurrect it (#30337). Best-effort: when the Keychain is down the delete
+        can't run, which is the documented recovery residual.
+        """
+        if self.platform != Platform.MACOS:
+            return
+        try:
+            macos_keychain.delete_password(
+                CLAUDE_CODE_KEYCHAIN_SERVICE, macos_keychain.keychain_account_name()
+            )
+        except Exception:
+            pass  # best-effort; a down Keychain can't be cleaned now
 
     def _write_credentials(self, credentials: str) -> None:
-        """Write credentials to Claude Code's storage.
+        """Write Claude Code's active credentials.
 
-        Claude Code stores credentials in:
-        - macOS: Keychain with service "Claude Code-credentials"
-        - Linux/WSL/Windows: File at ~/.claude/.credentials.json
+        macOS writes the Keychain when usable (recording backend ``"keychain"``)
+        and **leaves the plaintext file untouched**, mirroring Claude Code, which
+        preserves the file alongside a populated Keychain for container ``~/.claude``
+        sharing (#1414): cswap can't prove an existing file is its own stale fallback
+        vs. a credential another consumer relies on. If the Keychain write fails — or
+        the Keychain is already known unusable — it writes the plaintext file and
+        best-effort clears any stale Keychain entry (#30337), recording backend
+        ``"file"``. Linux/WSL/Windows always write the file.
 
         Raises:
             CredentialWriteError: If writing credentials fails.
         """
-        if self.platform == Platform.MACOS:
+        if self._use_keychain():
             try:
-                macos_keychain.set_password(
+                self._kc_call(
+                    macos_keychain.set_password,
                     CLAUDE_CODE_KEYCHAIN_SERVICE,
-                    os.environ.get("USER", "user"),
+                    macos_keychain.keychain_account_name(),
                     credentials,
                 )
-            except Exception as e:
-                raise CredentialWriteError(f"Failed to write credentials: {e}")
-        else:  # Linux/WSL/Windows - credentials stored in file
-            cred_dir = get_claude_config_home()
-            cred_dir.mkdir(parents=True, exist_ok=True)
-            cred_file = cred_dir / ".credentials.json"
-            try:
-                import tempfile
-                fd, tmp_path = tempfile.mkstemp(dir=str(cred_dir), suffix=".tmp")
-                try:
-                    os.write(fd, credentials.encode("utf-8"))
-                    os.close(fd)
-                    fd = -1
-                    os.replace(tmp_path, str(cred_file))
-                    if sys.platform != "win32":
-                        os.chmod(str(cred_file), 0o600)
-                except BaseException:
-                    if fd >= 0:
-                        os.close(fd)
-                    try:
-                        os.unlink(tmp_path)
-                    except OSError:
-                        pass
-                    raise
-            except Exception as e:
-                raise CredentialWriteError(f"Failed to write credentials: {e}")
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                # _kc_call flipped routing to file mode; fall through to the file.
+                # (A programming error is NOT caught here — it propagates.)
+                self._logger.warning(f"Keychain write failed, falling back to file: {e}")
+            else:
+                self._last_active_credentials_backend = "keychain"
+                return
+
+        # File mode: non-macOS, macOS Keychain known unusable, or a Keychain write
+        # that just failed. Write the plaintext file and (macOS) best-effort clear
+        # any stale Keychain entry so Claude Code's keychain-first read can't shadow
+        # it (#30337).
+        try:
+            self._write_active_credentials_file(credentials)
+        except Exception as e:
+            raise CredentialWriteError(f"Failed to write credentials: {e}")
+        self._delete_active_keychain_entry()
+        self._last_active_credentials_backend = "file"
 
     def _uses_file_backup_backend(self) -> bool:
-        """Whether per-account backup credentials live in files vs. the Keychain.
+        """Whether per-account backup *writes* go to files vs. the Keychain.
 
-        Linux/WSL/Windows store them as base64 files under ``credentials_dir``;
-        macOS (and any UNKNOWN platform) use the macOS Keychain (via the
-        ``security`` CLI). Windows moved to files because the Windows Credential
-        Manager rejects entries over ~2,500 bytes, which Claude Code session
-        credentials can exceed (#45).
+        Linux/WSL/Windows always use base64 ``.enc`` files under ``credentials_dir``
+        (Windows moved off the Credential Manager because it rejects entries over
+        ~2,500 bytes, #45). macOS uses the Keychain while it's usable and falls back
+        to ``.enc`` files when it isn't (headless/SSH/locked); UNKNOWN platforms have
+        no Keychain, so they use files too. Backup *reads* are ``.enc``-wins
+        regardless (see ``_read_account_credentials``).
         """
-        return self.platform in (Platform.LINUX, Platform.WSL, Platform.WINDOWS)
+        return not self._use_keychain()
 
-    def _read_account_credentials(self, account_num: str, email: str) -> str:
-        """Read account credentials from backup.
+    # -- backup credential backends ---------------------------------------
+    #
+    # Two backends for per-account backups: base64 ``.enc`` files under
+    # ``credentials_dir`` and the macOS Keychain (``SECURITY_SERVICE``). On macOS
+    # reads are ``.enc``-wins: a fallback ``.enc`` (written while the Keychain was
+    # unusable) is authoritative over a possibly-stale Keychain copy, so a Keychain
+    # that recovers can't shadow a newer file. A successful Keychain write
+    # therefore reconciles the ``.enc`` away (correctness-critical, not best-effort).
 
-        On Linux/WSL/Windows: Uses file-based storage (base64 files under
-        ``credentials_dir``). On macOS: Uses the Keychain via the ``security`` CLI.
+    def _backup_enc_path(self, account_num: str, email: str) -> Path:
+        return self.credentials_dir / f".creds-{account_num}-{email}.enc"
+
+    def _backup_username(self, account_num: str, email: str) -> str:
+        return f"account-{account_num}-{email}"
+
+    def _kc_read_backup(self, account_num: str, email: str) -> str:
+        """Read a per-account backup from the Keychain only (no file fallback).
+
+        Routes through ``_kc_call`` (so a failure flips the capability cache).
+        Returns ``""`` when the item is absent; raises on a Keychain failure so
+        the caller decides (normal reads swallow it; the migration defers).
         """
-        if self._uses_file_backup_backend():
-            cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
-            if cred_file.exists():
-                try:
-                    encoded = cred_file.read_text(encoding="utf-8")
-                    return base64.b64decode(encoded).decode("utf-8")
-                except Exception as e:
-                    self._logger.warning(f"Failed to read credentials file: {e}")
-                    return ""
-            return ""
-        else:
-            # macOS: per-account backup credentials in the Keychain via `security`.
-            username = f"account-{account_num}-{email}"
+        creds = self._kc_call(
+            macos_keychain.get_password,
+            SECURITY_SERVICE,
+            self._backup_username(account_num, email),
+        )
+        return creds or ""
+
+    def _kc_write_backup(self, account_num: str, email: str, credentials: str) -> None:
+        """Write a per-account backup to the Keychain only. Raises on failure."""
+        self._kc_call(
+            macos_keychain.set_password,
+            SECURITY_SERVICE,
+            self._backup_username(account_num, email),
+            credentials,
+        )
+
+    def _kc_delete_backup(self, account_num: str, email: str) -> None:
+        """Delete a per-account backup Keychain item only. Raises on failure."""
+        self._kc_call(
+            macos_keychain.delete_password,
+            SECURITY_SERVICE,
+            self._backup_username(account_num, email),
+        )
+
+    def _delete_backup_keychain_quiet(self, account_num: str, email: str) -> None:
+        """Best-effort backup Keychain delete (never raises)."""
+        try:
+            self._kc_delete_backup(account_num, email)
+        except Exception as e:
+            self._logger.warning(f"Failed to delete credentials from Keychain: {e}")
+
+    def _write_backup_enc(self, account_num: str, email: str, credentials: str) -> None:
+        """Atomically write a per-account backup ``.enc`` (base64) file."""
+        self.credentials_dir.mkdir(parents=True, exist_ok=True)
+        enc_file = self._backup_enc_path(account_num, email)
+        encoded = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
+        import tempfile
+        fd, tmp_path = tempfile.mkstemp(dir=str(self.credentials_dir), suffix=".tmp")
+        try:
+            os.write(fd, encoded.encode("utf-8"))
+            os.close(fd)
+            fd = -1
+            os.replace(tmp_path, str(enc_file))
+            if sys.platform != "win32":
+                os.chmod(str(enc_file), 0o600)
+        except BaseException:
+            if fd >= 0:
+                os.close(fd)
             try:
-                creds = macos_keychain.get_password(SECURITY_SERVICE, username)
-                return creds if creds else ""
-            except Exception as e:
-                self._logger.warning(f"Failed to read credentials from Keychain: {e}")
-                return ""
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
-    def _write_account_credentials(
+    def _reconcile_enc_after_keychain_write(
         self, account_num: str, email: str, credentials: str
     ) -> None:
-        """Write account credentials to backup.
+        """Stop a leftover ``.enc`` from shadowing a just-written Keychain backup.
 
-        On Linux/WSL/Windows: Uses file-based storage (base64 files under
-        ``credentials_dir``). On macOS: Uses the Keychain via the ``security`` CLI.
+        ``.enc``-wins reads make this correctness-critical: delete the ``.enc``; if
+        the delete fails, atomically rewrite it with the same fresh creds; if that
+        also fails, raise so the inconsistency surfaces rather than serving stale.
         """
-        if self._uses_file_backup_backend():
-            cred_file = self.credentials_dir / f".creds-{account_num}-{email}.enc"
-            try:
-                encoded = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
-                cred_file.write_text(encoded, encoding="utf-8")
-                if sys.platform != "win32":
-                    os.chmod(cred_file, 0o600)
-            except Exception as e:
-                self._logger.warning(f"Failed to write credentials file: {e}")
-                raise
-        else:
-            # macOS: per-account backup credentials in the Keychain via `security`.
-            username = f"account-{account_num}-{email}"
-            try:
-                macos_keychain.set_password(SECURITY_SERVICE, username, credentials)
-            except Exception as e:
-                self._logger.warning(f"Failed to write credentials to Keychain: {e}")
-                raise
-        # Backup credentials changed (re-login via --add-account, --add-token,
-        # import, switch backing up, or a usage-refresh rotation): a session
-        # profile seeded from the old credentials may now hold a stale or
-        # rotated-out token that still passes the local reuse check. Drop the
-        # profile's credential material so the next `cswap run` re-bootstraps
-        # from this fresh backup (history is preserved). A LIVE session keeps
-        # its own copy untouched — claude manages it; pulling credentials out
-        # from under a running process would be worse than the drift caveat —
-        # but gets a stale marker so setup_session re-bootstraps it once it
-        # is no longer live, instead of trusting the local reuse check.
+        enc_file = self._backup_enc_path(account_num, email)
+        if not enc_file.exists():
+            return
+        try:
+            enc_file.unlink()
+            return
+        except Exception as e:
+            self._logger.warning(
+                f"Could not delete .enc after Keychain backup write ({e}); "
+                "rewriting it with the fresh credentials to keep both consistent"
+            )
+        self._write_backup_enc(account_num, email, credentials)
+
+    def _post_backup_write(self, account_num: str, email: str) -> None:
+        """Invalidate the slot's session profile after backup credentials change.
+
+        Backup credentials changed (re-login via --add-account, --add-token,
+        import, switch backing up, or a usage-refresh rotation): a session profile
+        seeded from the old credentials may now hold a stale or rotated-out token
+        that still passes the local reuse check. Drop the profile's credential
+        material so the next `cswap run` re-bootstraps from this fresh backup
+        (history is preserved). A LIVE session keeps its own copy untouched — claude
+        manages it; pulling credentials out from under a running process would be
+        worse than the drift caveat — but gets a stale marker so setup_session
+        re-bootstraps it once it is no longer live.
+        """
         if self._live_session_pids(account_num, email):
             from claude_swap.session import mark_session_stale
 
@@ -393,32 +532,92 @@ class ClaudeAccountSwitcher:
         else:
             self._invalidate_session_credentials(account_num, email)
 
-    def _delete_account_credentials(self, account_num: str, email: str) -> None:
-        """Delete account credentials from backup.
+    def _read_account_credentials(self, account_num: str, email: str) -> str:
+        """Read account credentials from backup. ``""`` when missing.
 
-        On Linux/WSL/Windows: Deletes file-based credential storage.
-        On macOS: Removes from the Keychain via the ``security`` CLI.
+        macOS is ``.enc``-wins (a fallback file beats a possibly-stale Keychain
+        copy); only an absent or corrupt ``.enc`` falls through to the Keychain.
+        Linux/WSL/Windows read the ``.enc`` only.
         """
-        if self._uses_file_backup_backend():
-            cred_files = [self.credentials_dir / f".creds-{account_num}-{email}.enc"]
-            if str(account_num) != "None":
-                cred_files.append(self.credentials_dir / f".creds-None-{email}.enc")
-            for cred_file in cred_files:
-                try:
-                    if cred_file.exists():
-                        cred_file.unlink()
-                except Exception as e:
-                    self._logger.warning(f"Failed to delete credentials file: {e}")
-        else:
-            # macOS: per-account backup credentials in the Keychain via `security`.
-            usernames = [f"account-{account_num}-{email}"]
-            if str(account_num) != "None":
-                usernames.append(f"account-None-{email}")
-            for username in usernames:
-                try:
-                    macos_keychain.delete_password(SECURITY_SERVICE, username)
-                except Exception as e:
-                    self._logger.warning(f"Failed to delete credentials from Keychain: {e}")
+        enc_file = self._backup_enc_path(account_num, email)
+        if enc_file.exists():
+            try:
+                encoded = enc_file.read_text(encoding="utf-8").strip()
+                # validate=True: reject non-alphabet junk (e.g. "!!!!") instead of
+                # silently discarding it to empty bytes, which would let a corrupt
+                # .enc shadow a valid Keychain copy.
+                decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+            except Exception as e:
+                # Corrupt/garbled .enc → on macOS fall through to the Keychain copy.
+                self._logger.warning(f"Failed to read credentials file: {e}")
+            else:
+                if decoded:
+                    return decoded
+                # Empty/whitespace .enc is not a real backup → try the Keychain.
+        if self.platform == Platform.MACOS:
+            try:
+                return self._kc_read_backup(account_num, email)
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                self._logger.warning(f"Failed to read credentials from Keychain: {e}")
+        return ""
+
+    def _write_account_credentials(
+        self, account_num: str, email: str, credentials: str
+    ) -> None:
+        """Write account credentials to backup.
+
+        macOS writes the Keychain when usable, then reconciles the ``.enc`` away
+        (see ``_reconcile_enc_after_keychain_write``). When the Keychain is unusable
+        it writes the ``.enc`` atomically, then best-effort deletes any stale
+        Keychain copy so a recovered Keychain can't shadow the fresh file.
+        Linux/WSL/Windows write the ``.enc`` only.
+        """
+        if self._use_keychain():
+            try:
+                self._kc_write_backup(account_num, email, credentials)
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                # Keychain unusable; _kc_call flipped routing to file mode.
+                # (A programming error is NOT caught here — it propagates.)
+                self._logger.warning(
+                    f"Keychain backup write failed, falling back to file: {e}"
+                )
+            else:
+                self._reconcile_enc_after_keychain_write(account_num, email, credentials)
+                self._post_backup_write(account_num, email)
+                return
+
+        # File mode: write the .enc atomically, then (macOS) best-effort drop the
+        # stale Keychain copy so a recovered Keychain can't shadow the fresh file.
+        try:
+            self._write_backup_enc(account_num, email, credentials)
+        except Exception as e:
+            self._logger.warning(f"Failed to write credentials file: {e}")
+            raise
+        if self.platform == Platform.MACOS:
+            self._delete_backup_keychain_quiet(account_num, email)
+        self._post_backup_write(account_num, email)
+
+    def _delete_account_credentials(self, account_num: str, email: str) -> None:
+        """Delete account credentials from backup (both backends on macOS).
+
+        Removes the ``.enc`` file(s) and, on macOS, the Keychain item(s). The
+        Keychain delete is best-effort: if it's locked the item may linger as
+        harmless unreferenced cruft (the slot is gone from sequence.json; a re-add
+        overwrites it via ``-U``; purge sweeps it). Includes the legacy
+        ``account-None-{email}`` alias.
+        """
+        nums = [account_num]
+        if str(account_num) != "None":
+            nums.append("None")
+        for num in nums:
+            enc_file = self._backup_enc_path(num, email)
+            try:
+                if enc_file.exists():
+                    enc_file.unlink()
+            except Exception as e:
+                self._logger.warning(f"Failed to delete credentials file: {e}")
+            if self.platform == Platform.MACOS:
+                self._delete_backup_keychain_quiet(num, email)
 
     def _delete_account_files(self, account_num: str, email: str) -> None:
         """Delete all backup files for an account (credentials + config).
@@ -1957,15 +2156,21 @@ class ClaudeAccountSwitcher:
         print()
 
     def _print_switch_followup(self) -> None:
-        """Print the platform-appropriate note after a successful switch.
+        """Print the note after a successful switch, keyed to where the active
+        credential write actually landed.
 
-        A restart is never required: Claude Code clears its cached OAuth token
-        when ``.credentials.json`` changes (Linux/WSL/Windows — effective on the
-        next message) or when the macOS Keychain cache TTL (~30s) expires. Both
-        lines are therefore dim informational hints, not warnings; macOS adds
-        that a restart skips the ~30s wait.
+        A restart is never required: Claude Code clears its cached OAuth token when
+        ``.credentials.json`` changes (file storage — effective on the next message)
+        or when the macOS Keychain cache TTL (~30s) expires. Both lines are dim
+        hints, not warnings; the Keychain line adds that a restart skips the wait.
+        The file line also covers macOS when the Keychain was unavailable and the
+        switch fell back to the file.
         """
-        if self.platform == Platform.MACOS:
+        backend = self._last_active_credentials_backend
+        if backend is None:
+            # No write happened this run; fall back to the routing hint.
+            backend = "keychain" if self._use_keychain() else "file"
+        if backend == "keychain":
             print(dimmed(
                 "Switch takes effect within about 30 seconds — "
                 "restart Claude Code to apply immediately."
@@ -1977,9 +2182,10 @@ class ClaudeAccountSwitcher:
         """Remove all traces of claude-swap from the system.
 
         This removes:
-        - All stored account credentials (files on Linux/WSL/Windows, macOS
-          Keychain items via ``security`` on macOS), plus a best-effort sweep of
-          any pre-migration keyring / Windows Credential Manager entries left behind
+        - All stored account credentials (``.enc`` files on Linux/WSL/Windows; on
+          macOS both the Keychain items via ``security`` and any fallback ``.enc``
+          files), plus a best-effort sweep of any pre-migration keyring / Windows
+          Credential Manager entries left behind
         - The active backup directory (XDG path on Linux/WSL, ~/.claude-swap-backup elsewhere)
         - Any stale legacy ~/.claude-swap-backup directory left around from
           before the XDG migration
@@ -2016,10 +2222,10 @@ class ClaudeAccountSwitcher:
         print(f"  - Backup directory: {self.backup_dir}")
         if legacy_distinct and legacy.exists():
             print(f"  - Legacy backup directory: {legacy}")
-        if self._uses_file_backup_backend():
-            print("  - All stored account credential files")
+        if self.platform == Platform.MACOS:
+            print("  - All stored account credentials (macOS Keychain and/or files)")
         else:
-            print("  - All stored account credentials from the macOS Keychain")
+            print("  - All stored account credential files")
         if session_dirs:
             print("  - All session profiles and their Keychain entries")
         print()
@@ -2033,49 +2239,41 @@ class ClaudeAccountSwitcher:
 
         removed_items = []
 
-        # Remove credentials
+        # Remove credentials. On macOS backups may be in the Keychain and/or .enc
+        # files (auto-fallback), so clean both; Linux/WSL/Windows are file-only.
         data = self._get_sequence_data()
         if data:
             for account_num, account_info in data.get("accounts", {}).items():
                 email = account_info.get("email", "")
-                if self._uses_file_backup_backend():
-                    # Remove credential files (Linux/WSL/Windows)
-                    cred_files = [
-                        self.credentials_dir / f".creds-{account_num}-{email}.enc"
-                    ]
-                    if str(account_num) != "None":
-                        cred_files.append(
-                            self.credentials_dir / f".creds-None-{email}.enc"
-                        )
-                    for cred_file in cred_files:
-                        try:
-                            if cred_file.exists():
-                                cred_file.unlink()
-                                removed_items.append(f"Credential file: {cred_file.name}")
-                        except Exception:
-                            pass  # Ignore errors during purge
-                    if self.platform == Platform.WINDOWS:
-                        # Best-effort cleanup of any pre-migration Credential
-                        # Manager entries left behind if the keyring → file
-                        # migration never completed. Files are authoritative
-                        # now; these are just stale cruft.
-                        usernames = [f"account-{account_num}-{email}"]
-                        if str(account_num) != "None":
-                            usernames.append(f"account-None-{email}")
-                        _sweep_legacy_keyring(usernames, removed_items)
-                else:
-                    # macOS: remove the Keychain items via `security`.
-                    usernames = [f"account-{account_num}-{email}"]
-                    if str(account_num) != "None":
-                        usernames.append(f"account-None-{email}")
+                nums = [account_num]
+                if str(account_num) != "None":
+                    nums.append("None")
+                usernames = [f"account-{num}-{email}" for num in nums]
+
+                # .enc files (Linux/WSL/Windows always; macOS fallback copies).
+                for num in nums:
+                    cred_file = self.credentials_dir / f".creds-{num}-{email}.enc"
+                    try:
+                        if cred_file.exists():
+                            cred_file.unlink()
+                            removed_items.append(f"Credential file: {cred_file.name}")
+                    except Exception:
+                        pass  # Ignore errors during purge
+
+                # macOS Keychain items via `security` (current macOS backend).
+                if self.platform == Platform.MACOS:
                     for username in usernames:
                         try:
                             macos_keychain.delete_password(SECURITY_SERVICE, username)
                             removed_items.append(f"Credential: {username}")
                         except Exception:
                             pass  # Ignore errors during purge
-                    # Best-effort cleanup of any pre-migration keyring entries left
-                    # behind if the keyring → security migration never completed.
+
+                # Best-effort sweep of any pre-migration keyring / Credential
+                # Manager entries left behind by an incomplete keyring → files
+                # (Windows) or keyring → security (macOS) migration. Linux/WSL
+                # never used a keyring backend.
+                if self.platform in (Platform.MACOS, Platform.WINDOWS):
                     _sweep_legacy_keyring(usernames, removed_items)
 
         # Session-profile keychain entries must go BEFORE the backup dir:

--- a/tests/test_macos_keychain.py
+++ b/tests/test_macos_keychain.py
@@ -156,5 +156,57 @@ def test_delete_password_raises_on_other_nonzero():
             macos_keychain.delete_password("svc", "acct")
 
 
+# ---------------------------------------------------------------------------
+# timeouts — a wedged Keychain must surface as KeychainError, never a hang
+# ---------------------------------------------------------------------------
+
+
+def test_calls_pass_timeout_to_subprocess():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run:
+        run.return_value = _completed(0, stdout="x\n")
+        macos_keychain.get_password("svc", "acct")
+        assert run.call_args.kwargs.get("timeout") == macos_keychain._TIMEOUT
+
+
+@pytest.mark.parametrize("fn,args", [
+    ("get_password", ("svc", "acct")),
+    ("set_password", ("svc", "acct", "secret")),
+    ("delete_password", ("svc", "acct")),
+])
+def test_timeout_becomes_keychain_error(fn, args):
+    timeout = subprocess.TimeoutExpired(cmd="security", timeout=5)
+    with patch("claude_swap.macos_keychain.subprocess.run", side_effect=timeout):
+        with pytest.raises(macos_keychain.KeychainError):
+            getattr(macos_keychain, fn)(*args)
+
+
+def test_item_exists_stays_false_on_timeout_and_missing_binary():
+    # item_exists must never raise (it feeds cleanup, not the capability cache).
+    timeout = subprocess.TimeoutExpired(cmd="security", timeout=5)
+    with patch("claude_swap.macos_keychain.subprocess.run", side_effect=timeout):
+        assert macos_keychain.item_exists("svc", "acct") is False
+    with patch("claude_swap.macos_keychain.subprocess.run", side_effect=FileNotFoundError):
+        assert macos_keychain.item_exists("svc", "acct") is False
+
+
+# ---------------------------------------------------------------------------
+# keychain_account_name — mirror Claude Code's getUsername()
+# ---------------------------------------------------------------------------
+
+
+def test_keychain_account_name_prefers_user_env(monkeypatch):
+    monkeypatch.setenv("USER", "alice")
+    assert macos_keychain.keychain_account_name() == "alice"
+
+
+def test_keychain_account_name_no_user_env_avoids_legacy_default(monkeypatch):
+    # The old active-store default was the bare string "user", which mismatches
+    # Claude Code's OS-username on headless hosts ($USER unset). The shared helper
+    # must fall back to the OS username / "claude-code-user", never "user".
+    monkeypatch.delenv("USER", raising=False)
+    name = macos_keychain.keychain_account_name()
+    assert name and name != "user"
+
+
 # The real-Keychain round-trip test lives in test_macos_keychain_contract.py,
 # next to the `tmp_keychain` fixture it depends on.

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -18,6 +18,7 @@ import pytest
 
 from claude_swap import migrations
 from claude_swap.exceptions import MigrationIncomplete
+from claude_swap.macos_keychain import KeychainError
 from claude_swap.migrations import run_migrations
 from claude_swap.models import Platform
 from claude_swap.switcher import KEYRING_SERVICE, ClaudeAccountSwitcher
@@ -518,9 +519,11 @@ class TestMacosKeyringToSecurity:
         _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
         fake = FakeKeyring({(KEYRING_SERVICE, "account-1-a@example.com"): "sekret"})
 
-        # Force the security read-back to disagree with what was written.
+        # Force the security read-back to disagree with what was written. The
+        # migration reads the security service via the keychain-only helper
+        # (_kc_read_backup), not the transparent .enc-wins backup methods.
         with _patch_keyring(fake), patch.object(
-            switcher, "_read_account_credentials", side_effect=["", "WRONG"]
+            switcher, "_kc_read_backup", side_effect=["", "WRONG"]
         ):
             with pytest.raises(MigrationIncomplete):
                 migrations.migrate_macos_keyring_to_security(switcher)
@@ -563,6 +566,24 @@ class TestMacosKeyringToSecurity:
 
         # No fallback read happened → nothing landed in the new service.
         assert switcher._read_account_credentials("1", "a@example.com") == ""
+
+    def test_security_keychain_unusable_defers_and_writes_no_enc(self, temp_home):
+        # The destination (security-service) Keychain is unusable: the keychain-only
+        # pending pre-check raises, so the migration must defer rather than mistake
+        # an .enc for "already migrated" or write legacy creds to a file while
+        # claiming the security service.
+        switcher = _make_macos_switcher(temp_home)
+        _seed_sequence(switcher, {"1": {"email": "a@example.com"}})
+
+        with patch.object(switcher, "_kc_read_backup", side_effect=KeychainError("locked")):
+            run_migrations(switcher)  # swallows MigrationIncomplete → left unmarked
+
+        # Deferred cleanly: no fallback .enc written, migration not recorded.
+        assert not (switcher.credentials_dir / ".creds-1-a@example.com.enc").exists()
+        state_file = switcher.backup_dir / ".migrations.json"
+        if state_file.exists():
+            applied = json.loads(state_file.read_text()).get("applied", {})
+            assert "macos_keyring_to_security" not in applied
 
     def test_idempotent_via_runner_marks_applied(self, temp_home):
         switcher = _make_macos_switcher(temp_home)

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import sys
@@ -10,15 +11,27 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from claude_swap import macos_keychain
 from claude_swap.exceptions import (
     AccountNotFoundError,
     ConfigError,
     CredentialReadError,
     ValidationError,
 )
+from claude_swap.macos_keychain import KeychainError
 from claude_swap.models import Platform
-from claude_swap.paths import get_backup_root
-from claude_swap.switcher import ClaudeAccountSwitcher, SETUP_TOKEN_SCOPES
+from claude_swap.paths import get_backup_root, get_credentials_path
+from claude_swap.switcher import (
+    CLAUDE_CODE_KEYCHAIN_SERVICE,
+    ClaudeAccountSwitcher,
+    SECURITY_SERVICE,
+    SETUP_TOKEN_SCOPES,
+)
+
+
+def _raise_locked(*args, **kwargs):
+    """Stand-in for a locked/unavailable Keychain operation."""
+    raise KeychainError("locked")
 
 
 class TestEmailValidation:
@@ -2821,3 +2834,258 @@ class TestUsageAwareSwitch:
 
         # Anchored on the live account (2) → next is 3, not 2 (a no-op).
         assert s._get_sequence_data()["activeAccountNumber"] == 3
+
+
+class TestMacosKeychainFallback:
+    """macOS auto-fallback to file storage when the Keychain is unusable, plus the
+    ``.enc``-wins backup reconciliation.
+
+    The autouse ``block_real_keychain`` fixture fakes a *working* in-memory
+    Keychain; individual tests force failures by patching the ``macos_keychain``
+    wrapper to raise ``KeychainError`` (``_raise_locked``).
+    """
+
+    def _macos_switcher(self) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.MACOS
+        s._setup_directories()
+        return s
+
+    # -- capability cache -------------------------------------------------
+
+    def test_non_macos_never_uses_keychain(self, temp_home: Path):
+        for plat in (Platform.LINUX, Platform.WSL, Platform.WINDOWS):
+            s = ClaudeAccountSwitcher()
+            s.platform = plat
+            assert s._use_keychain() is False
+            assert s._uses_file_backup_backend() is True
+
+    def test_capability_cache_sticky_false(self, temp_home: Path, monkeypatch):
+        s = self._macos_switcher()
+        assert s._use_keychain() is True  # optimistic before any op
+
+        # A failing op flips routing to unusable for the rest of the process...
+        monkeypatch.setattr(macos_keychain, "get_password", _raise_locked)
+        with pytest.raises(KeychainError):
+            s._kc_call(macos_keychain.get_password, "svc", "acct")
+        assert s._use_keychain() is False
+
+        # ...and a later *success* must NOT flip it back (no split-brain).
+        monkeypatch.setattr(macos_keychain, "get_password", lambda *a, **k: "ok")
+        s._kc_call(macos_keychain.get_password, "svc", "acct")
+        assert s._use_keychain() is False
+
+    def test_item_exists_is_capability_neutral(
+        self, temp_home: Path, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        s._keychain_usable_cache = False  # already in file mode this run
+        block_real_keychain.data[("svc", "acct")] = "x"
+        # item_exists is NOT routed through _kc_call, so a True result must not
+        # resurrect the keychain routing.
+        assert macos_keychain.item_exists("svc", "acct") is True
+        assert s._use_keychain() is False
+
+    def test_capability_cache_is_process_local(self, temp_home: Path):
+        s1 = self._macos_switcher()
+        s1._keychain_usable_cache = False
+        assert s1._use_keychain() is False
+        # A fresh instance starts unknown and is optimistic again.
+        s2 = self._macos_switcher()
+        assert s2._keychain_usable_cache is None
+        assert s2._use_keychain() is True
+
+    def test_kc_call_propagates_programming_errors(self, temp_home: Path):
+        # A bug (not a keychain failure) must propagate and leave the cache
+        # untouched — it is not evidence the Keychain is unusable.
+        s = self._macos_switcher()
+
+        def boom(*a, **k):
+            raise TypeError("bug")
+
+        with pytest.raises(TypeError):
+            s._kc_call(boom)
+        assert s._keychain_usable_cache is None
+
+    def test_active_write_does_not_swallow_programming_errors(
+        self, temp_home: Path, monkeypatch
+    ):
+        # The narrowed fallback catch must let a real bug surface, not silently
+        # route to file storage with the cache still claiming "usable".
+        s = self._macos_switcher()
+
+        def boom(*a, **k):
+            raise TypeError("bug")
+
+        monkeypatch.setattr(macos_keychain, "set_password", boom)
+        with pytest.raises(TypeError):
+            s._write_credentials('{"x":1}')
+
+    # -- active store -----------------------------------------------------
+
+    def test_active_write_keys_keychain_by_account_name(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        monkeypatch.delenv("USER", raising=False)
+        s = self._macos_switcher()
+        s._write_credentials('{"x":1}')
+        acct = macos_keychain.keychain_account_name()
+        assert (CLAUDE_CODE_KEYCHAIN_SERVICE, acct) in block_real_keychain.data
+        # Never the legacy "user" default that mismatches Claude Code headless.
+        assert (CLAUDE_CODE_KEYCHAIN_SERVICE, "user") not in block_real_keychain.data
+        assert s._last_active_credentials_backend == "keychain"
+
+    def test_active_read_prefers_keychain_then_file(
+        self, temp_home: Path, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        acct = macos_keychain.keychain_account_name()
+        block_real_keychain.data[(CLAUDE_CODE_KEYCHAIN_SERVICE, acct)] = "FROM-KC"
+        cred = get_credentials_path()
+        cred.parent.mkdir(parents=True, exist_ok=True)
+        cred.write_text("FROM-FILE")
+        # Keychain has data → wins (matches Claude Code's keychain-first read).
+        assert s._read_credentials() == "FROM-KC"
+        # Keychain empty → falls through to the plaintext file.
+        del block_real_keychain.data[(CLAUDE_CODE_KEYCHAIN_SERVICE, acct)]
+        assert s._read_credentials() == "FROM-FILE"
+
+    def test_active_write_falls_back_to_file_and_clears_stale_keychain(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        acct = macos_keychain.keychain_account_name()
+        # A stale keychain entry that Claude Code's keychain-first read would
+        # otherwise resurrect (#30337).
+        block_real_keychain.data[(CLAUDE_CODE_KEYCHAIN_SERVICE, acct)] = "STALE"
+        monkeypatch.setattr(macos_keychain, "set_password", _raise_locked)
+
+        s._write_credentials('{"fresh":1}')
+
+        assert s._last_active_credentials_backend == "file"
+        assert get_credentials_path().read_text() == '{"fresh":1}'
+        assert (CLAUDE_CODE_KEYCHAIN_SERVICE, acct) not in block_real_keychain.data
+
+    def test_keychain_write_leaves_existing_file_untouched(
+        self, temp_home: Path, block_real_keychain
+    ):
+        # #1414: cswap must not delete a plaintext file it can't prove is its own.
+        s = self._macos_switcher()
+        cred = get_credentials_path()
+        cred.parent.mkdir(parents=True, exist_ok=True)
+        cred.write_text("PRESERVE-ME")
+        s._write_credentials('{"fresh":1}')  # keychain usable → writes keychain
+        assert s._last_active_credentials_backend == "keychain"
+        assert cred.read_text() == "PRESERVE-ME"
+
+    # -- backup store: .enc-wins -----------------------------------------
+
+    def _no_session(self, s):
+        return (
+            patch.object(s, "_live_session_pids", return_value=[]),
+            patch.object(s, "_invalidate_session_credentials"),
+        )
+
+    def test_backup_read_enc_wins_over_stale_keychain(
+        self, temp_home: Path, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        s._kc_write_backup("1", "a@example.com", "STALE-KC")
+        s._write_backup_enc("1", "a@example.com", "FRESH-FILE")
+        assert s._read_account_credentials("1", "a@example.com") == "FRESH-FILE"
+
+    def test_backup_keychain_write_deletes_enc(
+        self, temp_home: Path, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        s._write_backup_enc("1", "a@example.com", "OLD-FILE")
+        p1, p2 = self._no_session(s)
+        with p1, p2:
+            s._write_account_credentials("1", "a@example.com", "NEW-KC")
+        assert not s._backup_enc_path("1", "a@example.com").exists()
+        assert s._read_account_credentials("1", "a@example.com") == "NEW-KC"
+
+    def test_backup_enc_unlink_failure_rewrites_fresh(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        s._write_backup_enc("1", "a@example.com", "OLD-FILE")
+        enc = s._backup_enc_path("1", "a@example.com")
+
+        orig_unlink = Path.unlink
+
+        def flaky_unlink(self_path, *a, **k):
+            if self_path == enc:
+                raise OSError("cannot unlink")
+            return orig_unlink(self_path, *a, **k)
+
+        monkeypatch.setattr(Path, "unlink", flaky_unlink)
+        p1, p2 = self._no_session(s)
+        with p1, p2:
+            s._write_account_credentials("1", "a@example.com", "NEW-KC")
+        monkeypatch.setattr(Path, "unlink", orig_unlink)
+
+        # Could not delete the .enc → it was rewritten fresh, so .enc-wins reads
+        # still return the new creds (no stale shadow).
+        assert base64.b64decode(enc.read_text()).decode() == "NEW-KC"
+        assert s._read_account_credentials("1", "a@example.com") == "NEW-KC"
+
+    def test_backup_file_mode_writes_enc_and_clears_keychain(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        s._kc_write_backup("1", "a@example.com", "STALE-KC")  # seed keychain
+        monkeypatch.setattr(macos_keychain, "set_password", _raise_locked)
+        p1, p2 = self._no_session(s)
+        with p1, p2:
+            s._write_account_credentials("1", "a@example.com", "FILE-CREDS")
+        assert s._read_account_credentials("1", "a@example.com") == "FILE-CREDS"
+        # Stale keychain copy cleared (best-effort) so it can't resurface.
+        assert (SECURITY_SERVICE, "account-1-a@example.com") not in block_real_keychain.data
+
+    @pytest.mark.parametrize("bad", ["corrupt", "", "!!!!", "   ", "\n"])
+    def test_backup_bad_enc_falls_back_to_keychain(
+        self, temp_home: Path, block_real_keychain, bad
+    ):
+        # A corrupt / empty / whitespace .enc must not shadow a valid Keychain
+        # backup. Permissive base64 would decode "!!!!"/"" to empty bytes and let
+        # the junk file "win"; validate=True + a non-empty guard prevents that.
+        s = self._macos_switcher()
+        s._kc_write_backup("1", "a@example.com", "FROM-KC")
+        s._backup_enc_path("1", "a@example.com").write_text(bad)
+        assert s._read_account_credentials("1", "a@example.com") == "FROM-KC"
+
+    def test_backup_delete_removes_both_backends(
+        self, temp_home: Path, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        s._kc_write_backup("1", "a@example.com", "KC")
+        s._write_backup_enc("1", "a@example.com", "FILE")
+        s._delete_account_credentials("1", "a@example.com")
+        assert not s._backup_enc_path("1", "a@example.com").exists()
+        assert (SECURITY_SERVICE, "account-1-a@example.com") not in block_real_keychain.data
+
+    # -- healthy-Mac no-op guard & follow-up ------------------------------
+
+    def test_healthy_mac_reads_create_no_files(
+        self, temp_home: Path, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        s._kc_write_backup("1", "a@example.com", "KC")
+        # Reading a backup must not materialize an .enc on a healthy keychain.
+        assert s._read_account_credentials("1", "a@example.com") == "KC"
+        assert not s._backup_enc_path("1", "a@example.com").exists()
+        # Reading the (absent) active credential must not create the file.
+        assert s._read_credentials() == ""
+        assert not get_credentials_path().exists()
+
+    def test_switch_followup_reflects_recorded_backend(
+        self, temp_home: Path, capsys
+    ):
+        s = self._macos_switcher()
+        s._last_active_credentials_backend = "file"
+        s._print_switch_followup()
+        assert "next message" in capsys.readouterr().out
+        s._last_active_credentials_backend = "keychain"
+        s._print_switch_followup()
+        assert "30 seconds" in capsys.readouterr().out


### PR DESCRIPTION
Addresses #60

On macOS, cswap read/wrote credentials exclusively via the login Keychain. In headless / no-GUI sessions (SSH, remote VS Code Server, CI, or a worker account whose Aqua session belongs to another user) the Keychain is unreachable, so Claude Code falls back to plaintext `~/.claude/.credentials.json` — and every cswap command failed.

This mirrors Claude Code's own per-operation fallback **automatically** (no env var, no persisted setting): the real `security` result decides usability, so cswap and Claude Code can't disagree about where the live credential lives. Both credential stores fall back together; healthy Macs are unchanged.

## What changed
- **Detection**: a per-process capability cache learned from real Keychain ops (`_kc_call` / `_use_keychain`), sticky-`False` so one invocation can't split-brain between backends; `security` calls now have a 5s timeout.
- **Active store** (`Claude Code-credentials`): keychain-first read with file fallback; on keychain-write failure, write the file and clear any stale Keychain entry (#30337); on success, leave an existing file untouched (mirrors Claude Code's container-sharing behavior, anthropics/claude-code#1414).
- **Backup store**: `.enc`-wins reads so a recovered Keychain can't shadow a newer fallback file; strict reconciliation on Keychain writes; atomic `.enc` writes; delete removes both backends.
- **Headless account-name fix**: the active store now uses the same Claude-Code `getUsername()` mirror as session mode, so a missing `$USER` no longer keys a different Keychain item.
- **Migration isolation**: the keyring→security migration uses keychain-only helpers and defers when the Keychain is down.
- `--purge` cleans both backends on macOS; the post-switch message reflects where the write actually landed.

## Notes
- Auto-detection chosen over the env-var option from #60: a forced file mode on a working-Keychain Mac would drift from Claude Code (which re-migrates the live credential back into the Keychain on login/refresh).
- One documented residual, identical to Claude Code's own best-effort dual store: if the Keychain is down at write time, the stale-Keychain delete also fails, so a Keychain that later recovers may briefly shadow the file until the next Keychain-usable write.

## Tests
536 passed, 3 skipped. New coverage: capability-cache stickiness/process-locality, the `$USER` fix, active fallback + the leave-existing-file-untouched guarantee, `.enc`-wins with corrupt/empty `.enc` fallback, programming errors propagating (not swallowed into file fallback), migration isolation, and a healthy-Mac no-op guard.