### PR TITLE
Support managed API-key accounts (/login keys) on all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,21 +176,29 @@ Every payload carries a `schemaVersion` (currently `1`); on a handled error stdo
 
 </details>
 
-### Add an account from a raw OAuth token
+### Add an account from a raw token or API key
 
 If you only have a long-lived setup-token (e.g., produced by `claude setup-token`)
-and you don't want to log in via the browser flow first — useful on headless
-servers or when receiving a token from another machine — register it directly:
+or a managed API key (`sk-ant-api...`) and you don't want to log in via the browser
+flow first — useful on headless servers or when receiving a token from another
+machine — register it directly. The token type is auto-detected:
 
 ```bash
-cswap --add-token sk-ant-oat01-...
+cswap --add-token sk-ant-oat01-...           # OAuth setup-token
+cswap --add-token sk-ant-api03-...           # managed API key
 cswap --add-token sk-ant-oat01-... --slot 3
 cswap --add-token - --slot 3                 # read token from stdin
 cswap --add-token --email user@example.com   # optional label override
 ```
 
-`--email` is optional; omitted values use `setup-token-{slot}@token.local`.
-No Anthropic API calls are made.
+`--email` is optional; omitted values use `setup-token-{slot}@token.local`
+(or `api-key-{slot}@token.local` for API keys). No Anthropic API calls are made.
+
+**API-key accounts.** An `sk-ant-api...` value registers a managed API-key account
+(the kind Claude Code uses after `/login` with a key) rather than an OAuth
+setup-token. It switches like any other account; since API keys have no subscription
+quota, they show no usage and the usage-aware `--switch` strategies never skip them as
+rate-limited.
 
 ## Uninstall
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -102,7 +102,8 @@ def main() -> None:
         epilog="""
 Examples:
   %(prog)s --add-account
-  %(prog)s --add-token sk-ant-oat01-...
+  %(prog)s --add-token sk-ant-oat01-...           # OAuth setup-token
+  %(prog)s --add-token sk-ant-api03-...           # managed API key
   %(prog)s --add-token sk-ant-oat01-... --slot 3
   %(prog)s --add-token sk-ant-oat01-... --email me@example.com
   %(prog)s --add-token - --slot 3
@@ -169,7 +170,8 @@ Examples:
         metavar="EMAIL",
         help=(
             "Email address for the account. Optional with --add-token; "
-            "defaults to setup-token-{slot}@token.local since setup-tokens "
+            "defaults to setup-token-{slot}@token.local (or "
+            "api-key-{slot}@token.local for API keys) since these tokens "
             "carry no real email metadata."
         ),
     )
@@ -252,8 +254,9 @@ Examples:
         nargs="?",
         const="",
         help=(
-            "Register a raw OAuth setup-token as a new account. "
-            "Pass '-' to read from stdin or omit the value to be prompted securely."
+            "Register a raw OAuth setup-token or managed API key (sk-ant-api...) "
+            "as a new account; the type is auto-detected. Pass '-' to read from "
+            "stdin or omit the value to be prompted securely."
         ),
     )
 

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -18,25 +18,62 @@ orchestration would re-couple. The store owns only its two pieces of state:
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import os
 import sys
+import tempfile
 from pathlib import Path
 from typing import Protocol
 
 from claude_swap import macos_keychain
 from claude_swap.exceptions import CredentialWriteError
 from claude_swap.models import Platform
-from claude_swap.paths import get_claude_config_home, get_credentials_path
+from claude_swap.paths import (
+    get_claude_config_home,
+    get_credentials_path,
+    get_global_config_path,
+)
 
 # Service name for per-account backup credentials now managed via the ``security``
 # CLI on macOS. Deliberately distinct from KEYRING_SERVICE so old keyring items and
 # new security items coexist during migration (safe write → verify → delete).
 SECURITY_SERVICE = "claude-swap"
 
-# Service name of Claude Code's *active* credential in the macOS Keychain (read by
-# Claude Code itself; we read/write it when switching accounts).
+# Service name of Claude Code's *active* OAuth credential in the macOS Keychain
+# (read by Claude Code itself; we read/write it when switching accounts).
 CLAUDE_CODE_KEYCHAIN_SERVICE = "Claude Code-credentials"
+
+# Service name of Claude Code's *active* managed API key (``/login`` with an
+# ``sk-ant-api…`` key) in the macOS Keychain. Distinct from the OAuth service above
+# (no ``-credentials`` suffix); Claude Code resolves it on a separate auth axis
+# (``getApiKeyFromConfigOrMacOSKeychain``). On non-macOS the managed key instead
+# lives in ``~/.claude.json`` as ``primaryApiKey`` (see below).
+CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE = "Claude Code"
+
+
+def looks_like_api_key(credentials: str | None) -> bool:
+    """Whether a stored active credential is a raw managed API key vs OAuth JSON.
+
+    Strict on purpose: a managed key is a bare ``sk-ant-api…`` string, while every
+    OAuth/setup-token credential is a JSON object (``{"claudeAiOauth": …}``). Requiring
+    the ``sk-ant-api`` prefix (and that it isn't JSON) keeps a raw/garbled
+    ``sk-ant-oat…`` setup token from ever being misclassified as an API key.
+    """
+    if not credentials:
+        return False
+    text = credentials.strip()
+    return text.startswith("sk-ant-api") and not text.startswith("{")
+
+
+def approved_form(api_key: str) -> str:
+    """The value Claude Code stores in ``customApiKeyResponses.approved``.
+
+    Mirrors Claude Code's ``normalizeApiKeyForConfig`` (``apiKey.slice(-20)``): the
+    last 20 chars. Storing anything else makes Claude Code's "is this key approved?"
+    check miss and re-prompt the user to approve the key.
+    """
+    return api_key.strip()[-20:]
 
 
 class _StoreHost(Protocol):
@@ -104,17 +141,21 @@ class CredentialStore:
         return self._keychain_usable_cache is not False
 
     def _read_credentials(self) -> str | None:
-        """Read Claude Code's active credentials.
+        """Read Claude Code's active credential — OAuth *or* managed API key.
 
-        macOS reads the Keychain (service "Claude Code-credentials") when it's
-        usable — mirroring Claude Code's keychain-first read — and an empty or
-        failed Keychain falls through to the plaintext file
-        ``~/.claude/.credentials.json`` (where Claude Code itself falls back).
-        Linux/WSL/Windows always read the file. Non-mutating.
+        Tries the OAuth credential first (Keychain "Claude Code-credentials" on
+        macOS when usable, then the plaintext ``~/.claude/.credentials.json`` Claude
+        Code also falls back to), and only then the managed-key locations (macOS
+        Keychain "Claude Code", then ``~/.claude.json`` ``primaryApiKey``). Trying
+        OAuth fully first means a macOS OAuth login that only has a file fallback
+        (Keychain empty) is never misread as an API key. A returned managed key is a
+        raw ``sk-ant-api…`` string — callers distinguish it via ``looks_like_api_key``.
+        Non-mutating.
 
         Returns:
-            Credentials string if found, "" if not found, None on a file read error.
+            Credential string if found, "" if not found, None on a file read error.
         """
+        # 1. OAuth Keychain (macOS, when usable).
         if self._use_keychain():
             try:
                 val = self._kc_call(
@@ -131,16 +172,93 @@ class CredentialStore:
                 val = None
             if val:
                 return val
-            # Keychain empty (rc-44) or failed → read the plaintext fallback file.
 
+        # 2. OAuth plaintext file (Claude Code's own fallback; every platform).
         cred_file = get_credentials_path()
         if cred_file.exists():
             try:
-                return cred_file.read_text(encoding="utf-8")
+                text = cred_file.read_text(encoding="utf-8")
             except Exception as e:
                 self._host._logger.error(f"Failed to read credentials file: {e}")
                 return None
+            if text.strip():
+                return text
+
+        # 3. Managed API key (Keychain "Claude Code" on macOS, then primaryApiKey).
+        key = self._read_managed_key()
+        if key:
+            return key
         return ""
+
+    def _read_managed_key(self) -> str:
+        """Read the active managed API key, or "" when absent. Non-mutating.
+
+        macOS Keychain "Claude Code" (when usable) first, then ``~/.claude.json``
+        ``primaryApiKey`` — mirroring Claude Code's
+        ``getApiKeyFromConfigOrMacOSKeychain``.
+        """
+        if self._use_keychain():
+            try:
+                val = self._kc_call(
+                    macos_keychain.get_password,
+                    CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
+                    macos_keychain.keychain_account_name(),
+                )
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                self._host._logger.warning(f"Managed-key Keychain read failed: {e}")
+                val = None
+            if val:
+                return val
+        cfg = self._read_global_config()
+        if cfg:
+            key = cfg.get("primaryApiKey")
+            if isinstance(key, str) and key:
+                return key
+        return ""
+
+    def _read_global_config(self) -> dict | None:
+        """Read and parse ``~/.claude.json``, or None when absent/unreadable."""
+        path = get_global_config_path()
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            self._host._logger.warning(f"Failed to read global config: {e}")
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _update_global_config(self, mutator) -> None:
+        """Atomically apply ``mutator(dict)`` to ``~/.claude.json``, key-scoped.
+
+        Reads the current config, lets ``mutator`` change only the keys it owns
+        (``primaryApiKey`` / ``customApiKeyResponses``), and writes it back
+        atomically — preserving every other key (``oauthAccount``, projects,
+        settings). 0o600 mirrors the switcher's ``_write_json``.
+        """
+        path = get_global_config_path()
+        try:
+            data = self._read_global_config() or {}
+        except Exception as e:  # pragma: no cover - defensive
+            raise CredentialWriteError(f"Failed to read global config for update: {e}")
+        mutator(data)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
+            os.close(fd)
+            fd = -1
+            os.replace(tmp_path, str(path))
+            if sys.platform != "win32":
+                os.chmod(str(path), 0o600)
+        except BaseException:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def _write_active_credentials_file(self, credentials: str) -> None:
         """Atomically write Claude Code's plaintext active-credentials file."""
@@ -183,7 +301,134 @@ class CredentialStore:
             pass  # best-effort; a down Keychain can't be cleaned now
 
     def _write_credentials(self, credentials: str) -> None:
-        """Write Claude Code's active credentials.
+        """Write Claude Code's active credential, enforcing a single auth axis.
+
+        Detects the kind from the payload (raw ``sk-ant-api…`` key vs OAuth JSON) and
+        mirrors Claude Code's own ``saveApiKey``/``removeApiKey``: activating one axis
+        clears the other so a stale credential can't shadow the switch.
+
+        - **OAuth** → write the OAuth credential (see ``_write_oauth_credentials``),
+          then clear any managed key (Keychain "Claude Code" + ``primaryApiKey``;
+          ``approved`` left intact, as ``removeApiKey`` does).
+        - **API key** → record ``key[-20:]`` in ``approved`` and store the key (macOS
+          Keychain "Claude Code" when usable, else ``~/.claude.json`` ``primaryApiKey``),
+          then clear the OAuth credential (Keychain item + ``.credentials.json``).
+
+        Raises:
+            CredentialWriteError: If writing credentials fails.
+        """
+        if looks_like_api_key(credentials):
+            self._write_managed_credentials(credentials.strip())
+        else:
+            self._write_oauth_credentials(credentials)
+            self._clear_managed_key()
+
+    def _write_managed_credentials(self, api_key: str) -> None:
+        """Activate a managed API key, then clear OAuth (mutual exclusion).
+
+        Always records ``key[-20:]`` in ``customApiKeyResponses.approved`` (Claude
+        Code does this on every platform, even on Keychain success — otherwise it
+        re-prompts to approve the key). Stores the key in the macOS Keychain when
+        usable, else ``~/.claude.json`` ``primaryApiKey`` (matching ``saveApiKey``'s
+        keychain-then-config fallback). Finally clears the OAuth credential.
+
+        Raises:
+            CredentialWriteError: If persisting the key fails.
+        """
+        wrote_to_keychain = False
+        if self._use_keychain():
+            try:
+                self._kc_call(
+                    macos_keychain.set_password,
+                    CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
+                    macos_keychain.keychain_account_name(),
+                    api_key,
+                )
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                # _kc_call flipped routing to file mode; fall back to config below.
+                self._host._logger.warning(
+                    f"Managed-key Keychain write failed, falling back to config: {e}"
+                )
+            else:
+                wrote_to_keychain = True
+
+        approved = approved_form(api_key)
+
+        def _mutate(cfg: dict) -> None:
+            responses = cfg.get("customApiKeyResponses")
+            if not isinstance(responses, dict):
+                responses = {}
+            approved_list = responses.get("approved")
+            if not isinstance(approved_list, list):
+                approved_list = []
+            if approved not in approved_list:
+                approved_list.append(approved)
+            responses["approved"] = approved_list
+            responses.setdefault("rejected", [])
+            cfg["customApiKeyResponses"] = responses
+            if wrote_to_keychain:
+                # Keychain holds the key; keep it out of plaintext config.
+                cfg.pop("primaryApiKey", None)
+            else:
+                cfg["primaryApiKey"] = api_key
+
+        try:
+            self._update_global_config(_mutate)
+        except CredentialWriteError:
+            raise
+        except Exception as e:
+            raise CredentialWriteError(f"Failed to write managed API key: {e}")
+
+        # Mutual exclusion: drop the OAuth credential so it can't shadow the key.
+        self._clear_oauth_credential()
+        self._last_active_credentials_backend = (
+            "keychain" if wrote_to_keychain else "file"
+        )
+
+    def _clear_managed_key(self) -> None:
+        """Clear any active managed API key (Claude Code ``removeApiKey`` semantics).
+
+        Deletes the macOS Keychain "Claude Code" item (best-effort) and drops
+        ``primaryApiKey`` from ``~/.claude.json``. Leaves
+        ``customApiKeyResponses.approved`` untouched — ``removeApiKey`` doesn't clear
+        it either, and removing it would force recovering ``key[-20:]`` from the
+        Keychain for no benefit. A no-op (no config rewrite) when no key is present.
+        """
+        if self._host.platform == Platform.MACOS:
+            try:
+                macos_keychain.delete_password(
+                    CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
+                    macos_keychain.keychain_account_name(),
+                )
+            except Exception:
+                pass  # best-effort; a down Keychain can't be cleaned now
+        cfg = self._read_global_config()
+        if cfg is not None and cfg.get("primaryApiKey") is not None:
+            def _drop(c: dict) -> None:
+                c.pop("primaryApiKey", None)
+
+            try:
+                self._update_global_config(_drop)
+            except Exception as e:
+                self._host._logger.warning(f"Failed to clear primaryApiKey: {e}")
+
+    def _clear_oauth_credential(self) -> None:
+        """Clear the active OAuth credential — Keychain item and plaintext file.
+
+        Best-effort: a down Keychain or missing file is fine. Removing
+        ``.credentials.json`` stops Claude Code from falling back to a stale OAuth
+        login over the just-activated API key.
+        """
+        self._delete_active_keychain_entry()
+        cred_file = get_credentials_path()
+        try:
+            if cred_file.exists():
+                cred_file.unlink()
+        except OSError as e:
+            self._host._logger.warning(f"Failed to remove credentials file: {e}")
+
+    def _write_oauth_credentials(self, credentials: str) -> None:
+        """Write Claude Code's active OAuth credentials.
 
         macOS writes the Keychain when usable (recording backend ``"keychain"``)
         and **leaves the plaintext file untouched**, mirroring Claude Code, which

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -16,6 +16,9 @@ SCHEMA_VERSION = 1
 # JSON projection agree instead of scattering raw strings.
 USAGE_NO_CREDENTIALS = "no credentials"
 USAGE_TOKEN_EXPIRED = "token expired"
+# API-key (``/login`` managed key) accounts have no subscription quota; usage is
+# reported as this sentinel instead of being fetched from the OAuth usage API.
+USAGE_API_KEY = "api key"
 
 
 def _window_to_json(entry: dict) -> dict:
@@ -63,13 +66,16 @@ def usage_fields(entry: dict | str | None) -> tuple[str, dict | None]:
     """Map a collected usage entry to ``(usageStatus, usage|None)``.
 
     A collected entry is one of: a usage dict, the ``USAGE_TOKEN_EXPIRED`` sentinel
-    (active token expired while Claude Code owns it), the ``USAGE_NO_CREDENTIALS``
+    (active token expired while Claude Code owns it), the ``USAGE_API_KEY`` sentinel
+    (managed API-key account, no subscription quota), the ``USAGE_NO_CREDENTIALS``
     sentinel, or ``None`` (fetch failed).
     """
     if isinstance(entry, dict):
         return "ok", usage_to_json(entry)
     if entry == USAGE_TOKEN_EXPIRED:
         return "token_expired", None
+    if entry == USAGE_API_KEY:
+        return "api_key", None
     if isinstance(entry, str):
         return "no_credentials", None
     return "unavailable", None

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -199,6 +199,9 @@ class SessionManager:
             )
 
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
+        # Guard before the same-account direct-launch fast path below (which
+        # _exec's claude and never returns) — and before setup_session.
+        self._ensure_not_api_key(account_num, email)
 
         config_dir_preset = os.environ.get("CLAUDE_CONFIG_DIR")
         if config_dir_preset:
@@ -261,11 +264,27 @@ class SessionManager:
         os.execvpe(claude_bin, argv, env)
         raise AssertionError("unreachable")  # pragma: no cover
 
+    def _ensure_not_api_key(self, account_num: str, email: str) -> None:
+        """Reject API-key accounts in session mode (not supported yet).
+
+        Session bootstrap is OAuth-shaped — it seeds ``.credentials.json`` and
+        ``_is_session_valid`` requires ``authMethod == "claude.ai"`` — so an API-key
+        account would otherwise fail validation opaquely. Raise early with guidance.
+        """
+        if self.switcher._account_kind(account_num) == "api_key":
+            raise SessionError(
+                f"Account-{account_num} ({email}) is an API-key account; "
+                "'cswap run' (session mode) does not support API-key accounts yet. "
+                "Use 'cswap --switch-to' to make it your default login instead."
+            )
+
     # -- bootstrap -------------------------------------------------------
 
     def setup_session(self, identifier: str, share: bool) -> tuple[Path, str, str]:
         """Ensure a valid session profile exists; returns (dir, num, email)."""
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
+        # Defense-in-depth: also guard here (run() guards before its fast path).
+        self._ensure_not_api_key(account_num, email)
         session_dir = session_dir_for(self.switcher.backup_dir, account_num, email)
 
         # Deferred invalidation: backup credentials changed while this profile

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -25,6 +25,7 @@ from claude_swap import oauth
 from claude_swap.cache import MISSING, read_cache, write_cache
 from claude_swap.json_output import (
     SCHEMA_VERSION,
+    USAGE_API_KEY,
     USAGE_NO_CREDENTIALS,
     USAGE_TOKEN_EXPIRED,
     account_ref,
@@ -35,6 +36,7 @@ from claude_swap.credentials import (  # noqa: F401  (constants re-exported for 
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     SECURITY_SERVICE,
     CredentialStore,
+    looks_like_api_key,
 )
 from claude_swap.locking import FileLock
 from claude_swap.logging_config import setup_logging
@@ -569,6 +571,61 @@ class ClaudeAccountSwitcher:
             return False
         return self._find_account_slot(data, email, organization_uuid) is not None
 
+    def _account_kind(self, account_num: str | None) -> str:
+        """Stored kind for a managed slot: ``"api_key"`` or ``"oauth"`` (default).
+
+        Slots added before this field existed have no ``kind`` and read as
+        ``"oauth"`` (back-compat).
+        """
+        if account_num is None:
+            return "oauth"
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(str(account_num), {})
+        return "api_key" if record.get("kind") == "api_key" else "oauth"
+
+    def _reject_live_api_key_capture(self, creds: str) -> None:
+        """Guard for ``add_account``: never capture a live managed key as OAuth.
+
+        ``add_account`` snapshots the *live* active credential under an
+        ``oauthAccount`` identity. Now that ``_read_credentials`` can return a raw
+        ``sk-ant-api…`` key, a live ``/login`` key could be backed up as a kindless
+        account, corrupting the session-guard / export / collision logic that keys
+        off ``kind``. Reject with guidance toward the supported path instead.
+        """
+        if looks_like_api_key(creds):
+            raise ValidationError(
+                "Active login is an API-key account. Add it with "
+                "'cswap --add-token sk-ant-api...' instead of --add-account."
+            )
+
+    def _reject_cross_kind_collision(self, email: str, is_api_key: bool) -> None:
+        """Reject registering a token whose (email, personal-org) already exists as
+        the *other* kind.
+
+        Identity is matched on ``(email, organizationUuid)`` only, so two slots
+        sharing an email across kinds (one OAuth, one API key) could not be told
+        apart at switch time. Rather than thread ``kind`` through the whole identity
+        system, refuse the collision and point the user at a distinct ``--email``.
+        The default ``…@token.local`` labels never collide; this only guards a forced
+        ``--email``.
+        """
+        data = self._get_sequence_data()
+        if not data:
+            return
+        slot = self._find_account_slot(data, email, "")
+        if slot is None:
+            return
+        existing_kind = self._account_kind(slot)
+        new_kind = "api_key" if is_api_key else "oauth"
+        if existing_kind != new_kind:
+            existing_label = "API-key" if existing_kind == "api_key" else "OAuth"
+            new_label = "API-key" if is_api_key else "OAuth"
+            raise ValidationError(
+                f"'{email}' already exists as an {existing_label} account "
+                f"(slot {slot}); cannot add it as an {new_label} account. "
+                f"Pass a distinct --email."
+            )
+
     @staticmethod
     def _get_display_tag(email: str, org_name: str, org_uuid: str) -> str:
         """Return display tag for an account's org context."""
@@ -710,6 +767,7 @@ class ClaudeAccountSwitcher:
                 raise CredentialReadError("Failed to read credentials for current account")
             if not current_creds:
                 raise CredentialReadError("No credentials found for current account")
+            self._reject_live_api_key_capture(current_creds)
 
             config_path = self._get_claude_config_path()
             try:
@@ -787,6 +845,7 @@ class ClaudeAccountSwitcher:
             raise CredentialReadError("Failed to read credentials for current account")
         if not current_creds:
             raise CredentialReadError("No credentials found for current account")
+        self._reject_live_api_key_capture(current_creds)
 
         config_path = self._get_claude_config_path()
         try:
@@ -850,18 +909,21 @@ class ClaudeAccountSwitcher:
     def add_account_from_token(
         self, token: str, email: str | None = None, slot: int | None = None
     ) -> None:
-        """Register a raw OAuth setup-token as a new account.
+        """Register a raw OAuth setup-token or managed API key as a new account.
 
         Useful for headless servers or when the token is received from another
-        machine, without needing a prior Claude Code login on this machine.
-        No Anthropic API calls are made.
+        machine, without needing a prior Claude Code login on this machine. The
+        token type is auto-detected: an ``sk-ant-api…`` value is a managed API key
+        (stored raw, activated on Claude Code's API-key auth axis), anything else is
+        treated as an OAuth setup-token. No Anthropic API calls are made.
 
         Args:
-            token: Raw OAuth access token, or ``"-"`` to read one line from
-                   stdin, or ``""`` to prompt securely via getpass.
+            token: Raw OAuth setup-token or ``sk-ant-api…`` key, or ``"-"`` to read
+                   one line from stdin, or ``""`` to prompt securely via getpass.
             email: Email address to associate with the account. When omitted,
-                   defaults to ``setup-token-{slot}@token.local`` since
-                   setup-tokens carry no real email metadata.
+                   defaults to ``setup-token-{slot}@token.local`` (or
+                   ``api-key-{slot}@token.local`` for API keys) since these tokens
+                   carry no real email metadata.
             slot:  Slot number to use; auto-assigned when ``None``.
         """
         import getpass
@@ -869,11 +931,13 @@ class ClaudeAccountSwitcher:
         if token == "-":
             token = sys.stdin.readline().rstrip("\n")
         elif not token:
-            token = getpass.getpass("Setup token: ")
+            token = getpass.getpass("Token: ")
 
         token = token.strip()
         if not token:
             raise ValidationError("Token cannot be empty")
+
+        is_api_key = looks_like_api_key(token)
 
         if email and not self._validate_email(email):
             raise ValidationError(f"Invalid email format: {email}")
@@ -882,13 +946,40 @@ class ClaudeAccountSwitcher:
         self._init_sequence_file()
         self._migrate_org_fields()
 
-        # Synthesize a placeholder email when one isn't provided. Setup-tokens
+        # Synthesize a placeholder email when one isn't provided. These tokens
         # have no real email metadata, so requiring users to invent one is
         # noise; the slot number gives every default account a unique key.
         if not email:
             if slot is None:
                 slot = self._get_next_account_number()
-            email = f"setup-token-{slot}@token.local"
+            label = "api-key" if is_api_key else "setup-token"
+            email = f"{label}-{slot}@token.local"
+
+        # Don't silently overwrite/convert an existing account of the other kind:
+        # identity is matched on (email, org) only, so an api-key and an OAuth
+        # account sharing an email would be indistinguishable at switch time.
+        self._reject_cross_kind_collision(email, is_api_key)
+
+        # Build the credential payload by kind: a managed key is stored raw; an
+        # OAuth setup-token is wrapped in Claude Code's credential JSON. The
+        # synthesized config is identical for both (no real org metadata).
+        if is_api_key:
+            credentials = token
+        else:
+            credentials = json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": token,
+                    "scopes": list(SETUP_TOKEN_SCOPES),
+                }
+            })
+        config = json.dumps({
+            "oauthAccount": {
+                "emailAddress": email,
+                "accountUuid": "",
+                "organizationUuid": None,
+                "organizationName": None,
+            }
+        })
 
         # If the account already exists (same email, personal), refresh in place.
         if slot is None and self._account_exists(email, ""):
@@ -898,27 +989,14 @@ class ClaudeAccountSwitcher:
                 raise ConfigError(
                     f"Existing account metadata for {email} is inconsistent"
                 )
-            credentials = json.dumps({
-                "claudeAiOauth": {
-                    "accessToken": token,
-                    "scopes": list(SETUP_TOKEN_SCOPES),
-                }
-            })
-            config = json.dumps({
-                "oauthAccount": {
-                    "emailAddress": email,
-                    "accountUuid": "",
-                    "organizationUuid": None,
-                    "organizationName": None,
-                }
-            })
             self._write_account_credentials(account_num, email, credentials)
             self._write_account_config(account_num, email, config)
             seq["lastUpdated"] = get_timestamp()
             self._write_json(self.sequence_file, seq)
-            self._logger.info(f"Updated token for account {account_num}: {email}")
+            kind_label = "API key" if is_api_key else "token"
+            self._logger.info(f"Updated {kind_label} for account {account_num}: {email}")
             print(
-                f"{accent('Updated token')} for Account {account_num} "
+                f"{accent(f'Updated {kind_label}')} for Account {account_num} "
                 f"({email} {muted('[personal]')})."
             )
             return
@@ -964,21 +1042,6 @@ class ClaudeAccountSwitcher:
         else:
             account_num = str(self._get_next_account_number())
 
-        credentials = json.dumps({
-            "claudeAiOauth": {
-                "accessToken": token,
-                "scopes": list(SETUP_TOKEN_SCOPES),
-            }
-        })
-        config = json.dumps({
-            "oauthAccount": {
-                "emailAddress": email,
-                "accountUuid": "",
-                "organizationUuid": None,
-                "organizationName": None,
-            }
-        })
-
         if displace_slot:
             d_num, d_email = displace_slot
             self._delete_account_files(d_num, d_email)
@@ -1002,23 +1065,27 @@ class ClaudeAccountSwitcher:
         self._write_account_config(account_num, email, config)
 
         data = self._get_sequence_data()
-        data["accounts"][account_num] = {
+        record = {
             "email": email,
             "uuid": "",
             "organizationUuid": "",
             "organizationName": "",
             "added": get_timestamp(),
         }
+        if is_api_key:
+            record["kind"] = "api_key"
+        data["accounts"][account_num] = record
         if int(account_num) not in data["sequence"]:
             data["sequence"].append(int(account_num))
             data["sequence"].sort()
         data["lastUpdated"] = get_timestamp()
 
         self._write_json(self.sequence_file, data)
-        self._logger.info(f"Added account {account_num} from token: {email}")
+        source_label = "API key" if is_api_key else "token"
+        self._logger.info(f"Added account {account_num} from {source_label}: {email}")
         print(
             f"{accent('Added')} Account {account_num}: {email} "
-            f"{muted('[personal]')} {muted('(from token)')}"
+            f"{muted('[personal]')} {muted(f'(from {source_label})')}"
         )
 
     def remove_account(self, identifier: str) -> None:
@@ -1245,6 +1312,9 @@ class ClaudeAccountSwitcher:
             account_info: tuple[int, str, str, str, bool, str]
         ) -> dict | str | None:
             num, email, _, _, is_active, creds = account_info
+            if looks_like_api_key(creds):
+                # Managed API-key account: no subscription quota to fetch.
+                return USAGE_API_KEY
             if not creds or not oauth.extract_access_token(creds):
                 return USAGE_NO_CREDENTIALS
 
@@ -1416,6 +1486,8 @@ class ClaudeAccountSwitcher:
                 print(f"  {num}: {email} {muted(f'[{tag}]')}")
             if usage == USAGE_TOKEN_EXPIRED:
                 print(f"     {dimmed('token expired — Claude Code refreshes the active account')}")
+            elif usage == USAGE_API_KEY:
+                print(f"     {dimmed('API key (no quota)')}")
             elif isinstance(usage, str):
                 print(f"     {dimmed(usage)}")
             elif usage is None:
@@ -1478,6 +1550,9 @@ class ClaudeAccountSwitcher:
         owner-aware refresh decision to ``_fetch_active_usage``.
         """
         creds = self._read_credentials() or ""
+        if looks_like_api_key(creds):
+            # Managed API-key account: no subscription quota to fetch.
+            return USAGE_API_KEY
         if not creds or not oauth.extract_access_token(creds):
             return USAGE_NO_CREDENTIALS
         usage_cache_path = self.backup_dir / "cache" / "usage.json"
@@ -1570,6 +1645,8 @@ class ClaudeAccountSwitcher:
                     print(f"  {dimmed(connector)} {muted(line)}")
             elif usage == USAGE_TOKEN_EXPIRED:
                 print(f"  {dimmed('token expired — Claude Code refreshes the active account')}")
+            elif usage == USAGE_API_KEY:
+                print(f"  {dimmed('API key (no quota)')}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
         return None

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from claude_swap import __version__
+from claude_swap.credentials import looks_like_api_key
 from claude_swap.exceptions import (
     ConfigError,
     CredentialReadError,
@@ -199,18 +200,27 @@ def export_accounts(
         if not full:
             config_obj = _slim_config(config_obj, f"config for {email}")
 
-        accounts_payload.append(
-            {
-                "number": int(num),
-                "email": email,
-                "uuid": record.get("uuid", ""),
-                "organizationUuid": org_uuid,
-                "organizationName": record.get("organizationName", "") or "",
-                "added": record.get("added", ""),
-                "credentials": _parse_payload(creds_text, f"credentials for {email}"),
-                "config": config_obj,
-            }
-        )
+        # API-key accounts store the credential as a raw ``sk-ant-api…`` string,
+        # not OAuth JSON — carry it verbatim (and tag the kind) so the JSON parse
+        # below doesn't choke and import can restore it as-is.
+        is_api_key = looks_like_api_key(creds_text)
+        entry: dict[str, Any] = {
+            "number": int(num),
+            "email": email,
+            "uuid": record.get("uuid", ""),
+            "organizationUuid": org_uuid,
+            "organizationName": record.get("organizationName", "") or "",
+            "added": record.get("added", ""),
+            "credentials": (
+                creds_text.strip()
+                if is_api_key
+                else _parse_payload(creds_text, f"credentials for {email}")
+            ),
+            "config": config_obj,
+        }
+        if is_api_key:
+            entry["kind"] = "api_key"
+        accounts_payload.append(entry)
 
     if not accounts_payload:
         raise TransferError(
@@ -306,10 +316,23 @@ def import_accounts(
         org_uuid = raw.get("organizationUuid", "") or ""
         creds_obj = raw.get("credentials")
         config_obj = raw.get("config")
-        if not isinstance(creds_obj, dict) or not isinstance(config_obj, dict):
-            raise TransferError(
-                f"credentials and config for {email} must be JSON objects"
-            )
+        if not isinstance(config_obj, dict):
+            raise TransferError(f"config for {email} must be a JSON object")
+        # API-key accounts carry the credential as a raw string; OAuth accounts
+        # carry a JSON object.
+        is_api_key = raw.get("kind") == "api_key" or isinstance(creds_obj, str)
+        if is_api_key:
+            if not (isinstance(creds_obj, str) and looks_like_api_key(creds_obj)):
+                raise TransferError(
+                    f"API-key credentials for {email} must be a raw sk-ant-api… string"
+                )
+            creds_text = creds_obj.strip()
+        else:
+            if not isinstance(creds_obj, dict):
+                raise TransferError(
+                    f"credentials for {email} must be a JSON object"
+                )
+            creds_text = json.dumps(creds_obj)
         key = (email, org_uuid)
         if key in seen_keys:
             raise TransferError(
@@ -324,7 +347,8 @@ def import_accounts(
                 "org_name": raw.get("organizationName", "") or "",
                 "uuid": raw.get("uuid", "") or "",
                 "added": raw.get("added") or get_timestamp(),
-                "creds_text": json.dumps(creds_obj),
+                "kind": "api_key" if is_api_key else "oauth",
+                "creds_text": creds_text,
                 "config_text": json.dumps(config_obj, indent=2),
             }
         )
@@ -406,13 +430,16 @@ def import_accounts(
 
         data.setdefault("accounts", {})
         data.setdefault("sequence", [])
-        data["accounts"][target_num] = {
+        new_record = {
             "email": entry["email"],
             "uuid": entry["uuid"],
             "organizationUuid": entry["org_uuid"],
             "organizationName": entry["org_name"],
             "added": entry["added"],
         }
+        if entry["kind"] == "api_key":
+            new_record["kind"] = "api_key"
+        data["accounts"][target_num] = new_record
         if int(target_num) not in data["sequence"]:
             data["sequence"].append(int(target_num))
             data["sequence"].sort()

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -1,0 +1,366 @@
+"""Tests for managed API-key (``/login`` key) account support.
+
+Covers kind detection, ``--add-token`` auto-detection, the cross-kind collision
+guard, the ``add_account`` live-key guard, kind+platform-aware active credential
+read/write with OAuth↔API-key mutual exclusion, the "API key — no quota" usage
+display, the ``cswap run`` session guard, and export/import of raw keys.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap import macos_keychain
+from claude_swap import session as session_mod
+from claude_swap.credentials import (
+    CLAUDE_CODE_KEYCHAIN_SERVICE,
+    CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
+    approved_form,
+    looks_like_api_key,
+)
+from claude_swap.exceptions import SessionError, ValidationError
+from claude_swap.json_output import USAGE_API_KEY, usage_fields
+from claude_swap.models import Platform
+from claude_swap.paths import get_credentials_path, get_global_config_path
+from claude_swap.session import SessionManager
+from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.transfer import export_accounts, import_accounts
+
+API_KEY = "sk-ant-api03-" + "a1b2c3d4e5" * 4  # 53 chars
+OTHER_KEY = "sk-ant-api03-" + "z9y8x7w6v5" * 4
+OAUTH_JSON = json.dumps(
+    {"claudeAiOauth": {"accessToken": "tok", "refreshToken": "rtok", "expiresAt": 9}}
+)
+
+
+def _linux_switcher() -> ClaudeAccountSwitcher:
+    s = ClaudeAccountSwitcher()
+    s.platform = Platform.LINUX
+    s._setup_directories()
+    s._init_sequence_file()
+    return s
+
+
+def _macos_switcher() -> ClaudeAccountSwitcher:
+    s = ClaudeAccountSwitcher()
+    s.platform = Platform.MACOS
+    s._setup_directories()
+    s._init_sequence_file()
+    return s
+
+
+def _read_global_config() -> dict:
+    return json.loads(get_global_config_path().read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Kind detection helpers
+# ---------------------------------------------------------------------------
+
+
+class TestKindDetection:
+    def test_api_key_detected(self):
+        assert looks_like_api_key(API_KEY) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            None,
+            "sk-ant-oat01-abcdef",  # setup-token, not a key
+            OAUTH_JSON,  # OAuth JSON blob
+            '{"x": "sk-ant-api03-inside-json"}',  # JSON that merely contains a key
+        ],
+    )
+    def test_non_api_key(self, value):
+        assert looks_like_api_key(value) is False
+
+    def test_approved_form_is_last_20(self):
+        assert approved_form(API_KEY) == API_KEY[-20:]
+        assert len(approved_form(API_KEY)) == 20
+
+
+# ---------------------------------------------------------------------------
+# --add-token auto-detection
+# ---------------------------------------------------------------------------
+
+
+class TestAddTokenApiKey:
+    def test_adds_api_key_account(self, temp_home: Path, capsys):
+        s = _linux_switcher()
+        s.add_account_from_token(API_KEY)
+
+        assert s._account_kind("1") == "api_key"
+        # default synthesized label
+        data = s._get_sequence_data()
+        assert data["accounts"]["1"]["email"] == "api-key-1@token.local"
+        # the raw key is stored verbatim as the backup credential
+        assert s._read_account_credentials("1", "api-key-1@token.local") == API_KEY
+        out = capsys.readouterr().out
+        assert "Added" in out and "API key" in out
+
+    def test_setup_token_stays_oauth(self, temp_home: Path):
+        s = _linux_switcher()
+        s.add_account_from_token("sk-ant-oat01-abc")
+        assert s._account_kind("1") == "oauth"
+        email = s._get_sequence_data()["accounts"]["1"]["email"]
+        assert email == "setup-token-1@token.local"
+        blob = json.loads(s._read_account_credentials("1", email))
+        assert blob["claudeAiOauth"]["accessToken"] == "sk-ant-oat01-abc"
+
+    def test_refresh_in_place_same_api_key_account(self, temp_home: Path):
+        s = _linux_switcher()
+        s.add_account_from_token(API_KEY, email="me@example.com")
+        s.add_account_from_token(OTHER_KEY, email="me@example.com")
+        data = s._get_sequence_data()
+        assert len(data["accounts"]) == 1
+        assert s._read_account_credentials("1", "me@example.com") == OTHER_KEY
+
+
+class TestCrossKindCollision:
+    def test_api_key_rejected_when_email_is_oauth(self, temp_home: Path):
+        s = _linux_switcher()
+        s.add_account_from_token("sk-ant-oat01-abc", email="dup@example.com")
+        with pytest.raises(ValidationError, match="already exists as an OAuth account"):
+            s.add_account_from_token(API_KEY, email="dup@example.com")
+
+    def test_oauth_rejected_when_email_is_api_key(self, temp_home: Path):
+        s = _linux_switcher()
+        s.add_account_from_token(API_KEY, email="dup@example.com")
+        with pytest.raises(ValidationError, match="already exists as an API-key account"):
+            s.add_account_from_token("sk-ant-oat01-abc", email="dup@example.com")
+
+
+# ---------------------------------------------------------------------------
+# Active credential read/write + mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCredentialsLinux:
+    def test_activate_key_then_oauth(self, temp_home: Path):
+        s = _linux_switcher()
+        cred_file = get_credentials_path()
+        cred_file.parent.mkdir(parents=True, exist_ok=True)
+        cred_file.write_text(OAUTH_JSON, encoding="utf-8")
+
+        # Activate the API key: primaryApiKey + approved set, OAuth file cleared.
+        s._write_credentials(API_KEY)
+        cfg = _read_global_config()
+        assert cfg["primaryApiKey"] == API_KEY
+        assert API_KEY[-20:] in cfg["customApiKeyResponses"]["approved"]
+        assert not cred_file.exists()
+
+        # Switch back to OAuth: file restored, primaryApiKey dropped, approved kept.
+        s._write_credentials(OAUTH_JSON)
+        assert cred_file.read_text(encoding="utf-8") == OAUTH_JSON
+        cfg = _read_global_config()
+        assert "primaryApiKey" not in cfg
+        assert API_KEY[-20:] in cfg["customApiKeyResponses"]["approved"]
+
+    def test_read_credentials_returns_active_key(self, temp_home: Path):
+        s = _linux_switcher()
+        get_global_config_path().write_text(
+            json.dumps({"primaryApiKey": API_KEY}), encoding="utf-8"
+        )
+        assert s._read_credentials() == API_KEY
+
+    def test_oauth_file_not_misread_as_key(self, temp_home: Path):
+        s = _linux_switcher()
+        cred_file = get_credentials_path()
+        cred_file.parent.mkdir(parents=True, exist_ok=True)
+        cred_file.write_text(OAUTH_JSON, encoding="utf-8")
+        # primaryApiKey also present, but the OAuth file wins (read first).
+        get_global_config_path().write_text(
+            json.dumps({"primaryApiKey": API_KEY}), encoding="utf-8"
+        )
+        assert s._read_credentials() == OAUTH_JSON
+
+
+class TestWriteCredentialsMacOS:
+    def test_activate_key_uses_keychain_not_config(self, temp_home, block_real_keychain):
+        store = block_real_keychain
+        s = _macos_switcher()
+        acct = macos_keychain.keychain_account_name()
+        store.set_password(CLAUDE_CODE_KEYCHAIN_SERVICE, acct, OAUTH_JSON)
+
+        s._write_credentials(API_KEY)
+
+        # Key in the managed keychain service; OAuth keychain item cleared.
+        assert store.get_password(CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE, acct) == API_KEY
+        assert store.get_password(CLAUDE_CODE_KEYCHAIN_SERVICE, acct) is None
+        # approved recorded, but the full key stays OUT of plaintext config.
+        cfg = _read_global_config()
+        assert API_KEY[-20:] in cfg["customApiKeyResponses"]["approved"]
+        assert "primaryApiKey" not in cfg
+
+    def test_switch_back_to_oauth_clears_key(self, temp_home, block_real_keychain):
+        store = block_real_keychain
+        s = _macos_switcher()
+        s._write_credentials(API_KEY)
+        acct = macos_keychain.keychain_account_name()
+        assert store.get_password(CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE, acct) == API_KEY
+
+        s._write_credentials(OAUTH_JSON)
+        # managed keychain cleared, OAuth keychain populated, approved kept.
+        assert store.get_password(CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE, acct) is None
+        assert store.get_password(CLAUDE_CODE_KEYCHAIN_SERVICE, acct) == OAUTH_JSON
+        cfg = _read_global_config()
+        assert API_KEY[-20:] in cfg["customApiKeyResponses"]["approved"]
+
+    def test_read_credentials_from_managed_keychain(self, temp_home, block_real_keychain):
+        store = block_real_keychain
+        s = _macos_switcher()
+        acct = macos_keychain.keychain_account_name()
+        store.set_password(CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE, acct, API_KEY)
+        assert s._read_credentials() == API_KEY
+
+
+# ---------------------------------------------------------------------------
+# Usage display ("API key — no quota")
+# ---------------------------------------------------------------------------
+
+
+class TestUsageDisplay:
+    def test_usage_fields_maps_api_key(self):
+        assert usage_fields(USAGE_API_KEY) == ("api_key", None)
+
+    def test_collect_usage_short_circuits(self, temp_home: Path):
+        s = _linux_switcher()
+        info = [(2, "api-key-2@token.local", "", "", False, API_KEY)]
+        assert s._collect_usage(info) == [USAGE_API_KEY]
+
+    def test_active_account_usage_short_circuits(self, temp_home: Path):
+        s = _linux_switcher()
+        get_global_config_path().write_text(
+            json.dumps({"primaryApiKey": API_KEY}), encoding="utf-8"
+        )
+        assert s._active_account_usage("2", "api-key-2@token.local") == USAGE_API_KEY
+
+
+class TestStrategyBehaviour:
+    """API-key accounts are never *rate-limited* (next-available can fall back to
+    them), but `best` must NOT auto-prefer them — they have no measurable quota and
+    jumping to one would silently spend paid per-token credits."""
+
+    def test_api_key_headroom_is_unknown(self):
+        # None headroom == "unknown" == never auto-skipped by next-available.
+        from claude_swap import oauth
+
+        assert oauth.account_headroom(USAGE_API_KEY) is None
+
+    def test_best_does_not_jump_to_api_key_even_when_exhausted(
+        self, temp_home: Path, monkeypatch
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token("sk-ant-oat01-x", slot=1)  # OAuth, switchable
+        s.add_account_from_token(API_KEY, slot=2)  # API key, switchable
+        # Current OAuth account (1) is fully exhausted; the only other account is
+        # the no-quota API key. `best` must stay put rather than burn API credits.
+        monkeypatch.setattr(
+            s,
+            "_usage_by_account",
+            lambda: {"1": {"five_hour": {"pct": 100.0}}, "2": USAGE_API_KEY},
+        )
+        target, _ = s._select_best_switchable("1")
+        assert target is None
+
+
+# ---------------------------------------------------------------------------
+# add_account guard against capturing a live API-key login
+# ---------------------------------------------------------------------------
+
+
+class TestAddAccountGuard:
+    def test_rejects_live_api_key_login(self, temp_home: Path):
+        s = _linux_switcher()
+        # Lingering oauthAccount identity + an active managed key in config.
+        get_global_config_path().write_text(
+            json.dumps(
+                {
+                    "oauthAccount": {"emailAddress": "stale@example.com"},
+                    "primaryApiKey": API_KEY,
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValidationError, match="Active login is an API-key account"):
+            s.add_account()
+
+
+# ---------------------------------------------------------------------------
+# Session-mode guard
+# ---------------------------------------------------------------------------
+
+
+class TestSessionGuard:
+    def _seed_api_key_account(self) -> ClaudeAccountSwitcher:
+        s = _linux_switcher()
+        s.add_account_from_token(API_KEY, slot=2)
+        return s
+
+    def test_setup_session_rejects(self, temp_home: Path):
+        mgr = SessionManager(self._seed_api_key_account())
+        with pytest.raises(SessionError, match="does not support API-key accounts"):
+            mgr.setup_session("2", share=True)
+
+    def test_run_rejects_before_exec(self, temp_home: Path, monkeypatch):
+        mgr = SessionManager(self._seed_api_key_account())
+        monkeypatch.setattr(session_mod.shutil, "which", lambda name: "/fake/claude")
+        with pytest.raises(SessionError, match="does not support API-key accounts"):
+            mgr.run("2", [], share=True)
+
+
+# ---------------------------------------------------------------------------
+# Export / import of raw keys
+# ---------------------------------------------------------------------------
+
+
+class TestExportImport:
+    def test_round_trip_preserves_key_and_kind(self, tmp_path: Path):
+        src_home = tmp_path / "src"
+        (src_home / ".claude").mkdir(parents=True)
+        with _patched_home(src_home):
+            src = _linux_switcher()
+            src.add_account_from_token(API_KEY, slot=1)
+            out = tmp_path / "b.cswap"
+            export_accounts(src, str(out))
+            payload = json.loads(out.read_text(encoding="utf-8"))
+            # exported as a raw string, tagged api_key — not a JSON object.
+            assert payload["accounts"][0]["credentials"] == API_KEY
+            assert payload["accounts"][0]["kind"] == "api_key"
+
+        dst_home = tmp_path / "dst"
+        (dst_home / ".claude").mkdir(parents=True)
+        with _patched_home(dst_home):
+            dst = _linux_switcher()
+            import_accounts(dst, str(out))
+            assert dst._account_kind("1") == "api_key"
+            assert dst._read_account_credentials("1", "api-key-1@token.local") == API_KEY
+
+
+class _patched_home:
+    """Redirect HOME/Path.home() to ``home`` for export/import on two homes."""
+
+    def __init__(self, home: Path):
+        self.home = home
+        self._patches: list = []
+
+    def __enter__(self):
+        import os
+        from unittest.mock import patch
+
+        self._patches = [
+            patch.dict(os.environ, {"HOME": str(self.home), "USERPROFILE": str(self.home)}),
+            patch("pathlib.Path.home", return_value=self.home),
+        ]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._patches):
+            p.stop()
+        return False

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -428,14 +428,27 @@ class TestValidation:
         with pytest.raises(TransferError, match="not valid JSON"):
             import_accounts(s, str(f))
 
-    def test_credentials_must_be_object(self, temp_home: Path):
+    def test_credentials_garbage_string_rejected(self, temp_home: Path):
+        # A non-key string credential is interpreted as an API-key account and
+        # rejected because it isn't a valid sk-ant-api… key.
         s = _linux_switcher(temp_home)
         env = self._make_envelope()
         env["accounts"][0]["credentials"] = "a string"
         f = temp_home / "c.cswap"
         f.write_text(json.dumps(env))
 
-        with pytest.raises(TransferError, match="must be JSON objects"):
+        with pytest.raises(TransferError, match="must be a raw sk-ant-api"):
+            import_accounts(s, str(f))
+
+    def test_credentials_non_object_non_string_rejected(self, temp_home: Path):
+        # A list/number credential is neither a raw key nor a JSON object.
+        s = _linux_switcher(temp_home)
+        env = self._make_envelope()
+        env["accounts"][0]["credentials"] = [1, 2, 3]
+        f = temp_home / "c.cswap"
+        f.write_text(json.dumps(env))
+
+        with pytest.raises(TransferError, match="must be a JSON object"):
             import_accounts(s, str(f))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Adds first-class support for managed API-key accounts — the kind Claude Code uses after `/login` with an `sk-ant-api...` key — alongside existing OAuth (Pro/Max) accounts.

Supersedes #20 with an all-platform implementation that integrates with the current `CredentialStore` architecture.

## What's included
- **Register** an API key via `--add-token sk-ant-api...` (auto-detected vs `sk-ant-oat...` setup-tokens); synthesized identity like the existing setup-token flow, recorded with `kind: "api_key"`.
- **Switch** to/from API-key accounts on macOS (Keychain `"Claude Code"`) and Linux/WSL/Windows (`~/.claude.json` `primaryApiKey` + `customApiKeyResponses.approved`), mirroring Claude Code's own `saveApiKey`/`removeApiKey` semantics.
- **Mutual exclusion**: activating one auth axis clears the other, so a stale OAuth login or API key can't shadow the switch (both directions, all platforms).
- **Usage display**: API-key accounts show `API key (no quota)` in `--list`/`--status` (and `usageStatus: "api_key"` in `--json`); `next-available` treats them as never rate-limited, `best` doesn't auto-jump to them (no measurable quota).
- **Guards**: `--add-account` refuses to capture a live API-key login (points to `--add-token`); cross-kind email collisions are rejected; `cswap run` (session mode) rejects API-key accounts for now.
- **Export/import** keeps the raw key intact.

## Tests
New `tests/test_api_key_accounts.py` (27 tests) plus an updated transfer test. Full suite: 594 passed, 3 skipped. Manually verified end-to-end on WSL (add → list → switch both ways → run guard → export/import).