### PR TITLE
feat: map accounts to directories for automatic per-repo selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,27 @@ Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usag
 <img src="assets/tui-watch.png" width="760" alt="cswap watch — live 5h/7d usage bars for every account, with reset times and the active account marked">
 
 
+### Use a specific account per directory (auto-select)
+
+Map an account to a repo/project directory, then launch with no account argument
+and claude-swap picks the mapped account automatically — in session mode, so
+different repos can run different accounts at the same time.
+
+~~~bash
+cswap map 2 ~/work/client-app        # map a path to account 2 (work)
+cswap map user@example.com           # map the CURRENT directory to an account
+cswap map                            # list all mappings
+cswap unmap ~/work/client-app        # remove a mapping (defaults to cwd)
+
+cd ~/work/client-app/src
+cswap run                            # no account → launches account 2 [session mode]
+~~~
+
+The nearest mapped ancestor directory wins, so subfolders inherit their parent's
+mapping. In an unmapped directory, `cswap run` (with no account) just launches
+Claude Code with your current default login. Mappings are stored locally per
+machine and are not included in `--export` / `--import`.
+
 ### Refresh expired tokens
 
 If an account's token expires, log back into Claude Code with that account and re-run:
@@ -144,6 +165,10 @@ This will update the stored credentials without creating a duplicate.
 
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
+cswap run                       # Run the current dir's mapped account (or default login if unmapped)
+cswap map 2 ~/work/app          # Map a directory to an account
+cswap map                       # List directory→account mappings
+cswap unmap ~/work/app          # Remove a directory mapping
 cswap auto                      # Auto-switch when nearing rate limits (see above)
 cswap config                    # Show or edit settings (see Configuration below)
 cswap list                      # Show all accounts with 5h/7d usage and reset times

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -10,7 +10,14 @@ import sys
 from claude_swap import __version__
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
-from claude_swap.printer import dimmed, error, force_utf8_output, muted
+from claude_swap.printer import (
+    accent,
+    dimmed,
+    error,
+    force_utf8_output,
+    muted,
+    warning,
+)
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -125,8 +132,10 @@ Examples:
     )
     parser.add_argument(
         "account",
+        nargs="?",
         metavar="NUM|EMAIL",
-        help="Account to run (number or email)",
+        help="Account to run (number or email). Omit to use the current "
+        "directory's mapping (see `cswap map`).",
     )
     parser.add_argument(
         "--no-share",
@@ -158,20 +167,162 @@ Examples:
 
     try:
         switcher = ClaudeAccountSwitcher(debug=args.debug)
-
-        if sys.platform != "win32":
-            if os.geteuid() == 0 and not switcher._is_running_in_container():
-                error("Error: Do not run this script as root (unless running in a container)")
-                sys.exit(1)
+        _guard_root(switcher)
 
         from claude_swap.session import SessionManager
 
-        SessionManager(switcher).run(
-            args.account,
-            tail,
-            share=not args.no_share,
-            share_history=args.share_history,
-        )
+        manager = SessionManager(switcher)
+
+        if args.account is not None:
+            manager.run(
+                args.account,
+                tail,
+                share=not args.no_share,
+                share_history=args.share_history,
+            )
+            return  # only reachable in tests where exec/exit is mocked
+
+        # No account given: resolve from the current directory's mapping.
+        slot, email = switcher.slot_for_directory(os.getcwd())
+        if slot is not None:
+            manager.run(
+                slot,
+                tail,
+                share=not args.no_share,
+                share_history=args.share_history,
+            )
+            return  # only reachable in tests
+        if email is not None:
+            warning(
+                f"Mapped account {email} no longer exists — "
+                "launching the default account."
+            )
+        else:
+            print(
+                dimmed(
+                    f"No account mapped for {os.getcwd()} — "
+                    "launching the default account."
+                )
+            )
+        manager.exec_default(tail)
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
+def _guard_root(switcher: ClaudeAccountSwitcher) -> None:
+    """Refuse to run as root outside a container (shared by run/map/unmap)."""
+    if sys.platform != "win32":
+        if os.geteuid() == 0 and not switcher._is_running_in_container():
+            error("Error: Do not run this script as root (unless running in a container)")
+            sys.exit(1)
+
+
+def _map_command(argv: list[str]) -> None:
+    """Handle `cswap map [NUM|EMAIL] [PATH]`.
+
+    With no NUM|EMAIL, lists all mappings. Otherwise maps PATH (default: the
+    current directory) to the given account. Pre-dispatched before the main
+    parser for the same reason as `run` (the main parser's required
+    mutually-exclusive group can't hold a positional subcommand).
+    """
+    parser = argparse.ArgumentParser(
+        prog="cswap map",
+        description=(
+            "Map a stored account to a directory so `cswap run` (with no "
+            "account) auto-launches it there. With no arguments, lists all "
+            "mappings."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap map 2 ~/work/client-app
+  cswap map user@example.com          # map the current directory
+  cswap map                           # list all mappings
+        """,
+    )
+    parser.add_argument(
+        "account",
+        nargs="?",
+        metavar="NUM|EMAIL",
+        help="Account to map (number or email). Omit to list mappings.",
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        metavar="PATH",
+        help="Directory to map (default: current directory)",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+
+        from claude_swap.mappings import MappingStore, normalize_path
+
+        store = MappingStore(switcher.backup_dir)
+
+        if args.account is None:
+            switcher.list_mappings()
+            return
+
+        account_num, email, org_uuid = switcher.resolve_account(args.account)
+        target = args.path or os.getcwd()
+        if not os.path.isdir(target):
+            warning(f"Warning: {target} is not an existing directory (mapping it anyway)")
+        previous = store.get(target)
+        store.set(target, email, org_uuid)
+
+        shown = normalize_path(target)
+        if previous and previous.get("email") != email:
+            prev_email = previous.get("email")
+            print(
+                f"{accent('Mapped')} {shown} → Account-{account_num} ({email}) "
+                f"{muted(f'(was {prev_email})')}"
+            )
+        else:
+            print(f"{accent('Mapped')} {shown} → Account-{account_num} ({email})")
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
+def _unmap_command(argv: list[str]) -> None:
+    """Handle `cswap unmap [PATH]` — remove a directory→account mapping."""
+    parser = argparse.ArgumentParser(
+        prog="cswap unmap",
+        description="Remove a directory → account mapping (default: current directory).",
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        metavar="PATH",
+        help="Directory to unmap (default: current directory)",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+
+        from claude_swap.mappings import MappingStore, normalize_path
+
+        store = MappingStore(switcher.backup_dir)
+        target = args.path or os.getcwd()
+        shown = normalize_path(target)
+        if store.remove(target):
+            print(f"{accent('Unmapped')} {shown}")
+        else:
+            print(dimmed(f"No mapping for {shown}"))
     except ClaudeSwitchError as e:
         error(f"Error: {e}")
         sys.exit(1)
@@ -528,6 +679,12 @@ def main() -> None:
     if len(sys.argv) > 1 and sys.argv[1] == "config":
         _config_command(sys.argv[2:])
         return
+    if argv and argv[0] == "map":
+        _map_command(argv[1:])
+        return
+    if argv and argv[0] == "unmap":
+        _unmap_command(argv[1:])
+        return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like
     # lazygit/k9s). TTY-gated on both ends so scripts and pipes keep getting
@@ -555,6 +712,10 @@ Commands:
   %(prog)s add-token [TOKEN|-]        register a setup-token or API key
   %(prog)s remove <num|email>         remove an account
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
+  %(prog)s run                        run the current dir's mapped account
+  %(prog)s map <num|email> [path]     map a directory to an account
+  %(prog)s map                        list directory mappings
+  %(prog)s unmap [path]               remove a directory mapping
   %(prog)s auto                       auto-switch when nearing rate limits
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s export <path>              export accounts

--- a/src/claude_swap/mappings.py
+++ b/src/claude_swap/mappings.py
@@ -1,0 +1,141 @@
+"""Directory → account mappings for `cswap run` auto-resolution.
+
+Maps a normalized absolute directory path to a stored account identity
+(email + organizationUuid). `cswap run` with no account argument resolves the
+current working directory to the nearest mapped ancestor and launches that
+account in session mode.
+
+Persisted to ``<backup_dir>/mappings.json``. Identity is stored as the stable
+(email, organizationUuid) composite rather than the slot number, since slot
+numbers are reused when accounts are removed and re-added. This module is
+deliberately decoupled from ``switcher`` (it never imports it): callers resolve
+an entry's (email, org) to a live slot via the switcher themselves.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from claude_swap.models import get_timestamp
+
+SCHEMA_VERSION = 1
+
+
+def normalize_path(p: str | Path) -> str:
+    """Normalize a path to a stable, comparable mapping key.
+
+    Expands ``~``, makes the path absolute, resolves symlinks, and applies
+    ``os.path.normcase`` (case-folding on Windows, a no-op on POSIX) so the
+    same directory always produces the same key regardless of how it was typed.
+    """
+    resolved = Path(p).expanduser().resolve()
+    return os.path.normcase(str(resolved))
+
+
+class MappingStore:
+    """Reads and writes ``<backup_dir>/mappings.json``."""
+
+    def __init__(self, backup_dir: Path):
+        self.path = Path(backup_dir) / "mappings.json"
+
+    def load(self) -> dict[str, dict]:
+        """Return the normalized-path → entry map (empty on missing/corrupt)."""
+        if not self.path.exists():
+            return {}
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        mappings = data.get("mappings", {})
+        return mappings if isinstance(mappings, dict) else {}
+
+    def all(self) -> dict[str, dict]:
+        """Public alias for the full mapping table."""
+        return self.load()
+
+    def get(self, path: str | Path) -> dict | None:
+        """Exact-match lookup for a normalized path (no ancestor walk)."""
+        return self.load().get(normalize_path(path))
+
+    def set(self, path: str | Path, email: str, org_uuid: str) -> None:
+        """Upsert a mapping for ``path`` and persist atomically."""
+        mappings = self.load()
+        mappings[normalize_path(path)] = {
+            "email": email,
+            "organizationUuid": org_uuid or "",
+            "added": get_timestamp(),
+        }
+        self._write(mappings)
+
+    def remove(self, path: str | Path) -> bool:
+        """Delete the mapping for ``path``; return whether one was removed."""
+        mappings = self.load()
+        if mappings.pop(normalize_path(path), None) is None:
+            return False
+        self._write(mappings)
+        return True
+
+    def prune_account(self, email: str, org_uuid: str) -> int:
+        """Drop every mapping pointing at (email, org_uuid). Return count removed."""
+        mappings = self.load()
+        org = org_uuid or ""
+        doomed = [
+            key
+            for key, entry in mappings.items()
+            if entry.get("email") == email
+            and (entry.get("organizationUuid", "") or "") == org
+        ]
+        for key in doomed:
+            del mappings[key]
+        if doomed:
+            self._write(mappings)
+        return len(doomed)
+
+    def resolve(self, cwd: str | Path) -> tuple[str, dict] | None:
+        """Return (key, entry) of the longest mapped ancestor of ``cwd``.
+
+        A mapping matches when its directory equals ``cwd`` or is an ancestor
+        of it. The most specific (longest path) match wins, so nested folders
+        inherit the closest mapping. All candidates lie on the single
+        root→cwd chain, so the longest key string is the deepest match.
+        """
+        target = Path(normalize_path(cwd))
+        best: tuple[str, dict] | None = None
+        best_len = -1
+        for key, entry in self.load().items():
+            candidate = Path(key)
+            if candidate == target or candidate in target.parents:
+                if len(key) > best_len:
+                    best = (key, entry)
+                    best_len = len(key)
+        return best
+
+    def _write(self, mappings: dict[str, dict]) -> None:
+        """Atomically write the mappings file (tempfile + os.replace)."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(self.path.parent, 0o700)
+        payload = json.dumps(
+            {"schemaVersion": SCHEMA_VERSION, "mappings": mappings}, indent=2
+        )
+        fd, tmp = tempfile.mkstemp(
+            dir=str(self.path.parent), prefix=".mappings-", suffix=".tmp"
+        )
+        try:
+            if sys.platform != "win32":
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+            os.replace(tmp, self.path)
+        except OSError:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -372,6 +372,22 @@ class SessionManager:
         env["CLAUDE_CONFIG_DIR"] = str(session_dir)
         self._exec(claude_bin, claude_args, env=env)
 
+    def exec_default(self, claude_args: list[str]) -> NoReturn:
+        """Launch plain Claude Code with the current default login.
+
+        Used by `cswap run` (no account) when the cwd has no mapping, or its
+        mapped account no longer exists. Equivalent to typing `claude`
+        directly: the unmodified environment is passed through (no session
+        profile, no auth-override scrubbing), so whatever the default login
+        resolves to is what runs.
+        """
+        claude_bin = shutil.which("claude")
+        if not claude_bin:
+            raise SessionError(
+                "'claude' was not found on PATH. Install Claude Code first."
+            )
+        self._exec(claude_bin, claude_args, env=dict(os.environ))
+
     def _exec(self, claude_bin: str, claude_args: list[str], env: dict[str, str]) -> NoReturn:
         """Hand the terminal over to claude. Never returns.
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -484,6 +484,20 @@ class ClaudeAccountSwitcher:
             config_file.unlink()
         self._delete_session_profile(account_num, email)
 
+    def _prune_mappings(self, email: str, org_uuid: str) -> None:
+        """Drop directory mappings for an identity that no longer has a slot.
+
+        Called wherever an identity leaves the account table for good
+        (remove_account, add_account/add_token slot overwrite). Slot
+        *migration* and --import --force keep the (email, org) identity that
+        mappings are keyed by, so they need no pruning.
+        """
+        from claude_swap.mappings import MappingStore
+
+        pruned = MappingStore(self.backup_dir).prune_account(email, org_uuid or "")
+        if pruned:
+            print(dimmed(f"Removed {pruned} directory mapping(s) for this account"))
+
     def _read_account_config(self, account_num: str, email: str) -> str:
         """Read account config from backup."""
         config_file = self.configs_dir / f".claude-config-{account_num}-{email}.json"
@@ -546,6 +560,51 @@ class ClaudeAccountSwitcher:
             record.get("email", ""),
             record.get("organizationUuid", "") or "",
         )
+
+    def slot_for_directory(self, directory: str | Path) -> tuple[str | None, str | None]:
+        """Resolve a directory to its mapped account slot, for `cswap run`.
+
+        Returns (slot, email): (None, None) when no mapping covers the
+        directory, (None, email) when a mapping exists but its account was
+        removed, and (slot, email) when the mapping resolves.
+        """
+        from claude_swap.mappings import MappingStore
+
+        match = MappingStore(self.backup_dir).resolve(directory)
+        if match is None:
+            return None, None
+        _, entry = match
+        email = entry.get("email", "")
+        seq = self._get_sequence_data_migrated() or {}
+        slot = self._find_account_slot(
+            seq, email, entry.get("organizationUuid", "") or ""
+        )
+        return slot, email
+
+    def list_mappings(self) -> None:
+        """Print all directory → account mappings (for `cswap map`)."""
+        from claude_swap.mappings import MappingStore
+
+        mappings = MappingStore(self.backup_dir).all()
+        if not mappings:
+            print(dimmed("No directory mappings yet."))
+            print(muted("Map one with: cswap map <NUM|EMAIL> [PATH]"))
+            return
+        seq = self._get_sequence_data_migrated() or {}
+        print(bolded("Directory mappings:"))
+        for path in sorted(mappings):
+            entry = mappings[path]
+            email = entry.get("email", "")
+            org_uuid = entry.get("organizationUuid", "") or ""
+            slot = self._find_account_slot(seq, email, org_uuid)
+            if slot:
+                account = seq.get("accounts", {}).get(slot, {})
+                tag = self._get_display_tag(
+                    email, account.get("organizationName", ""), org_uuid
+                )
+                print(f"  {path} {dimmed('→')} {slot}: {email} {muted(f'[{tag}]')}")
+            else:
+                print(f"  {path} {dimmed('→')} {email} {muted('(account removed)')}")
 
     def read_account_credentials(self, account_num: str, email: str) -> str:
         """Public wrapper for session bootstrap. Empty string when missing."""
@@ -1162,7 +1221,11 @@ class ClaudeAccountSwitcher:
                         if answer not in ("y", "yes"):
                             print(dimmed("Cancelled"))
                             return
-                    displace_slot = (account_num, existing_email)
+                    displace_slot = (
+                        account_num,
+                        existing_email,
+                        existing.get("organizationUuid", "") or "",
+                    )
         else:
             account_num = str(self._get_next_account_number())
 
@@ -1191,13 +1254,14 @@ class ClaudeAccountSwitcher:
 
         # Now safe to perform destructive cleanup (new account data is in memory)
         if displace_slot:
-            d_num, d_email = displace_slot
+            d_num, d_email, d_org = displace_slot
             self._delete_account_files(d_num, d_email)
             data = self._get_sequence_data()
             if int(d_num) in data["sequence"]:
                 data["sequence"].remove(int(d_num))
             del data["accounts"][d_num]
             self._write_json(self.sequence_file, data)
+            self._prune_mappings(d_email, d_org)
 
         if migrate_from:
             data = self._get_sequence_data()
@@ -1383,18 +1447,23 @@ class ClaudeAccountSwitcher:
                         if answer not in ("y", "yes"):
                             print(dimmed("Cancelled"))
                             return
-                    displace_slot = (account_num, existing_email)
+                    displace_slot = (
+                        account_num,
+                        existing_email,
+                        existing.get("organizationUuid", "") or "",
+                    )
         else:
             account_num = str(self._get_next_account_number())
 
         if displace_slot:
-            d_num, d_email = displace_slot
+            d_num, d_email, d_org = displace_slot
             self._delete_account_files(d_num, d_email)
             data = self._get_sequence_data()
             if int(d_num) in data["sequence"]:
                 data["sequence"].remove(int(d_num))
             del data["accounts"][d_num]
             self._write_json(self.sequence_file, data)
+            self._prune_mappings(d_email, d_org)
 
         if migrate_from:
             data = self._get_sequence_data()
@@ -1520,6 +1589,8 @@ class ClaudeAccountSwitcher:
         self._write_json(self.sequence_file, data)
         self._logger.info(f"Removed account {account_num}: {email}")
         print(f"{accent('Removed')} Account-{account_num} ({email})")
+
+        self._prune_mappings(email, account_info.get("organizationUuid", ""))
 
     def _build_accounts_info(self) -> list[tuple[int, str, str, str, bool, str]]:
         """Build per-account (num, email, org_name, org_uuid, is_active, creds).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,12 +8,13 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from claude_swap import __version__
 from claude_swap import cli
+from claude_swap.switcher import ClaudeAccountSwitcher
 
 # src layout: ensure subprocess can find claude_swap
 _SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
@@ -610,13 +611,6 @@ class TestRunCommand:
         calls = self._dispatch(["run", "2", "--", "--no-share"])
         assert ("run", "2", ["--no-share"], True, False) in calls
 
-    def test_run_without_account_errors(self, capsys):
-        with patch.object(sys, "argv", ["claude-swap", "run"]):
-            with pytest.raises(SystemExit) as excinfo:
-                cli.main()
-        assert excinfo.value.code == 2
-        assert "NUM|EMAIL" in capsys.readouterr().err
-
     def test_run_unknown_flag_errors(self, capsys):
         with patch.object(sys, "argv", ["claude-swap", "run", "2", "--bogus"]):
             with pytest.raises(SystemExit) as excinfo:
@@ -990,3 +984,336 @@ class TestAutoCommand:
                 cli.main()
         assert excinfo.value.code == 1
         assert "nope" in capsys.readouterr().err  # printer.error -> stderr
+
+
+class TestMapCommand:
+    """`cswap map` / `cswap unmap` directory-mapping commands."""
+
+    def _seeded_switcher_env(self, temp_home):
+        """Build a real switcher with one managed account (slot 2)."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["2"] = {
+            "email": "work@co.com",
+            "uuid": "u2",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [2]
+        switcher._write_json(switcher.sequence_file, data)
+        return switcher
+
+    def test_map_account_to_path(self, temp_home, capsys):
+        from claude_swap.mappings import MappingStore, normalize_path
+        self._seeded_switcher_env(temp_home)
+        target = temp_home / "proj"
+        target.mkdir()
+
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._map_command(["2", str(target)])
+
+        store = MappingStore(ClaudeAccountSwitcher().backup_dir)
+        entry = store.get(target)
+        assert entry is not None
+        assert entry["email"] == "work@co.com"
+        assert "Mapped" in capsys.readouterr().out
+
+    def test_map_nonexistent_path_warns_but_maps(self, temp_home, capsys):
+        from claude_swap.mappings import MappingStore
+        self._seeded_switcher_env(temp_home)
+        target = temp_home / "not-created-yet"
+
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._map_command(["2", str(target)])
+
+        assert MappingStore(ClaudeAccountSwitcher().backup_dir).get(target) is not None
+        assert "is not an existing directory" in capsys.readouterr().out
+
+    def test_map_by_email_defaults_to_cwd(self, temp_home, monkeypatch, capsys):
+        from claude_swap.mappings import MappingStore
+        self._seeded_switcher_env(temp_home)
+        cwd = temp_home / "here"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._map_command(["work@co.com"])
+
+        store = MappingStore(ClaudeAccountSwitcher().backup_dir)
+        assert store.get(cwd) is not None
+
+    def test_map_unknown_account_errors(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit) as exc:
+                cli._map_command(["999", str(temp_home)])
+        assert exc.value.code == 1
+        assert "Error" in capsys.readouterr().err
+
+    def test_map_list_empty(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._map_command([])
+        assert "No directory mappings yet" in capsys.readouterr().out
+
+    def test_map_list_shows_entries(self, temp_home, capsys):
+        from claude_swap.mappings import MappingStore
+        switcher = self._seeded_switcher_env(temp_home)
+        target = temp_home / "proj"
+        target.mkdir()
+        MappingStore(switcher.backup_dir).set(target, "work@co.com", "")
+
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._map_command([])
+
+        out = capsys.readouterr().out
+        assert "Directory mappings" in out
+        assert "work@co.com" in out
+        assert "2:" in out  # slot number resolved
+
+    def test_map_list_flags_removed_account(self, temp_home, capsys):
+        from claude_swap.mappings import MappingStore
+        switcher = self._seeded_switcher_env(temp_home)
+        target = temp_home / "proj"
+        target.mkdir()
+        # Map an account identity that is not in the sequence.
+        MappingStore(switcher.backup_dir).set(target, "ghost@co.com", "")
+
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._map_command([])
+
+        assert "account removed" in capsys.readouterr().out
+
+    def test_unmap_removes(self, temp_home, capsys):
+        from claude_swap.mappings import MappingStore
+        switcher = self._seeded_switcher_env(temp_home)
+        target = temp_home / "proj"
+        target.mkdir()
+        store = MappingStore(switcher.backup_dir)
+        store.set(target, "work@co.com", "")
+
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._unmap_command([str(target)])
+
+        assert store.get(target) is None
+        assert "Unmapped" in capsys.readouterr().out
+
+    def test_unmap_nonexistent_notes(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        target = temp_home / "proj"
+        target.mkdir()
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._unmap_command([str(target)])
+        assert "No mapping for" in capsys.readouterr().out
+
+    def test_map_dispatched_from_main(self, temp_home):
+        """`cswap map` routes through main() to _map_command."""
+        with patch("claude_swap.cli._map_command") as map_fn, \
+             patch.object(sys, "argv", ["claude-swap", "map", "2", "/tmp/x"]):
+            cli.main()
+        map_fn.assert_called_once_with(["2", "/tmp/x"])
+
+    def test_unmap_dispatched_from_main(self, temp_home):
+        with patch("claude_swap.cli._unmap_command") as unmap_fn, \
+             patch.object(sys, "argv", ["claude-swap", "unmap", "/tmp/x"]):
+            cli.main()
+        unmap_fn.assert_called_once_with(["/tmp/x"])
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="root guard is POSIX-only")
+    def test_unmap_refuses_root(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=0, create=True), \
+             patch.object(ClaudeAccountSwitcher, "_is_running_in_container", return_value=False):
+            with pytest.raises(SystemExit) as exc:
+                cli._unmap_command([str(temp_home)])
+        assert exc.value.code == 1
+        assert "root" in capsys.readouterr().err
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="root guard is POSIX-only")
+    def test_map_refuses_root(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=0, create=True), \
+             patch.object(ClaudeAccountSwitcher, "_is_running_in_container", return_value=False):
+            with pytest.raises(SystemExit) as exc:
+                cli._map_command(["2", str(temp_home)])
+        assert exc.value.code == 1
+        assert "root" in capsys.readouterr().err
+
+
+class TestRunAutoResolve:
+    """`cswap run` with no account resolves the cwd's directory mapping."""
+
+    def _fake_manager(self, calls):
+        class FakeSessionManager:
+            def __init__(self, switcher):
+                pass
+
+            def run(self, identifier, claude_args, share=True, share_history=False):
+                calls.append(("run", identifier, claude_args, share, share_history))
+
+            def exec_default(self, claude_args):
+                calls.append(("exec_default", claude_args))
+
+        return FakeSessionManager
+
+    def _fake_switcher(self, backup, seq):
+        sw = MagicMock()
+        sw.backup_dir = backup
+        sw._get_sequence_data_migrated.return_value = seq
+        # Use the real resolvers, not MagicMock auto-attrs.
+        sw._find_account_slot = ClaudeAccountSwitcher._find_account_slot
+        sw.slot_for_directory = (
+            lambda d: ClaudeAccountSwitcher.slot_for_directory(sw, d)
+        )
+        return sw
+
+    def test_mapped_dir_runs_resolved_account(self, tmp_path, monkeypatch):
+        from claude_swap.mappings import MappingStore
+
+        repo = tmp_path / "work" / "client-app"
+        repo.mkdir(parents=True)
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        MappingStore(backup).set(repo, "work@co.com", "org-1")
+        seq = {
+            "accounts": {
+                "2": {
+                    "email": "work@co.com",
+                    "organizationUuid": "org-1",
+                    "organizationName": "Co",
+                }
+            },
+            "sequence": [2],
+        }
+        calls = []
+        monkeypatch.chdir(repo)
+        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher",
+                   return_value=self._fake_switcher(backup, seq)), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run"]):
+            cli.main()
+        assert ("run", "2", [], True, False) in calls
+
+    def test_mapped_subdir_inherits(self, tmp_path, monkeypatch):
+        from claude_swap.mappings import MappingStore
+
+        repo = tmp_path / "work"
+        sub = repo / "client" / "src"
+        sub.mkdir(parents=True)
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        MappingStore(backup).set(repo, "work@co.com", "")
+        seq = {
+            "accounts": {"2": {"email": "work@co.com", "organizationUuid": "",
+                                "organizationName": ""}},
+            "sequence": [2],
+        }
+        calls = []
+        monkeypatch.chdir(sub)
+        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher",
+                   return_value=self._fake_switcher(backup, seq)), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run"]):
+            cli.main()
+        assert ("run", "2", [], True, False) in calls
+
+    def test_unmapped_dir_falls_back_to_default(self, tmp_path, monkeypatch, capsys):
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        calls = []
+        monkeypatch.chdir(scratch)
+        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher",
+                   return_value=self._fake_switcher(backup, {"accounts": {}, "sequence": []})), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run"]):
+            cli.main()
+        assert ("exec_default", []) in calls
+        assert "No account mapped" in capsys.readouterr().out
+
+    def test_removed_account_falls_back_with_warning(self, tmp_path, monkeypatch, capsys):
+        from claude_swap.mappings import MappingStore
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        MappingStore(backup).set(repo, "ghost@co.com", "")
+        calls = []
+        monkeypatch.chdir(repo)
+        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher",
+                   return_value=self._fake_switcher(backup, {"accounts": {}, "sequence": []})), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run"]):
+            cli.main()
+        assert ("exec_default", []) in calls
+        assert "no longer exists" in capsys.readouterr().out
+
+    def test_explicit_account_still_runs(self, tmp_path, monkeypatch):
+        """An explicit account argument bypasses mapping resolution."""
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        calls = []
+        monkeypatch.chdir(tmp_path)
+        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher",
+                   return_value=self._fake_switcher(backup, {"accounts": {}, "sequence": []})), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run", "3"]):
+            cli.main()
+        assert ("run", "3", [], True, False) in calls
+
+    def test_no_account_forwards_tail(self, tmp_path, monkeypatch):
+        from claude_swap.mappings import MappingStore
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        MappingStore(backup).set(repo, "work@co.com", "")
+        seq = {
+            "accounts": {"2": {"email": "work@co.com", "organizationUuid": "",
+                                "organizationName": ""}},
+            "sequence": [2],
+        }
+        calls = []
+        monkeypatch.chdir(repo)
+        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher",
+                   return_value=self._fake_switcher(backup, seq)), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run", "--", "--resume"]):
+            cli.main()
+        assert ("run", "2", ["--resume"], True, False) in calls
+
+    def test_no_account_forwards_share_history(self, tmp_path, monkeypatch):
+        """--share-history survives the mapped-account resolution path."""
+        from claude_swap.mappings import MappingStore
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        MappingStore(backup).set(repo, "work@co.com", "")
+        seq = {
+            "accounts": {"2": {"email": "work@co.com", "organizationUuid": "",
+                                "organizationName": ""}},
+            "sequence": [2],
+        }
+        calls = []
+        monkeypatch.chdir(repo)
+        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher",
+                   return_value=self._fake_switcher(backup, seq)), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run", "--share-history"]):
+            cli.main()
+        assert ("run", "2", [], True, True) in calls

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -1,0 +1,185 @@
+"""Tests for the directory → account mapping store (claude_swap.mappings)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from claude_swap.mappings import MappingStore, normalize_path
+
+
+def test_set_then_get_exact(tmp_path: Path):
+    backup = tmp_path / "backup"
+    repo = tmp_path / "work" / "app"
+    repo.mkdir(parents=True)
+    store = MappingStore(backup)
+
+    store.set(repo, "work@co.com", "org-1")
+
+    entry = store.get(repo)
+    assert entry is not None
+    assert entry["email"] == "work@co.com"
+    assert entry["organizationUuid"] == "org-1"
+    assert entry["added"]  # timestamp present
+
+
+def test_get_missing_returns_none(tmp_path: Path):
+    store = MappingStore(tmp_path / "backup")
+    assert store.get(tmp_path / "nope") is None
+
+
+def test_resolve_exact_dir(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = MappingStore(tmp_path / "backup")
+    store.set(repo, "a@x.com", "")
+
+    match = store.resolve(repo)
+    assert match is not None
+    assert match[0] == normalize_path(repo)
+    assert match[1]["email"] == "a@x.com"
+
+
+def test_resolve_nested_subdir_inherits(tmp_path: Path):
+    repo = tmp_path / "repo"
+    sub = repo / "src" / "deep"
+    sub.mkdir(parents=True)
+    store = MappingStore(tmp_path / "backup")
+    store.set(repo, "a@x.com", "")
+
+    match = store.resolve(sub)
+    assert match is not None
+    assert match[1]["email"] == "a@x.com"
+
+
+def test_resolve_longest_ancestor_wins(tmp_path: Path):
+    outer = tmp_path / "work"
+    inner = outer / "client"
+    cwd = inner / "src"
+    cwd.mkdir(parents=True)
+    store = MappingStore(tmp_path / "backup")
+    store.set(outer, "outer@x.com", "")
+    store.set(inner, "inner@x.com", "")
+
+    match = store.resolve(cwd)
+    assert match is not None
+    assert match[1]["email"] == "inner@x.com"
+
+
+def test_resolve_sibling_prefix_does_not_match(tmp_path: Path):
+    mapped = tmp_path / "foo" / "bar"
+    sibling = tmp_path / "foo" / "barbaz"
+    mapped.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    store = MappingStore(tmp_path / "backup")
+    store.set(mapped, "a@x.com", "")
+
+    assert store.resolve(sibling) is None
+
+
+def test_resolve_unmapped_returns_none(tmp_path: Path):
+    store = MappingStore(tmp_path / "backup")
+    store.set(tmp_path / "a", "a@x.com", "")
+    other = tmp_path / "b"
+    other.mkdir()
+    assert store.resolve(other) is None
+
+
+def test_remove(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = MappingStore(tmp_path / "backup")
+    store.set(repo, "a@x.com", "")
+
+    assert store.remove(repo) is True
+    assert store.get(repo) is None
+    assert store.remove(repo) is False  # already gone
+
+
+def test_set_overwrites_same_key(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = MappingStore(tmp_path / "backup")
+    store.set(repo, "a@x.com", "")
+    store.set(repo, "b@x.com", "org-9")
+
+    entry = store.get(repo)
+    assert entry["email"] == "b@x.com"
+    assert entry["organizationUuid"] == "org-9"
+    assert len(store.all()) == 1
+
+
+def test_prune_account(tmp_path: Path):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    c = tmp_path / "c"
+    for d in (a, b, c):
+        d.mkdir()
+    store = MappingStore(tmp_path / "backup")
+    store.set(a, "work@x.com", "org-1")
+    store.set(b, "work@x.com", "org-1")
+    store.set(c, "personal@x.com", "")
+
+    removed = store.prune_account("work@x.com", "org-1")
+
+    assert removed == 2
+    assert store.get(a) is None
+    assert store.get(b) is None
+    assert store.get(c) is not None
+
+
+def test_load_missing_file_is_empty(tmp_path: Path):
+    store = MappingStore(tmp_path / "backup")
+    assert store.load() == {}
+    assert store.all() == {}
+    assert store.resolve(tmp_path) is None
+
+
+def test_load_corrupt_file_is_empty(tmp_path: Path):
+    backup = tmp_path / "backup"
+    backup.mkdir()
+    (backup / "mappings.json").write_text("{ not json", encoding="utf-8")
+    store = MappingStore(backup)
+    assert store.load() == {}
+
+
+def test_normalize_path_expands_and_resolves(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Relative + trailing slash + "." segment all collapse to one key.
+    a = normalize_path(repo)
+    b = normalize_path(str(repo) + "/")
+    c = normalize_path(repo / "." )
+    assert a == b == c
+
+
+def test_persisted_schema(tmp_path: Path):
+    import json
+    backup = tmp_path / "backup"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = MappingStore(backup)
+    store.set(repo, "a@x.com", "org-1")
+
+    data = json.loads((backup / "mappings.json").read_text())
+    assert data["schemaVersion"] == 1
+    assert normalize_path(repo) in data["mappings"]
+
+
+def test_normalize_path_applies_normcase(monkeypatch, tmp_path: Path):
+    """normalize_path runs paths through os.path.normcase (Windows case-fold)."""
+    import claude_swap.mappings as m
+
+    calls = []
+
+    def fake_normcase(s):
+        calls.append(s)
+        return s.lower()
+
+    monkeypatch.setattr(m.os.path, "normcase", fake_normcase)
+    repo = tmp_path / "Repo"
+    repo.mkdir()
+
+    key = m.normalize_path(repo)
+
+    assert calls, "normalize_path did not call os.path.normcase"
+    assert key == key.lower(), "normcase result was not applied to the key"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -801,6 +801,22 @@ class TestRun:
 
         assert exc.value.env["ANTHROPIC_API_KEY"] == "sk-ant-key"
 
+    def test_exec_default_uses_plain_env(self, manager, capture_exec, monkeypatch):
+        """exec_default launches plain claude with the unmodified environment."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-key")
+        with pytest.raises(_ExecCalled) as exc:
+            manager.exec_default(["--resume"])
+
+        assert exc.value.binary == "/fake/bin/claude"
+        assert exc.value.argv == ["/fake/bin/claude", "--resume"]
+        # Plain claude behavior: API key is NOT scrubbed (unlike session mode).
+        assert exc.value.env["ANTHROPIC_API_KEY"] == "sk-ant-key"
+
+    def test_exec_default_claude_not_on_path(self, manager, monkeypatch):
+        monkeypatch.setattr(session_mod.shutil, "which", lambda name: None)
+        with pytest.raises(SessionError, match="not found on PATH"):
+            manager.exec_default([])
+
 
 class TestExec:
     """The _exec() terminal handoff dispatches per-platform (runs on any host)."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -5711,3 +5711,96 @@ class TestStashStorageHardening:
         assert entry_id in entries
         raw = store._stash_entry_path(entry_id).read_text().strip()
         assert base64.b64decode(raw, validate=True).decode() == "bytes-1"
+
+
+class TestRemoveAccountPrunesMappings:
+    """Removing an account drops any directory mappings pointing at it."""
+
+    def test_remove_account_prunes_mappings(self, temp_home, monkeypatch):
+        from claude_swap.mappings import MappingStore
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["1"] = {
+            "email": "a@x.com",
+            "uuid": "u1",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [1]
+        switcher._write_json(switcher.sequence_file, data)
+
+        store = MappingStore(switcher.backup_dir)
+        store.set(temp_home, "a@x.com", "")
+        assert store.get(temp_home) is not None
+
+        monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+        switcher.remove_account("1")
+
+        assert store.get(temp_home) is None
+
+    def _config_switcher(self, temp_home, email):
+        """Write a live claude config for ``email`` and return a switcher."""
+        config = {
+            "oauthAccount": {
+                "emailAddress": email,
+                "accountUuid": "uuid-" + email,
+                "organizationUuid": "",
+                "organizationName": "",
+            }
+        }
+        (temp_home / ".claude.json").write_text(json.dumps(config))
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        return switcher
+
+    def test_slot_overwrite_prunes_displaced_mappings(self, temp_home):
+        """Overwriting a slot with a different account drops the old one's mappings."""
+        from claude_swap.mappings import MappingStore
+
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+
+        switcher = self._config_switcher(temp_home, "a@x.com")
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account(slot=3)
+
+        store = MappingStore(switcher.backup_dir)
+        store.set(temp_home, "a@x.com", "")
+
+        switcher = self._config_switcher(temp_home, "b@x.com")
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"), \
+             patch("builtins.input", return_value="y"):
+            switcher.add_account(slot=3)
+
+        assert store.get(temp_home) is None
+
+    def test_slot_migration_keeps_mappings(self, temp_home):
+        """Moving an account to another slot keeps its identity-keyed mappings."""
+        from claude_swap.mappings import MappingStore
+
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+
+        switcher = self._config_switcher(temp_home, "a@x.com")
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account()  # lands in slot 1
+
+        store = MappingStore(switcher.backup_dir)
+        store.set(temp_home, "a@x.com", "")
+
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account(slot=5)  # same identity, new slot
+
+        assert store.get(temp_home) is not None
+        assert switcher.slot_for_directory(str(temp_home)) == ("5", "a@x.com")


### PR DESCRIPTION
## What & why

Adds **per-directory account mappings** so the right Claude account is selected automatically per repo/project — e.g. a personal account for one repo and a work account for another, without switching by hand each time.

`cswap map <NUM|EMAIL> [PATH]` binds a directory (default: current) to a stored account. `cswap run` with **no account argument** then auto-launches the account mapped to the current directory in session mode (per-terminal isolation, so two repos can run different accounts at the same time). The nearest mapped ancestor directory wins, so subfolders inherit. In an unmapped directory, `cswap run` falls back to launching plain `claude` with the current default login.

```bash
cswap map 2 ~/work/client-app     # map a directory to account 2
cswap map user@example.com        # map the current directory
cswap map                         # list mappings
cswap unmap ~/work/client-app     # remove a mapping

cd ~/work/client-app/src
cswap run                         # -> launches account 2 [session mode]
cd ~/scratch
cswap run                         # -> plain claude, current default login (unmapped)
```

## Design notes

- New `MappingStore` (`mappings.py`) persists `<backup_dir>/mappings.json`, keyed by a normalized absolute path and valued by the stable `(email, organizationUuid)` identity rather than the slot number, so mappings survive remove/re-add renumbering. Atomic `0600` writes; nearest-ancestor resolution uses `Path` semantics (so `/foo/bar` never matches `/foo/barbaz`).
- `map` / `unmap` are pre-dispatched in `cli.py` exactly like the existing `run` subcommand.
- `SessionManager.exec_default` handles the unmapped fallback — it passes the **unmodified** environment so it behaves exactly like typing `claude` (no auth-override scrubbing, unlike an explicit `cswap run N`).
- Mappings are intentionally local-only: excluded from `--export` / `--import` (paths are machine-specific) and removed by `--purge` (they live under the backup dir). `remove-account` prunes any mappings pointing at the removed account.
- `mappings.py` has no dependency on `switcher` (mirrors the existing `session.py` decoupling).

## Testing

- 35 new tests (`test_mappings.py`, plus additions to `test_cli.py`, `test_session.py`, `test_switcher.py`) covering nearest-ancestor / sibling-prefix resolution, path normalization (incl. Windows `normcase`), corrupt/missing file handling, account pruning, the `run` no-account resolution + fallback paths, and the root guards.
- Full suite: **601 passed, 3 skipped**.

## Notes

- No new dependencies (standard library only); no changes to existing behavior or the package version.
- Developed with the help of Claude Code (Claude Opus); I reviewed the full diff before opening this PR. Happy to adjust the command surface (e.g. `map`/`unmap` naming), behavior, or scope to fit the project's direction.
