### PR TITLE
feat: add --share-history flag to cswap run for unified conversation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ cswap run 2                     # launch Claude Code as account 2, here only
 cswap run user@example.com      # by email
 cswap run 2 -- --resume         # everything after '--' is forwarded to claude
 cswap run 2 --no-share          # don't share your ~/.claude customizations
+cswap run 2 --share-history     # one conversation history across all accounts
 ```
 
-Your `~/.claude` customizations (settings, keybindings, CLAUDE.md, skills, commands, agents) are shared into the session by default — use `--no-share` for a bare profile. Conversation history stays per-account.
+Your `~/.claude` customizations (settings, keybindings, CLAUDE.md, skills, commands, agents) are shared into the session by default — use `--no-share` for a bare profile.
+
+Conversation history stays per-account by default. Pass `--share-history` to share `projects/` and `history.jsonl` from `~/.claude` instead, so every account sees (and `--resume` lists) the same conversations. Any history the profile already accumulated is merged into `~/.claude` on first use — nothing disappears. `--no-share-history` returns the profile to per-account history. Not supported on Windows yet (sharing uses copies there, which would fork the history rather than share it).
 
 ### Refresh expired tokens
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -47,6 +47,7 @@ Examples:
   cswap run 2
   cswap run user@example.com
   cswap run 2 --no-share
+  cswap run 2 --share-history
   cswap run 2 -- --resume
         """,
     )
@@ -62,6 +63,18 @@ Examples:
             "Don't share settings/keybindings/CLAUDE.md/skills/commands/agents "
             "from ~/.claude into the session profile (and remove previously "
             "shared items)"
+        ),
+    )
+    parser.add_argument(
+        "--share-history",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Share conversation history (projects/ and history.jsonl) from "
+            "~/.claude into the session profile, so every account sees one "
+            "unified history. History the profile already accumulated is "
+            "merged into ~/.claude first. --no-share-history restores "
+            "per-account history (the default). Not supported on Windows."
         ),
     )
     parser.add_argument(
@@ -81,7 +94,12 @@ Examples:
 
         from claude_swap.session import SessionManager
 
-        SessionManager(switcher).run(args.account, tail, share=not args.no_share)
+        SessionManager(switcher).run(
+            args.account,
+            tail,
+            share=not args.no_share,
+            share_history=args.share_history,
+        )
     except ClaudeSwitchError as e:
         error(f"Error: {e}")
         sys.exit(1)

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -22,6 +22,14 @@ detects symlinks and writes through to the target, so in-session ``/config``
 changes land in ``~/.claude``), copies re-synced on every launch on Windows.
 A manifest records what cswap created so removal never touches user data.
 
+History sharing (``--share-history``, opt-in): additionally links
+``projects/`` (conversation transcripts — what ``claude --resume`` lists) and
+``history.jsonl`` (prompt history) from ``~/.claude``, so all accounts see one
+unified conversation history. POSIX-only: Windows shares by re-synced copy,
+which would fork history rather than share it. If the profile already
+accumulated its own history, it is merged into ``~/.claude`` first so nothing
+disappears from ``--resume``.
+
 This module must not import ``switcher`` (switcher imports us for the
 session-aware guards); it receives a ``ClaudeAccountSwitcher`` instance.
 """
@@ -53,8 +61,9 @@ if TYPE_CHECKING:
 
 # Items mirrored from ~/.claude into session profiles when sharing is on.
 # Deliberately excludes anything account- or instance-scoped: plugins/,
-# projects/ (per-account history is a feature), sessions/, ide/,
-# .claude.json, .credentials.json, statsig/ and other telemetry.
+# sessions/, ide/, .claude.json, .credentials.json, statsig/ and other
+# telemetry. projects/ and history.jsonl are per-account by default and move
+# to HISTORY_ITEMS sharing only with the opt-in --share-history flag.
 SHARED_ITEMS = (
     "settings.json",
     "keybindings.json",
@@ -62,6 +71,13 @@ SHARED_ITEMS = (
     "skills",
     "commands",
     "agents",
+)
+
+# Conversation-history items linked additionally under --share-history.
+# POSIX symlinks only: Windows copy-mode would fork history, not share it.
+HISTORY_ITEMS = (
+    "projects",
+    "history.jsonl",
 )
 
 # Records which entries in a session profile cswap created (so --no-share and
@@ -190,12 +206,24 @@ class SessionManager:
 
     # -- launch ----------------------------------------------------------
 
-    def run(self, identifier: str, claude_args: list[str], share: bool = True) -> NoReturn:
+    def run(
+        self,
+        identifier: str,
+        claude_args: list[str],
+        share: bool = True,
+        share_history: bool = False,
+    ) -> NoReturn:
         """Launch Claude Code as the given account in the current terminal."""
         claude_bin = shutil.which("claude")
         if not claude_bin:
             raise SessionError(
                 "'claude' was not found on PATH. Install Claude Code first."
+            )
+        if share_history and self.switcher.platform == Platform.WINDOWS:
+            raise SessionError(
+                "--share-history is not supported on Windows yet: sharing uses "
+                "re-synced copies there, which would fork the history instead "
+                "of sharing it."
             )
 
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
@@ -234,7 +262,9 @@ class SessionManager:
                 f"override the selected account inside Claude Code."
             )
 
-        session_dir, account_num, email = self.setup_session(identifier, share)
+        session_dir, account_num, email = self.setup_session(
+            identifier, share, share_history
+        )
 
         print(
             f"{accent('Launching')} Account-{account_num} ({email}) "
@@ -280,7 +310,9 @@ class SessionManager:
 
     # -- bootstrap -------------------------------------------------------
 
-    def setup_session(self, identifier: str, share: bool) -> tuple[Path, str, str]:
+    def setup_session(
+        self, identifier: str, share: bool, share_history: bool = False
+    ) -> tuple[Path, str, str]:
         """Ensure a valid session profile exists; returns (dir, num, email)."""
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
         # Defense-in-depth: also guard here (run() guards before its fast path).
@@ -298,7 +330,7 @@ class SessionManager:
 
         # Cheap reuse check without the lock: most launches hit this.
         if not stale and self._is_session_valid(session_dir, email, org_uuid):
-            self._sync_sharing(session_dir, share)
+            self._sync_sharing(session_dir, share, share_history)
             return session_dir, account_num, email
 
         with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
@@ -310,11 +342,11 @@ class SessionManager:
                 self.switcher._invalidate_session_credentials(account_num, email)
                 (session_dir / STALE_MARKER).unlink(missing_ok=True)
             if self._is_session_valid(session_dir, email, org_uuid):
-                self._sync_sharing(session_dir, share)
+                self._sync_sharing(session_dir, share, share_history)
                 return session_dir, account_num, email
 
             self._bootstrap(session_dir, account_num, email, org_uuid)
-            self._sync_sharing(session_dir, share)
+            self._sync_sharing(session_dir, share, share_history)
 
             if not self._is_session_valid(session_dir, email, org_uuid):
                 self._cleanup_failed_session(session_dir)
@@ -463,34 +495,54 @@ class SessionManager:
 
     # -- sharing ---------------------------------------------------------
 
-    def _sync_sharing(self, session_dir: Path, share: bool) -> None:
-        """Mirror SHARED_ITEMS from ~/.claude into the profile (or undo it).
+    def _sync_sharing(
+        self, session_dir: Path, share: bool, share_history: bool = False
+    ) -> None:
+        """Mirror shared items from ~/.claude into the profile (or undo it).
 
-        Idempotent; runs on every launch. Deliberately sources from the
-        default ``~/.claude`` (not ``get_claude_config_home()``): sharing
+        ``share`` governs SHARED_ITEMS (customizations); ``share_history``
+        governs HISTORY_ITEMS (conversation history) — independent concerns,
+        so ``--no-share --share-history`` gives a bare profile with unified
+        history. Idempotent; runs on every launch. Deliberately sources from
+        the default ``~/.claude`` (not ``get_claude_config_home()``): sharing
         always mirrors the default profile, even when ``CLAUDE_CONFIG_DIR``
         is set in the invoking environment. Lock-free on the reuse path:
-        concurrent ``run`` vs ``run --no-share`` is last-writer-wins and
-        self-heals on the next launch.
+        concurrent runs with different flags are last-writer-wins and
+        self-heal on the next launch.
         """
         if not session_dir.is_dir():
             return
+        # History links are POSIX-only (run() rejects the flag on Windows;
+        # this also drops any links left by a POSIX→Windows profile move).
+        if self.switcher.platform == Platform.WINDOWS:
+            share_history = False
+        active_items = (SHARED_ITEMS if share else ()) + (
+            HISTORY_ITEMS if share_history else ()
+        )
         source_root = Path.home() / ".claude"
         manifest_path = session_dir / SHARE_MANIFEST
         managed = self._read_manifest(manifest_path)
 
-        if not share:
-            for name in managed:
+        # A flag turned off since last launch: remove the links we created
+        # for it (never plain files/dirs the user accumulated themselves).
+        for name in managed:
+            if name not in active_items:
                 self._remove_managed(session_dir / name)
+        if not active_items:
             manifest_path.unlink(missing_ok=True)
             return
 
         use_symlinks = self.switcher.platform != Platform.WINDOWS
         new_managed: list[str] = []
 
-        for name in SHARED_ITEMS:
+        for name in active_items:
             src = source_root / name
             dest = session_dir / name
+
+            if name in HISTORY_ITEMS and not self._prepare_history_share(
+                src, dest, name in managed, session_dir
+            ):
+                continue
 
             if not src.exists():
                 # Source vanished (or never existed): prune our own entry.
@@ -544,13 +596,108 @@ class SessionManager:
         # truncated file.
         self._write_manifest(manifest_path, new_managed)
 
+    def _prepare_history_share(
+        self, src: Path, dest: Path, dest_managed: bool, session_dir: Path
+    ) -> bool:
+        """Make a history item linkable; returns False to skip it this launch.
+
+        Handles the two ways a history item differs from a plain shared item:
+        the profile may already hold real history that must survive (merged
+        into ``~/.claude``, never discarded — the generic loop would just
+        refuse), and the share source may not exist yet on a fresh install
+        (created empty so there is something to link).
+        """
+        if dest.exists() and not dest.is_symlink() and not dest_managed:
+            # Real per-account history accumulated before the flag existed.
+            # Merging moves files out from under any claude still running in
+            # this profile, so only migrate when the profile is quiescent.
+            if live_sessions_for(session_dir):
+                print(
+                    dimmed(
+                        f"Not sharing {dest.name} yet: another session is "
+                        "using this profile — retrying on the next launch."
+                    )
+                )
+                return False
+            try:
+                self._merge_history_into_source(src, dest)
+            except OSError as e:
+                self._logger.warning(
+                    f"Could not merge {dest.name} into {src}: {e}"
+                )
+                print(
+                    dimmed(
+                        f"Not sharing {dest.name}: merging the profile's "
+                        "existing history failed (see log)."
+                    )
+                )
+                return False
+            print(
+                dimmed(
+                    f"Merged the profile's existing {dest.name} into "
+                    f"{src} — conversation history is now shared."
+                )
+            )
+        if not src.exists():
+            # Fresh ~/.claude (or first run): seed an empty share target so
+            # the generic loop below has something to link.
+            try:
+                if dest.name.endswith(".jsonl"):
+                    src.parent.mkdir(parents=True, exist_ok=True)
+                    src.touch()
+                else:
+                    src.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                self._logger.warning(f"Could not create {src}: {e}")
+                return False
+        return True
+
+    @staticmethod
+    def _merge_history_into_source(src: Path, dest: Path) -> None:
+        """Move the profile's own history at ``dest`` into ``src``.
+
+        Directories merge file-by-file (transcript filenames are UUIDs, so
+        collisions mean identical sessions — first writer wins and the
+        duplicate is dropped). ``history.jsonl`` merges by appending lines
+        not already present. ``dest`` is removed once empty; any failure
+        raises OSError and leaves remaining files in place for the next try.
+        """
+        if dest.is_dir():
+            src.mkdir(parents=True, exist_ok=True)
+            for path in sorted(dest.rglob("*"), reverse=True):
+                rel = path.relative_to(dest)
+                target = src / rel
+                if path.is_dir():
+                    path.rmdir()  # children already moved (reverse walk)
+                    continue
+                if target.exists():
+                    path.unlink()
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(path), str(target))
+            dest.rmdir()
+        else:
+            existing: set[str] = set()
+            if src.exists():
+                existing = set(src.read_text(encoding="utf-8").splitlines())
+            lines = [
+                line
+                for line in dest.read_text(encoding="utf-8").splitlines()
+                if line and line not in existing
+            ]
+            if lines:
+                src.parent.mkdir(parents=True, exist_ok=True)
+                with src.open("a", encoding="utf-8") as f:
+                    f.write("\n".join(lines) + "\n")
+            dest.unlink()
+
     @staticmethod
     def _read_manifest(manifest_path: Path) -> list[str]:
         try:
             data = json.loads(manifest_path.read_text(encoding="utf-8"))
             items = data.get("items", [])
             # Only ever act on names we could have created.
-            return [i for i in items if i in SHARED_ITEMS]
+            return [i for i in items if i in SHARED_ITEMS + HISTORY_ITEMS]
         except (OSError, json.JSONDecodeError, AttributeError):
             return []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -431,8 +431,8 @@ class TestRunCommand:
             def __init__(self, switcher):
                 calls.append(("init", switcher))
 
-            def run(self, identifier, claude_args, share=True):
-                calls.append(("run", identifier, claude_args, share))
+            def run(self, identifier, claude_args, share=True, share_history=False):
+                calls.append(("run", identifier, claude_args, share, share_history))
 
         with patch("claude_swap.session.SessionManager", FakeSessionManager), \
              patch("claude_swap.cli.ClaudeAccountSwitcher"), \
@@ -443,24 +443,32 @@ class TestRunCommand:
 
     def test_run_dispatches_with_defaults(self):
         calls = self._dispatch(["run", "2"])
-        assert ("run", "2", [], True) in calls
+        assert ("run", "2", [], True, False) in calls
 
     def test_run_by_email(self):
         calls = self._dispatch(["run", "user@example.com"])
-        assert ("run", "user@example.com", [], True) in calls
+        assert ("run", "user@example.com", [], True, False) in calls
 
     def test_no_share_flag(self):
         calls = self._dispatch(["run", "2", "--no-share"])
-        assert ("run", "2", [], False) in calls
+        assert ("run", "2", [], False, False) in calls
+
+    def test_share_history_flag(self):
+        calls = self._dispatch(["run", "2", "--share-history"])
+        assert ("run", "2", [], True, True) in calls
+
+    def test_no_share_history_flag(self):
+        calls = self._dispatch(["run", "2", "--no-share-history"])
+        assert ("run", "2", [], True, False) in calls
 
     def test_tail_forwarded_verbatim(self):
         calls = self._dispatch(["run", "2", "--", "--resume", "--model", "x"])
-        assert ("run", "2", ["--resume", "--model", "x"], True) in calls
+        assert ("run", "2", ["--resume", "--model", "x"], True, False) in calls
 
     def test_tail_may_contain_run_flags(self):
         """Args after `--` are NOT parsed by cswap, even if they look like ours."""
         calls = self._dispatch(["run", "2", "--", "--no-share"])
-        assert ("run", "2", ["--no-share"], True) in calls
+        assert ("run", "2", ["--no-share"], True, False) in calls
 
     def test_run_without_account_errors(self, capsys):
         with patch.object(sys, "argv", ["claude-swap", "run"]):
@@ -498,7 +506,7 @@ class TestRunCommand:
             def __init__(self, switcher):
                 pass
 
-            def run(self, identifier, claude_args, share=True):
+            def run(self, identifier, claude_args, share=True, share_history=False):
                 from claude_swap.exceptions import SessionError
 
                 raise SessionError("boom")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -927,3 +927,144 @@ class TestGuards:
         assert not (session_dir / ".credentials.json").exists()
         assert (session_dir / ".claude.json").exists()
         assert block_real_keychain.get_password(service, account) is None
+
+
+# ---------------------------------------------------------------------------
+# history sharing (--share-history)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def history_setup(share_setup, temp_home: Path):
+    """share_setup plus conversation history on both sides."""
+    source, session_dir, mgr = share_setup
+    (source / "projects").mkdir()
+    (source / "projects" / "-home-user-app").mkdir()
+    (source / "projects" / "-home-user-app" / "aaa.jsonl").write_text("main-a\n")
+    (source / "history.jsonl").write_text('{"p": "main"}\n')
+    return source, session_dir, mgr
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="history sharing is POSIX-only")
+class TestShareHistoryPosix:
+    def test_not_shared_by_default(self, history_setup):
+        source, session_dir, mgr = history_setup
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert not (session_dir / "projects").exists()
+        assert not (session_dir / "history.jsonl").exists()
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "projects" not in manifest["items"]
+
+    def test_links_history_items(self, history_setup):
+        source, session_dir, mgr = history_setup
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert (session_dir / "projects").readlink() == source / "projects"
+        assert (session_dir / "history.jsonl").readlink() == source / "history.jsonl"
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert {"projects", "history.jsonl"} <= set(manifest["items"])
+
+    def test_creates_missing_source(self, share_setup):
+        source, session_dir, mgr = share_setup  # no history in ~/.claude yet
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert (source / "projects").is_dir()
+        assert (source / "history.jsonl").is_file()
+        assert (session_dir / "projects").readlink() == source / "projects"
+
+    def test_merges_existing_profile_history(self, history_setup):
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "bbb.jsonl").write_text("profile-b\n")
+        (session_dir / "projects" / "-home-user-other").mkdir()
+        (session_dir / "projects" / "-home-user-other" / "ccc.jsonl").write_text(
+            "profile-c\n"
+        )
+        (session_dir / "history.jsonl").write_text(
+            '{"p": "main"}\n{"p": "profile"}\n'
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        # Profile history landed in ~/.claude, alongside what was there.
+        merged = source / "projects"
+        assert (merged / "-home-user-app" / "aaa.jsonl").read_text() == "main-a\n"
+        assert (merged / "-home-user-app" / "bbb.jsonl").read_text() == "profile-b\n"
+        assert (merged / "-home-user-other" / "ccc.jsonl").read_text() == "profile-c\n"
+        # Prompt history merged without duplicating shared lines.
+        assert source / "history.jsonl" == (session_dir / "history.jsonl").readlink()
+        lines = (source / "history.jsonl").read_text().splitlines()
+        assert lines.count('{"p": "main"}') == 1
+        assert '{"p": "profile"}' in lines
+        # And the profile now links to the shared copy.
+        assert (session_dir / "projects").readlink() == merged
+
+    def test_merge_collision_keeps_target(self, history_setup):
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "aaa.jsonl").write_text("profile-duplicate\n")
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert (
+            source / "projects" / "-home-user-app" / "aaa.jsonl"
+        ).read_text() == "main-a\n"
+        assert (session_dir / "projects").is_symlink()
+
+    def test_merge_deferred_while_profile_live(self, history_setup, monkeypatch):
+        source, session_dir, mgr = history_setup
+        (session_dir / "projects").mkdir()
+        (session_dir / "projects" / "x.jsonl").write_text("live\n")
+        monkeypatch.setattr(
+            session_mod, "live_sessions_for", lambda _dir: [object()]
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        # Untouched: no merge, no link, not claimed in the manifest.
+        assert not (session_dir / "projects").is_symlink()
+        assert (session_dir / "projects" / "x.jsonl").read_text() == "live\n"
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "projects" not in manifest["items"]
+
+    def test_toggle_off_removes_links_keeps_data(self, history_setup):
+        source, session_dir, mgr = history_setup
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+        mgr._sync_sharing(session_dir, share=True, share_history=False)
+
+        assert not (session_dir / "projects").exists()
+        assert not (session_dir / "history.jsonl").exists()
+        # Shared source data is never touched; customizations stay linked.
+        assert (source / "projects" / "-home-user-app" / "aaa.jsonl").exists()
+        assert (session_dir / "settings.json").is_symlink()
+
+    def test_share_history_independent_of_no_share(self, history_setup):
+        source, session_dir, mgr = history_setup
+        mgr._sync_sharing(session_dir, share=False, share_history=True)
+
+        assert (session_dir / "projects").is_symlink()
+        assert not (session_dir / "settings.json").exists()
+
+
+class TestShareHistoryWindows:
+    def test_sync_never_links_history_in_copy_mode(self, history_setup):
+        source, session_dir, mgr = history_setup
+        mgr.switcher.platform = Platform.WINDOWS
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert not (session_dir / "projects").exists()
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "projects" not in manifest["items"]
+
+    def test_run_rejects_flag(self, history_setup, monkeypatch):
+        source, session_dir, mgr = history_setup
+        mgr.switcher.platform = Platform.WINDOWS
+        monkeypatch.setattr(
+            session_mod.shutil, "which", lambda _name: "/usr/bin/claude"
+        )
+
+        with pytest.raises(SessionError, match="Windows"):
+            mgr.run(ACCOUNT_NUM, [], share=True, share_history=True)


### PR DESCRIPTION
# PR description written by Human:

I wanted to be able to share the sessions that I had between my work and personal accounts but this wasn't possible before. Worked with Fable to implement this as a flag. Hope you don't mind me making this PR.

Closes #74

---

# PR description written by Fable high:

## Summary

Adds an opt-in `--share-history` flag to `cswap run` that shares conversation
history (`projects/` and `history.jsonl`) from `~/.claude` into the session
profile, so every account sees — and `claude --resume` lists — the same
conversations.

```bash
cswap run 2 --share-history     # one conversation history across all accounts
cswap run 2 --no-share-history  # back to per-account history (the default)
```

## Motivation

Per-account history is a deliberate default and stays that way. But when you
use multiple accounts as *one person* (e.g. switching accounts to spread usage
limits), per-account history splits your conversations across profiles:
`--resume` under account 2 can't see the session you started under account 1.
This flag lets those users opt into a single unified history while keeping
customization sharing (`--no-share`) an independent choice.

## What it does

- **New flag** on `cswap run`: `--share-history` /
  `--no-share-history` (default: off). Independent of `--no-share`, so
  `--no-share --share-history` gives a bare profile with unified history.
- **Sharing mechanism**: the same symlink machinery as `SHARED_ITEMS`, extended
  with a new `HISTORY_ITEMS` tuple (`projects/`, `history.jsonl`). Links are
  recorded in the existing `.cswap-shared.json` manifest, so removal only ever
  touches cswap-created links, never user data.
- **No data loss on first use**: if the profile already accumulated its own
  history before the flag existed, it is merged into `~/.claude` first —
  transcript directories merge file-by-file (filenames are UUIDs, so a
  collision means the identical session; first writer wins), and
  `history.jsonl` merges by appending lines not already present. Nothing
  disappears from `--resume`.
- **Safe with live sessions**: merging moves files out from under any `claude`
  still running in the profile, so if the profile has live sessions the merge
  is deferred with a notice and retried on the next launch.
- **Toggling off is clean**: `--no-share-history` removes the links (data stays
  in `~/.claude`) and the profile goes back to accumulating its own history.
- **Fresh installs work**: if `~/.claude` has no history yet, an empty share
  target is seeded so there is something to link.

## Windows

Not supported in this PR, and rejected explicitly with a clear error. On
Windows, sharing uses re-synced copies instead of symlinks — a copied history
would *fork* on first write rather than stay shared, which is worse than not
having the feature. `_sync_sharing` additionally drops history links
defensively in copy mode, so a profile moved from POSIX to Windows self-heals.

**Windows support is feasible as a follow-up PR** — nothing here blocks it. This PR focuses on macOS/Linux because that is what we can actually test, and the failure mode of getting Windows wrong is silent history forking — exactly what the feature exists to prevent.

A sketch for whoever picks it up:

- `projects/` (the transcripts) can be shared with an NTFS **directory
  junction** (`_winapi.CreateJunction` / `mklink /J`) — works on every
  Windows install with no admin rights or Developer Mode. The link-detection
  code (`dest.is_symlink()`, `_remove_managed`) needs to become
  junction-aware (`Path.is_junction()` on Python 3.12+, `st_reparse_tag`
  before that).
- `history.jsonl` needs a real **file symlink**, which requires Developer
  Mode (or elevation). A capability probe at launch can pick between linking
  it, or sharing `projects/` alone with a notice — unified transcripts are
  the point; prompt history is a nicety.
- **Hardlinks should not be used**: if Claude Code ever rewrites
  `history.jsonl` via temp-file-and-rename, a hardlink silently forks.
- The merge logic (`_merge_history_into_source`) is already
  platform-neutral and needs no changes.

The main cost is verification on real Windows, not the code itself.

## Design notes

- `projects/` and `history.jsonl` were deliberately excluded from
  `SHARED_ITEMS` ("per-account history is a feature") — this PR keeps that
  default and moves them behind an explicit opt-in rather than changing the
  exclusion.
- The merge raises `OSError` on any failure and leaves remaining files in
  place, so a partial merge is retried (not lost) on the next launch.
- Manifest reads still filter to names cswap could have created, now
  `SHARED_ITEMS + HISTORY_ITEMS` — a corrupted or hand-edited manifest can
  never cause removal of arbitrary entries.
- Concurrency model is unchanged: lock-free on the reuse path, last-writer-wins
  between concurrent runs with different flags, self-healing on next launch.

## Testing

- `643 passed, 3 skipped` (full suite, POSIX).
- New tests:
  - CLI: flag parsing for `--share-history` / `--no-share-history`, defaults,
    and that args after `--` are still forwarded verbatim.
  - Session (POSIX): not shared by default; links created and recorded in the
    manifest; missing source seeded; existing profile history merged (both
    `projects/` and `history.jsonl`, including dedup and collision handling);
    merge deferred while the profile has live sessions; toggling off removes
    links but keeps data; independence from `--no-share`.
  - Windows: `run` rejects the flag with a clear error; `_sync_sharing` never
    links history in copy mode.

## Docs

README updated: new example line plus a paragraph explaining the behavior,
the merge-on-first-use guarantee, `--no-share-history`, and the Windows
limitation. Module docstring and CLI `--help` cover the same ground.

https://claude.ai/code/session_012JvGuwHK7mdPbxE9bHTs95
