### PR TITLE
Refresh active account token in --list/--status when safe

### DIFF
--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -11,6 +11,12 @@ from __future__ import annotations
 # Bump only on a breaking change to any payload shape. Scripts key off this.
 SCHEMA_VERSION = 1
 
+# Sentinel entries that ``_collect_usage`` / ``_fetch_active_usage`` yield in place
+# of a usage dict. Kept here (the serialization hub) so the human renderer and the
+# JSON projection agree instead of scattering raw strings.
+USAGE_NO_CREDENTIALS = "no credentials"
+USAGE_TOKEN_EXPIRED = "token expired"
+
 
 def _window_to_json(entry: dict) -> dict:
     """Project a 5h/7d usage window to JSON, preserving raw ``resetsAt``."""
@@ -56,11 +62,14 @@ def usage_to_json(usage: dict) -> dict:
 def usage_fields(entry: dict | str | None) -> tuple[str, dict | None]:
     """Map a collected usage entry to ``(usageStatus, usage|None)``.
 
-    ``_collect_usage`` yields one of: a usage dict, the string ``"no credentials"``,
-    or ``None`` (fetch failed).
+    A collected entry is one of: a usage dict, the ``USAGE_TOKEN_EXPIRED`` sentinel
+    (active token expired while Claude Code owns it), the ``USAGE_NO_CREDENTIALS``
+    sentinel, or ``None`` (fetch failed).
     """
     if isinstance(entry, dict):
         return "ok", usage_to_json(entry)
+    if entry == USAGE_TOKEN_EXPIRED:
+        return "token_expired", None
     if isinstance(entry, str):
         return "no_credentials", None
     return "unavailable", None

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -25,6 +25,8 @@ from claude_swap import oauth
 from claude_swap.cache import MISSING, read_cache, write_cache
 from claude_swap.json_output import (
     SCHEMA_VERSION,
+    USAGE_NO_CREDENTIALS,
+    USAGE_TOKEN_EXPIRED,
     account_ref,
     account_row,
     usage_fields,
@@ -1129,6 +1131,106 @@ class ClaudeAccountSwitcher:
             accounts_info.append((num, email, org_name, org_uuid, is_active, creds))
         return accounts_info
 
+    def _active_cc_running(self) -> bool:
+        """Whether any default-profile Claude Code instance is running.
+
+        Fails closed: if instance detection raises, assume an owner may exist so we
+        never refresh the live credential out from under a running Claude Code.
+        """
+        try:
+            sessions, ides = get_running_instances()
+            return bool(sessions or ides)
+        except Exception:
+            self._logger.debug("Failed to detect running Claude instances", exc_info=True)
+            return True
+
+    def _fetch_active_usage(
+        self, account_num: str, email: str, creds: str
+    ) -> dict | str | None:
+        """Usage for the active/default account, refreshing its token only when safe.
+
+        The active credential is the one Claude Code concurrently owns, so cswap
+        normally leaves it alone (issue #62). But when no *owner* is detected —
+        neither a default-profile Claude Code (``_active_cc_running``) nor a live
+        ``cswap run`` session for this same account (``_live_session_pids``) — there
+        is no concurrent refresher, so an expired token can be refreshed and written
+        back to the **active** store (Claude Code reads the rotated credential on its
+        next start).
+
+        When an owner *is* present and the token is expired, returns the
+        ``USAGE_TOKEN_EXPIRED`` sentinel so the UI shows an intentional line rather
+        than a bare "usage unavailable".
+        """
+        oauth_data = oauth.extract_oauth_data(creds)
+        if not oauth_data or not oauth_data.get("accessToken"):
+            return USAGE_NO_CREDENTIALS
+
+        owned = self._active_cc_running() or bool(
+            self._live_session_pids(account_num, email)
+        )
+        if owned:
+            usage = oauth.fetch_usage_for_account(
+                account_num, email, creds, is_active=True,
+            )
+            if usage is None and oauth.is_oauth_token_expired(oauth_data.get("expiresAt")):
+                return USAGE_TOKEN_EXPIRED
+            return usage
+
+        # No owner detected → safe to refresh the active token. Reuse the inactive
+        # refresh machinery (proactive refresh + 401 retry), persisting the rotated
+        # credential to BOTH the active store and the backup. Do NOT hold the lock
+        # across the network refresh: FileLock is non-reentrant and persist_active
+        # re-acquires it (regressing commit a07c767 would deadlock and silently drop
+        # the refreshed token).
+        original_refresh = oauth_data.get("refreshToken")
+        persist_skipped = False
+
+        def persist_active(num: str, acct_email: str, new_creds: str) -> None:
+            nonlocal persist_skipped
+            with FileLock(self.lock_file):
+                live = self._read_credentials() or ""
+                live_oauth = oauth.extract_oauth_data(live) if live else None
+                live_refresh = live_oauth.get("refreshToken") if live_oauth else None
+                # Re-check owners + refresh-token lineage under the lock. If a Claude
+                # Code / session appeared, or an external write (e.g. a user /login)
+                # replaced the credential since we read it, skip rather than clobber a
+                # live process's newer credential. Best effort, not perfectly atomic.
+                if (
+                    self._active_cc_running()
+                    or self._live_session_pids(num, acct_email)
+                    or live_refresh != original_refresh
+                ):
+                    persist_skipped = True
+                    self._logger.warning(
+                        "Active-account refresh for %s (%s): owner appeared or refresh "
+                        "token changed mid-refresh; discarding rotated credential.",
+                        num, acct_email,
+                    )
+                    return
+                # A write failure leaves the live store holding the now-consumed
+                # original refresh token, so mark the persist as skipped (never show
+                # usage for it) and re-raise — oauth._persist swallows the exception
+                # but logs its "failed to persist" warning first.
+                try:
+                    self._write_credentials(new_creds)  # active store — Claude Code reads this
+                    self._write_account_credentials(num, acct_email, new_creds)  # backup in sync
+                except Exception:
+                    persist_skipped = True
+                    raise
+
+        usage = oauth.fetch_usage_for_account(
+            account_num, email, creds,
+            is_active=False, persist_credentials=persist_active,
+        )
+        # If we refreshed but discarded the rotated credential, never show usage for
+        # a credential we didn't keep — surface the expired state and let Claude Code
+        # settle it.
+        if persist_skipped:
+            return USAGE_TOKEN_EXPIRED
+        if usage is None and oauth.is_oauth_token_expired(oauth_data.get("expiresAt")):
+            return USAGE_TOKEN_EXPIRED
+        return usage
+
     def _collect_usage(
         self, accounts_info: list[tuple[int, str, str, str, bool, str]]
     ) -> list[dict | str | None]:
@@ -1144,7 +1246,13 @@ class ClaudeAccountSwitcher:
         ) -> dict | str | None:
             num, email, _, _, is_active, creds = account_info
             if not creds or not oauth.extract_access_token(creds):
-                return "no credentials"
+                return USAGE_NO_CREDENTIALS
+
+            # The active/default account owns the live credential — route it through
+            # the owner-aware path that refreshes only when no Claude Code/session is
+            # running and writes the rotated credential back to the active store.
+            if is_active:
+                return self._fetch_active_usage(str(num), email, creds)
 
             def persist(acct_num: str, acct_email: str, new_creds: str) -> None:
                 with FileLock(self.lock_file):
@@ -1160,7 +1268,7 @@ class ClaudeAccountSwitcher:
 
             return oauth.fetch_usage_for_account(
                 str(num), email, creds,
-                is_active=is_active or has_live_session,
+                is_active=has_live_session,
                 persist_credentials=persist,
             )
 
@@ -1306,7 +1414,9 @@ class ClaudeAccountSwitcher:
                 print(f"  {num}: {email} {muted(f'[{tag}]')}{marker}")
             else:
                 print(f"  {num}: {email} {muted(f'[{tag}]')}")
-            if isinstance(usage, str):
+            if usage == USAGE_TOKEN_EXPIRED:
+                print(f"     {dimmed('token expired — Claude Code refreshes the active account')}")
+            elif isinstance(usage, str):
                 print(f"     {dimmed(usage)}")
             elif usage is None:
                 print(f"     {dimmed('usage unavailable')}")
@@ -1361,23 +1471,21 @@ class ClaudeAccountSwitcher:
     ) -> dict | str | None:
         """Usage for the active account as a ``_collect_usage``-style entry.
 
-        Returns ``"no credentials"`` when the live store has no usable token, a
-        usage dict on success, or ``None`` when the fetch fails. Reuses (and
-        refreshes) the same ``cache/usage.json`` list_accounts writes — cache-first,
-        fetching with ``is_active=True`` so cswap never refreshes Claude Code's live
-        credentials, and merging into existing entries so other rows survive.
+        Returns ``USAGE_NO_CREDENTIALS`` when the live store has no usable token, a
+        usage dict on success, ``USAGE_TOKEN_EXPIRED`` when the token is expired and
+        Claude Code owns it, or ``None`` when the fetch fails. Reuses the same
+        ``cache/usage.json`` list_accounts writes — cache-first — and delegates the
+        owner-aware refresh decision to ``_fetch_active_usage``.
         """
         creds = self._read_credentials() or ""
         if not creds or not oauth.extract_access_token(creds):
-            return "no credentials"
+            return USAGE_NO_CREDENTIALS
         usage_cache_path = self.backup_dir / "cache" / "usage.json"
         cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
         if (cached is not MISSING and isinstance(cached, dict)
                 and account_num in cached):
             return cached[account_num]
-        usage = oauth.fetch_usage_for_account(
-            account_num, current_email, creds, is_active=True,
-        )
+        usage = self._fetch_active_usage(account_num, current_email, creds)
         existing = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
         existing[account_num] = usage
         write_cache(usage_cache_path, existing)
@@ -1460,6 +1568,8 @@ class ClaudeAccountSwitcher:
                 for j, line in enumerate(lines):
                     connector = "└" if j == len(lines) - 1 else "├"
                     print(f"  {dimmed(connector)} {muted(line)}")
+            elif usage == USAGE_TOKEN_EXPIRED:
+                print(f"  {dimmed('token expired — Claude Code refreshes the active account')}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
         return None

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -42,9 +42,13 @@ class TestJsonHelpers:
         assert out["spend"]["resetsAt"] == "2026-07-01T00:00:00Z"
 
     def test_usage_fields_variants(self):
+        from claude_swap.json_output import USAGE_NO_CREDENTIALS, USAGE_TOKEN_EXPIRED
+
         assert usage_fields({"five_hour": {"pct": 1.0}})[0] == "ok"
         assert usage_fields({"five_hour": {"pct": 1.0}})[1] == {"fiveHour": {"pct": 1.0}}
+        assert usage_fields(USAGE_NO_CREDENTIALS) == ("no_credentials", None)
         assert usage_fields("no credentials") == ("no_credentials", None)
+        assert usage_fields(USAGE_TOKEN_EXPIRED) == ("token_expired", None)
         assert usage_fields(None) == ("unavailable", None)
 
     def test_error_envelope_shape(self):

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -453,10 +453,10 @@ class TestStatusCache:
         assert "25%" in output
         assert "60%" in output
 
-    def test_status_fetches_on_cache_miss_with_is_active_true(
+    def test_status_fetches_with_is_active_true_when_cc_running(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
     ):
-        """On cache miss, fetch with is_active=True (never refresh active creds) and write back."""
+        """When Claude Code is running, fetch with is_active=True (never refresh live creds)."""
         from claude_swap.cache import read_cache, MISSING
 
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
@@ -472,6 +472,7 @@ class TestStatusCache:
         }
 
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch.object(switcher, "_active_cc_running", return_value=True), \
              patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage_result) as mock_fetch:
             switcher.status()
 
@@ -599,16 +600,15 @@ class TestListAccountsUsage:
         output = capsys.readouterr().out
         assert "no credentials" in output
 
-    def test_list_persist_writes_only_backup_never_live(
+    def test_list_never_writes_live_while_claude_code_running(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
     ):
-        """Inactive account refresh persists to backup only — never touches live.
+        """While Claude Code owns the active account, list never writes live creds.
 
-        Regression guard for the design drift where the persist closure used
-        to rewrite live credentials for the active account. Per
-        OAUTH_REFRESH_REDESIGN.md, cswap must never write to live creds — that
-        would race with Claude Code's own refresh (which coordinates via a
-        ~/.claude/ lockfile cswap doesn't honor).
+        Refreshing the live credential in parallel would race with Claude Code's own
+        refresh (which coordinates via a ~/.claude/ lockfile cswap doesn't honor) and
+        could trip refresh-token reuse detection. The active row stays hands-off
+        (is_active=True) whenever an owner is detected; only inactive backups refresh.
         """
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
         active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
@@ -623,20 +623,21 @@ class TestListAccountsUsage:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
+        def mock_fetch(account_num, email, credentials, is_active, persist_credentials=None):
             # Simulate a refresh on the inactive account only.
-            if not is_active:
+            if not is_active and persist_credentials is not None:
                 persist_credentials(account_num, email, refreshed_creds)
             return None
 
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_active_cc_running", return_value=True), \
              patch.object(switcher, "_write_credentials") as write_live, \
              patch.object(switcher, "_write_account_credentials") as write_backup, \
              patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
             switcher.list_accounts()
 
-        # Live creds must never be written from list_accounts()
+        # Live creds must never be written while Claude Code is running.
         write_live.assert_not_called()
         # Backup was written for the inactive account (2) only.
         write_backup.assert_called_once_with("2", "account2@example.com", refreshed_creds)
@@ -729,6 +730,225 @@ class TestListAccountsUsage:
         output = capsys.readouterr().out
         # Should show live data (10%), not cached data (25%)
         assert "10%" in output
+
+
+class TestActiveAccountRefresh:
+    """`_fetch_active_usage`: refresh the active token only when no owner is running."""
+
+    # Active credential with an already-expired access token (expiresAt in 1970).
+    _EXPIRED = json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "sk-active",
+            "refreshToken": "rt-orig",
+            "expiresAt": 1000,
+        }
+    })
+    _REFRESHED = json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "sk-new",
+            "refreshToken": "rt-new",
+            "expiresAt": 9999999999000,
+        }
+    })
+
+    def _switcher(self, sample_sequence_data):
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+        return switcher
+
+    def test_no_owner_refreshes_and_writes_both_stores(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """No Claude Code / session running → refresh and persist to live + backup."""
+        switcher = self._switcher(sample_sequence_data)
+        usage_result = {"five_hour": {"pct": 10}}
+
+        def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
+            assert is_active is False  # no owner → refresh enabled
+            persist_credentials(account_num, email, self._REFRESHED)
+            return usage_result
+
+        with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch.object(switcher, "_active_cc_running", return_value=False), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch.object(switcher, "_write_credentials") as write_live, \
+             patch.object(switcher, "_write_account_credentials") as write_backup, \
+             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+            result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+
+        assert result == usage_result
+        write_live.assert_called_once_with(self._REFRESHED)
+        write_backup.assert_called_once_with("1", "test@example.com", self._REFRESHED)
+
+    def test_cc_running_stays_handsoff_and_reports_token_expired(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """Claude Code running + expired token → no refresh, returns the sentinel."""
+        from claude_swap.json_output import USAGE_TOKEN_EXPIRED
+
+        switcher = self._switcher(sample_sequence_data)
+
+        with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch.object(switcher, "_active_cc_running", return_value=True), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch.object(switcher, "_write_credentials") as write_live, \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None) as mock_fetch:
+            result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+
+        assert result == USAGE_TOKEN_EXPIRED
+        assert mock_fetch.call_args.kwargs.get("is_active") is True
+        write_live.assert_not_called()
+
+    def test_live_session_blocks_refresh(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """A live `cswap run` session for the same account blocks active refresh."""
+        switcher = self._switcher(sample_sequence_data)
+
+        with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch.object(switcher, "_active_cc_running", return_value=False), \
+             patch.object(switcher, "_live_session_pids", return_value=[4242]), \
+             patch.object(switcher, "_write_credentials") as write_live, \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None) as mock_fetch:
+            switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+
+        assert mock_fetch.call_args.kwargs.get("is_active") is True
+        write_live.assert_not_called()
+
+    def test_lineage_mismatch_skips_write_and_reports_token_expired(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """If the live refresh token changes between read and persist, discard the write."""
+        from claude_swap.json_output import USAGE_TOKEN_EXPIRED
+
+        switcher = self._switcher(sample_sequence_data)
+        # Live store now holds a *different* refresh token (e.g. user re-logged in).
+        live_changed = json.dumps({
+            "claudeAiOauth": {"accessToken": "sk-x", "refreshToken": "rt-someone-else"},
+        })
+        usage_result = {"five_hour": {"pct": 10}}
+
+        def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
+            persist_credentials(account_num, email, self._REFRESHED)
+            return usage_result  # in-memory token would fetch fine...
+
+        with patch.object(switcher, "_read_credentials", return_value=live_changed), \
+             patch.object(switcher, "_active_cc_running", return_value=False), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch.object(switcher, "_write_credentials") as write_live, \
+             patch.object(switcher, "_write_account_credentials") as write_backup, \
+             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+            result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+
+        # ...but we discarded the rotated credential, so never show its usage.
+        assert result == USAGE_TOKEN_EXPIRED
+        write_live.assert_not_called()
+        write_backup.assert_not_called()
+
+    def test_write_failure_reports_token_expired(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """If persisting the rotated credential raises, never show usage for it."""
+        from claude_swap.json_output import USAGE_TOKEN_EXPIRED
+
+        switcher = self._switcher(sample_sequence_data)
+        usage_result = {"five_hour": {"pct": 10}}
+
+        def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
+            # oauth._persist swallows the write error after logging — mirror that.
+            try:
+                persist_credentials(account_num, email, self._REFRESHED)
+            except Exception:
+                pass
+            return usage_result  # refreshed in-memory token still fetches fine
+
+        with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch.object(switcher, "_active_cc_running", return_value=False), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch.object(switcher, "_write_credentials", side_effect=OSError("disk full")), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+            result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+
+        assert result == USAGE_TOKEN_EXPIRED
+
+    def test_detection_failure_fails_closed(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """If instance detection raises, assume an owner exists and do not refresh."""
+        switcher = self._switcher(sample_sequence_data)
+
+        with patch("claude_swap.switcher.get_running_instances",
+                   side_effect=OSError("boom")):
+            assert switcher._active_cc_running() is True
+
+        with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch("claude_swap.switcher.get_running_instances", side_effect=OSError("boom")), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch.object(switcher, "_write_credentials") as write_live, \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None) as mock_fetch:
+            switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+
+        assert mock_fetch.call_args.kwargs.get("is_active") is True
+        write_live.assert_not_called()
+
+    def test_refresh_network_call_does_not_hold_the_lock(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """The lock must be free during the refresh network call (no a07c767 regression)."""
+        from claude_swap.locking import FileLock
+
+        switcher = self._switcher(sample_sequence_data)
+        lock_free_during_fetch = {"ok": False}
+
+        def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
+            probe = FileLock(switcher.lock_file)
+            lock_free_during_fetch["ok"] = probe.acquire(timeout=0.5)
+            if lock_free_during_fetch["ok"]:
+                probe.release()
+            persist_credentials(account_num, email, self._REFRESHED)
+            return {"five_hour": {"pct": 10}}
+
+        with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch.object(switcher, "_active_cc_running", return_value=False), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch.object(switcher, "_write_credentials"), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+            switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+
+        assert lock_free_during_fetch["ok"] is True
+
+    def test_no_token_returns_no_credentials(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """Missing access token short-circuits before any owner check or fetch."""
+        from claude_swap.json_output import USAGE_NO_CREDENTIALS
+
+        switcher = self._switcher(sample_sequence_data)
+        with patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
+            result = switcher._fetch_active_usage("1", "test@example.com", "")
+        assert result == USAGE_NO_CREDENTIALS
+        mock_fetch.assert_not_called()
+
+    def test_list_renders_token_expired_line(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        """End-to-end: --list shows the intentional message for the active account."""
+        switcher = self._switcher(sample_sequence_data)
+        backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
+
+        with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_active_cc_running", return_value=True), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
+            switcher.list_accounts()
+
+        output = capsys.readouterr().out
+        assert "token expired — Claude Code refreshes the active account" in output
 
 
 class TestPerformSwitchPostDisplay:


### PR DESCRIPTION
## What

`cswap --list`/`--status` previously couldn't refresh the **active** account's expired token (Claude Code owns it), so it showed a bare `usage unavailable` while every other account showed usage. Addresses #62 

Now:
- **No Claude Code instance or `cswap run` session owning the account** → cswap refreshes the active token and writes the rotated credential back to the active store, so usage shows normally.
- **An owner is running** → cswap stays hands-off and shows `token expired — Claude Code refreshes the active account` instead of looking broken. JSON gains `usageStatus: "token_expired"`.

## Why it's safe

The danger of refreshing the active token is racing Claude Code's own refresh (uncoordinated rotation can trip refresh-token reuse detection). That race only exists when an owner is running, so the refresh is gated on detecting none. Additional guards:
- Fail-closed instance detection (assume owned on error).
- Live `cswap run` session guard (shares the same token family).
- The refresh network call never holds the lock (avoids the a07c767 deadlock); persist is lock-only.
- Refresh-token lineage re-check before writing, plus a persist-skip/write-failure override so usage is never shown for a credential that wasn't kept.

## Tests

New `TestActiveAccountRefresh` covers all gates and failure paths; two prior "never touch live" regression tests updated to the owner-conditional invariant. Full suite: 566 passed, 3 skipped.