### PR TITLE
fix(macOS): show "keychain unavailable" instead of "no credentials" when the active Keychain is locked, and retry the read

### DIFF
--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -23,8 +23,9 @@ import logging
 import os
 import sys
 import tempfile
+import time
 from pathlib import Path
-from typing import Protocol
+from typing import NamedTuple, Protocol
 
 from claude_swap import macos_keychain
 from claude_swap.exceptions import CredentialWriteError
@@ -50,6 +51,30 @@ CLAUDE_CODE_KEYCHAIN_SERVICE = "Claude Code-credentials"
 # (``getApiKeyFromConfigOrMacOSKeychain``). On non-macOS the managed key instead
 # lives in ``~/.claude.json`` as ``primaryApiKey`` (see below).
 CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE = "Claude Code"
+
+# Bounded retry for the active OAuth-credential Keychain read. A locked/contended
+# login Keychain can fail a single `security` call transiently — e.g. just after
+# wake while the keychain is still settling, or under contention with Claude Code's
+# own statusline polling the same item — and a second attempt a moment later
+# usually succeeds. This is an I/O backoff between retries of an external CLI, NOT
+# a sleep papering over an internal race.
+_ACTIVE_READ_ATTEMPTS = 2
+_ACTIVE_READ_RETRY_DELAY = 0.3  # seconds between attempts
+
+
+class ActiveCredentials(NamedTuple):
+    """Outcome of reading Claude Code's active credential.
+
+    ``value`` is the credential string (OAuth JSON or a raw managed key), ``""``
+    when none exists in any backend, or ``None`` on a plaintext-file read error.
+    ``keychain_unavailable`` is True only when the macOS OAuth Keychain read failed
+    (locked / denied / timeout) and nothing else covered it — letting callers
+    distinguish a transiently unreadable Keychain from a genuinely empty slot,
+    instead of collapsing both into a misleading "no credentials".
+    """
+
+    value: str | None
+    keychain_unavailable: bool
 
 
 def looks_like_api_key(credentials: str | None) -> bool:
@@ -141,10 +166,50 @@ class CredentialStore:
         return self._keychain_usable_cache is not False
 
     def _read_credentials(self) -> str | None:
-        """Read Claude Code's active credential — OAuth *or* managed API key.
+        """Read Claude Code's active credential — OAuth *or* managed API key (value).
+
+        Thin wrapper over :meth:`_read_active_credentials` preserving the historic
+        ``str | None`` contract the switch paths rely on: credential string if
+        found, ``""`` if not found, ``None`` on a file read error.
+        """
+        return self._read_active_credentials().value
+
+    def _read_active_oauth_keychain(self) -> tuple[str | None, bool]:
+        """Read the active OAuth Keychain item with a bounded retry.
+
+        Returns ``(value, failed)``. ``value`` is the credential string, or
+        ``None`` when the item is absent (rc-44) or unreadable. ``failed`` is True
+        only when *every* attempt raised a KeychainError (locked / denied /
+        timeout); a genuinely absent item (rc-44, returned as ``None`` without
+        raising) reports ``failed=False`` and is not retried. The retry rides out
+        a transient lock/contention — it does not paper over an internal race.
+        """
+        last_error: Exception | None = None
+        for attempt in range(_ACTIVE_READ_ATTEMPTS):
+            try:
+                value = self._kc_call(
+                    macos_keychain.get_password,
+                    CLAUDE_CODE_KEYCHAIN_SERVICE,
+                    macos_keychain.keychain_account_name(),
+                )
+                return value, False
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                last_error = e
+                if attempt + 1 < _ACTIVE_READ_ATTEMPTS:
+                    time.sleep(_ACTIVE_READ_RETRY_DELAY)
+        # Every attempt failed: _kc_call has flipped routing to file mode.
+        self._host._logger.warning(
+            f"Keychain read failed after {_ACTIVE_READ_ATTEMPTS} attempt(s), "
+            f"trying file: {last_error}"
+        )
+        return None, True
+
+    def _read_active_credentials(self) -> ActiveCredentials:
+        """Read Claude Code's active credential, classifying the outcome.
 
         Tries the OAuth credential first (Keychain "Claude Code-credentials" on
-        macOS when usable, then the plaintext ``~/.claude/.credentials.json`` Claude
+        macOS when usable — with a bounded retry to ride out a transient
+        lock/contention — then the plaintext ``~/.claude/.credentials.json`` Claude
         Code also falls back to), and only then the managed-key locations (macOS
         Keychain "Claude Code", then ``~/.claude.json`` ``primaryApiKey``). Trying
         OAuth fully first means a macOS OAuth login that only has a file fallback
@@ -152,26 +217,22 @@ class CredentialStore:
         raw ``sk-ant-api…`` string — callers distinguish it via ``looks_like_api_key``.
         Non-mutating.
 
-        Returns:
-            Credential string if found, "" if not found, None on a file read error.
+        Reports ``keychain_unavailable`` when the OAuth Keychain read failed and
+        nothing else covered it, so the display layer can say "keychain unavailable"
+        rather than "no credentials" for a merely-unreadable slot — which would
+        otherwise nudge the user into an unnecessary re-login.
         """
-        # 1. OAuth Keychain (macOS, when usable).
+        keychain_failed = False
+        # 1. OAuth Keychain (macOS, when usable), with a bounded retry.
         if self._use_keychain():
-            try:
-                val = self._kc_call(
-                    macos_keychain.get_password,
-                    CLAUDE_CODE_KEYCHAIN_SERVICE,
-                    macos_keychain.keychain_account_name(),
-                )
-            except macos_keychain.KEYCHAIN_ERRORS as e:
-                # Locked / denied / unavailable Keychain (rc-44 "not found" comes
-                # back as None, not raised). _kc_call has flipped routing to file
-                # mode; fall through to the plaintext file Claude Code uses too.
-                # (A programming error is NOT caught here — it propagates.)
-                self._host._logger.warning(f"Keychain read failed, trying file: {e}")
-                val = None
+            val, keychain_failed = self._read_active_oauth_keychain()
             if val:
-                return val
+                return ActiveCredentials(val, False)
+        elif self._host.platform == Platform.MACOS:
+            # Keychain already known unusable this process (a prior op failed and the
+            # capability cache stuck to file mode): if nothing is found below, that
+            # absence is "keychain unavailable", not a genuinely empty slot.
+            keychain_failed = True
 
         # 2. OAuth plaintext file (Claude Code's own fallback; every platform).
         cred_file = get_credentials_path()
@@ -180,15 +241,17 @@ class CredentialStore:
                 text = cred_file.read_text(encoding="utf-8")
             except Exception as e:
                 self._host._logger.error(f"Failed to read credentials file: {e}")
-                return None
+                return ActiveCredentials(None, False)
             if text.strip():
-                return text
+                return ActiveCredentials(text, False)
 
         # 3. Managed API key (Keychain "Claude Code" on macOS, then primaryApiKey).
         key = self._read_managed_key()
         if key:
-            return key
-        return ""
+            return ActiveCredentials(key, False)
+        # Nothing anywhere. Flag a failed-and-uncovered OAuth Keychain read so the
+        # UI distinguishes it from a real empty slot.
+        return ActiveCredentials("", keychain_failed)
 
     def _read_managed_key(self) -> str:
         """Read the active managed API key, or "" when absent. Non-mutating.

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -19,6 +19,10 @@ USAGE_TOKEN_EXPIRED = "token expired"
 # API-key (``/login`` managed key) accounts have no subscription quota; usage is
 # reported as this sentinel instead of being fetched from the OAuth usage API.
 USAGE_API_KEY = "api key"
+# The active account's macOS Keychain was unreadable (locked / denied / timeout)
+# with no plaintext fallback — distinct from a genuinely empty slot, so the user
+# isn't misled into an unnecessary re-login.
+USAGE_KEYCHAIN_UNAVAILABLE = "keychain unavailable"
 
 
 def _window_to_json(entry: dict) -> dict:
@@ -67,8 +71,9 @@ def usage_fields(entry: dict | str | None) -> tuple[str, dict | None]:
 
     A collected entry is one of: a usage dict, the ``USAGE_TOKEN_EXPIRED`` sentinel
     (active token expired while Claude Code owns it), the ``USAGE_API_KEY`` sentinel
-    (managed API-key account, no subscription quota), the ``USAGE_NO_CREDENTIALS``
-    sentinel, or ``None`` (fetch failed).
+    (managed API-key account, no subscription quota), the
+    ``USAGE_KEYCHAIN_UNAVAILABLE`` sentinel (active Keychain unreadable), the
+    ``USAGE_NO_CREDENTIALS`` sentinel, or ``None`` (fetch failed).
     """
     if isinstance(entry, dict):
         return "ok", usage_to_json(entry)
@@ -76,6 +81,8 @@ def usage_fields(entry: dict | str | None) -> tuple[str, dict | None]:
         return "token_expired", None
     if entry == USAGE_API_KEY:
         return "api_key", None
+    if entry == USAGE_KEYCHAIN_UNAVAILABLE:
+        return "keychain_unavailable", None
     if isinstance(entry, str):
         return "no_credentials", None
     return "unavailable", None

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -26,6 +26,7 @@ from claude_swap.cache import MISSING, read_cache, write_cache
 from claude_swap.json_output import (
     SCHEMA_VERSION,
     USAGE_API_KEY,
+    USAGE_KEYCHAIN_UNAVAILABLE,
     USAGE_NO_CREDENTIALS,
     USAGE_TOKEN_EXPIRED,
     account_ref,
@@ -35,6 +36,7 @@ from claude_swap.json_output import (
 from claude_swap.credentials import (  # noqa: F401  (constants re-exported for migrations/tests)
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     SECURITY_SERVICE,
+    ActiveCredentials,
     CredentialStore,
     looks_like_api_key,
 )
@@ -156,6 +158,12 @@ class ClaudeAccountSwitcher:
         # Constructed BEFORE run_migrations(), which performs storage ops on macOS.
         # One store per switcher: the capability cache is per-process.
         self._store = CredentialStore(self)
+
+        # Set by _build_accounts_info: True when the active account's OAuth
+        # credential could not be read because the macOS Keychain was unavailable
+        # (locked / denied / timeout) with no fallback — so the usage row shows
+        # "keychain unavailable" instead of a misleading "no credentials".
+        self._active_keychain_unavailable = False
 
         # Run any pending one-time data migrations (e.g. relocating Windows
         # backup credentials out of Credential Manager into files). Imported
@@ -284,6 +292,9 @@ class ClaudeAccountSwitcher:
 
     def _read_credentials(self) -> str | None:
         return self._store._read_credentials()
+
+    def _read_active_credentials(self) -> ActiveCredentials:
+        return self._store._read_active_credentials()
 
     def _write_credentials(self, credentials: str) -> None:
         self._store._write_credentials(credentials)
@@ -1188,6 +1199,10 @@ class ClaudeAccountSwitcher:
             active_num = self._find_account_slot(data, current_email, current_org_uuid)
 
         accounts_info: list[tuple[int, str, str, str, bool, str]] = []
+        # Reset each build; set below only when the active slot's OAuth Keychain
+        # read failed with no fallback. Read by _collect_usage.fetch (main thread
+        # writes it here before the fetch pool starts → no data race).
+        self._active_keychain_unavailable = False
         for num in data.get("sequence", []):
             account = data.get("accounts", {}).get(str(num), {})
             email = account.get("email", "unknown")
@@ -1196,7 +1211,9 @@ class ClaudeAccountSwitcher:
             is_active = str(num) == active_num
 
             if is_active:
-                creds = self._read_credentials() or ""
+                active = self._read_active_credentials()
+                creds = active.value or ""
+                self._active_keychain_unavailable = active.keychain_unavailable
             else:
                 creds = self._read_account_credentials(str(num), email)
 
@@ -1321,6 +1338,8 @@ class ClaudeAccountSwitcher:
                 # Managed API-key account: no subscription quota to fetch.
                 return USAGE_API_KEY
             if not creds or not oauth.extract_access_token(creds):
+                if is_active and self._active_keychain_unavailable:
+                    return USAGE_KEYCHAIN_UNAVAILABLE
                 return USAGE_NO_CREDENTIALS
 
             # The active/default account owns the live credential — route it through
@@ -1493,6 +1512,8 @@ class ClaudeAccountSwitcher:
                 print(f"     {dimmed('token expired — Claude Code refreshes the active account')}")
             elif usage == USAGE_API_KEY:
                 print(f"     {dimmed('API key (no quota)')}")
+            elif usage == USAGE_KEYCHAIN_UNAVAILABLE:
+                print(f"     {dimmed('keychain unavailable — locked or in use; try again')}")
             elif isinstance(usage, str):
                 print(f"     {dimmed(usage)}")
             elif usage is None:
@@ -1548,17 +1569,21 @@ class ClaudeAccountSwitcher:
     ) -> dict | str | None:
         """Usage for the active account as a ``_collect_usage``-style entry.
 
-        Returns ``USAGE_NO_CREDENTIALS`` when the live store has no usable token, a
-        usage dict on success, ``USAGE_TOKEN_EXPIRED`` when the token is expired and
-        Claude Code owns it, or ``None`` when the fetch fails. Reuses the same
-        ``cache/usage.json`` list_accounts writes — cache-first — and delegates the
-        owner-aware refresh decision to ``_fetch_active_usage``.
+        Returns ``USAGE_NO_CREDENTIALS`` when the live store has no usable token,
+        ``USAGE_KEYCHAIN_UNAVAILABLE`` when the OAuth Keychain read failed with no
+        fallback, a usage dict on success, ``USAGE_TOKEN_EXPIRED`` when the token is
+        expired and Claude Code owns it, or ``None`` when the fetch fails. Reuses the
+        same ``cache/usage.json`` list_accounts writes — cache-first — and delegates
+        the owner-aware refresh decision to ``_fetch_active_usage``.
         """
-        creds = self._read_credentials() or ""
+        active = self._read_active_credentials()
+        creds = active.value or ""
         if looks_like_api_key(creds):
             # Managed API-key account: no subscription quota to fetch.
             return USAGE_API_KEY
         if not creds or not oauth.extract_access_token(creds):
+            if active.keychain_unavailable:
+                return USAGE_KEYCHAIN_UNAVAILABLE
             return USAGE_NO_CREDENTIALS
         usage_cache_path = self.backup_dir / "cache" / "usage.json"
         cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
@@ -1652,6 +1677,8 @@ class ClaudeAccountSwitcher:
                 print(f"  {dimmed('token expired — Claude Code refreshes the active account')}")
             elif usage == USAGE_API_KEY:
                 print(f"  {dimmed('API key (no quota)')}")
+            elif usage == USAGE_KEYCHAIN_UNAVAILABLE:
+                print(f"  {dimmed('keychain unavailable — locked or in use; try again')}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
         return None

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -15,6 +15,7 @@ from claude_swap.json_output import (
     usage_fields,
     usage_to_json,
 )
+from claude_swap.credentials import ActiveCredentials
 from claude_swap.models import Platform
 from claude_swap.switcher import ClaudeAccountSwitcher
 
@@ -42,13 +43,18 @@ class TestJsonHelpers:
         assert out["spend"]["resetsAt"] == "2026-07-01T00:00:00Z"
 
     def test_usage_fields_variants(self):
-        from claude_swap.json_output import USAGE_NO_CREDENTIALS, USAGE_TOKEN_EXPIRED
+        from claude_swap.json_output import (
+            USAGE_KEYCHAIN_UNAVAILABLE,
+            USAGE_NO_CREDENTIALS,
+            USAGE_TOKEN_EXPIRED,
+        )
 
         assert usage_fields({"five_hour": {"pct": 1.0}})[0] == "ok"
         assert usage_fields({"five_hour": {"pct": 1.0}})[1] == {"fiveHour": {"pct": 1.0}}
         assert usage_fields(USAGE_NO_CREDENTIALS) == ("no_credentials", None)
         assert usage_fields("no credentials") == ("no_credentials", None)
         assert usage_fields(USAGE_TOKEN_EXPIRED) == ("token_expired", None)
+        assert usage_fields(USAGE_KEYCHAIN_UNAVAILABLE) == ("keychain_unavailable", None)
         assert usage_fields(None) == ("unavailable", None)
 
     def test_error_envelope_shape(self):
@@ -93,7 +99,8 @@ class TestListJson:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
              patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage):
             payload = switcher.list_accounts(json_output=True)
@@ -120,7 +127,8 @@ class TestListJson:
 
         # Account 1 active with creds but the fetch fails (None → unavailable);
         # account 2 has no backup creds (→ no_credentials).
-        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
              patch.object(switcher, "_read_account_credentials", return_value=""), \
              patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
             payload = switcher.list_accounts(json_output=True)
@@ -160,7 +168,8 @@ class TestStatusJson:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
              patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage):
             payload = switcher.status(json_output=True)
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -21,6 +21,7 @@ from claude_swap.exceptions import (
 from claude_swap.macos_keychain import KeychainError
 from claude_swap.models import Platform
 from claude_swap.paths import get_backup_root, get_credentials_path
+from claude_swap.credentials import ActiveCredentials
 from claude_swap.switcher import (
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     ClaudeAccountSwitcher,
@@ -444,7 +445,8 @@ class TestStatusCache:
         }
         write_cache(switcher.backup_dir / "cache" / "usage.json", cached_usage)
 
-        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
              patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
             switcher.status()
 
@@ -471,7 +473,8 @@ class TestStatusCache:
             "seven_day": {"pct": 50, "clock": "Jan 2 03:00", "countdown": "0m"},
         }
 
-        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
              patch.object(switcher, "_active_cc_running", return_value=True), \
              patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage_result) as mock_fetch:
             switcher.status()
@@ -507,7 +510,8 @@ class TestStatusCache:
 
         usage_result = {"five_hour": {"pct": 10, "clock": "Jan 1 03:00", "countdown": "0m"}}
 
-        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
              patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage_result):
             switcher.status()
 
@@ -940,7 +944,8 @@ class TestActiveAccountRefresh:
         switcher = self._switcher(sample_sequence_data)
         backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
 
-        with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(self._EXPIRED, False)), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
              patch.object(switcher, "_active_cc_running", return_value=True), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
@@ -3169,6 +3174,98 @@ class TestMacosKeychainFallback:
         # Keychain empty → falls through to the plaintext file.
         del block_real_keychain.data[(CLAUDE_CODE_KEYCHAIN_SERVICE, acct)]
         assert s._read_credentials() == "FROM-FILE"
+
+    def test_active_read_retries_transient_keychain_failure(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        # A single transient Keychain failure is retried; the second attempt
+        # succeeds, so the read returns the credential rather than falling back.
+        s = self._macos_switcher()
+        acct = macos_keychain.keychain_account_name()
+        block_real_keychain.data[(CLAUDE_CODE_KEYCHAIN_SERVICE, acct)] = "FROM-KC"
+        monkeypatch.setattr("claude_swap.credentials._ACTIVE_READ_RETRY_DELAY", 0)
+
+        calls = {"n": 0}
+        real_get = macos_keychain.get_password
+
+        def flaky_get(service, account):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise KeychainError("transient lock")
+            return real_get(service, account)
+
+        monkeypatch.setattr(macos_keychain, "get_password", flaky_get)
+
+        result = s._read_active_credentials()
+        assert result.value == "FROM-KC"
+        assert result.keychain_unavailable is False
+        assert calls["n"] == 2  # failed once, retried once, succeeded
+
+    def test_active_read_keychain_unavailable_no_fallback(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        # OAuth Keychain unreadable on every attempt AND no file / managed-key
+        # fallback → report keychain_unavailable, distinct from an empty slot.
+        s = self._macos_switcher()
+        monkeypatch.setattr(macos_keychain, "get_password", _raise_locked)
+        monkeypatch.setattr("claude_swap.credentials._ACTIVE_READ_RETRY_DELAY", 0)
+        assert not get_credentials_path().exists()
+
+        result = s._read_active_credentials()
+        assert result.value == ""
+        assert result.keychain_unavailable is True
+        # The legacy value-only contract still reads as empty.
+        assert s._read_credentials() == ""
+
+    def test_active_read_keychain_failure_covered_by_file(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        # A failed OAuth Keychain read covered by a plaintext file is NOT
+        # "unavailable".
+        s = self._macos_switcher()
+        cred = get_credentials_path()
+        cred.parent.mkdir(parents=True, exist_ok=True)
+        cred.write_text("FROM-FILE")
+        monkeypatch.setattr(macos_keychain, "get_password", _raise_locked)
+        monkeypatch.setattr("claude_swap.credentials._ACTIVE_READ_RETRY_DELAY", 0)
+
+        result = s._read_active_credentials()
+        assert result.value == "FROM-FILE"
+        assert result.keychain_unavailable is False
+
+    def test_active_read_absent_item_is_not_keychain_unavailable(
+        self, temp_home: Path, block_real_keychain
+    ):
+        # rc-44 "not found" (item genuinely absent, no raise) with no fallback is a
+        # real empty slot → "no credentials", never "keychain unavailable". No
+        # retry happens because nothing was raised.
+        s = self._macos_switcher()
+        assert not get_credentials_path().exists()
+
+        result = s._read_active_credentials()
+        assert result.value == ""
+        assert result.keychain_unavailable is False
+
+    def test_list_active_shows_keychain_unavailable(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict,
+        monkeypatch, block_real_keychain, capsys
+    ):
+        # Regression: the active account rendered "no credentials" when the
+        # Keychain was merely locked, nudging the user into an unnecessary
+        # re-login. It must now read "keychain unavailable" instead.
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        s = self._macos_switcher()
+        s._write_json(s.sequence_file, sample_sequence_data)
+        monkeypatch.setattr(macos_keychain, "get_password", _raise_locked)
+        monkeypatch.setattr("claude_swap.credentials._ACTIVE_READ_RETRY_DELAY", 0)
+        assert not get_credentials_path().exists()
+
+        s.list_accounts()
+        out = capsys.readouterr().out
+        assert "test@example.com" in out and "(active)" in out
+        # The active row shows the intentional, actionable line — not the
+        # misleading "no credentials" that prompted the re-login.
+        assert "keychain unavailable — locked or in use; try again" in out
 
     def test_active_write_falls_back_to_file_and_clears_stale_keychain(
         self, temp_home: Path, monkeypatch, block_real_keychain


### PR DESCRIPTION
On macOS, `cswap --list` / `--status` shows the active account as **"no credentials"** when the login Keychain is merely *transiently unreadable* — e.g. locked just after wake, or contended with Claude Code's own statusline polling the same `Claude Code-credentials` item. On a Keychain-only setup (no `~/.claude/.credentials.json` fallback present), the single failed `security` read collapses to `""`, which is indistinguishable from a genuinely empty slot — so the user is nudged into an unnecessary re-login even though the credential is intact.

## What this does

1. **Retry the active OAuth Keychain read once** (bounded, short backoff) to ride out a transient lock/contention before falling back. A genuinely absent item (rc-44, returned as `None` without raising) is **not** retried.
2. **Classify the read** via a new `ActiveCredentials(value, keychain_unavailable)` result. When the OAuth Keychain read fails *and nothing else covers it* (no plaintext file, no managed API key), the active usage row now renders:

   ```
   keychain unavailable — locked or in use; try again
   ```

   instead of the misleading `no credentials`. JSON `--list`/`--status` get a distinct `usageStatus: "keychain_unavailable"` (sibling of the existing `token_expired` / `api_key` / `no_credentials`).

A genuinely absent credential still reads as `no credentials`, so there is no behavior change for the empty-slot case.

## Notes

- `_read_credentials` keeps its historic `str | None` contract; the switch paths are unchanged. The classification lives in a new `_read_active_credentials()` that `_read_credentials` delegates to.
- The retry is an I/O backoff between attempts of an external CLI (`security`), not a sleep papering over an internal race; a hard lock simply surfaces the new "keychain unavailable" line.

## Tests

- +5 tests: retry-then-succeed, keychain-unavailable-with-no-fallback, failure-covered-by-file, rc-44-absent-is-not-unavailable, and an end-to-end `--list` rendering check; plus a `usage_fields` mapping assertion.
- Full suite: **631 passed, 3 skipped**.