### PR TITLE
feat: auto-switch accounts by usage threshold (cswap autoswitch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ Or let claude-swap auto-pick by remaining quota — `cswap --switch --strategy b
 
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.
 
+### Auto-switch by usage
+
+Instead of switching by hand, let claude-swap watch your quota and hop to the freshest account *before* the active one hits its limit. Run the setup wizard:
+
+```bash
+cswap autoswitch
+```
+
+The wizard is a small menu — set a **common threshold** that applies to every account (e.g. switch at 85% usage), optionally **override individual accounts** (e.g. keep your work account until 95%), set the poll interval, and start/stop the background watcher. Each change is saved as you go.
+
+The watcher polls each account's quota every interval and, when the **active** account's usage (the higher of its 5-hour / 7-day window) reaches its threshold, switches to the account with the most quota left — exactly `cswap --switch --strategy best`. If no other account has more headroom (or there's only one account), it stays put and logs why; it never switches onto a worse account.
+
+```bash
+cswap autoswitch start      # run the watcher in the background
+cswap autoswitch status     # rules + per-account usage vs threshold
+cswap autoswitch check      # evaluate once now and switch if over threshold
+cswap autoswitch stop       # stop the watcher
+```
+
+Rules are stored in `autoswitch.json` in the backup directory, and the watcher writes a log to `autoswitch.log` there. A swap rewrites the credentials file Claude Code reads, so it takes full effect on Claude's **next** start — a session already running keeps the account it loaded.
+
 ### Run multiple accounts at the same time (session mode)
 
 Launch Claude Code as a specific account in the current terminal only — every other terminal and the VS Code extension stay on your default account, so two accounts can work in parallel.
@@ -98,6 +119,7 @@ This will update the stored credentials without creating a duplicate.
 
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
+cswap autoswitch                # Set up / control auto-switching by usage % (start/stop/status/check)
 cswap --list                    # Show all accounts with 5h/7d usage and reset times
 cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1,0 +1,508 @@
+"""Threshold-driven automatic account switching for Claude Swap.
+
+`ccs autoswitch` lets you set a usage-% threshold (a common/global one plus
+optional per-account overrides) and run a background watcher that polls each
+account's quota and swaps to the freshest account when the active one crosses
+its threshold — so you keep working past a single account's limit without
+switching by hand.
+
+The actual switching is delegated to the existing, well-tested
+``ClaudeAccountSwitcher.switch(strategy="best")``; this module only adds the
+*gate* (don't switch until the active account is over its threshold), the
+persisted rule set, the wizard, and the detached watcher process.
+
+Caveat: ccs swaps the credentials file Claude Code reads, so a swap fully takes
+effect on Claude's *next* start — a session already running keeps the
+credentials it loaded.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from claude_swap import oauth
+from claude_swap.exceptions import ConfigError
+from claude_swap.models import get_timestamp
+from claude_swap.printer import accent, bolded, dimmed, muted, warning
+from claude_swap.process_detection import is_pid_alive
+
+if TYPE_CHECKING:
+    from claude_swap.switcher import ClaudeAccountSwitcher
+
+# Default rule set. Any field missing from autoswitch.json falls back to these.
+DEFAULTS: dict = {
+    "enabled": False,
+    "globalThreshold": 85,  # switch when max(5h%, 7d%) >= this
+    "overrides": {},  # account number (str) -> usage %
+    "interval": 600,  # watcher poll seconds (10 min)
+    "strategy": "best",  # "best" | "next-available"
+}
+
+# Usage % must leave room both to actually trigger (< 100) and to be meaningful
+# (> 0). The watcher should not poll more often than the usage cache TTL (15s)
+# nor so rarely it misses a window.
+MIN_THRESHOLD = 1
+MAX_THRESHOLD = 99
+MIN_INTERVAL = 30
+
+
+# --- Config storage -------------------------------------------------------
+
+
+def _config_path(switcher: ClaudeAccountSwitcher) -> Path:
+    return switcher.backup_dir / "autoswitch.json"
+
+
+def _pid_path(switcher: ClaudeAccountSwitcher) -> Path:
+    return switcher.backup_dir / "autoswitch.pid"
+
+
+def _log_path(switcher: ClaudeAccountSwitcher) -> Path:
+    return switcher.backup_dir / "autoswitch.log"
+
+
+def load_config(switcher: ClaudeAccountSwitcher) -> dict:
+    """Load autoswitch.json, filling any missing field with its default."""
+    raw = switcher._read_json(_config_path(switcher)) or {}
+    cfg = dict(DEFAULTS)
+    cfg.update({k: v for k, v in raw.items() if k in DEFAULTS})
+    # Defensive copies so callers never mutate the DEFAULTS dict.
+    cfg["overrides"] = dict(cfg.get("overrides") or {})
+    return cfg
+
+
+def save_config(switcher: ClaudeAccountSwitcher, cfg: dict) -> None:
+    """Persist the rule set to autoswitch.json."""
+    switcher.backup_dir.mkdir(parents=True, exist_ok=True)
+    payload = {k: cfg.get(k, DEFAULTS[k]) for k in DEFAULTS}
+    switcher._write_json(_config_path(switcher), payload)
+
+
+def effective_threshold(cfg: dict, num: str | None) -> int:
+    """Per-account override if set, else the global threshold."""
+    overrides = cfg.get("overrides") or {}
+    if num is not None and str(num) in overrides:
+        return int(overrides[str(num)])
+    return int(cfg.get("globalThreshold", DEFAULTS["globalThreshold"]))
+
+
+# --- One-shot evaluation (the unit the watcher loops) ---------------------
+
+
+def _active_account_num(switcher: ClaudeAccountSwitcher) -> str | None:
+    """Slot number of the live Claude account, or None if none/unmanaged."""
+    identity = switcher._get_current_account()
+    if identity is None:
+        return None
+    email, org_uuid = identity
+    data = switcher._get_sequence_data_migrated()
+    if not data:
+        return None
+    return switcher._find_account_slot(data, email, org_uuid)
+
+
+def evaluate_and_switch(switcher: ClaudeAccountSwitcher, cfg: dict) -> dict:
+    """Check the active account once and switch if it's over its threshold.
+
+    Returns a small result dict (used both for ``ccs autoswitch check`` output
+    and the watcher log). Never raises on network/usage failure — an
+    unmeasurable account is reported as a no-op, not an error.
+    """
+    active = _active_account_num(switcher)
+    if active is None:
+        return {
+            "switched": False,
+            "reason": "no-active-account",
+            "active": None,
+            "pct": None,
+            "threshold": None,
+            "message": "No managed Claude account is active.",
+        }
+
+    headroom = oauth.account_headroom(switcher._usage_by_account().get(str(active)))
+    if headroom is None:
+        return {
+            "switched": False,
+            "reason": "usage-unavailable",
+            "active": active,
+            "pct": None,
+            "threshold": effective_threshold(cfg, active),
+            "message": f"Account-{active}: usage unavailable, skipping.",
+        }
+
+    pct = round(100.0 - headroom, 1)
+    threshold = effective_threshold(cfg, active)
+    if pct < threshold:
+        return {
+            "switched": False,
+            "reason": "under-threshold",
+            "active": active,
+            "pct": pct,
+            "threshold": threshold,
+            "message": f"Account-{active} at {pct:.0f}% (< {threshold}%), staying.",
+        }
+
+    # Over threshold: delegate to the proven "best" engine. It only lands on an
+    # account with strictly more headroom, and stays put otherwise.
+    result = switcher.switch(strategy=cfg.get("strategy", "best"), json_output=True) or {}
+    to = result.get("to") or {}
+    target = to.get("number")
+    switched = bool(result.get("switched"))
+    over = f"Account-{active} at {pct:.0f}% (>= {threshold}%)"
+    if switched:
+        reason = "switched"
+        msg = f"{over} -> switched to Account-{target} ({to.get('email', '')})."
+    elif result.get("reason") == "only-one-account":
+        # Nothing to switch to — there's just this one managed account.
+        reason = "only-one-account"
+        msg = f"{over} but it's the only managed account, staying. Add more with 'ccs add'."
+    else:
+        # Every other account is equal or worse (or unmeasurable); staying is
+        # the safe choice rather than moving onto a worse account.
+        reason = "no-better-account"
+        msg = f"{over} but no other account has more headroom, staying."
+    return {
+        "switched": switched,
+        "reason": reason,
+        "active": active,
+        "pct": pct,
+        "threshold": threshold,
+        "target": target,
+        "message": msg,
+    }
+
+
+# --- Watcher process management -------------------------------------------
+
+
+def _read_pid(switcher: ClaudeAccountSwitcher) -> int | None:
+    """Return the watcher PID if the file exists and the process is alive.
+
+    Liveness uses the project's cross-platform :func:`is_pid_alive` (POSIX
+    ``os.kill(pid, 0)`` / Windows ``OpenProcess``) — never a kill probe.
+    """
+    path = _pid_path(switcher)
+    try:
+        pid = int(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+    if is_pid_alive(pid):
+        return pid
+    # Stale file from a crashed/killed watcher — clean it up opportunistically.
+    path.unlink(missing_ok=True)
+    return None
+
+
+def is_running(switcher: ClaudeAccountSwitcher) -> bool:
+    return _read_pid(switcher) is not None
+
+
+def start_watcher(switcher: ClaudeAccountSwitcher) -> int:
+    """Spawn the detached watcher process. Returns its PID.
+
+    Refuses to start a second watcher while one is alive.
+    """
+    existing = _read_pid(switcher)
+    if existing is not None:
+        raise ConfigError(
+            f"Auto-switch watcher is already running (PID {existing}). "
+            "Run 'ccs autoswitch stop' first."
+        )
+
+    switcher.backup_dir.mkdir(parents=True, exist_ok=True)
+    log = open(_log_path(switcher), "a", encoding="utf-8")  # noqa: SIM115 (handed to child)
+    try:
+        cmd = [sys.executable, "-m", "claude_swap", "autoswitch", "__run"]
+        kwargs: dict = {
+            "stdin": subprocess.DEVNULL,
+            "stdout": log,
+            "stderr": log,
+            "close_fds": True,
+            "cwd": str(switcher.backup_dir),
+        }
+        if sys.platform == "win32":
+            kwargs["creationflags"] = (
+                subprocess.DETACHED_PROCESS  # type: ignore[attr-defined]
+                | subprocess.CREATE_NEW_PROCESS_GROUP
+            )
+        else:
+            kwargs["start_new_session"] = True
+        proc = subprocess.Popen(cmd, **kwargs)
+    finally:
+        log.close()
+
+    cfg = load_config(switcher)
+    cfg["enabled"] = True
+    save_config(switcher, cfg)
+
+    # ``proc.pid`` is the spawned interpreter, which on some platforms (e.g. the
+    # Windows venv launcher shim) differs from the daemon that ends up running
+    # the loop and writing the PID file. Prefer the daemon's own recorded PID so
+    # the reported value matches ``status``/``stop``; fall back to ``proc.pid``.
+    for _ in range(20):
+        recorded = _read_pid(switcher)
+        if recorded is not None:
+            return recorded
+        time.sleep(0.1)
+    return proc.pid
+
+
+def stop_watcher(switcher: ClaudeAccountSwitcher) -> bool:
+    """Terminate the watcher if running. Returns True if one was stopped."""
+    pid = _read_pid(switcher)
+    cfg = load_config(switcher)
+    cfg["enabled"] = False
+    save_config(switcher, cfg)
+
+    if pid is None:
+        _pid_path(switcher).unlink(missing_ok=True)
+        return False
+
+    try:
+        # POSIX: graceful SIGTERM (watcher cleans up its PID file).
+        # Windows: os.kill with a non-CTRL signal calls TerminateProcess.
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        pass
+    # The PID file may not be removed by a hard-killed watcher; clear it here.
+    _pid_path(switcher).unlink(missing_ok=True)
+    return True
+
+
+def run_watcher(switcher: ClaudeAccountSwitcher) -> None:
+    """Blocking poll loop. This is the detached child's own entry point.
+
+    Writes its PID file, then loops ``evaluate_and_switch`` every ``interval``
+    seconds, logging each outcome. Transient errors are logged, never fatal.
+    """
+    pid_file = _pid_path(switcher)
+    switcher.backup_dir.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(str(os.getpid()), encoding="utf-8")
+
+    stopping = {"flag": False}
+
+    def _handle_term(_signum, _frame):
+        stopping["flag"] = True
+
+    if sys.platform != "win32":
+        signal.signal(signal.SIGTERM, _handle_term)
+
+    def _log(msg: str) -> None:
+        try:
+            with open(_log_path(switcher), "a", encoding="utf-8") as fh:
+                fh.write(f"{get_timestamp()}  {msg}\n")
+        except OSError:
+            pass
+
+    try:
+        cfg = load_config(switcher)
+        _log(f"watcher started (pid {os.getpid()}, interval {cfg['interval']}s, global {cfg['globalThreshold']}%)")
+        while not stopping["flag"]:
+            cfg = load_config(switcher)  # re-read so wizard edits take effect live
+            try:
+                result = evaluate_and_switch(switcher, cfg)
+                _log(result["message"])
+            except Exception as exc:  # never let one bad poll kill the watcher
+                _log(f"poll error: {exc!r}")
+            # Sleep in short slices so a SIGTERM (POSIX) ends promptly.
+            slept = 0
+            interval = max(MIN_INTERVAL, int(cfg.get("interval", DEFAULTS["interval"])))
+            while slept < interval and not stopping["flag"]:
+                time.sleep(min(2, interval - slept))
+                slept += 2
+    finally:
+        _log("watcher stopped")
+        pid_file.unlink(missing_ok=True)
+
+
+def watcher_status(switcher: ClaudeAccountSwitcher) -> dict:
+    """Snapshot of running state + rules for display."""
+    cfg = load_config(switcher)
+    return {
+        "running": is_running(switcher),
+        "pid": _read_pid(switcher),
+        "config": cfg,
+        "log": str(_log_path(switcher)),
+    }
+
+
+# --- Human-facing commands (called from cli.py) ---------------------------
+
+
+def print_status(switcher: ClaudeAccountSwitcher) -> None:
+    """`ccs autoswitch status` — running state, rules, and per-account usage."""
+    st = watcher_status(switcher)
+    cfg = st["config"]
+
+    if st["running"]:
+        state = f"{accent('running')} {dimmed('(PID ' + str(st['pid']) + ')')}"
+    else:
+        state = dimmed("stopped")
+    print(f"{bolded('Auto-switch:')} {state}")
+    print(f"  {dimmed('Global threshold:')} {cfg['globalThreshold']}%   "
+          f"{dimmed('poll every')} {cfg['interval']}s   "
+          f"{dimmed('strategy')} {cfg['strategy']}")
+
+    overrides = cfg.get("overrides") or {}
+    data = switcher._get_sequence_data() or {}
+    accounts = data.get("accounts", {})
+    if not accounts:
+        print(f"  {dimmed('No managed accounts yet.')}")
+        return
+
+    usage = switcher._usage_by_account()
+    active = _active_account_num(switcher)
+    print(f"  {dimmed('Accounts (usage vs threshold):')}")
+    for num in sorted(accounts, key=lambda n: int(n)):
+        email = accounts[num].get("email", "")
+        thr = effective_threshold(cfg, num)
+        tag = " (override)" if str(num) in overrides else ""
+        headroom = oauth.account_headroom(usage.get(str(num)))
+        if headroom is None:
+            usage_str = dimmed("usage n/a")
+        else:
+            pct = 100.0 - headroom
+            mark = accent("OVER") if pct >= thr else muted(f"{pct:.0f}%")
+            usage_str = f"{mark} / {thr}%{tag}"
+        marker = bolded("*") if str(num) == str(active) else " "
+        print(f"   {marker} Account-{num} {muted(email)}: {usage_str}")
+
+
+def print_check(switcher: ClaudeAccountSwitcher) -> None:
+    """`ccs autoswitch check` — evaluate once now and switch if over threshold."""
+    cfg = load_config(switcher)
+    result = evaluate_and_switch(switcher, cfg)
+    if result["switched"]:
+        print(f"{accent('Switched:')} {result['message']}")
+    else:
+        print(f"{dimmed('No switch:')} {result['message']}")
+
+
+def _prompt_int(prompt: str, lo: int, hi: int) -> int | None:
+    """Prompt for an int in [lo, hi]; return None if blank/cancelled."""
+    raw = input(prompt).strip()
+    if not raw:
+        return None
+    try:
+        val = int(raw)
+    except ValueError:
+        warning(f"  Not a number: {raw!r}")
+        return None
+    if not (lo <= val <= hi):
+        warning(f"  Must be between {lo} and {hi}.")
+        return None
+    return val
+
+
+def run_wizard(switcher: ClaudeAccountSwitcher) -> None:
+    """`ccs autoswitch` — interactive setup. Easy, tick-as-you-go."""
+    print(bolded("Auto-switch setup"))
+    print(dimmed(
+        "Swap to the account with the most quota left when the active one "
+        "crosses its limit.\n"
+    ))
+
+    while True:
+        cfg = load_config(switcher)
+        running = is_running(switcher)
+        print(f"{dimmed('Current rules:')} global {bolded(str(cfg['globalThreshold']) + '%')}, "
+              f"poll {cfg['interval']}s, watcher {accent('on') if running else dimmed('off')}")
+        overrides = cfg.get("overrides") or {}
+        if overrides:
+            pretty = ", ".join(f"#{n}={p}%" for n, p in sorted(overrides.items(), key=lambda kv: int(kv[0])))
+            print(f"{dimmed('  per-account overrides:')} {pretty}")
+
+        print()
+        print(f"  {bolded('1')}  Set global threshold %")
+        print(f"  {bolded('2')}  Set / clear a per-account override")
+        print(f"  {bolded('3')}  Set poll interval (seconds)")
+        print(f"  {bolded('4')}  {'Stop' if running else 'Start'} the background watcher")
+        print(f"  {bolded('5')}  Done")
+        choice = input("Choose [1-5]: ").strip()
+
+        if choice == "1":
+            val = _prompt_int(
+                f"  New global threshold % [{MIN_THRESHOLD}-{MAX_THRESHOLD}], blank to keep: ",
+                MIN_THRESHOLD, MAX_THRESHOLD,
+            )
+            if val is not None:
+                cfg["globalThreshold"] = val
+                save_config(switcher, cfg)
+                print(f"  {accent('✓')} Global threshold set to {val}%")
+        elif choice == "2":
+            _override_submenu(switcher, cfg)
+        elif choice == "3":
+            val = _prompt_int(
+                f"  Poll interval seconds [>= {MIN_INTERVAL}], blank to keep: ",
+                MIN_INTERVAL, 86400,
+            )
+            if val is not None:
+                cfg["interval"] = val
+                save_config(switcher, cfg)
+                print(f"  {accent('✓')} Poll interval set to {val}s")
+        elif choice == "4":
+            if running:
+                stop_watcher(switcher)
+                print(f"  {accent('✓')} Watcher stopped")
+            else:
+                pid = start_watcher(switcher)
+                print(f"  {accent('✓')} Watcher started (PID {pid})")
+        elif choice in ("5", "q", ""):
+            print(dimmed("Done. Run 'ccs autoswitch status' anytime to check."))
+            return
+        else:
+            warning(f"  Unknown choice: {choice!r}")
+        print()
+
+
+def _override_submenu(switcher: ClaudeAccountSwitcher, cfg: dict) -> None:
+    """Set or clear a single per-account threshold override."""
+    data = switcher._get_sequence_data() or {}
+    accounts = data.get("accounts", {})
+    if not accounts:
+        warning("  No managed accounts yet — add some with 'ccs add'.")
+        return
+
+    overrides = cfg.get("overrides") or {}
+    print(dimmed("  Accounts:"))
+    for num in sorted(accounts, key=lambda n: int(n)):
+        cur = overrides.get(str(num))
+        suffix = f"  (override {cur}%)" if cur is not None else f"  (uses global {cfg['globalThreshold']}%)"
+        print(f"    {bolded(num)}  {accounts[num].get('email', '')}{dimmed(suffix)}")
+
+    target = input("  Account number to set (blank to cancel): ").strip()
+    if not target:
+        return
+    if target not in accounts:
+        warning(f"  No such account: {target}")
+        return
+
+    val = input(
+        f"  Threshold % for Account-{target} [{MIN_THRESHOLD}-{MAX_THRESHOLD}], "
+        f"or 'x' to clear override: "
+    ).strip()
+    if val.lower() == "x":
+        overrides.pop(str(target), None)
+        cfg["overrides"] = overrides
+        save_config(switcher, cfg)
+        print(f"  {accent('✓')} Cleared override for Account-{target} "
+              f"(now uses global {cfg['globalThreshold']}%)")
+        return
+    try:
+        num_val = int(val)
+    except ValueError:
+        warning(f"  Not a number: {val!r}")
+        return
+    if not (MIN_THRESHOLD <= num_val <= MAX_THRESHOLD):
+        warning(f"  Must be between {MIN_THRESHOLD} and {MAX_THRESHOLD}.")
+        return
+    overrides[str(target)] = num_val
+    cfg["overrides"] = overrides
+    save_config(switcher, cfg)
+    print(f"  {accent('✓')} Account-{target} will switch at {num_val}%")

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -90,11 +90,89 @@ Examples:
         sys.exit(130)
 
 
+def _autoswitch_command(argv: list[str]) -> None:
+    """Handle `cswap autoswitch [start|stop|status|check]` (bare = setup wizard).
+
+    Pre-dispatched like `run` because it has its own sub-verbs that can't coexist
+    with main()'s required mutually-exclusive flag group. The hidden `__run` verb
+    is the entry point the detached watcher process re-invokes on itself.
+    """
+    parser = argparse.ArgumentParser(
+        prog="cswap autoswitch",
+        description=(
+            "Automatically switch to the account with the most quota left when "
+            "the active one crosses a usage-% threshold. Run with no subcommand "
+            "for the interactive setup wizard."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Subcommands:
+  (none)    interactive setup wizard (set thresholds, start/stop watcher)
+  start     start the background watcher
+  stop      stop the background watcher
+  status    show watcher state, rules, and per-account usage vs threshold
+  check     evaluate once now and switch if over threshold
+
+Examples:
+  cswap autoswitch            # set it up
+  cswap autoswitch start      # run the watcher in the background
+  cswap autoswitch status
+        """,
+    )
+    parser.add_argument(
+        "subcommand",
+        nargs="?",
+        choices=["start", "stop", "status", "check", "__run"],
+        help="What to do (omit for the setup wizard)",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    try:
+        from claude_swap import autoswitch
+
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+
+        if sys.platform != "win32":
+            if os.geteuid() == 0 and not switcher._is_running_in_container():
+                error("Error: Do not run this script as root (unless running in a container)")
+                sys.exit(1)
+
+        if args.subcommand == "__run":
+            autoswitch.run_watcher(switcher)
+        elif args.subcommand == "start":
+            pid = autoswitch.start_watcher(switcher)
+            print(f"Auto-switch watcher started (PID {pid}).")
+            print(dimmed("Stop it with 'cswap autoswitch stop'."))
+        elif args.subcommand == "stop":
+            stopped = autoswitch.stop_watcher(switcher)
+            print("Auto-switch watcher stopped." if stopped
+                  else dimmed("No auto-switch watcher was running."))
+        elif args.subcommand == "status":
+            autoswitch.print_status(switcher)
+        elif args.subcommand == "check":
+            autoswitch.print_check(switcher)
+        else:
+            autoswitch.run_wizard(switcher)
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
 def main() -> None:
     """Main entry point for the CLI."""
     if len(sys.argv) > 1 and sys.argv[1] == "run":
         _run_command(sys.argv[2:])
         return  # only reachable in tests where exec/exit is mocked
+
+    # `autoswitch` (alias `auto`) has its own sub-verbs, so it's pre-dispatched
+    # like `run` rather than mapped to a flag.
+    if len(sys.argv) > 1 and sys.argv[1] in ("autoswitch", "auto"):
+        _autoswitch_command(sys.argv[2:])
+        return
 
     parser = argparse.ArgumentParser(
         description="Multi-Account Switcher for Claude Code",
@@ -114,6 +192,8 @@ Examples:
   %(prog)s --switch-to user@example.com
   %(prog)s run 2                            # run account 2 in this terminal only
   %(prog)s run 2 -- --resume                # forward args after '--' to claude
+  %(prog)s autoswitch                       # set up auto-switching by usage %% (wizard)
+  %(prog)s autoswitch start                 # background watcher: switch before a limit hits
   %(prog)s --remove-account user@example.com
   %(prog)s --status
   %(prog)s --purge

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -1,0 +1,286 @@
+"""Tests for threshold-driven auto-switching (autoswitch module)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap import autoswitch
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+def _seed(switcher: ClaudeAccountSwitcher, data: dict) -> None:
+    switcher.backup_dir.mkdir(parents=True, exist_ok=True)
+    switcher._write_json(switcher.sequence_file, data)
+
+
+def _usage(pct_5h: float | None = None, pct_7d: float | None = None) -> dict:
+    """Build a usage dict shaped like oauth.build_usage_result (only pct used)."""
+    usage: dict = {}
+    if pct_5h is not None:
+        usage["five_hour"] = {"pct": pct_5h}
+    if pct_7d is not None:
+        usage["seven_day"] = {"pct": pct_7d}
+    return usage
+
+
+# --- Config -------------------------------------------------------------
+
+
+class TestConfig:
+    def test_defaults_when_no_file(self, temp_home: Path):
+        cfg = autoswitch.load_config(ClaudeAccountSwitcher())
+        assert cfg["globalThreshold"] == 85
+        assert cfg["enabled"] is False
+        assert cfg["overrides"] == {}
+        assert cfg["interval"] == 600
+
+    def test_round_trip(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        cfg = autoswitch.load_config(switcher)
+        cfg["globalThreshold"] = 70
+        cfg["overrides"] = {"2": 95}
+        cfg["interval"] = 300
+        autoswitch.save_config(switcher, cfg)
+
+        reread = autoswitch.load_config(switcher)
+        assert reread["globalThreshold"] == 70
+        assert reread["overrides"] == {"2": 95}
+        assert reread["interval"] == 300
+        # Only known keys are persisted.
+        on_disk = json.loads((switcher.backup_dir / "autoswitch.json").read_text())
+        assert set(on_disk) == set(autoswitch.DEFAULTS)
+
+    def test_unknown_keys_ignored(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        (switcher.backup_dir).mkdir(parents=True, exist_ok=True)
+        (switcher.backup_dir / "autoswitch.json").write_text(
+            json.dumps({"globalThreshold": 50, "bogus": 1})
+        )
+        cfg = autoswitch.load_config(switcher)
+        assert cfg["globalThreshold"] == 50
+        assert "bogus" not in cfg
+
+    def test_effective_threshold_override_beats_global(self):
+        cfg = {"globalThreshold": 85, "overrides": {"2": 95}}
+        assert autoswitch.effective_threshold(cfg, "1") == 85  # falls back to global
+        assert autoswitch.effective_threshold(cfg, "2") == 95  # override wins
+        assert autoswitch.effective_threshold(cfg, None) == 85
+
+
+# --- evaluate_and_switch ------------------------------------------------
+
+
+class TestEvaluate:
+    def _switcher(self, monkeypatch, *, active, usage_map):
+        """A switcher with mocked identity + usage; switch() records its calls."""
+        switcher = ClaudeAccountSwitcher()
+        monkeypatch.setattr(autoswitch, "_active_account_num", lambda s: active)
+        monkeypatch.setattr(
+            ClaudeAccountSwitcher, "_usage_by_account", lambda self: usage_map
+        )
+        calls: list = []
+
+        def fake_switch(self, strategy=None, json_output=False):
+            calls.append(strategy)
+            return {
+                "switched": True,
+                "to": {"number": 2, "email": "b@example.com"},
+            }
+
+        monkeypatch.setattr(ClaudeAccountSwitcher, "switch", fake_switch)
+        return switcher, calls
+
+    def test_over_threshold_switches(self, temp_home: Path, monkeypatch):
+        switcher, calls = self._switcher(
+            monkeypatch, active="1", usage_map={"1": _usage(pct_5h=92.0)}
+        )
+        cfg = {"globalThreshold": 85, "overrides": {}, "strategy": "best"}
+        result = autoswitch.evaluate_and_switch(switcher, cfg)
+        assert result["switched"] is True
+        assert result["target"] == 2
+        assert calls == ["best"]
+
+    def test_under_threshold_noop(self, temp_home: Path, monkeypatch):
+        switcher, calls = self._switcher(
+            monkeypatch, active="1", usage_map={"1": _usage(pct_5h=40.0)}
+        )
+        cfg = {"globalThreshold": 85, "overrides": {}, "strategy": "best"}
+        result = autoswitch.evaluate_and_switch(switcher, cfg)
+        assert result["switched"] is False
+        assert result["reason"] == "under-threshold"
+        assert calls == []  # switch never attempted
+
+    def test_per_account_override_applies(self, temp_home: Path, monkeypatch):
+        # 88% is under the global 85?... no: 88 >= 85 would fire globally, but the
+        # override raises Account-1's threshold to 95, so 88% must NOT fire.
+        switcher, calls = self._switcher(
+            monkeypatch, active="1", usage_map={"1": _usage(pct_5h=88.0)}
+        )
+        cfg = {"globalThreshold": 85, "overrides": {"1": 95}, "strategy": "best"}
+        result = autoswitch.evaluate_and_switch(switcher, cfg)
+        assert result["switched"] is False
+        assert result["reason"] == "under-threshold"
+        assert calls == []
+
+    def test_binding_window_is_the_max(self, temp_home: Path, monkeypatch):
+        # 7d window at 90% binds even though 5h is low.
+        switcher, calls = self._switcher(
+            monkeypatch, active="1", usage_map={"1": _usage(pct_5h=10.0, pct_7d=90.0)}
+        )
+        cfg = {"globalThreshold": 85, "overrides": {}, "strategy": "best"}
+        result = autoswitch.evaluate_and_switch(switcher, cfg)
+        assert result["switched"] is True
+
+    def test_usage_unavailable_noop(self, temp_home: Path, monkeypatch):
+        switcher, calls = self._switcher(
+            monkeypatch, active="1", usage_map={"1": None}
+        )
+        cfg = {"globalThreshold": 85, "overrides": {}, "strategy": "best"}
+        result = autoswitch.evaluate_and_switch(switcher, cfg)
+        assert result["switched"] is False
+        assert result["reason"] == "usage-unavailable"
+        assert calls == []
+
+    def test_no_active_account_noop(self, temp_home: Path, monkeypatch):
+        switcher, calls = self._switcher(monkeypatch, active=None, usage_map={})
+        cfg = {"globalThreshold": 85, "overrides": {}, "strategy": "best"}
+        result = autoswitch.evaluate_and_switch(switcher, cfg)
+        assert result["switched"] is False
+        assert result["reason"] == "no-active-account"
+
+    def test_single_account_over_threshold_stays(self, temp_home: Path, monkeypatch):
+        # Only one managed account: over threshold but nowhere to go.
+        switcher = ClaudeAccountSwitcher()
+        monkeypatch.setattr(autoswitch, "_active_account_num", lambda s: "1")
+        monkeypatch.setattr(
+            ClaudeAccountSwitcher, "_usage_by_account",
+            lambda self: {"1": _usage(pct_5h=99.0)},
+        )
+        # switch() reports the only-one-account no-op (matches real switcher).
+        monkeypatch.setattr(
+            ClaudeAccountSwitcher, "switch",
+            lambda self, strategy=None, json_output=False: {
+                "switched": False, "reason": "only-one-account", "to": None,
+            },
+        )
+        cfg = {"globalThreshold": 85, "overrides": {}, "strategy": "best"}
+        result = autoswitch.evaluate_and_switch(switcher, cfg)
+        assert result["switched"] is False
+        assert result["reason"] == "only-one-account"
+        assert "only managed account" in result["message"]
+
+
+# --- Watcher process management -----------------------------------------
+
+
+class TestWatcher:
+    def test_start_refuses_when_already_running(self, temp_home: Path, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        monkeypatch.setattr(autoswitch, "_read_pid", lambda s: 4321)
+        with pytest.raises(Exception) as exc:
+            autoswitch.start_watcher(switcher)
+        assert "already running" in str(exc.value)
+
+    def test_start_spawns_and_marks_enabled(self, temp_home: Path, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        # No daemon writes a PID file here, so start_watcher falls back to
+        # proc.pid; neutralize the poll sleep so the fallback is reached fast.
+        monkeypatch.setattr(autoswitch, "_read_pid", lambda s: None)
+        monkeypatch.setattr(autoswitch.time, "sleep", lambda *a: None)
+
+        spawned = {}
+
+        class FakeProc:
+            pid = 9999
+
+        def fake_popen(cmd, **kwargs):
+            spawned["cmd"] = cmd
+            spawned["kwargs"] = kwargs
+            return FakeProc()
+
+        monkeypatch.setattr(autoswitch.subprocess, "Popen", fake_popen)
+        pid = autoswitch.start_watcher(switcher)
+        assert pid == 9999
+        assert spawned["cmd"][-2:] == ["autoswitch", "__run"]
+        assert autoswitch.load_config(switcher)["enabled"] is True
+
+    def test_stop_clears_pid_and_disables(self, temp_home: Path, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        switcher.backup_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = switcher.backup_dir / "autoswitch.pid"
+        pid_file.write_text("12345")
+        cfg = autoswitch.load_config(switcher)
+        cfg["enabled"] = True
+        autoswitch.save_config(switcher, cfg)
+
+        monkeypatch.setattr(autoswitch, "_read_pid", lambda s: 12345)
+        killed = {}
+        monkeypatch.setattr(autoswitch.os, "kill", lambda p, s: killed.setdefault("pid", p))
+
+        assert autoswitch.stop_watcher(switcher) is True
+        assert killed["pid"] == 12345
+        assert not pid_file.exists()
+        assert autoswitch.load_config(switcher)["enabled"] is False
+
+    def test_stop_when_not_running(self, temp_home: Path, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        monkeypatch.setattr(autoswitch, "_read_pid", lambda s: None)
+        assert autoswitch.stop_watcher(switcher) is False
+
+    def test_read_pid_cleans_stale_file(self, temp_home: Path, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        switcher.backup_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = switcher.backup_dir / "autoswitch.pid"
+        pid_file.write_text("424242")
+        monkeypatch.setattr(autoswitch, "is_pid_alive", lambda pid: False)
+        assert autoswitch._read_pid(switcher) is None
+        assert not pid_file.exists()  # stale file removed
+
+
+# --- Wizard -------------------------------------------------------------
+
+
+class TestWizard:
+    def test_set_global_then_done(self, temp_home: Path, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        monkeypatch.setattr(autoswitch, "is_running", lambda s: False)
+        # Choose 1 (set global) -> 70 -> 5 (done)
+        answers = iter(["1", "70", "5"])
+        monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+        autoswitch.run_wizard(switcher)
+        assert autoswitch.load_config(switcher)["globalThreshold"] == 70
+
+    def test_invalid_threshold_rejected(self, temp_home: Path, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        monkeypatch.setattr(autoswitch, "is_running", lambda s: False)
+        # 1 -> 150 (out of range, ignored) -> 5 (done): global stays default 85
+        answers = iter(["1", "150", "5"])
+        monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+        autoswitch.run_wizard(switcher)
+        assert autoswitch.load_config(switcher)["globalThreshold"] == 85
+
+    def test_set_and_clear_override(self, temp_home: Path, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        _seed(switcher, {
+            "activeAccountNumber": 1,
+            "sequence": [1, 2],
+            "accounts": {
+                "1": {"email": "a@example.com", "uuid": "u1"},
+                "2": {"email": "b@example.com", "uuid": "u2"},
+            },
+        })
+        monkeypatch.setattr(autoswitch, "is_running", lambda s: False)
+        # 2 (override submenu) -> account "2" -> 90  ; then 5 done
+        answers = iter(["2", "2", "90", "5"])
+        monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+        autoswitch.run_wizard(switcher)
+        assert autoswitch.load_config(switcher)["overrides"] == {"2": 90}
+
+        # Now clear it: 2 -> account "2" -> "x" ; then 5 done
+        answers = iter(["2", "2", "x", "5"])
+        monkeypatch.setattr("builtins.input", lambda *a: next(answers))
+        autoswitch.run_wizard(switcher)
+        assert autoswitch.load_config(switcher)["overrides"] == {}


### PR DESCRIPTION
## What

Adds `cswap autoswitch` — a background watcher that polls each account's quota and switches to the account with the most headroom **before** the active one hits its limit, so you keep working past a single account's rate limit without switching by hand.

```bash
cswap autoswitch          # interactive setup wizard
cswap autoswitch start    # run the watcher in the background
cswap autoswitch status   # rules + per-account usage vs threshold
cswap autoswitch check    # evaluate once now and switch if over threshold
cswap autoswitch stop     # stop the watcher
```

## How

- **New `autoswitch` module.** Persisted rule set in `autoswitch.json` — a common/global usage-% threshold plus optional **per-account overrides**.
- **Reuses the existing engine.** The actual switch is delegated to `switch(strategy="best")`; autoswitch only adds the *gate* (don't switch until the active account's usage — the higher of its 5h/7d window — reaches its threshold). It therefore never moves onto a worse account, and with one/zero accounts it stays put and logs why.
- **Cross-platform detached watcher.** `start`/`stop`/`status` via a PID file, reusing `process_detection.is_pid_alive`; POSIX `start_new_session`, Windows `DETACHED_PROCESS`. Polls on an interval, logs each decision to `autoswitch.log`, survives transient/network errors.
- **CLI.** `autoswitch` (alias `auto`) is pre-dispatched like `run`, with sub-verbs `start`/`stop`/`status`/`check` and a bare wizard.

A swap rewrites the credentials file Claude Code reads, so it takes full effect on Claude's **next** start (a running session keeps the credentials it loaded) — documented in the README.

## Tests

`tests/test_autoswitch.py` (19 tests): config round-trip + defaults, `effective_threshold` (override beats global), `evaluate_and_switch` for over/under-threshold, per-account override, binding-window = max(5h, 7d), usage-unavailable, no-active-account, single-account stays put; watcher start/stop/refuse-double-start/stale-PID cleanup; and the wizard via scripted input.

## Note

I'm aware there are already a few auto-switch proposals open (#69, #65, #50, #57). This one is intentionally minimal and CLI-first: it doesn't add a daemon framework or UI, it just gates the existing `--strategy best` logic behind a configurable threshold and runs it on a timer. Happy to align with whichever direction the maintainer prefers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)