### PR TITLE
Add --json structured output (issue #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,36 @@ cswap --import backup.cswap --force          # Overwrite existing
 
 The export file is plaintext JSON. If you need encryption, pipe through your tool of choice (e.g. `cswap --export - | gpg -c > backup.gpg`).
 
+### JSON output for scripting
+
+Add `--json` to `--list`, `--status`, `--switch`, or `--switch-to` to emit a single machine-readable JSON object on stdout (human-readable notices go to stderr). Useful for scripting auto-swap and quota tracking.
+
+```bash
+cswap --list --json                 # all accounts with usage/quota
+cswap --status --json               # current active account
+cswap --switch --strategy best --json   # switch, then report the result
+cswap --switch-to 2 --json
+```
+
+<details>
+<summary>Example output & schema notes</summary>
+
+```json
+{
+  "schemaVersion": 1,
+  "activeAccountNumber": 2,
+  "accounts": [
+    { "number": 2, "email": "you@example.com", "active": true, "usageStatus": "ok",
+      "usage": { "fiveHour": { "pct": 25.0, "resetsAt": "2026-06-22T23:29:59Z" },
+                 "sevenDay": { "pct": 16.0, "resetsAt": "2026-06-26T17:59:59Z" } } }
+  ]
+}
+```
+
+Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
+
+</details>
+
 ### Add an account from a raw OAuth token
 
 If you only have a long-lived setup-token (e.g., produced by `claude setup-token`)

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 
 from claude_swap import __version__
 from claude_swap.exceptions import ClaudeSwitchError
+from claude_swap.json_output import error_envelope
 from claude_swap.printer import dimmed, error, muted
 from claude_swap.switcher import ClaudeAccountSwitcher
 
@@ -139,6 +141,14 @@ Examples:
         help="Show OAuth token expiry state (use with --list)",
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit machine-readable JSON to stdout (use with --list, --status, "
+            "--switch, or --switch-to). See README 'JSON output for scripting'."
+        ),
+    )
+    parser.add_argument(
         "--strategy",
         choices=["best", "next-available"],
         metavar="{best,next-available}",
@@ -252,6 +262,16 @@ Examples:
     if args.token_status and not args.list:
         parser.error("--token-status can only be used with --list")
 
+    if args.json and not (args.list or args.status or args.switch or args.switch_to):
+        parser.error(
+            "--json can only be used with --list, --status, --switch, or --switch-to"
+        )
+
+    if args.json and args.token_status:
+        # Token status is not part of the JSON v1 schema; reject rather than
+        # silently ignore it (a future additive field can add it).
+        parser.error("--token-status cannot be combined with --json")
+
     if args.strategy is not None and not args.switch:
         parser.error("--strategy can only be used with --switch")
 
@@ -285,6 +305,9 @@ Examples:
     # init-time failures (e.g. MigrationError on a backup-dir collision)
     # are presented like every other ClaudeSwitchError: clean stderr line,
     # exit 1, no traceback.
+    # JSON-capable commands return a payload; the CLI is the single point that
+    # serializes it (so no command writes JSON to stdout itself).
+    payload: dict | None = None
     try:
         switcher = ClaudeAccountSwitcher(debug=args.debug)
 
@@ -305,15 +328,16 @@ Examples:
         elif args.remove_account:
             switcher.remove_account(args.remove_account)
         elif args.list:
-            switcher.list_accounts(
+            payload = switcher.list_accounts(
                 show_token_status=args.token_status,
+                json_output=args.json,
             )
         elif args.switch:
-            switcher.switch(strategy=args.strategy)
+            payload = switcher.switch(strategy=args.strategy, json_output=args.json)
         elif args.switch_to:
-            switcher.switch_to(args.switch_to)
+            payload = switcher.switch_to(args.switch_to, json_output=args.json)
         elif args.status:
-            switcher.status()
+            payload = switcher.status(json_output=args.json)
         elif args.purge:
             switcher.purge()
         elif args.export:
@@ -335,17 +359,30 @@ Examples:
                 sys.exit(1)
             sys.exit(tui_run(switcher))
     except ClaudeSwitchError as e:
-        error(f"Error: {e}")
+        # In JSON mode keep stdout pure JSON: emit the structured error envelope
+        # there (exit 1) instead of a red stderr line.
+        if args.json:
+            print(json.dumps(error_envelope(e), indent=2))
+        else:
+            error(f"Error: {e}")
         sys.exit(1)
     except KeyboardInterrupt:
-        print(f"\n{dimmed('Operation cancelled')}")
+        # Route the cancellation note to stderr in JSON mode so stdout stays
+        # parseable (the guarantee covers completion / handled errors, not Ctrl-C).
+        print(
+            f"\n{dimmed('Operation cancelled')}",
+            file=sys.stderr if args.json else sys.stdout,
+        )
         sys.exit(130)
+
+    if args.json and payload is not None:
+        print(json.dumps(payload, indent=2))
 
     # Passive update notification (never fails). Skipped after --purge so we
     # don't immediately recreate <backup_root>/cache/update_check.json inside
     # the directory we just deleted. Skipped after --upgrade as a safety guard
     # in case the dispatch is later refactored to fall through.
-    if not args.purge and not args.upgrade:
+    if not args.purge and not args.upgrade and not args.json:
         from claude_swap.update_check import check_for_update
 
         msg = check_for_update(__version__)

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -1,0 +1,101 @@
+"""Serialization helpers for ``--json`` structured output.
+
+Centralizes the schema-v1 shapes so ``--list``/``--status``/``--switch`` agree on
+field names (camelCase, matching the export envelope in transfer.py) and on how the
+internal usage dict is projected to JSON. Callers build payloads here; the CLI does
+the single ``json.dumps`` (see cli.py).
+"""
+
+from __future__ import annotations
+
+# Bump only on a breaking change to any payload shape. Scripts key off this.
+SCHEMA_VERSION = 1
+
+
+def _window_to_json(entry: dict) -> dict:
+    """Project a 5h/7d usage window to JSON, preserving raw ``resetsAt``."""
+    out: dict = {"pct": entry["pct"]}
+    if "resets_at" in entry:
+        out["resetsAt"] = entry["resets_at"]
+    if "countdown" in entry:
+        out["countdown"] = entry["countdown"]
+    if "clock" in entry:
+        out["clock"] = entry["clock"]
+    return out
+
+
+def usage_to_json(usage: dict) -> dict:
+    """Convert the internal usage dict to its camelCase JSON projection.
+
+    Sub-keys are emitted only when present in the source (the API does not always
+    return every window or pay-as-you-go spend).
+    """
+    out: dict = {}
+    if "five_hour" in usage:
+        out["fiveHour"] = _window_to_json(usage["five_hour"])
+    if "seven_day" in usage:
+        out["sevenDay"] = _window_to_json(usage["seven_day"])
+    if "spend" in usage:
+        spend = usage["spend"]
+        spend_out: dict = {
+            "used": spend["used"],
+            "limit": spend["limit"],
+            "pct": spend["pct"],
+            "currency": spend["currency"],
+        }
+        if "resets_at" in spend:
+            spend_out["resetsAt"] = spend["resets_at"]
+        if "countdown" in spend:
+            spend_out["countdown"] = spend["countdown"]
+        if "clock" in spend:
+            spend_out["clock"] = spend["clock"]
+        out["spend"] = spend_out
+    return out
+
+
+def usage_fields(entry: dict | str | None) -> tuple[str, dict | None]:
+    """Map a collected usage entry to ``(usageStatus, usage|None)``.
+
+    ``_collect_usage`` yields one of: a usage dict, the string ``"no credentials"``,
+    or ``None`` (fetch failed).
+    """
+    if isinstance(entry, dict):
+        return "ok", usage_to_json(entry)
+    if isinstance(entry, str):
+        return "no_credentials", None
+    return "unavailable", None
+
+
+def account_ref(number: int | None, email: str) -> dict:
+    """A minimal account reference, used for switch ``from``/``to``."""
+    return {"number": number, "email": email}
+
+
+def account_row(
+    number: int,
+    email: str,
+    org_name: str,
+    org_uuid: str,
+    active: bool,
+    usage_entry: dict | str | None,
+) -> dict:
+    """A full account row for ``--list``."""
+    status, usage = usage_fields(usage_entry)
+    return {
+        "number": number,
+        "email": email,
+        "organizationName": org_name,
+        "organizationUuid": org_uuid,
+        "isOrganization": bool(org_uuid),
+        "active": active,
+        "usageStatus": status,
+        "usage": usage,
+    }
+
+
+def error_envelope(exc: Exception) -> dict:
+    """The structured error payload emitted on a handled ClaudeSwitchError."""
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "error": {"type": type(exc).__name__, "message": str(exc)},
+    }

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -168,6 +168,7 @@ def build_usage_result(data: dict) -> dict | None:
     if h5:
         h5_entry = {"pct": h5["utilization"]}
         if h5.get("resets_at"):
+            h5_entry["resets_at"] = h5["resets_at"]
             h5_entry["countdown"], h5_entry["clock"] = format_reset(h5["resets_at"])
         result["five_hour"] = h5_entry
 
@@ -175,6 +176,7 @@ def build_usage_result(data: dict) -> dict | None:
     if d7:
         d7_entry = {"pct": d7["utilization"]}
         if d7.get("resets_at"):
+            d7_entry["resets_at"] = d7["resets_at"]
             d7_entry["countdown"], d7_entry["clock"] = format_reset(d7["resets_at"])
         result["seven_day"] = d7_entry
 
@@ -196,6 +198,7 @@ def build_usage_result(data: dict) -> dict | None:
                     "currency": eu.get("currency", "USD"),
                 }
                 if eu.get("resets_at"):
+                    spend_entry["resets_at"] = eu["resets_at"]
                     spend_entry["countdown"], spend_entry["clock"] = format_reset(eu["resets_at"])
                 result["spend"] = spend_entry
             except (TypeError, ValueError) as e:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -23,6 +23,12 @@ from claude_swap.exceptions import (
 )
 from claude_swap import oauth
 from claude_swap.cache import MISSING, read_cache, write_cache
+from claude_swap.json_output import (
+    SCHEMA_VERSION,
+    account_ref,
+    account_row,
+    usage_fields,
+)
 from claude_swap.credentials import (  # noqa: F401  (constants re-exported for migrations/tests)
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     SECURITY_SERVICE,
@@ -1241,18 +1247,56 @@ class ClaudeAccountSwitcher:
             return None, "exhausted"
         return None, "stay"
 
+    def _build_list_payload(
+        self,
+        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        usages: list[dict | str | None],
+    ) -> dict:
+        """Build the ``--list --json`` payload from gathered account + usage data."""
+        active_num: int | None = None
+        accounts = []
+        for (num, email, org_name, org_uuid, is_active, _), usage in zip(
+            accounts_info, usages
+        ):
+            if is_active:
+                active_num = num
+            accounts.append(
+                account_row(num, email, org_name, org_uuid, is_active, usage)
+            )
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "activeAccountNumber": active_num,
+            "accounts": accounts,
+        }
+
     def list_accounts(
         self,
         show_token_status: bool = False,
-    ) -> None:
-        """List all managed accounts."""
+        json_output: bool = False,
+    ) -> dict | None:
+        """List all managed accounts.
+
+        In ``json_output`` mode, returns the schema-v1 payload (printing nothing)
+        for the CLI to serialize; otherwise prints the human view and returns None.
+        """
         if not self.sequence_file.exists():
+            # JSON mode must never prompt — emit an empty list instead of the
+            # interactive first-run setup.
+            if json_output:
+                return {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "activeAccountNumber": None,
+                    "accounts": [],
+                }
             print(dimmed("No accounts are managed yet."))
             self._first_run_setup()
-            return
+            return None
 
         accounts_info = self._build_accounts_info()
         usages = self._collect_usage(accounts_info)
+
+        if json_output:
+            return self._build_list_payload(accounts_info, usages)
 
         print(bolded("Accounts:"))
         for i, ((num, email, org_name, org_uuid, is_active, _), usage) in enumerate(zip(accounts_info, usages)):
@@ -1312,18 +1356,90 @@ class ClaudeAccountSwitcher:
         except Exception:
             self._logger.debug("Failed to detect running instances", exc_info=True)
 
-    def status(self) -> None:
-        """Display current account status."""
+    def _active_account_usage(
+        self, account_num: str, current_email: str
+    ) -> dict | str | None:
+        """Usage for the active account as a ``_collect_usage``-style entry.
+
+        Returns ``"no credentials"`` when the live store has no usable token, a
+        usage dict on success, or ``None`` when the fetch fails. Reuses (and
+        refreshes) the same ``cache/usage.json`` list_accounts writes — cache-first,
+        fetching with ``is_active=True`` so cswap never refreshes Claude Code's live
+        credentials, and merging into existing entries so other rows survive.
+        """
+        creds = self._read_credentials() or ""
+        if not creds or not oauth.extract_access_token(creds):
+            return "no credentials"
+        usage_cache_path = self.backup_dir / "cache" / "usage.json"
+        cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
+        if (cached is not MISSING and isinstance(cached, dict)
+                and account_num in cached):
+            return cached[account_num]
+        usage = oauth.fetch_usage_for_account(
+            account_num, current_email, creds, is_active=True,
+        )
+        existing = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
+        existing[account_num] = usage
+        write_cache(usage_cache_path, existing)
+        return usage
+
+    def _build_status_payload(self) -> dict:
+        """Build the ``--status --json`` payload (no active / unmanaged / managed)."""
+        identity = self._get_current_account()
+        if identity is None:
+            return {"schemaVersion": SCHEMA_VERSION, "active": None}
+        current_email, current_org_uuid = identity
+
+        data = self._get_sequence_data_migrated()
+        if not data:
+            return {
+                "schemaVersion": SCHEMA_VERSION,
+                "active": {"email": current_email, "managed": False},
+            }
+
+        account_num = self._find_account_slot(data, current_email, current_org_uuid)
+        if not account_num:
+            return {
+                "schemaVersion": SCHEMA_VERSION,
+                "active": {"email": current_email, "managed": False},
+            }
+
+        acct = data["accounts"][account_num]
+        org_name = acct.get("organizationName", "") or ""
+        org_uuid = acct.get("organizationUuid", "") or ""
+        status, usage = usage_fields(
+            self._active_account_usage(account_num, current_email)
+        )
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "active": {
+                "number": int(account_num),
+                "email": current_email,
+                "organizationName": org_name,
+                "organizationUuid": org_uuid,
+                "isOrganization": bool(org_uuid),
+                "managed": True,
+                "usageStatus": status,
+                "usage": usage,
+            },
+            "totalManagedAccounts": len(data.get("accounts", {})),
+        }
+
+    def status(self, json_output: bool = False) -> dict | None:
+        """Display current account status (or return the schema-v1 payload)."""
+        if json_output:
+            return self._build_status_payload()
+
         identity = self._get_current_account()
         if identity is None:
             print(f"{bolded('Status:')} {dimmed('No active Claude account')}")
-            return
+            return None
         current_email, current_org_uuid = identity
 
         data = self._get_sequence_data_migrated()
         if not data:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
-            return
+            return None
 
         account_num = self._find_account_slot(data, current_email, current_org_uuid)
         org_name = ""
@@ -1338,32 +1454,15 @@ class ClaudeAccountSwitcher:
                 f"({current_email} {muted(f'[{tag}]')})"
             )
             print(f"  {dimmed(f'Total managed accounts: {total}')}")
-            creds = self._read_credentials() or ""
-            if creds and oauth.extract_access_token(creds):
-                # Reuse the cache list_accounts writes (cache-first). On miss,
-                # fetch with is_active=True (Claude Code owns active credentials,
-                # cswap must not refresh them) and merge into existing entries so
-                # other accounts' rows survive.
-                usage_cache_path = self.backup_dir / "cache" / "usage.json"
-                cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
-                if (cached is not MISSING and isinstance(cached, dict)
-                        and account_num in cached):
-                    usage = cached[account_num]
-                else:
-                    usage = oauth.fetch_usage_for_account(
-                        account_num, current_email, creds,
-                        is_active=True,
-                    )
-                    existing = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
-                    existing[account_num] = usage
-                    write_cache(usage_cache_path, existing)
-                if isinstance(usage, dict):
-                    lines = _format_usage_lines(usage)
-                    for j, line in enumerate(lines):
-                        connector = "└" if j == len(lines) - 1 else "├"
-                        print(f"  {dimmed(connector)} {muted(line)}")
+            usage = self._active_account_usage(account_num, current_email)
+            if isinstance(usage, dict):
+                lines = _format_usage_lines(usage)
+                for j, line in enumerate(lines):
+                    connector = "└" if j == len(lines) - 1 else "├"
+                    print(f"  {dimmed(connector)} {muted(line)}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
+        return None
 
     def _first_run_setup(self) -> None:
         """First-run setup workflow."""
@@ -1384,7 +1483,68 @@ class ClaudeAccountSwitcher:
 
         self.add_account()
 
-    def switch(self, strategy: str | None = None) -> None:
+    def _switch_result_from_op(
+        self, op: dict, strategy: str, extra_warnings: list[str] | None = None
+    ) -> dict:
+        """Build a switch result from a ``_perform_switch`` return value.
+
+        ``switched`` is derived from whether the live identity actually changed
+        (``from != to``) — covering recorded/live drift in plain rotation, not just
+        ``switch_to`` onto the already-active account.
+        """
+        from_ref = op["from"]
+        to_ref = op["to"]
+        switched = from_ref != to_ref
+        if switched:
+            reason = "switched"
+            message = f"Switched to Account-{to_ref['number']} ({to_ref['email']})"
+        else:
+            reason = "already-active"
+            message = f"Already on Account-{to_ref['number']} ({to_ref['email']})"
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "switched": switched,
+            "from": from_ref,
+            "to": to_ref,
+            "strategy": strategy,
+            "reason": reason,
+            "message": message,
+            "warnings": (extra_warnings or []) + op["warnings"],
+        }
+
+    def _switch_noop(
+        self,
+        *,
+        strategy: str,
+        reason: str,
+        message: str,
+        from_ref: dict | None = None,
+        to_ref: dict | None = None,
+        warnings: list[str] | None = None,
+    ) -> dict:
+        """Build a no-op switch result (``switched: false``).
+
+        For a no-op the user neither left nor arrived anywhere — ``from`` and
+        ``to`` are both the current account. Callers pass ``to_ref`` (where they
+        stayed); ``from_ref`` defaults to it so every ``switched: false`` payload
+        reports ``from == to``.
+        """
+        if from_ref is None:
+            from_ref = to_ref
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "switched": False,
+            "from": from_ref,
+            "to": to_ref,
+            "strategy": strategy,
+            "reason": reason,
+            "message": message,
+            "warnings": warnings or [],
+        }
+
+    def switch(
+        self, strategy: str | None = None, json_output: bool = False
+    ) -> dict | None:
         """Switch to next account in sequence.
 
         Args:
@@ -1402,6 +1562,9 @@ class ClaudeAccountSwitcher:
         normal path (a live Claude login present); the fresh-machine path (no
         live login, e.g. right after --import) ignores them.
         """
+        strategy_label = strategy if strategy in ("best", "next-available") else "rotation"
+        warnings: list[str] = []
+
         if not self.sequence_file.exists():
             raise ConfigError("No accounts are managed yet")
 
@@ -1426,11 +1589,16 @@ class ClaudeAccountSwitcher:
 
             target = str(preferred)
             if not self._account_is_switchable(target):
-                print(
-                    f"{accent('Skipping')} Account-{target} "
-                    f"(no stored credentials/config, re-add with "
-                    f"cswap --add-account --slot {target})"
-                )
+                if json_output:
+                    warnings.append(
+                        f"Skipped Account-{target} (no stored credentials/config)"
+                    )
+                else:
+                    print(
+                        f"{accent('Skipping')} Account-{target} "
+                        f"(no stored credentials/config, re-add with "
+                        f"cswap --add-account --slot {target})"
+                    )
                 fallback = next(
                     (str(num) for num in sequence
                      if str(num) != target and self._account_is_switchable(str(num))),
@@ -1442,27 +1610,49 @@ class ClaudeAccountSwitcher:
                         "Re-add a slot with: cswap --add-account --slot <number>"
                     )
                 target = fallback
-            self._perform_switch(target)
-            return
+            op = self._perform_switch(target, emit_output=not json_output)
+            return (
+                self._switch_result_from_op(op, strategy_label, warnings)
+                if json_output else None
+            )
 
         current_email, current_org_uuid = identity
 
         # Check if current account is managed
         if not self._account_exists(current_email, current_org_uuid):
+            # In JSON mode, don't silently auto-add (a surprising side effect in
+            # automation) — report it as a structured no-op instead.
+            if json_output:
+                ref = account_ref(None, current_email)
+                return self._switch_noop(
+                    strategy=strategy_label,
+                    reason="unmanaged-account",
+                    from_ref=ref,
+                    to_ref=ref,
+                    message="Active account is not managed; run cswap --add-account",
+                )
             print(f"{accent('Notice:')} Active account '{current_email}' was not managed.")
             self.add_account()
             data = self._get_sequence_data()
             account_num = data.get("activeAccountNumber")
             print(f"It has been automatically added as Account-{account_num}.")
             print(dimmed("Please run the switch command again to switch to the next account."))
-            return
+            return None
 
         data = self._get_sequence_data()
         sequence = data.get("sequence", [])
 
         if len(sequence) < 2:
+            if json_output:
+                num = self._find_account_slot(data, current_email, current_org_uuid)
+                return self._switch_noop(
+                    strategy=strategy_label,
+                    reason="only-one-account",
+                    to_ref=account_ref(int(num), current_email) if num else None,
+                    message="Only one account is managed. Add more accounts to switch between.",
+                )
             print(dimmed("Only one account is managed. Add more accounts to switch between."))
-            return
+            return None
 
         active_account = data.get("activeAccountNumber")
         # Where the user actually is right now (live identity), falling back to
@@ -1472,44 +1662,96 @@ class ClaudeAccountSwitcher:
         if current_num is None:
             current_num = str(active_account) if active_account is not None else None
 
+        current_ref = (
+            account_ref(int(current_num), current_email) if current_num else None
+        )
+
         # Usage-aware "jump to most headroom". Only switches when another
         # account is provably better; otherwise stays put (never moves onto a
         # worse or unverifiable account). Bare `cswap --switch` rotates anyway.
         if strategy == "best":
             target, note = self._select_best_switchable(current_num)
             if target is not None:
-                self._perform_switch(target)
-                return
+                op = self._perform_switch(target, emit_output=not json_output)
+                return (
+                    self._switch_result_from_op(op, strategy_label, warnings)
+                    if json_output else None
+                )
             if note == "current-unavailable":
+                if json_output:
+                    return self._switch_noop(
+                        strategy=strategy_label, reason="usage-unavailable",
+                        to_ref=current_ref,
+                        message=(
+                            f"Current account usage is unavailable — staying on "
+                            f"Account-{current_num}."
+                        ),
+                    )
                 print(dimmed(
                     f"Current account usage is unavailable — staying on "
                     f"Account-{current_num}. Run cswap --switch to rotate."
                 ))
-                return
+                return None
             if note == "no-comparison":
+                if json_output:
+                    return self._switch_noop(
+                        strategy=strategy_label, reason="usage-unavailable",
+                        to_ref=current_ref,
+                        message=(
+                            f"No other account has usage data to compare — staying "
+                            f"on Account-{current_num}."
+                        ),
+                    )
                 print(dimmed(
                     f"No other account has usage data to compare — staying on "
                     f"Account-{current_num}. Run cswap --switch to rotate."
                 ))
-                return
+                return None
             if note == "incomplete-comparison":
+                if json_output:
+                    return self._switch_noop(
+                        strategy=strategy_label, reason="usage-unavailable",
+                        to_ref=current_ref,
+                        message=(
+                            f"No account with known usage has more remaining quota; "
+                            f"some usage is unavailable — staying on Account-{current_num}."
+                        ),
+                    )
                 print(dimmed(
                     f"No account with known usage has more remaining quota; some "
                     f"usage is unavailable — staying on Account-{current_num}."
                 ))
-                return
+                return None
             if note == "stay":
+                if json_output:
+                    return self._switch_noop(
+                        strategy=strategy_label, reason="already-best",
+                        to_ref=current_ref,
+                        message=(
+                            f"Already on the account with the most remaining quota "
+                            f"(Account-{current_num})."
+                        ),
+                    )
                 print(
                     f"{accent('Already on the account with the most remaining quota')} "
                     f"(Account-{current_num})."
                 )
-                return
+                return None
             if note == "exhausted":
+                if json_output:
+                    return self._switch_noop(
+                        strategy=strategy_label, reason="candidates-exhausted",
+                        to_ref=current_ref,
+                        message=(
+                            f"All accounts are at their 5h/7d limit — staying on "
+                            f"Account-{current_num}."
+                        ),
+                    )
                 warning(
                     f"All accounts are at their 5h/7d limit — staying on "
                     f"Account-{current_num}."
                 )
-                return
+                return None
             # note == "none": fall through; rotation reports the lack of targets.
 
         # Find current index and get next, skipping broken candidates.
@@ -1539,17 +1781,27 @@ class ClaudeAccountSwitcher:
         for offset in range(1, len(sequence)):
             candidate = str(sequence[(current_index + offset) % len(sequence)])
             if not self._account_is_switchable(candidate):
-                print(
-                    f"{accent('Skipping')} Account-{candidate} "
-                    f"(no stored credentials/config, re-add with "
-                    f"cswap --add-account --slot {candidate})"
-                )
+                if json_output:
+                    warnings.append(
+                        f"Skipped Account-{candidate} (no stored credentials/config)"
+                    )
+                else:
+                    print(
+                        f"{accent('Skipping')} Account-{candidate} "
+                        f"(no stored credentials/config, re-add with "
+                        f"cswap --add-account --slot {candidate})"
+                    )
                 continue
             if strategy == "next-available":
                 headroom = oauth.account_headroom(usage.get(candidate))
                 if headroom is not None and headroom <= 0:
                     skipped_exhausted.append(candidate)
-                    print(f"{accent('Skipping')} Account-{candidate} (at 5h/7d limit)")
+                    if json_output:
+                        warnings.append(
+                            f"Skipped Account-{candidate} (at 5h/7d limit)"
+                        )
+                    else:
+                        print(f"{accent('Skipping')} Account-{candidate} (at 5h/7d limit)")
                     continue
             next_account = candidate
             break
@@ -1557,22 +1809,43 @@ class ClaudeAccountSwitcher:
         # Every rotation target is at its limit. Switching onto an exhausted
         # account would not help, so stay on the current one instead.
         if next_account is None and skipped_exhausted:
+            if json_output:
+                return self._switch_noop(
+                    strategy=strategy_label, reason="candidates-exhausted",
+                    to_ref=current_ref, warnings=warnings,
+                    message=(
+                        f"All other accounts are at their 5h/7d limit — staying on "
+                        f"Account-{current_num}."
+                    ),
+                )
             warning(
                 f"All other accounts are at their 5h/7d limit — staying on "
                 f"Account-{current_num}."
             )
-            return
+            return None
 
         if next_account is None:
+            if json_output:
+                return self._switch_noop(
+                    strategy=strategy_label, reason="no-valid-target",
+                    to_ref=current_ref, warnings=warnings,
+                    message="No other accounts have valid stored credentials/config.",
+                )
             print(dimmed(
                 "No other accounts have valid stored credentials/config.\n"
                 "Re-add a skipped slot with: cswap --add-account --slot <number>"
             ))
-            return
+            return None
 
-        self._perform_switch(next_account)
+        op = self._perform_switch(next_account, emit_output=not json_output)
+        return (
+            self._switch_result_from_op(op, strategy_label, warnings)
+            if json_output else None
+        )
 
-    def switch_to(self, identifier: str) -> None:
+    def switch_to(
+        self, identifier: str, json_output: bool = False
+    ) -> dict | None:
         """Switch to specific account."""
         if not self.sequence_file.exists():
             raise ConfigError("No accounts are managed yet")
@@ -1585,27 +1858,31 @@ class ClaudeAccountSwitcher:
             if not self._validate_email(identifier):
                 raise ValidationError(f"Invalid email format: {identifier}")
 
-            # For email identifiers, handle ambiguous matches interactively
-            data = self._get_sequence_data()
-            matches = [
-                num for num, acc in (data or {}).get("accounts", {}).items()
-                if acc.get("email") == identifier
-            ]
-            if len(matches) > 1:
-                print(f"Multiple accounts found for '{identifier}':")
-                for num in matches:
-                    acc = data["accounts"][num]
-                    tag = self._get_display_tag(
-                        acc.get("email", ""),
-                        acc.get("organizationName", ""),
-                        acc.get("organizationUuid", ""),
-                    )
-                    print(f"  {num}: {identifier} {muted(f'[{tag}]')}")
-                choice = input("Enter account number to switch to: ").strip()
-                if not choice.isdigit() or choice not in matches:
-                    print(dimmed("Cancelled"))
-                    return
-                identifier = choice
+            # For email identifiers, handle ambiguous matches interactively —
+            # except in JSON mode, where we never prompt. There we fall through
+            # to _resolve_account_identifier, which raises a ConfigError listing
+            # the matching slots (+ org labels) → structured error envelope.
+            if not json_output:
+                data = self._get_sequence_data()
+                matches = [
+                    num for num, acc in (data or {}).get("accounts", {}).items()
+                    if acc.get("email") == identifier
+                ]
+                if len(matches) > 1:
+                    print(f"Multiple accounts found for '{identifier}':")
+                    for num in matches:
+                        acc = data["accounts"][num]
+                        tag = self._get_display_tag(
+                            acc.get("email", ""),
+                            acc.get("organizationName", ""),
+                            acc.get("organizationUuid", ""),
+                        )
+                        print(f"  {num}: {identifier} {muted(f'[{tag}]')}")
+                    choice = input("Enter account number to switch to: ").strip()
+                    if not choice.isdigit() or choice not in matches:
+                        print(dimmed("Cancelled"))
+                        return None
+                    identifier = choice
 
         target_account = self._resolve_account_identifier(identifier)
         if not target_account:
@@ -1617,14 +1894,44 @@ class ClaudeAccountSwitcher:
         if target_account not in data.get("accounts", {}):
             raise AccountNotFoundError(f"Account-{target_account} does not exist")
 
-        self._perform_switch(target_account)
+        # JSON mode: short-circuit a no-op before mutating. Re-activating the
+        # account you're already on would otherwise re-write credentials, take
+        # the lock, and (on macOS) touch the Keychain — wasteful for a scripted
+        # idempotent "ensure active = N". Human mode keeps its existing behavior.
+        if json_output and data:
+            identity = self._get_current_account()
+            if identity is not None:
+                cur_slot = self._find_account_slot(data, identity[0], identity[1])
+                if cur_slot == target_account:
+                    email = (
+                        data.get("accounts", {}).get(target_account, {}).get("email", "")
+                    )
+                    ref = account_ref(int(target_account), email)
+                    return self._switch_noop(
+                        strategy="direct",
+                        reason="already-active",
+                        from_ref=ref,
+                        to_ref=ref,
+                        message=f"Already on Account-{target_account} ({email})",
+                    )
 
-    def _perform_switch(self, target_account: str) -> None:
+        op = self._perform_switch(target_account, emit_output=not json_output)
+        return self._switch_result_from_op(op, "direct") if json_output else None
+
+    def _perform_switch(self, target_account: str, emit_output: bool = True) -> dict:
         """Perform the actual account switch with transaction support.
+
+        Returns ``{"from": ref|None, "to": ref, "warnings": [...]}``, capturing the
+        left/landed identities under the lock so callers don't reconstruct ``from``
+        after the mutation. When ``emit_output`` is False (JSON mode) all human
+        output is suppressed — the live-session warning, the "Switched"/"Activated"
+        lines, the nested list_accounts() summary and the followup — and the
+        live-session warning rides back in ``warnings`` instead.
 
         The post-switch display runs after the lock releases so that persist
         callbacks inside list_accounts() can re-acquire it.
         """
+        warnings_out: list[str] = []
         # Session-mode drift warning (warn, never block): switching the
         # default login to an account that also has a live session profile
         # puts the same refresh token in two config dirs — if the server
@@ -1636,7 +1943,7 @@ class ClaudeAccountSwitcher:
         if pre_email:
             pids = self._live_session_pids(target_account, pre_email)
             if pids:
-                warning(
+                msg = (
                     f"Account-{target_account} ({pre_email}) has a live session-mode "
                     f"Claude instance (PID {', '.join(map(str, pids))}). Running the "
                     "same account as both the default login and a session can make "
@@ -1644,12 +1951,17 @@ class ClaudeAccountSwitcher:
                     "session later fails to authenticate, exit it and re-run "
                     f"'cswap run {target_account}'."
                 )
+                if emit_output:
+                    warning(msg)
+                else:
+                    warnings_out.append(msg)
 
         with FileLock(self.lock_file):
             data = self._get_sequence_data()
             active_account = data.get("activeAccountNumber")
             current_account = str(active_account) if active_account is not None else None
             target_email = data["accounts"][target_account]["email"]
+            to_ref = account_ref(int(target_account), target_email)
             current_identity = self._get_current_account()
             if current_identity is not None:
                 current_email, current_org_uuid = current_identity
@@ -1665,6 +1977,12 @@ class ClaudeAccountSwitcher:
             # live Claude credential still exists). In both cases, skip the
             # back-up-current step so we never write account-None-* backups.
             if current_identity is None or current_account is None:
+                # Account left: None on a fresh machine (no live account at all),
+                # else the unmanaged live account (slot unknown to cswap).
+                from_ref = (
+                    None if current_identity is None
+                    else account_ref(None, current_identity[0])
+                )
                 target_creds = self._read_account_credentials(
                     target_account, target_email
                 )
@@ -1756,15 +2074,17 @@ class ClaudeAccountSwitcher:
                 self._logger.info(
                     f"Activated account {target_account} (no prior live account)"
                 )
-                print(
-                    f"{accent('Activated')} Account-{target_account} ({target_email})"
-                )
-                print()
-                self._print_switch_followup()
-                print()
-                return
+                if emit_output:
+                    print(
+                        f"{accent('Activated')} Account-{target_account} ({target_email})"
+                    )
+                    print()
+                    self._print_switch_followup()
+                    print()
+                return {"from": from_ref, "to": to_ref, "warnings": warnings_out}
 
             current_email, _ = current_identity
+            from_ref = account_ref(int(current_account), current_email)
 
             # Create transaction for rollback capability
             try:
@@ -1859,16 +2179,20 @@ class ClaudeAccountSwitcher:
                 raise
 
         # Lock released. Safe to do network I/O and let persist callbacks
-        # re-acquire the lock from inside list_accounts().
-        print(f"{accent('Switched to')} Account-{target_account} ({target_email})")
-        try:
-            self.list_accounts()
-        except Exception as e:
-            self._logger.warning(f"Post-switch usage display failed: {e!r}")
-            print(dimmed("  (usage display unavailable — run `cswap --list` to retry)"))
-        print()
-        self._print_switch_followup()
-        print()
+        # re-acquire the lock from inside list_accounts(). All of this is display
+        # only — suppressed in JSON mode (the nested list_accounts() would
+        # otherwise leak human output onto the JSON stdout).
+        if emit_output:
+            print(f"{accent('Switched to')} Account-{target_account} ({target_email})")
+            try:
+                self.list_accounts()
+            except Exception as e:
+                self._logger.warning(f"Post-switch usage display failed: {e!r}")
+                print(dimmed("  (usage display unavailable — run `cswap --list` to retry)"))
+            print()
+            self._print_switch_followup()
+            print()
+        return {"from": from_ref, "to": to_ref, "warnings": warnings_out}
 
     def _print_switch_followup(self) -> None:
         """Print the note after a successful switch, keyed to where the active

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -132,6 +133,7 @@ class TestCLI:
 
         switcher_cls.return_value.list_accounts.assert_called_once_with(
             show_token_status=True,
+            json_output=False,
         )
 
     def test_strategy_best_requires_switch(self, capsys):
@@ -168,7 +170,9 @@ class TestCLI:
              patch("claude_swap.update_check.check_for_update", return_value=None):
             cli.main()
 
-        switcher_cls.return_value.switch.assert_called_once_with(strategy="best")
+        switcher_cls.return_value.switch.assert_called_once_with(
+            strategy="best", json_output=False
+        )
 
     def test_plain_switch_passes_no_strategy(self):
         """Bare --switch forwards strategy=None."""
@@ -178,7 +182,9 @@ class TestCLI:
              patch("claude_swap.update_check.check_for_update", return_value=None):
             cli.main()
 
-        switcher_cls.return_value.switch.assert_called_once_with(strategy=None)
+        switcher_cls.return_value.switch.assert_called_once_with(
+            strategy=None, json_output=False
+        )
 
     def test_slot_flag_requires_add_account(self, capsys):
         """--slot should only be accepted alongside --add-account or --add-token."""
@@ -506,3 +512,68 @@ class TestRunCommand:
 
         assert excinfo.value.code == 1
         assert "boom" in capsys.readouterr().err
+
+
+class TestJsonOutputCli:
+    """CLI wiring for ``--json``: validation, single serialization, error envelope."""
+
+    def test_json_rejected_without_supported_command(self, capsys):
+        """--purge --json is rejected (bare --json instead hits the required-group error)."""
+        with patch.object(sys, "argv", ["claude-swap", "--purge", "--json"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+        assert "--json can only be used with" in capsys.readouterr().err
+
+    def test_token_status_with_json_rejected(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "--list", "--token-status", "--json"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+        assert "--token-status cannot be combined with --json" in capsys.readouterr().err
+
+    def test_list_json_serialized_to_stdout(self, capsys):
+        payload = {"schemaVersion": 1, "activeAccountNumber": None, "accounts": []}
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "--list", "--json"]), \
+             patch("os.geteuid", return_value=1000), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            switcher_cls.return_value.list_accounts.return_value = payload
+            cli.main()
+
+        switcher_cls.return_value.list_accounts.assert_called_once_with(
+            show_token_status=False, json_output=True,
+        )
+        out = capsys.readouterr().out
+        assert json.loads(out) == payload  # exactly one JSON object, no extra text
+
+    def test_switch_json_forwarded_and_serialized(self, capsys):
+        payload = {"schemaVersion": 1, "switched": True}
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "--switch", "--json"]), \
+             patch("os.geteuid", return_value=1000), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            switcher_cls.return_value.switch.return_value = payload
+            cli.main()
+
+        switcher_cls.return_value.switch.assert_called_once_with(
+            strategy=None, json_output=True,
+        )
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_error_envelope_on_stdout_with_exit_1(self, capsys):
+        from claude_swap.exceptions import ConfigError
+
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "--status", "--json"]), \
+             patch("os.geteuid", return_value=1000), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            switcher_cls.return_value.status.side_effect = ConfigError("nope")
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)  # error went to stdout as JSON
+        assert envelope["error"] == {"type": "ConfigError", "message": "nope"}
+        assert captured.err == ""  # nothing on stderr in JSON mode

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,0 +1,354 @@
+"""Tests for ``--json`` structured output (issue #63)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap.exceptions import ConfigError, SwitchError
+from claude_swap.json_output import (
+    SCHEMA_VERSION,
+    error_envelope,
+    usage_fields,
+    usage_to_json,
+)
+from claude_swap.models import Platform
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+# --------------------------------------------------------------------------- #
+# Serialization helpers
+# --------------------------------------------------------------------------- #
+class TestJsonHelpers:
+    def test_usage_to_json_maps_keys_and_preserves_raw_reset(self):
+        usage = {
+            "five_hour": {"pct": 25.0, "resets_at": "2026-06-22T23:00:00Z",
+                          "countdown": "4h", "clock": "02:00"},
+            "seven_day": {"pct": 16.0},
+            "spend": {"used": 12.5, "limit": 300.0, "pct": 4.0, "currency": "USD",
+                      "resets_at": "2026-07-01T00:00:00Z"},
+        }
+        out = usage_to_json(usage)
+        assert out["fiveHour"] == {
+            "pct": 25.0, "resetsAt": "2026-06-22T23:00:00Z",
+            "countdown": "4h", "clock": "02:00",
+        }
+        # seven_day had no reset → only pct, camelCased key
+        assert out["sevenDay"] == {"pct": 16.0}
+        assert out["spend"]["used"] == 12.5
+        assert out["spend"]["resetsAt"] == "2026-07-01T00:00:00Z"
+
+    def test_usage_fields_variants(self):
+        assert usage_fields({"five_hour": {"pct": 1.0}})[0] == "ok"
+        assert usage_fields({"five_hour": {"pct": 1.0}})[1] == {"fiveHour": {"pct": 1.0}}
+        assert usage_fields("no credentials") == ("no_credentials", None)
+        assert usage_fields(None) == ("unavailable", None)
+
+    def test_error_envelope_shape(self):
+        env = error_envelope(SwitchError("boom"))
+        assert env == {
+            "schemaVersion": SCHEMA_VERSION,
+            "error": {"type": "SwitchError", "message": "boom"},
+        }
+
+
+# --------------------------------------------------------------------------- #
+# --list --json
+# --------------------------------------------------------------------------- #
+class TestListJson:
+    def test_empty_list_no_prompt(self, temp_home: Path):
+        """No accounts in JSON mode returns an empty payload — never prompts."""
+        switcher = ClaudeAccountSwitcher()
+        with patch.object(switcher, "_first_run_setup") as first_run, \
+             patch("builtins.input") as fake_input:
+            payload = switcher.list_accounts(json_output=True)
+        first_run.assert_not_called()
+        fake_input.assert_not_called()
+        assert payload == {
+            "schemaVersion": SCHEMA_VERSION,
+            "activeAccountNumber": None,
+            "accounts": [],
+        }
+
+    def test_list_payload(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict, capsys,
+    ):
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
+        usage = {
+            "five_hour": {"pct": 10.0, "resets_at": "2026-01-01T00:00:00Z",
+                          "countdown": "1h", "clock": "01:00"},
+        }
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage):
+            payload = switcher.list_accounts(json_output=True)
+
+        # Method itself prints nothing — the CLI serializes.
+        assert capsys.readouterr().out == ""
+        assert payload["schemaVersion"] == SCHEMA_VERSION
+        assert payload["activeAccountNumber"] == 1  # live-resolved active slot
+        acct1 = next(a for a in payload["accounts"] if a["number"] == 1)
+        assert acct1["active"] is True
+        assert acct1["usageStatus"] == "ok"
+        assert acct1["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
+
+    def test_usage_status_no_credentials_and_unavailable(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        # Account 1 active with creds but the fetch fails (None → unavailable);
+        # account 2 has no backup creds (→ no_credentials).
+        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch.object(switcher, "_read_account_credentials", return_value=""), \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
+            payload = switcher.list_accounts(json_output=True)
+
+        by_num = {a["number"]: a for a in payload["accounts"]}
+        assert by_num[1]["usageStatus"] == "unavailable"
+        assert by_num[1]["usage"] is None
+        assert by_num[2]["usageStatus"] == "no_credentials"
+
+
+# --------------------------------------------------------------------------- #
+# --status --json
+# --------------------------------------------------------------------------- #
+class TestStatusJson:
+    def test_status_no_active(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        assert switcher.status(json_output=True) == {
+            "schemaVersion": SCHEMA_VERSION,
+            "active": None,
+        }
+
+    def test_status_unmanaged(self, temp_home: Path, mock_claude_config: Path):
+        switcher = ClaudeAccountSwitcher()
+        payload = switcher.status(json_output=True)
+        assert payload["active"] == {"email": "test@example.com", "managed": False}
+
+    def test_status_managed(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict, capsys,
+    ):
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        usage = {"five_hour": {"pct": 25.0, "resets_at": "2026-01-01T00:00:00Z",
+                               "countdown": "1h", "clock": "01:00"}}
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage):
+            payload = switcher.status(json_output=True)
+
+        assert capsys.readouterr().out == ""
+        active = payload["active"]
+        assert active["number"] == 1
+        assert active["managed"] is True
+        assert active["usageStatus"] == "ok"
+        assert active["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
+        assert payload["totalManagedAccounts"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# --switch / --switch-to --json
+# --------------------------------------------------------------------------- #
+def _two_account_stores(temp_home: Path, sample_sequence_data: dict):
+    """Switcher with accounts 1 (active) & 2, backed by in-memory cred/config stores."""
+    sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+    switcher = ClaudeAccountSwitcher()
+    switcher._setup_directories()
+    switcher.platform = Platform.LINUX
+    switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+    live_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-1", "refreshToken": "rt-1"}})
+    (temp_home / ".claude" / ".credentials.json").write_text(live_creds)
+
+    creds_store = {
+        ("1", "test@example.com"): live_creds,
+        ("2", "account2@example.com"): json.dumps(
+            {"claudeAiOauth": {"accessToken": "sk-2", "refreshToken": "rt-2"}}
+        ),
+    }
+    configs_store = {
+        ("1", "test@example.com"): json.dumps(
+            {"oauthAccount": {"emailAddress": "test@example.com", "accountUuid": "test-uuid-1234"}}
+        ),
+        ("2", "account2@example.com"): json.dumps(
+            {"oauthAccount": {"emailAddress": "account2@example.com", "accountUuid": "uuid-2"}}
+        ),
+    }
+    return switcher, creds_store, configs_store, {"creds": live_creds}
+
+
+def _install_patches(switcher, creds_store, configs_store, live_state):
+    patches = [
+        patch.object(switcher, "_read_account_credentials",
+                     side_effect=lambda n, e: creds_store.get((str(n), e), "")),
+        patch.object(switcher, "_write_account_credentials",
+                     side_effect=lambda n, e, c: creds_store.__setitem__((str(n), e), c)),
+        patch.object(switcher, "_read_account_config",
+                     side_effect=lambda n, e: configs_store.get((str(n), e), "")),
+        patch.object(switcher, "_write_account_config",
+                     side_effect=lambda n, e, c: configs_store.__setitem__((str(n), e), c)),
+        patch.object(switcher, "_read_credentials",
+                     side_effect=lambda: live_state.get("creds", "")),
+        patch.object(switcher, "_write_credentials",
+                     side_effect=lambda c: live_state.__setitem__("creds", c)),
+        # Don't make network calls from the (suppressed) post-switch usage path.
+        patch("claude_swap.oauth.fetch_usage_for_account", return_value=None),
+    ]
+    for p in patches:
+        p.start()
+    return patches
+
+
+class TestSwitchJson:
+    def test_switch_to_result_no_leakage(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict, capsys,
+    ):
+        switcher, creds, configs, live = _two_account_stores(temp_home, sample_sequence_data)
+        patches = _install_patches(switcher, creds, configs, live)
+        try:
+            result = switcher.switch_to("2", json_output=True)
+        finally:
+            for p in patches:
+                p.stop()
+
+        # No human output leaked onto stdout — the method only returns the dict.
+        assert capsys.readouterr().out == ""
+        assert result["switched"] is True
+        assert result["strategy"] == "direct"
+        assert result["reason"] == "switched"
+        assert result["from"] == {"number": 1, "email": "test@example.com"}
+        assert result["to"] == {"number": 2, "email": "account2@example.com"}
+        assert result["warnings"] == []
+
+    def test_switch_to_already_active_short_circuits(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        """--switch-to onto the active account is a no-op: no mutation at all."""
+        switcher, creds, configs, live = _two_account_stores(temp_home, sample_sequence_data)
+        patches = _install_patches(switcher, creds, configs, live)
+        try:
+            with patch.object(switcher, "_perform_switch") as perform:
+                result = switcher.switch_to("1", json_output=True)
+        finally:
+            for p in patches:
+                p.stop()
+        perform.assert_not_called()  # short-circuited before any write
+        assert result["switched"] is False
+        assert result["reason"] == "already-active"
+        assert result["from"] == result["to"] == {"number": 1, "email": "test@example.com"}
+
+    def test_noop_from_equals_to(
+        self, temp_home: Path, mock_claude_config: Path,
+    ):
+        """Every switched:false payload reports from == to (the current account)."""
+        single = {
+            "activeAccountNumber": 1,
+            "lastUpdated": "2024-01-01T00:00:00Z",
+            "sequence": [1],
+            "accounts": {"1": {"email": "test@example.com", "uuid": "u1",
+                               "added": "2024-01-01T00:00:00Z"}},
+        }
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, single)
+        result = switcher.switch(json_output=True)
+        assert result["switched"] is False
+        assert result["from"] == result["to"] == {"number": 1, "email": "test@example.com"}
+
+    def test_switch_to_from_unmanaged_account(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        """Current live account unmanaged → --switch-to proceeds, from.number is null."""
+        # Managed accounts use other emails; the live account (test@example.com)
+        # is not among them.
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher.platform = Platform.LINUX
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+        live_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-x"}})
+        (temp_home / ".claude" / ".credentials.json").write_text(live_creds)
+        creds = {("2", "account2@example.com"): json.dumps(
+            {"claudeAiOauth": {"accessToken": "sk-2"}})}
+        configs = {("2", "account2@example.com"): json.dumps(
+            {"oauthAccount": {"emailAddress": "account2@example.com", "accountUuid": "uuid-2"}})}
+        patches = _install_patches(switcher, creds, configs, {"creds": live_creds})
+        try:
+            result = switcher.switch_to("2", json_output=True)
+        finally:
+            for p in patches:
+                p.stop()
+        assert result["switched"] is True
+        assert result["from"] == {"number": None, "email": "test@example.com"}
+        assert result["to"]["number"] == 2
+
+    def test_switch_to_ambiguous_email_raises(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data_with_org: dict,
+    ):
+        """Ambiguous email in JSON mode raises (no interactive prompt)."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data_with_org)
+        with patch("builtins.input") as fake_input:
+            with pytest.raises(ConfigError, match="ambiguous"):
+                switcher.switch_to("user@example.com", json_output=True)
+        fake_input.assert_not_called()
+
+    def test_switch_only_one_account(
+        self, temp_home: Path, mock_claude_config: Path,
+    ):
+        single = {
+            "activeAccountNumber": 1,
+            "lastUpdated": "2024-01-01T00:00:00Z",
+            "sequence": [1],
+            "accounts": {"1": {"email": "test@example.com", "uuid": "u1",
+                               "added": "2024-01-01T00:00:00Z"}},
+        }
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, single)
+        result = switcher.switch(json_output=True)
+        assert result["switched"] is False
+        assert result["reason"] == "only-one-account"
+
+    def test_switch_unmanaged_account_is_noop_without_add(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        """Plain --switch from an unmanaged account: structured no-op, no auto-add."""
+        # Live account (test@example.com) not in the managed set.
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+        with patch.object(switcher, "add_account") as add:
+            result = switcher.switch(json_output=True)
+        add.assert_not_called()
+        assert result["switched"] is False
+        assert result["reason"] == "unmanaged-account"
+        assert result["from"] == {"number": None, "email": "test@example.com"}


### PR DESCRIPTION
Adds a `--json` flag to `--list`, `--status`, `--switch`, and `--switch-to` that emits a single versioned JSON object on stdout for scripting auto-swap and quota tracking. Addresses #63. 

```bash
cswap --list --json                     # all accounts with usage/quota
cswap --status --json                   # current active account
cswap --switch --strategy best --json   # switch, then report the result
cswap --switch-to 2 --json
```

```json
{ "schemaVersion": 1, "switched": true,
  "from": { "number": 3, "email": "a@example.com" },
  "to":   { "number": 2, "email": "b@example.com" },
  "strategy": "best", "reason": "switched", "warnings": [] }
```