### PR TITLE
Use OS-native TLS trust via truststore to fix inactive-account token refresh on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ version = "0.15.0"
 description = "Multi-account switcher for Claude Code"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["keyring>=25.0.0"]
+dependencies = [
+    "keyring>=25.0.0",
+    "truststore>=0.10.4",
+]
 authors = [{name = "Onur Cetinkol", email = "onurcetinkol@gmail.com"}]
 license = {text = "MIT"}
 keywords = ["claude", "claude-code", "account-switcher", "cli"]

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -90,8 +90,34 @@ Examples:
         sys.exit(130)
 
 
+def _use_native_tls() -> None:
+    """Route TLS trust decisions through the OS-native verifier.
+
+    Claude's token endpoint (``platform.claude.com``) serves a Let's Encrypt
+    chain. Python's stdlib ``ssl`` uses OpenSSL, which on Windows loads the
+    system cert store as a flat set and matches CA certs by *subject name*, so a
+    stale, expired duplicate of an intermediate (e.g. an old ``ISRG Root X2``
+    left in the user's store) can shadow the valid path and fail verification
+    with "certificate has expired" even though the served chain is valid — which
+    silently breaks inactive-account token refresh. The OS-native verifiers
+    (SChannel on Windows, SecureTransport on macOS) build the chain correctly
+    and don't trip on the expired duplicate — the same reason Claude Code (Node,
+    with its own bundled roots) is unaffected. ``truststore`` delegates to them.
+
+    Best-effort: on any failure fall back to stdlib ``ssl`` rather than block
+    the CLI over a TLS-trust nicety.
+    """
+    try:
+        import truststore
+
+        truststore.inject_into_ssl()
+    except Exception:
+        pass
+
+
 def main() -> None:
     """Main entry point for the CLI."""
+    _use_native_tls()
     if len(sys.argv) > 1 and sys.argv[1] == "run":
         _run_command(sys.argv[2:])
         return  # only reachable in tests where exec/exit is mocked

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,7 @@ version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },
+    { name = "truststore" },
 ]
 
 [package.dev-dependencies]
@@ -53,7 +54,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "keyring", specifier = ">=25.0.0" }]
+requires-dist = [
+    { name = "keyring", specifier = ">=25.0.0" },
+    { name = "truststore", specifier = ">=0.10.4" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]
@@ -260,4 +264,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]


### PR DESCRIPTION
## Problem

On Windows, `cswap` silently failed to refresh OAuth tokens for **inactive** accounts — they showed as `usage unavailable` / `oauth: expired` even with a valid refresh token present.

The root cause is TLS, not OAuth. `platform.claude.com` (the token-refresh endpoint) serves a Let's Encrypt chain. Python's stdlib `ssl` uses OpenSSL, which on Windows loads the system cert store as a flat set and matches CA certs by **subject name**. A stale, expired duplicate of `ISRG Root X2` (from Let's Encrypt's root rotation) left in the user's `CurrentUser\CA` store shadows the valid path, so verification fails with `certificate has expired` — even though the chain the server actually serves is valid (it verifies fine against the still-valid `ISRG Root X1`). The failure is only logged at DEBUG, so it surfaces as a bare "usage unavailable".

Active accounts are unaffected because Claude Code (Node) refreshes those using its own bundled CA roots and never touches the Windows store — which is why only inactive-account refresh (done by cswap itself) broke.

## Fix

Route TLS trust through the OS-native verifier via `truststore.inject_into_ssl()` at CLI startup — SChannel on Windows, Security.framework on macOS, the distro CA bundle on Linux. This is the same trust the rest of the OS (and Node/curl/Chrome) use, and it builds the chain correctly instead of tripping on the expired duplicate. Best-effort: on any failure it falls back to stdlib `ssl`, so the CLI can never be blocked by it.

## Verification

- With the expired duplicate still in the store: stdlib OpenSSL fails, `truststore` verifies OK (TLS 1.3).
- `cswap --list` now shows the previously-broken inactive account as `oauth: fresh` with usage; the token is refreshed and persisted.
- Existing test suite unaffected.
