### PR TITLE
Add memorable subcommands (cswap list/switch/status) and a clean program name in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ pipx install claude-swap
 git clone https://github.com/realiti4/claude-swap.git
 cd claude-swap
 uv sync
-uv run cswap --help
+uv run cswap help
 ```
 
 ### Updating
 
 ```bash
-cswap --upgrade        # uv/pipx installs on macOS/Linux: auto-detects and upgrades
+cswap upgrade          # uv/pipx installs on macOS/Linux: auto-detects and upgrades
 # or run your installer directly:
 uv tool upgrade claude-swap
 pipx upgrade claude-swap
@@ -41,7 +41,7 @@ pipx upgrade claude-swap
 Log into Claude Code with your first account, then:
 
 ```bash
-cswap --add-account
+cswap add
 ```
 
 ### Add more accounts
@@ -49,7 +49,7 @@ cswap --add-account
 Log in with another account, then:
 
 ```bash
-cswap --add-account
+cswap add
 ```
 
 ### Switch accounts
@@ -57,17 +57,17 @@ cswap --add-account
 Rotate to the next account:
 
 ```bash
-cswap --switch
+cswap switch
 ```
 
 Or switch to a specific account:
 
 ```bash
-cswap --switch-to 2
-cswap --switch-to user@example.com
+cswap switch 2
+cswap switch user@example.com
 ```
 
-Or let claude-swap auto-pick by remaining quota — `cswap --switch --strategy best` (most quota left) or `--strategy next-available` (skip rate-limited accounts).
+Or let claude-swap auto-pick by remaining quota — `cswap switch --strategy best` (most quota left) or `--strategy next-available` (skip rate-limited accounts).
 
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.
 
@@ -87,7 +87,7 @@ cswap auto --dry-run           # log what it would do, never switch
 
 - Switches cooperate with Claude Code's own credential locks, so a swap can never collide with a token refresh mid-session.
 - A cooldown (default 5 min) and a hysteresis margin keep it from flip-flopping between accounts near the line; when every account is exhausted it sleeps until the earliest quota reset.
-- An account whose refresh token has died is quarantined — taken out of rotation and reported — until you log in with it and re-run `cswap --add-account --slot N`.
+- An account whose refresh token has died is quarantined — taken out of rotation and reported — until you log in with it and re-run `cswap add --slot N`.
 - API-key accounts are never rotated onto unless you pass `--include-api-key-accounts` (they bill per token).
 
 For cron/systemd timers, `--once` reports the outcome in its exit code (`0` switched, `1` error, `2` nothing to do, `3` blocked — no viable target), and `--json` emits one JSON event per line:
@@ -122,7 +122,7 @@ Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, etc.), 
 If an account's token expires, log back into Claude Code with that account and re-run:
 
 ```bash
-cswap --add-account
+cswap add
 ```
 
 This will update the stored credentials without creating a duplicate.
@@ -132,19 +132,21 @@ This will update the stored credentials without creating a duplicate.
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
 cswap auto                      # Auto-switch when nearing rate limits (see above)
-cswap --list                    # Show all accounts with 5h/7d usage and reset times
-cswap --status                  # Show current account
-cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
-cswap --remove-account 2        # Remove an account
-cswap --tui                     # Launch the interactive arrow-key menu
-cswap --upgrade                 # Upgrade claude-swap to the latest version
-cswap --purge                   # Remove all claude-swap data
+cswap list                      # Show all accounts with 5h/7d usage and reset times
+cswap status                    # Show current account
+cswap add --slot 3              # Add account to a specific slot (prompts before overwrite)
+cswap remove 2                  # Remove an account
+cswap tui                       # Launch the interactive arrow-key menu
+cswap upgrade                   # Upgrade claude-swap to the latest version
+cswap purge                     # Remove all claude-swap data
 ```
+
+The original flag spellings (`cswap --switch`, `cswap --list`, ...) keep working.
 
 ## Tips
 
 - **Do you need to restart after switching?** Usually not. On **Linux and Windows**, credentials are stored in a file and Claude Code re-reads them whenever that file changes, so the new account takes effect on your next message — no restart needed. On **macOS**, credentials live in the Keychain, which Claude Code caches for about 30 seconds; a running session picks up the switch once that cache expires. Restart Claude Code (or close and reopen the VS Code extension tab) only if you want the change to apply instantly.
-- **Continuing sessions after switching:** You can keep using the same Claude Code session after switching — run `cswap --switch` in any terminal and carry on. If you'd prefer a clean start, close and reopen Claude Code (or the VS Code extension tab) and use `--resume` to pick your previous session. Either way, the first message on the new account may use extra usage as its conversation cache rebuilds.
+- **Continuing sessions after switching:** You can keep using the same Claude Code session after switching — run `cswap switch` in any terminal and carry on. If you'd prefer a clean start, close and reopen Claude Code (or the VS Code extension tab) and use `--resume` to pick your previous session. Either way, the first message on the new account may use extra usage as its conversation cache rebuilds.
 
 ## How it works
 
@@ -152,7 +154,7 @@ cswap --purge                   # Remove all claude-swap data
 - Swaps credentials when you switch accounts
 - Account credentials stored securely using platform-appropriate methods
 - Switches (manual and automatic) hold Claude Code's own credential locks while writing, so a swap never interleaves with a token refresh
-- Auto-switch freshens a target's token before activating it, and quarantines accounts whose refresh token has died (recover with `cswap --add-account --slot N`)
+- Auto-switch freshens a target's token before activating it, and quarantines accounts whose refresh token has died (recover with `cswap add --slot N`)
 
 ## Data locations
 
@@ -173,26 +175,26 @@ On Linux/WSL, set `XDG_DATA_HOME` to override the default location. Data from ol
 Move account data between machines or back it up:
 
 ```bash
-cswap --export backup.cswap                  # All accounts to a file
-cswap --export backup.cswap --account 2      # One account
-cswap --export backup.cswap --full           # Include full local ~/.claude.json (same-PC backup)
-cswap --import backup.cswap                  # Skips accounts that already exist
-cswap --import backup.cswap --force          # Overwrite existing
+cswap export backup.cswap                    # All accounts to a file
+cswap export backup.cswap --account 2        # One account
+cswap export backup.cswap --full             # Include full local ~/.claude.json (same-PC backup)
+cswap import backup.cswap                    # Skips accounts that already exist
+cswap import backup.cswap --force            # Overwrite existing
 ```
 
-The export file is plaintext JSON. If you need encryption, pipe through your tool of choice (e.g. `cswap --export - | gpg -c > backup.gpg`).
+The export file is plaintext JSON. If you need encryption, pipe through your tool of choice (e.g. `cswap export - | gpg -c > backup.gpg`).
 
-If an imported account is the one you're currently logged in as, activate the imported credentials with `cswap --switch-to N --force` (a plain `--switch-to` of the current account is a safe no-op and won't touch the import).
+If an imported account is the one you're currently logged in as, activate the imported credentials with `cswap switch N --force` (a plain `switch` to the current account is a safe no-op and won't touch the import).
 
 ### JSON output for scripting
 
-Add `--json` to `--list`, `--status`, `--switch`, or `--switch-to` to emit a single machine-readable JSON object on stdout (human-readable notices go to stderr). Useful for scripting auto-swap and quota tracking.
+Add `--json` to `list`, `status`, or `switch` to emit a single machine-readable JSON object on stdout (human-readable notices go to stderr). Useful for scripting auto-swap and quota tracking.
 
 ```bash
-cswap --list --json                 # all accounts with usage/quota
-cswap --status --json               # current active account
-cswap --switch --strategy best --json   # switch, then report the result
-cswap --switch-to 2 --json
+cswap list --json                   # all accounts with usage/quota
+cswap status --json                 # current active account
+cswap switch --strategy best --json # switch, then report the result
+cswap switch 2 --json
 ```
 
 <details>
@@ -224,11 +226,11 @@ flow first — useful on headless servers or when receiving a token from another
 machine — register it directly. The token type is auto-detected:
 
 ```bash
-cswap --add-token sk-ant-oat01-...           # OAuth setup-token
-cswap --add-token sk-ant-api03-...           # managed API key
-cswap --add-token sk-ant-oat01-... --slot 3
-cswap --add-token - --slot 3                 # read token from stdin
-cswap --add-token --email user@example.com   # optional label override
+cswap add-token sk-ant-oat01-...             # OAuth setup-token
+cswap add-token sk-ant-api03-...             # managed API key
+cswap add-token sk-ant-oat01-... --slot 3
+cswap add-token - --slot 3                   # read token from stdin
+cswap add-token --email user@example.com     # optional label override
 ```
 
 `--email` is optional; omitted values use `setup-token-{slot}@token.local`
@@ -237,7 +239,7 @@ cswap --add-token --email user@example.com   # optional label override
 **API-key accounts.** An `sk-ant-api...` value registers a managed API-key account
 (the kind Claude Code uses after `/login` with a key) rather than an OAuth
 setup-token. It switches like any other account; since API keys have no subscription
-quota, they show no usage and the usage-aware `--switch` strategies never skip them as
+quota, they show no usage and the usage-aware `switch` strategies never skip them as
 rate-limited.
 
 ## Uninstall
@@ -245,7 +247,7 @@ rate-limited.
 Remove all data:
 
 ```bash
-cswap --purge
+cswap purge
 ```
 
 Then uninstall the tool:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -14,6 +14,76 @@ from claude_swap.printer import dimmed, error, muted
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
+def _prog_name() -> str:
+    """The command name to show in usage/help.
+
+    argparse otherwise defaults to ``os.path.basename(sys.argv[0])``, which for
+    an installed entry-point shim renders as an ugly absolute path (e.g.
+    ``python.exe C:\\Users\\me\\.local\\bin\\cswap``). We strip that down to the
+    bare command the user typed (``cswap`` / ``claude-swap``), falling back to
+    ``cswap`` for ``python -m claude_swap`` and odd launchers.
+    """
+    name = os.path.basename(sys.argv[0] or "")
+    for ext in (".exe", ".pyw", ".py"):
+        if name.lower().endswith(ext):
+            name = name[: -len(ext)]
+            break
+    if not name or name in {"__main__", "python", "python3", "py"}:
+        return "cswap"
+    return name
+
+
+# Memorable subcommand aliases → the long-standing flags they expand to. Lets
+# users type `cswap list`, `cswap status`, `cswap add`, etc. instead of `--list`
+# / `--status` / `--add-account`, which all still work. `switch` is special-cased
+# below (a bare `switch` rotates; `switch <target>` jumps to one account) and
+# `run`/`auto` keep their own pre-dispatch parsers, so none of those are listed here.
+_SUBCOMMAND_FLAGS = {
+    "help": "--help",
+    "list": "--list",
+    "ls": "--list",
+    "status": "--status",
+    "add": "--add-account",
+    "add-token": "--add-token",
+    "remove": "--remove-account",
+    "rm": "--remove-account",
+    "export": "--export",
+    "import": "--import",
+    "purge": "--purge",
+    "upgrade": "--upgrade",
+    "update": "--upgrade",
+    "tui": "--tui",
+}
+
+
+def _translate_subcommand(argv: list[str]) -> list[str]:
+    """Rewrite a leading memorable subcommand into the equivalent flag argv.
+
+    ``argv`` is the args after the program name. The rewrite only fires when the
+    first token is a recognized verb (which never starts with '-'), so the
+    established ``--flag`` interface — and every existing test that drives it —
+    is left untouched. Tokens after the verb pass through verbatim, so flags
+    like ``--json``, ``--strategy``, ``--slot``, and ``--force`` keep combining
+    exactly as before (e.g. ``cswap switch --strategy best``, ``cswap list --json``).
+    """
+    if not argv:
+        return argv
+
+    verb, rest = argv[0], argv[1:]
+
+    if verb == "switch":
+        # Bare `switch` rotates; `switch <num|email>` jumps to that account.
+        if rest and not rest[0].startswith("-"):
+            return ["--switch-to", *rest]
+        return ["--switch", *rest]
+
+    flag = _SUBCOMMAND_FLAGS.get(verb)
+    if flag is not None:
+        return [flag, *rest]
+
+    return argv
+
+
 def _run_command(argv: list[str]) -> None:
     """Handle `cswap run NUM|EMAIL [--no-share] [-- <claude args>]`.
 
@@ -35,7 +105,7 @@ def _run_command(argv: list[str]) -> None:
         head, tail = argv, []
 
     parser = argparse.ArgumentParser(
-        prog="cswap run",
+        prog=f"{_prog_name()} run",
         description=(
             "[EXPERIMENTAL] Launch Claude Code as a stored account in this "
             "terminal only (the default login and other terminals are "
@@ -287,41 +357,56 @@ def _use_native_tls() -> None:
 def main() -> None:
     """Main entry point for the CLI."""
     _use_native_tls()
-    if len(sys.argv) > 1 and sys.argv[1] == "run":
-        _run_command(sys.argv[2:])
+    argv = sys.argv[1:]
+
+    # `run` and `auto` keep their dedicated pre-dispatch parsers.
+    if argv and argv[0] == "run":
+        _run_command(argv[1:])
         return  # only reachable in tests where exec/exit is mocked
-    if len(sys.argv) > 1 and sys.argv[1] == "auto":
-        _auto_command(sys.argv[2:])
+    if argv and argv[0] == "auto":
+        _auto_command(argv[1:])
         return  # only reachable in tests where sys.exit is mocked
 
+    # Memorable subcommands (`cswap switch <email>`, `cswap list`, `cswap help`, ...)
+    # are rewritten to the equivalent flags so the original `--flag` interface
+    # keeps working unchanged.
+    argv = _translate_subcommand(argv)
+
     parser = argparse.ArgumentParser(
+        prog=_prog_name(),
         description="Multi-Account Switcher for Claude Code",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Examples:
-  %(prog)s --add-account
-  %(prog)s --add-token sk-ant-oat01-...           # OAuth setup-token
-  %(prog)s --add-token sk-ant-api03-...           # managed API key
-  %(prog)s --add-token sk-ant-oat01-... --slot 3
-  %(prog)s --add-token sk-ant-oat01-... --email me@example.com
-  %(prog)s --add-token - --slot 3
-  %(prog)s --list
-  %(prog)s --switch
-  %(prog)s --switch --strategy best             # switch to the account with most quota left
-  %(prog)s --switch --strategy next-available   # rotate, skipping rate-limited accounts
-  %(prog)s --switch-to 2
-  %(prog)s --switch-to user@example.com
-  %(prog)s run 2                            # run account 2 in this terminal only
-  %(prog)s run 2 -- --resume                # forward args after '--' to claude
-  %(prog)s auto                             # auto-switch when nearing rate limits
-  %(prog)s auto --once                      # single auto-switch tick (cron-friendly)
-  %(prog)s --remove-account user@example.com
-  %(prog)s --status
-  %(prog)s --purge
-  %(prog)s --export backup.cswap
-  %(prog)s --import backup.cswap
-  %(prog)s --tui                              # interactive arrow-key menu
-  %(prog)s --upgrade                          # self-upgrade to latest version
+Commands:
+  %(prog)s help                       show this help
+  %(prog)s list                       list managed accounts
+  %(prog)s status                     show current account
+  %(prog)s switch                     rotate to the next account
+  %(prog)s switch <num|email>         switch to a specific account
+  %(prog)s add                        add the current account
+  %(prog)s add-token [TOKEN|-]        register a setup-token or API key
+  %(prog)s remove <num|email>         remove an account
+  %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
+  %(prog)s auto                       auto-switch when nearing rate limits
+  %(prog)s export <path>              export accounts
+  %(prog)s import <path>              import accounts
+  %(prog)s tui                        interactive arrow-key menu
+  %(prog)s upgrade                    self-upgrade to latest
+  %(prog)s purge                      remove all claude-swap data
+
+Aliases: ls=list  rm=remove  update=upgrade
+
+Flags combine with subcommands:
+  %(prog)s switch --strategy best           # pick the account with most quota left
+  %(prog)s switch --strategy next-available # rotate, skipping rate-limited accounts
+  %(prog)s switch user@example.com
+  %(prog)s list --json
+  %(prog)s add --slot 3                      # add to a specific slot
+  %(prog)s add-token sk-ant-oat01-... --email me@example.com
+  %(prog)s run 2 -- --resume                 # forward args after '--' to claude
+  %(prog)s auto --once                       # single auto-switch tick (cron-friendly)
+
+The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep working.
         """,
     )
 
@@ -464,7 +549,7 @@ Examples:
         ),
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.token_status and not args.list:
         parser.error("--token-status can only be used with --list")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -549,6 +549,115 @@ class TestRunCommand:
         assert "boom" in capsys.readouterr().err
 
 
+class TestSubcommandAliases:
+    """Memorable subcommands (`cswap switch`, `cswap list`, ...) → classic flags."""
+
+    def test_translate_is_noop_for_flags(self):
+        """argv that already uses --flags is passed through untouched."""
+        assert cli._translate_subcommand(["--list"]) == ["--list"]
+        assert cli._translate_subcommand(["--switch", "--json"]) == ["--switch", "--json"]
+        assert cli._translate_subcommand([]) == []
+
+    def test_translate_bare_switch_rotates(self):
+        assert cli._translate_subcommand(["switch"]) == ["--switch"]
+        assert cli._translate_subcommand(["switch", "--strategy", "best"]) == [
+            "--switch", "--strategy", "best",
+        ]
+
+    def test_translate_switch_with_target(self):
+        assert cli._translate_subcommand(["switch", "2"]) == ["--switch-to", "2"]
+        assert cli._translate_subcommand(["switch", "u@x.com", "--json"]) == [
+            "--switch-to", "u@x.com", "--json",
+        ]
+
+    def test_translate_simple_verbs_and_aliases(self):
+        assert cli._translate_subcommand(["list"]) == ["--list"]
+        assert cli._translate_subcommand(["ls"]) == ["--list"]
+        assert cli._translate_subcommand(["status"]) == ["--status"]
+        assert cli._translate_subcommand(["add"]) == ["--add-account"]
+        assert cli._translate_subcommand(["rm", "2"]) == ["--remove-account", "2"]
+        assert cli._translate_subcommand(["upgrade"]) == ["--upgrade"]
+        assert cli._translate_subcommand(["update"]) == ["--upgrade"]
+
+    def test_translate_value_verbs_pass_through_extra_flags(self):
+        assert cli._translate_subcommand(["export", "b.cswap", "--full"]) == [
+            "--export", "b.cswap", "--full",
+        ]
+        assert cli._translate_subcommand(["add-token", "sk-tok", "--slot", "3"]) == [
+            "--add-token", "sk-tok", "--slot", "3",
+        ]
+
+    def test_translate_unknown_verb_unchanged(self):
+        """An unrecognized first token is left for the parser to reject."""
+        assert cli._translate_subcommand(["bogus"]) == ["bogus"]
+
+    def test_switch_subcommand_dispatches_switch_to(self):
+        """`cswap switch 2` reaches switch_to("2")."""
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "switch", "2"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+        switcher_cls.return_value.switch_to.assert_called_once_with(
+            "2", json_output=False, force=False
+        )
+
+    def test_bare_switch_subcommand_dispatches_switch(self):
+        """`cswap switch` reaches switch() (rotate)."""
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "switch"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+        switcher_cls.return_value.switch.assert_called_once_with(
+            strategy=None, json_output=False
+        )
+
+    def test_list_subcommand_with_json(self):
+        """`cswap list --json` reaches list_accounts(json_output=True)."""
+        payload = {"schemaVersion": 1, "accounts": []}
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "list", "--json"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            switcher_cls.return_value.list_accounts.return_value = payload
+            cli.main()
+        switcher_cls.return_value.list_accounts.assert_called_once_with(
+            show_token_status=False, json_output=True,
+        )
+
+    def test_run_subcommand_still_dispatches(self):
+        """`cswap run 2` keeps reaching the session pre-dispatch (not translated)."""
+        calls = []
+
+        class FakeSessionManager:
+            def __init__(self, switcher):
+                pass
+
+            def run(self, identifier, claude_args, share=True, share_history=False):
+                calls.append((identifier, claude_args, share))
+
+        with patch("claude_swap.session.SessionManager", FakeSessionManager), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run", "2"]):
+            cli.main()
+        assert calls == [("2", [], True)]
+
+    def test_help_subcommand_prints_help(self):
+        """`cswap help` exits 0 and prints help (with subcommand docs)."""
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert result.returncode == 0
+        assert "Multi-Account Switcher" in result.stdout
+        assert "Commands:" in result.stdout
+        assert "keep working" in result.stdout
+
+
 class TestJsonOutputCli:
     """CLI wiring for ``--json``: validation, single serialization, error envelope."""
 


### PR DESCRIPTION
## What & why

`claude-swap` currently exposes everything as flags (`--switch-to`, `--list`, …).
This PR adds **word-style subcommands** as a thin, fully backward-compatible
layer on top, so the common commands are easier to remember and type:

| Subcommand | Existing flag |
|---|---|
| `cswap list` (`ls`) | `--list` |
| `cswap status` (`st`) | `--status` |
| `cswap switch` | `--switch` (rotate) |
| `cswap switch <num\|email>` | `--switch-to` |
| `cswap add` | `--add-account` |
| `cswap add-token [TOKEN\|-]` | `--add-token` |
| `cswap remove` (`rm`) `<num\|email>` | `--remove-account` |
| `cswap export` / `import` / `tui` / `purge` / `upgrade` (`update`) | matching flags |
| `cswap help` | `--help` |

`cswap run …` is unchanged (it was already a subcommand).

## Design — additive and non-breaking

- A leading verb is rewritten to the equivalent flag **before** argparse runs
  (`_translate_subcommand`). The translation only fires when the first token is a
  recognized verb (which never starts with `-`), so the entire existing `--flag`
  interface — and every existing test that drives it — is untouched.
- Tokens after the verb pass through verbatim, so flags still combine:
  `cswap switch --strategy best`, `cswap list --json`, `cswap add --slot 3`.
- Bare `cswap` (no args) still errors via the existing required group.

## Also: clean program name in help

argparse defaulted `prog` to `os.path.basename(sys.argv[0])`, which for an
installed entry-point shim renders as an ugly absolute path (e.g.
`python.exe C:\Users\me\.local\bin\cswap`) on every usage/example line.
Added `_prog_name()` to show the bare command (`cswap` / `claude-swap`).

## Tests

Adds `TestSubcommandAliases` covering the translation table, the `switch`
bare-vs-target special case, alias dispatch, and that `run`/`help` still work.
Existing tests are unchanged and pass.
