### PR TITLE
Render TUI menu actions in-place and add a live Watch dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ cswap --upgrade                 # Upgrade claude-swap to the latest version
 cswap --purge                   # Remove all claude-swap data
 ```
 
+In the interactive TUI, read-only and switch/remove actions now render in a scrollable panel **inside** the menu (no more scrolling stdout). The **Watch** item opens a live dashboard of the active account and per-account usage that auto-refreshes on a configurable interval (`+`/`-` to change it, `r` to refresh now, `q` to exit). Usage itself is cached for 15s, so very short intervals re-render cached numbers rather than re-fetching.
+
 ## Tips
 
 - **Do you need to restart after switching?** Usually not. On **Linux and Windows**, credentials are stored in a file and Claude Code re-reads them whenever that file changes, so the new account takes effect on your next message — no restart needed. On **macOS**, credentials live in the Keychain, which Claude Code caches for about 30 seconds; a running session picks up the switch once that cache expires. Restart Claude Code (or close and reopen the VS Code extension tab) only if you want the change to apply instantly.

--- a/src/claude_swap/printer.py
+++ b/src/claude_swap/printer.py
@@ -7,6 +7,7 @@ restrained aesthetic. Falls back to plain text when colors aren't supported.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 import time
@@ -67,6 +68,23 @@ def colors_enabled() -> bool:
     if _colors_enabled is None:
         _colors_enabled = _detect_color_support()
     return _colors_enabled
+
+
+@contextlib.contextmanager
+def force_color():
+    """Temporarily force colored output on, restoring the prior cache after.
+
+    Used by the TUI when capturing CLI output into a buffer: capture redirects
+    stdout to a non-tty StringIO, which would otherwise disable color — but the
+    TUI re-renders the ANSI itself, so it wants the codes emitted.
+    """
+    global _colors_enabled
+    saved = _colors_enabled
+    _colors_enabled = True
+    try:
+        yield
+    finally:
+        _colors_enabled = saved
 
 
 def _style(text: str, *codes: str) -> str:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1088,8 +1088,12 @@ class ClaudeAccountSwitcher:
             f"{muted('[personal]')} {muted(f'(from {source_label})')}"
         )
 
-    def remove_account(self, identifier: str) -> None:
-        """Remove account from managed accounts."""
+    def remove_account(self, identifier: str, assume_yes: bool = False) -> None:
+        """Remove account from managed accounts.
+
+        When ``assume_yes`` is True the confirmation prompt is skipped (used by
+        the TUI, which collects confirmation before calling).
+        """
         if not self.sequence_file.exists():
             raise ConfigError("No accounts are managed yet")
 
@@ -1145,13 +1149,14 @@ class ClaudeAccountSwitcher:
         if str(active_account) == account_num:
             warning(f"Warning: Account-{account_num} ({email}) is currently active")
 
-        confirm = input(
-            f"Are you sure you want to permanently remove "
-            f"Account-{account_num} ({email})? [y/N] "
-        )
-        if confirm.lower() != "y":
-            print(dimmed("Cancelled"))
-            return
+        if not assume_yes:
+            confirm = input(
+                f"Are you sure you want to permanently remove "
+                f"Account-{account_num} ({email})? [y/N] "
+            )
+            if confirm.lower() != "y":
+                print(dimmed("Cancelled"))
+                return
 
         # Remove backup files
         self._delete_account_files(account_num, email)

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -15,17 +15,151 @@ Design constraints:
 
 from __future__ import annotations
 
+import contextlib
 import curses
+import io
+import re
 import sys
+import time
 from typing import Callable
 
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap import printer
 
 
 # Minimum terminal size we render in. Below this, we bail to plain CLI advice.
 _MIN_ROWS = 12
 _MIN_COLS = 60
+
+
+# --- ANSI → curses style mapping -------------------------------------------
+# printer.py emits a fixed, small set of SGR codes. We tokenize captured output
+# into our own style bitflags (parse-time, curses-free) and resolve them to
+# curses attributes at draw time (_style_to_attr), after initscr().
+_STYLE_BOLD = 1
+_STYLE_DIM = 2
+_STYLE_RED = 4
+_STYLE_YELLOW = 8
+_STYLE_ACCENT = 16
+_STYLE_MUTED = 32
+
+# SGR parameter string (between ESC[ and m) → style flag. Each printer token is
+# reset-terminated, so flags accumulate within a token and clear on reset.
+_SGR_PARAM_TO_STYLE: dict[str, int] = {
+    "1": _STYLE_BOLD,
+    "2": _STYLE_DIM,
+    "31": _STYLE_RED,
+    "33": _STYLE_YELLOW,
+    "38;5;173": _STYLE_ACCENT,  # printer accent (warm salmon)
+    "38;5;250": _STYLE_MUTED,   # printer muted (soft gray)
+}
+
+_SGR_RE = re.compile(r"\x1b\[([0-9;]*)m")
+
+
+def _ansi_segments(text: str) -> list[tuple[str, int]]:
+    """Split a single line into ``(visible_text, style_flags)`` runs.
+
+    Escape sequences are removed from the visible text. Unknown SGR codes are
+    ignored. A reset (``0`` or empty) clears all flags. Plain text returns a
+    single ``(text, 0)`` run; an empty string returns ``[("", 0)]``.
+    """
+    segments: list[tuple[str, int]] = []
+    flags = 0
+    pos = 0
+    for m in _SGR_RE.finditer(text):
+        if m.start() > pos:
+            segments.append((text[pos:m.start()], flags))
+        param = m.group(1)
+        if param in ("", "0"):
+            flags = 0
+        else:
+            flags |= _SGR_PARAM_TO_STYLE.get(param, 0)
+        pos = m.end()
+    if pos < len(text):
+        segments.append((text[pos:], flags))
+    return [(t, f) for (t, f) in segments if t != ""] or [("", 0)]
+
+
+def _clamp_interval(n: int, lo: int = 1, hi: int = 60) -> int:
+    """Clamp a watch refresh interval (seconds) into ``[lo, hi]``."""
+    return max(lo, min(hi, n))
+
+
+# Curses color pair numbers (initialized lazily by _init_colors).
+_PAIR_RED = 1
+_PAIR_YELLOW = 2
+_PAIR_ACCENT = 3
+_PAIR_MUTED = 4
+
+_colors_initialized = False
+
+
+def _init_colors() -> None:
+    """Initialize curses color pairs once. Safe on no-color terminals."""
+    global _colors_initialized
+    if _colors_initialized:
+        return
+    _colors_initialized = True
+    try:
+        if not curses.has_colors():
+            return
+        curses.start_color()
+        try:
+            curses.use_default_colors()
+            bg = -1
+        except curses.error:
+            bg = curses.COLOR_BLACK
+        curses.init_pair(_PAIR_RED, curses.COLOR_RED, bg)
+        curses.init_pair(_PAIR_YELLOW, curses.COLOR_YELLOW, bg)
+        if getattr(curses, "COLORS", 0) >= 256:
+            curses.init_pair(_PAIR_ACCENT, 173, bg)
+            curses.init_pair(_PAIR_MUTED, 250, bg)
+        else:
+            curses.init_pair(_PAIR_ACCENT, curses.COLOR_YELLOW, bg)
+            curses.init_pair(_PAIR_MUTED, curses.COLOR_WHITE, bg)
+    except curses.error:
+        pass
+
+
+def _style_to_attr(flags: int) -> int:
+    """Resolve our style flags to a curses attribute int. Never raises."""
+    attr = curses.A_NORMAL
+    if flags & _STYLE_BOLD:
+        attr |= curses.A_BOLD
+    if flags & _STYLE_DIM:
+        attr |= curses.A_DIM
+    try:
+        if not curses.has_colors():
+            return attr
+        if flags & _STYLE_RED:
+            attr |= curses.color_pair(_PAIR_RED)
+        elif flags & _STYLE_YELLOW:
+            attr |= curses.color_pair(_PAIR_YELLOW)
+        elif flags & _STYLE_ACCENT:
+            attr |= curses.color_pair(_PAIR_ACCENT)
+        elif flags & _STYLE_MUTED:
+            attr |= curses.color_pair(_PAIR_MUTED)
+    except curses.error:
+        pass
+    return attr
+
+
+def _addstr_ansi(stdscr, y: int, x: int, text: str, max_width: int) -> None:
+    """Draw an ANSI-styled line clipped to ``max_width`` visible characters."""
+    remaining = max_width
+    cx = x
+    for seg_text, flags in _ansi_segments(text):
+        if remaining <= 0:
+            break
+        chunk = seg_text[:remaining]
+        try:
+            stdscr.addstr(y, cx, chunk, _style_to_attr(flags))
+        except curses.error:
+            pass
+        cx += len(chunk)
+        remaining -= len(chunk)
 
 
 def run(switcher: ClaudeAccountSwitcher) -> int:
@@ -56,6 +190,7 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
         return 2
 
     curses.curs_set(0)  # hide cursor
+    _init_colors()
     has_token_flow = hasattr(switcher, "add_account_from_token")
 
     while True:
@@ -66,6 +201,7 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
             ("Refresh credentials (current login, in-place)", "refresh"),
             ("List accounts (with usage)", "list"),
             ("Status", "status"),
+            ("Watch (live status + usage)", "watch"),
             ("Quit", "quit"),
         ]
         choice = _select_from(
@@ -87,9 +223,11 @@ def _main_loop(stdscr: "curses._CursesWindow", switcher: ClaudeAccountSwitcher) 
             elif choice == "refresh":
                 _do_refresh(stdscr, switcher)
             elif choice == "list":
-                _shell_out(stdscr, lambda: switcher.list_accounts())
+                _run_inline(stdscr, "Accounts", lambda: switcher.list_accounts())
             elif choice == "status":
-                _shell_out(stdscr, switcher.status)
+                _run_inline(stdscr, "Status", switcher.status)
+            elif choice == "watch":
+                _do_watch(stdscr, switcher)
         except ClaudeSwitchError as e:
             _show_message(stdscr, f"Error: {e}", is_error=True)
         except KeyboardInterrupt:
@@ -110,7 +248,7 @@ def _do_switch(stdscr, switcher: ClaudeAccountSwitcher) -> None:
     choice = _select_from(stdscr, "switch to", items=items)
     if choice is None:
         return
-    _shell_out(stdscr, lambda: switcher.switch_to(choice))
+    _run_inline(stdscr, "Switch account", lambda: switcher.switch_to(choice))
 
 
 def _do_add(stdscr, switcher: ClaudeAccountSwitcher, has_token_flow: bool) -> None:
@@ -155,7 +293,10 @@ def _do_remove(stdscr, switcher: ClaudeAccountSwitcher) -> None:
         return
     if not _confirm(stdscr, f"Remove account {choice}? Type 'y' to confirm: "):
         return
-    _shell_out(stdscr, lambda: switcher.remove_account(choice))
+    _run_inline(
+        stdscr, "Remove account",
+        lambda: switcher.remove_account(choice, assume_yes=True),
+    )
 
 
 def _do_refresh(stdscr, switcher: ClaudeAccountSwitcher) -> None:
@@ -169,6 +310,65 @@ def _do_refresh(stdscr, switcher: ClaudeAccountSwitcher) -> None:
         return
     email, _org = identity
     _shell_out(stdscr, lambda: switcher.add_account(slot=None))
+
+
+def _do_watch(stdscr, switcher: ClaudeAccountSwitcher) -> None:
+    """Live, auto-refreshing dashboard of status + usage (read-only)."""
+    seq = switcher._get_sequence_data() or {}
+    if not seq.get("accounts"):
+        _show_message(stdscr, "No managed accounts to watch. Add one first.")
+        return
+    _watch_loop(stdscr, switcher)
+
+
+def _watch_loop(stdscr, switcher: ClaudeAccountSwitcher, interval: int = 5) -> None:
+    """Re-capture ``list_accounts()`` every ``interval`` seconds and redraw.
+
+    Usage is cache-gated at switcher._USAGE_CACHE_TTL (15s), so sub-15s
+    intervals re-render cached usage rather than re-fetching from the network.
+    """
+    stdscr.timeout(250)  # non-blocking getch, 250ms tick
+    try:
+        last_refresh = 0.0
+        body: list[str] = []
+        while True:
+            now = time.monotonic()
+            if now - last_refresh >= interval:
+                body = _capture(lambda: switcher.list_accounts()).splitlines()
+                now = time.monotonic()  # recompute after the (possibly slow) fetch
+                last_refresh = now
+
+            stdscr.erase()
+            rows, cols = stdscr.getmaxyx()
+            _draw_header(stdscr, "Watch", _status_line(switcher), cols)
+            age = int(now - last_refresh)
+            meta = (
+                f"every {interval}s · updated {age}s ago · "
+                f"[+/-] interval  [r] refresh  [q] back"
+            )
+            try:
+                stdscr.addstr(3, 2, meta[: cols - 4], curses.A_DIM)
+            except curses.error:
+                pass
+            body_top = 5
+            for i, line in enumerate(body):
+                y = body_top + i
+                if y >= rows - 1:
+                    break
+                _addstr_ansi(stdscr, y, 2, line, cols - 4)
+            stdscr.refresh()
+
+            key = stdscr.getch()
+            if key in (ord("q"), 27):
+                return
+            elif key in (ord("+"), ord("=")):
+                interval = _clamp_interval(interval + 1)
+            elif key in (ord("-"), ord("_")):
+                interval = _clamp_interval(interval - 1)
+            elif key == ord("r"):
+                last_refresh = 0.0
+    finally:
+        stdscr.timeout(-1)  # restore blocking input
 
 
 # ---------------------------------------------------------------------------
@@ -323,10 +523,83 @@ def _show_message(stdscr, msg: str, is_error: bool = False) -> None:
     stdscr.getch()
 
 
+def _pager(stdscr, title: str, lines: list[str], subtitle: str = "") -> None:
+    """Scrollable read-only view of ``lines`` (which may contain ANSI codes)."""
+    top = 0
+    while True:
+        stdscr.erase()
+        rows, cols = stdscr.getmaxyx()
+        _draw_header(stdscr, title, subtitle, cols)
+        body_top = 4
+        body_height = max(1, rows - body_top - 1)  # reserve the footer row
+        max_top = max(0, len(lines) - body_height)
+        top = min(top, max_top)
+        for i in range(body_height):
+            li = top + i
+            if li >= len(lines):
+                break
+            _addstr_ansi(stdscr, body_top + i, 2, lines[li], cols - 4)
+        more = "  (more ↓)" if top < max_top else ""
+        footer = f"[↑/↓ PgUp/PgDn] scroll  [q] back{more}"
+        try:
+            stdscr.addstr(rows - 1, 2, footer[: cols - 4], curses.A_DIM)
+        except curses.error:
+            pass
+        stdscr.refresh()
+
+        key = stdscr.getch()
+        if key in (curses.KEY_UP, ord("k")):
+            top = max(0, top - 1)
+        elif key in (curses.KEY_DOWN, ord("j")):
+            top = min(max_top, top + 1)
+        elif key in (curses.KEY_NPAGE, ord("d")):
+            top = min(max_top, top + body_height)
+        elif key in (curses.KEY_PPAGE, ord("u")):
+            top = max(0, top - body_height)
+        elif key in (curses.KEY_HOME, ord("g")):
+            top = 0
+        elif key in (curses.KEY_END, ord("G")):
+            top = max_top
+        elif key in (curses.KEY_ENTER, 10, 13, 27, ord("q")):
+            return
+
+
 def _draw_header(stdscr, title: str, subtitle: str, cols: int) -> None:
     stdscr.addstr(1, 2, title[: cols - 4], curses.A_BOLD)
     if subtitle:
         stdscr.addstr(2, 2, subtitle[: cols - 4], curses.A_DIM)
+
+
+def _capture(fn: Callable[[], None]) -> str:
+    """Run ``fn`` capturing stdout+stderr (with color forced on) into a string.
+
+    ``sys.stdin`` is swapped for an empty stream so an unexpected ``input()``
+    raises ``EOFError`` instead of blocking the curses session. The in-scope
+    actions (list/status/switch/remove) never prompt; this is defensive.
+    """
+    buf = io.StringIO()
+    saved_stdin = sys.stdin
+    sys.stdin = io.StringIO()
+    try:
+        with printer.force_color(), \
+                contextlib.redirect_stdout(buf), \
+                contextlib.redirect_stderr(buf):
+            try:
+                fn()
+            except ClaudeSwitchError as e:
+                print(f"Error: {e}")
+            except EOFError:
+                print("Error: interactive input is not available here.")
+            except KeyboardInterrupt:
+                print("Operation cancelled.")
+    finally:
+        sys.stdin = saved_stdin
+    return buf.getvalue()
+
+
+def _run_inline(stdscr, title: str, fn: Callable[[], None]) -> None:
+    """Run ``fn``, capturing its output and showing it in the in-TUI pager."""
+    _pager(stdscr, title, _capture(fn).splitlines())
 
 
 def _shell_out(stdscr, fn: Callable[[], None]) -> None:

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -138,3 +138,16 @@ class TestLinePrinters:
         printer.warning("be careful")
         captured = capsys.readouterr()
         assert "\033[33m" in captured.out
+
+
+def test_force_color_overrides_and_restores():
+    from claude_swap import printer
+    saved = printer._colors_enabled
+    try:
+        printer._colors_enabled = False
+        with printer.force_color():
+            assert printer.colors_enabled() is True
+            assert printer.accent("X") == "\x1b[38;5;173mX\x1b[0m"
+        assert printer._colors_enabled is False
+    finally:
+        printer._colors_enabled = saved

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -780,6 +780,14 @@ class TestGuards:
         assert not session_dir.exists()
         assert block_real_keychain.get_password(service, account) is None
 
+    def test_remove_account_assume_yes_skips_prompt(self, seeded_switcher, monkeypatch):
+        monkeypatch.setattr(
+            "builtins.input", lambda *a: pytest.fail("prompt must not be reached")
+        )
+        seeded_switcher.remove_account(ACCOUNT_NUM, assume_yes=True)
+        data = seeded_switcher._get_sequence_data()
+        assert ACCOUNT_NUM not in data["accounts"]
+
     def test_delete_account_files_chokepoint_refuses_live(self, seeded_switcher):
         session_dir = session_dir_for(
             seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -167,14 +167,10 @@ class TestDoSwitch:
         switcher = ClaudeAccountSwitcher()
 
         screen = _stub_screen()
-        # Pick the second item (slot 2) with one DOWN + ENTER
-        screen.getch.side_effect = [tui.curses.KEY_DOWN, 10, ord("\n")]
+        # Pick the second item (slot 2): one DOWN + ENTER, then 'q' to leave pager.
+        screen.getch.side_effect = [tui.curses.KEY_DOWN, 10, ord("q")]
 
-        with patch.object(switcher, "switch_to") as mock_switch, \
-             patch("claude_swap.tui.curses.def_prog_mode"), \
-             patch("claude_swap.tui.curses.endwin"), \
-             patch("claude_swap.tui.curses.reset_prog_mode"), \
-             patch("builtins.input", return_value=""):
+        with patch.object(switcher, "switch_to") as mock_switch:
             tui._do_switch(screen, switcher)
 
         mock_switch.assert_called_once_with("2")
@@ -278,19 +274,14 @@ class TestDoRemove:
         switcher = ClaudeAccountSwitcher()
 
         screen = _stub_screen()
-        keys = [10]  # pick first slot
-        keys += [ord("y"), 10]  # confirm: y
-        screen.getch.side_effect = keys
+        # pick first slot, confirm 'y' + Enter, then 'q' to leave the pager.
+        screen.getch.side_effect = [10, ord("y"), 10, ord("q")]
 
         with patch.object(switcher, "remove_account") as mock_rm, \
-             patch("claude_swap.tui.curses.def_prog_mode"), \
-             patch("claude_swap.tui.curses.endwin"), \
-             patch("claude_swap.tui.curses.reset_prog_mode"), \
-             patch("claude_swap.tui.curses.curs_set"), \
-             patch("builtins.input", return_value=""):
+             patch("claude_swap.tui.curses.curs_set"):
             tui._do_remove(screen, switcher)
 
-        mock_rm.assert_called_once_with("3")
+        mock_rm.assert_called_once_with("3", assume_yes=True)
 
 
 # --------------------------------------------------------------------------- #
@@ -337,3 +328,210 @@ class TestCliIntegration:
                 cli.main()
             assert exc.value.code == 0
         mock_run.assert_called_once_with(switcher_cls.return_value)
+
+
+class TestClampInterval:
+    def test_in_range(self):
+        assert tui._clamp_interval(5) == 5
+
+    def test_below_min(self):
+        assert tui._clamp_interval(0) == 1
+        assert tui._clamp_interval(-3) == 1
+
+    def test_above_max(self):
+        assert tui._clamp_interval(999) == 60
+
+    def test_custom_bounds(self):
+        assert tui._clamp_interval(100, lo=2, hi=10) == 10
+
+
+class TestAnsiSegments:
+    def test_plain_text_single_run(self):
+        assert tui._ansi_segments("hello") == [("hello", 0)]
+
+    def test_empty_string(self):
+        assert tui._ansi_segments("") == [("", 0)]
+
+    def test_bold_run(self):
+        assert tui._ansi_segments("\x1b[1mX\x1b[0m") == [("X", tui._STYLE_BOLD)]
+
+    def test_stacked_bold_accent(self):
+        # printer.bold_accent emits "\x1b[1m\x1b[38;5;173m...\x1b[0m"
+        segs = tui._ansi_segments("\x1b[1m\x1b[38;5;173mY\x1b[0m")
+        assert segs == [("Y", tui._STYLE_BOLD | tui._STYLE_ACCENT)]
+
+    def test_mixed_runs_with_reset(self):
+        segs = tui._ansi_segments("a\x1b[2mb\x1b[0mc")
+        assert segs == [("a", 0), ("b", tui._STYLE_DIM), ("c", 0)]
+
+    def test_muted_and_red_and_yellow(self):
+        assert tui._ansi_segments("\x1b[38;5;250mm\x1b[0m") == [("m", tui._STYLE_MUTED)]
+        assert tui._ansi_segments("\x1b[31mr\x1b[0m") == [("r", tui._STYLE_RED)]
+        assert tui._ansi_segments("\x1b[33my\x1b[0m") == [("y", tui._STYLE_YELLOW)]
+
+    def test_unknown_code_ignored(self):
+        assert tui._ansi_segments("\x1b[99mZ\x1b[0m") == [("Z", 0)]
+
+
+class TestStyleToAttr:
+    def test_bold_maps_to_a_bold(self):
+        # A_BOLD is a plain constant available without initscr.
+        assert tui._style_to_attr(tui._STYLE_BOLD) & tui.curses.A_BOLD
+
+    def test_dim_maps_to_a_dim(self):
+        assert tui._style_to_attr(tui._STYLE_DIM) & tui.curses.A_DIM
+
+    def test_no_flags_is_normal(self):
+        assert tui._style_to_attr(0) == tui.curses.A_NORMAL
+
+    def test_color_lookup_without_initscr_does_not_raise(self):
+        # has_colors()/color_pair() raise outside initscr; must be swallowed.
+        attr = tui._style_to_attr(tui._STYLE_ACCENT)
+        assert isinstance(attr, int)
+
+
+class TestAddstrAnsi:
+    def test_draws_each_run_clipped(self):
+        screen = _stub_screen()
+        tui._addstr_ansi(screen, 4, 2, "\x1b[1mAB\x1b[0mCD", max_width=3)
+        # First run "AB" (bold) then "C" (clipped from "CD" at width 3).
+        calls = [c.args for c in screen.addstr.call_args_list]
+        drawn = "".join(a[2] for a in calls)
+        assert drawn == "ABC"
+
+    def test_swallows_curses_error(self):
+        screen = _stub_screen()
+        screen.addstr.side_effect = tui.curses.error
+        # Must not raise.
+        tui._addstr_ansi(screen, 4, 2, "x", max_width=10)
+
+
+class TestPager:
+    def test_returns_on_q(self):
+        screen = _stub_screen(rows=10, cols=40)
+        screen.getch.side_effect = [ord("q")]
+        tui._pager(screen, "T", [f"line{i}" for i in range(50)])
+
+    def test_returns_on_escape(self):
+        screen = _stub_screen()
+        screen.getch.side_effect = [27]
+        tui._pager(screen, "T", ["a", "b"])
+
+    def test_returns_on_enter(self):
+        screen = _stub_screen()
+        screen.getch.side_effect = [10]
+        tui._pager(screen, "T", ["a"])
+
+    def test_scroll_down_then_quit_no_error(self):
+        screen = _stub_screen(rows=8, cols=40)
+        screen.getch.side_effect = [
+            tui.curses.KEY_DOWN, tui.curses.KEY_NPAGE,
+            tui.curses.KEY_END, tui.curses.KEY_HOME, ord("q"),
+        ]
+        tui._pager(screen, "T", [f"row{i}" for i in range(100)])
+
+    def test_short_content_does_not_overscroll(self):
+        screen = _stub_screen(rows=30, cols=40)
+        screen.getch.side_effect = [tui.curses.KEY_DOWN, tui.curses.KEY_NPAGE, ord("q")]
+        tui._pager(screen, "T", ["only line"])
+
+
+class TestRunInline:
+    def test_captures_colored_output_and_pages(self):
+        screen = _stub_screen()
+        seen = {}
+
+        def fake_pager(s, title, lines, subtitle=""):
+            seen["title"] = title
+            seen["lines"] = lines
+
+        def fn():
+            from claude_swap import printer
+            print(printer.accent("hello"))
+            print("plain")
+
+        with patch("claude_swap.tui._pager", side_effect=fake_pager):
+            tui._run_inline(screen, "Title", fn)
+
+        assert seen["title"] == "Title"
+        # Color is forced on during capture → accent line carries ANSI.
+        assert any("hello" in line for line in seen["lines"])
+        assert "\x1b[38;5;173m" in "\n".join(seen["lines"])
+        assert "plain" in seen["lines"]
+
+    def test_stray_input_becomes_message_and_stdin_restored(self):
+        import sys as _sys
+        screen = _stub_screen()
+        before = _sys.stdin
+
+        def fn():
+            input("give me something")  # no stdin → EOFError
+
+        with patch("claude_swap.tui._pager") as mock_pager:
+            tui._run_inline(screen, "T", fn)
+
+        assert _sys.stdin is before  # restored
+        lines = mock_pager.call_args.args[2]
+        assert any("input is not available" in line for line in lines)
+
+    def test_switch_error_captured(self):
+        screen = _stub_screen()
+
+        def fn():
+            raise ClaudeSwitchError("boom")
+
+        with patch("claude_swap.tui._pager") as mock_pager:
+            tui._run_inline(screen, "T", fn)
+        lines = mock_pager.call_args.args[2]
+        assert any("boom" in line for line in lines)
+
+
+class TestWatch:
+    def test_empty_state_returns_without_loop(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        screen.getch.return_value = ord("q")  # dismiss _show_message
+        with patch.object(switcher, "list_accounts") as mock_list:
+            tui._do_watch(screen, switcher)
+        mock_list.assert_not_called()
+
+    def test_refreshes_then_quits(self, temp_home: Path):
+        _make_seq(temp_home, [("1", "a@x.com")])
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        screen.getch.side_effect = [ord("q")]
+        with patch.object(switcher, "list_accounts") as mock_list, \
+             patch("claude_swap.tui.time.monotonic", return_value=100.0):
+            tui._watch_loop(screen, switcher, interval=5)
+        mock_list.assert_called()  # at least one refresh before quit
+        screen.timeout.assert_any_call(250)
+        screen.timeout.assert_any_call(-1)
+
+    def test_plus_raises_interval(self, temp_home: Path):
+        _make_seq(temp_home, [("1", "a@x.com")])
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        # First loop refreshes (monotonic 100), then '+' (interval→6),
+        # then 'q'. monotonic stays 100 so no second refresh.
+        screen.getch.side_effect = [ord("+"), ord("q")]
+        with patch.object(switcher, "list_accounts") as mock_list, \
+             patch("claude_swap.tui.time.monotonic", return_value=100.0):
+            tui._watch_loop(screen, switcher, interval=5)
+        assert mock_list.call_count == 1
+
+
+class TestInitColors:
+    def test_initializes_pairs_when_color_supported(self):
+        with patch("claude_swap.tui.curses.has_colors", return_value=True), \
+             patch("claude_swap.tui.curses.start_color"), \
+             patch("claude_swap.tui.curses.use_default_colors"), \
+             patch("claude_swap.tui.curses.init_pair") as mock_pair, \
+             patch("claude_swap.tui.curses.COLORS", 256, create=True):
+            tui._colors_initialized = False
+            tui._init_colors()
+        assert mock_pair.call_count == 4
+
+    def test_no_color_terminal_is_safe(self):
+        with patch("claude_swap.tui.curses.has_colors", return_value=False):
+            tui._colors_initialized = False
+            tui._init_colors()  # must not raise


### PR DESCRIPTION
## What this does

The interactive TUI (`cswap --tui`) had one rough edge: every action dropped out of the curses menu, printed to stdout, and waited for Enter. After a couple of actions the screen was a wall of scrollback and it was hard to follow what had happened.

This PR keeps everything on screen.

### In-place rendering
**List**, **Status**, **Switch** and **Remove** now render inside a scrollable panel *within* the menu instead of dumping to stdout. The action's output is captured, the existing printer colors are mapped onto curses attributes (so it looks the same), and the result is shown in a small pager — arrows / PgUp / PgDn to scroll, `q` to go back. **Add** and **Refresh** still shell out, since they can need the real terminal for login.

### Watch dashboard
A new **Watch** menu item opens a live, read-only dashboard of the active account and per-account usage that auto-refreshes on a timer. `+`/`-` change the interval, `r` refreshes now, `q` exits. Usage is cache-gated at 15s, so very short intervals re-render cached numbers rather than hammering the API.

### Bonus
`remove_account` gained an `assume_yes` flag (default off, so the CLI is unchanged). The TUI already confirms before removing, so it no longer double-prompts.

## Screenshots

Main menu (with the new Watch entry):

![menu](https://github.com/Steamvis/claude-swap/releases/download/tui-screenshots/tui-menu.png)

`List accounts` rendered in-place — a scrollable panel, no more stdout dump:

![list](https://github.com/Steamvis/claude-swap/releases/download/tui-screenshots/tui-list.png)

The Watch dashboard:

![watch](https://github.com/Steamvis/claude-swap/releases/download/tui-screenshots/tui-watch.png)

## Notes

- **No new dependencies** — rendering uses the stdlib `curses` module.
- Graceful fallback to bold/dim/plain on no-color or very small terminals.
- Tests added for the ANSI tokenizer, color mapping, the pager, output capture, the watch loop, and `assume_yes`. Full suite: **626 passed, 3 skipped**.
