### PR TITLE
Auto-switch: cswap auto — switch accounts before hitting rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,39 @@ Or let claude-swap auto-pick by remaining quota — `cswap --switch --strategy b
 
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.
 
+### Automatic switching
+
+Let claude-swap watch your usage and switch for you. When the active account's 5-hour or 7-day window reaches the threshold (default 90%), it switches to the account with the most quota left — before you hit the limit, and safe to run while Claude Code is working:
+
+```bash
+cswap auto                     # foreground loop, polls every 60s
+cswap auto --threshold 80      # switch earlier
+cswap auto --once              # single check-and-switch, for cron/scripts
+cswap auto --dry-run           # log what it would do, never switch
+```
+
+<details>
+<summary>How it behaves & advanced usage</summary>
+
+- Switches cooperate with Claude Code's own credential locks, so a swap can never collide with a token refresh mid-session.
+- A cooldown (default 5 min) and a hysteresis margin keep it from flip-flopping between accounts near the line; when every account is exhausted it sleeps until the earliest quota reset.
+- An account whose refresh token has died is quarantined — taken out of rotation and reported — until you log in with it and re-run `cswap --add-account --slot N`.
+- API-key accounts are never rotated onto unless you pass `--include-api-key-accounts` (they bill per token).
+
+For cron/systemd timers, `--once` reports the outcome in its exit code (`0` switched, `1` error, `2` nothing to do, `3` blocked — no viable target), and `--json` emits one JSON event per line:
+
+```bash
+*/5 * * * * cswap auto --once --json >> ~/.cswap-auto.log 2>&1
+```
+
+Defaults are configurable in `settings.json` in the backup root (see [Data locations](#data-locations)) — flags override it:
+
+```json
+{ "schemaVersion": 1, "autoswitch": { "threshold": 90, "intervalSeconds": 60, "cooldownSeconds": 300 } }
+```
+
+</details>
+
 ### Run multiple accounts at the same time (session mode)
 
 Launch Claude Code as a specific account in the current terminal only — every other terminal and the VS Code extension stay on your default account, so two accounts can work in parallel.
@@ -98,6 +131,7 @@ This will update the stored credentials without creating a duplicate.
 
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
+cswap auto                      # Auto-switch when nearing rate limits (see above)
 cswap --list                    # Show all accounts with 5h/7d usage and reset times
 cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
@@ -117,6 +151,8 @@ cswap --purge                   # Remove all claude-swap data
 - Backs up OAuth tokens and config when you add an account
 - Swaps credentials when you switch accounts
 - Account credentials stored securely using platform-appropriate methods
+- Switches (manual and automatic) hold Claude Code's own credential locks while writing, so a swap never interleaves with a token refresh
+- Auto-switch freshens a target's token before activating it, and quarantines accounts whose refresh token has died (recover with `cswap --add-account --slot N`)
 
 ## Data locations
 
@@ -126,7 +162,7 @@ cswap --purge                   # Remove all claude-swap data
 | macOS | macOS Keychain | `~/.claude-swap-backup/` |
 | Linux / WSL | File-based (inside the backup directory, under `credentials/`) | `${XDG_DATA_HOME:-~/.local/share}/claude-swap/` |
 
-Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`.
+Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`. Tool preferences (`settings.json`) and auto-switch state (`autoswitch_state.json` — cooldown and quarantined accounts; delete it to reset) live in the backup directory root.
 
 On Linux/WSL, set `XDG_DATA_HOME` to override the default location. Data from older installs under `~/.claude-swap-backup/` is migrated automatically on first run.
 
@@ -177,6 +213,8 @@ cswap --switch-to 2 --json
 Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
 
 </details>
+
+`cswap auto --json` emits an event *stream* instead — one JSON object per line (`{"schemaVersion":1,"event":"switch","ts":…, …}` with kinds like `poll`, `switch`, `no-switch`, `account-quarantined`, `all-exhausted`, `error`). The contract is additive: new kinds and fields may appear, so scripts should ignore unknown ones.
 
 ### Add an account from a raw token or API key
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1,0 +1,796 @@
+"""Auto-switch engine: poll usage, switch accounts before they hit rate limits.
+
+``AutoSwitchEngine`` is UI-agnostic — no printing, no argparse, no TUI
+imports. It composes a :class:`ClaudeAccountSwitcher`, evaluates a threshold
+policy each :meth:`~AutoSwitchEngine.tick`, and reports everything through
+typed events handed to an ``on_event`` callback; the CLI renders them as
+human lines or JSONL, and any future frontend (TUI dashboard, menubar) can
+consume the same stream.
+
+Policy in one paragraph: when the active account's *binding window* (the
+higher of its 5h/7d utilization) crosses ``settings.threshold``, switch to
+the candidate with the most headroom — proactively, so the old account is
+still valid while a running Claude Code picks the new one up (this is what
+makes the macOS ~30s Keychain cache latency harmless). Candidates must sit
+``hysteresis_pct`` below the threshold so two accounts hovering at the line
+never ping-pong, and a ``cooldown_seconds`` floor bounds the switch rate
+(bypassed only when the active account is hard at its limit). Before
+activation the target's token is *freshened* (refreshed if it expires within
+10 minutes — twice Claude Code's refresh buffer, so a running Claude Code's
+under-lock re-read sees a fresh token and aborts its own refresh); a target
+whose refresh token is dead gets quarantined instead of activated. When the
+active account's own usage becomes unreadable for ``unhealthy_ticks``
+consecutive ticks, the engine fails over to any healthy candidate.
+
+Cooldown and quarantine persist in ``<backup_root>/autoswitch_state.json``
+(so cron-driven ``cswap auto --once`` ticks behave across processes), mutated
+read-modify-write under a dedicated file lock.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import json
+import random
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import ClassVar
+
+from claude_swap import oauth
+from claude_swap.exceptions import ClaudeSwitchError
+from claude_swap.json_output import SCHEMA_VERSION
+from claude_swap.locking import FileLock
+from claude_swap.settings import AutoSwitchSettings, atomic_write_json
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+STATE_FILENAME = "autoswitch_state.json"
+STATE_SCHEMA_VERSION = 1
+
+# Freshen targets whose access token expires within this window: twice Claude
+# Code's own 5-minute refresh buffer, so its post-lock "abort refresh if not
+# expired" re-read holds with margin after our swap.
+FRESHEN_BUFFER_MS = 10 * 60 * 1000
+
+# Sleep caps around a known quota reset: a little slack past the reset, and
+# never trust one long sleep (laptops suspend, clocks drift) — cap and
+# re-evaluate.
+RESET_SLACK_S = 60.0
+MAX_SLEEP_S = 6 * 3600.0
+NO_RESET_FALLBACK_S = 300.0
+
+
+def _now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AutoSwitchEvent:
+    """Base event. ``to_json()`` payloads are additive: consumers must ignore
+    unknown ``event`` kinds and unknown fields."""
+
+    kind: ClassVar[str] = "event"
+    ts: str = field(default_factory=_now_iso, kw_only=True)
+
+    def _fields(self) -> dict:
+        return {}
+
+    def to_json(self) -> dict:
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "event": self.kind,
+            "ts": self.ts,
+            **self._fields(),
+        }
+
+    def human(self) -> str:  # pragma: no cover - overridden
+        return self.kind
+
+
+@dataclass(frozen=True)
+class PollEvent(AutoSwitchEvent):
+    kind: ClassVar[str] = "poll"
+    active: dict | None  # account_ref shape, or None
+    headroom: dict[str, float | None]  # account number → headroom pct (None=unknown)
+    threshold: float
+
+    def _fields(self) -> dict:
+        return {
+            "active": self.active,
+            "headroomPct": self.headroom,
+            "threshold": self.threshold,
+        }
+
+    def human(self) -> str:
+        if self.active is None:
+            return "poll: no active account"
+        num = self.active.get("number")
+        h = self.headroom.get(str(num))
+        used = f"{100 - h:.0f}% used" if h is not None else "usage unknown"
+        others = ", ".join(
+            f"#{n}: {100 - v:.0f}%" if v is not None else f"#{n}: ?"
+            for n, v in self.headroom.items()
+            if n != str(num)
+        )
+        tail = f" | others: {others}" if others else ""
+        return (
+            f"Account-{num} ({self.active.get('email')}): {used} "
+            f"(switch at {self.threshold:.0f}%){tail}"
+        )
+
+
+@dataclass(frozen=True)
+class SwitchEvent(AutoSwitchEvent):
+    kind: ClassVar[str] = "switch"
+    trigger: str  # "proactive" | "at-limit" | "failover"
+    from_ref: dict | None
+    to_ref: dict | None
+    warnings: list[str] = field(default_factory=list)
+    dry_run: bool = False
+
+    def _fields(self) -> dict:
+        return {
+            "trigger": self.trigger,
+            "from": self.from_ref,
+            "to": self.to_ref,
+            "warnings": self.warnings,
+            "dryRun": self.dry_run,
+        }
+
+    def human(self) -> str:
+        src = (
+            f"Account-{self.from_ref.get('number')}" if self.from_ref else "(none)"
+        )
+        dst = (
+            f"Account-{self.to_ref.get('number')} ({self.to_ref.get('email')})"
+            if self.to_ref
+            else "?"
+        )
+        prefix = "[dry-run] would switch" if self.dry_run else "Switched"
+        return f"{prefix} {src} -> {dst} ({self.trigger})"
+
+
+@dataclass(frozen=True)
+class NoSwitchEvent(AutoSwitchEvent):
+    kind: ClassVar[str] = "no-switch"
+    reason: str
+    detail: str = ""
+
+    def _fields(self) -> dict:
+        return {"reason": self.reason, "detail": self.detail}
+
+    def human(self) -> str:
+        return f"no switch: {self.reason}" + (f" ({self.detail})" if self.detail else "")
+
+
+@dataclass(frozen=True)
+class QuarantineEvent(AutoSwitchEvent):
+    kind: ClassVar[str] = "account-quarantined"
+    number: str
+    email: str
+    reason: str
+
+    def _fields(self) -> dict:
+        return {"number": self.number, "email": self.email, "reason": self.reason}
+
+    def human(self) -> str:
+        return (
+            f"Account-{self.number} ({self.email}) quarantined: {self.reason}. "
+            f"Log in with it and run 'cswap --add-account --slot {self.number}' "
+            "to recover."
+        )
+
+
+@dataclass(frozen=True)
+class UnquarantineEvent(AutoSwitchEvent):
+    kind: ClassVar[str] = "account-unquarantined"
+    number: str
+    email: str
+    reason: str = "credentials-replaced"
+
+    def _fields(self) -> dict:
+        return {"number": self.number, "email": self.email, "reason": self.reason}
+
+    def human(self) -> str:
+        return f"Account-{self.number} ({self.email}) back in rotation ({self.reason})"
+
+
+@dataclass(frozen=True)
+class AllExhaustedEvent(AutoSwitchEvent):
+    kind: ClassVar[str] = "all-exhausted"
+    earliest_reset_at: str | None
+
+    def _fields(self) -> dict:
+        return {"earliestResetAt": self.earliest_reset_at}
+
+    def human(self) -> str:
+        if self.earliest_reset_at:
+            return f"all accounts exhausted; earliest reset {self.earliest_reset_at}"
+        return "all accounts exhausted; no reset time known"
+
+
+@dataclass(frozen=True)
+class SleepEvent(AutoSwitchEvent):
+    kind: ClassVar[str] = "sleep"
+    seconds: float
+    until: str
+
+    def _fields(self) -> dict:
+        return {"seconds": round(self.seconds, 1), "until": self.until}
+
+    def human(self) -> str:
+        return f"sleeping {self.seconds / 60:.0f}m (until {self.until})"
+
+
+@dataclass(frozen=True)
+class ErrorEvent(AutoSwitchEvent):
+    kind: ClassVar[str] = "error"
+    message: str
+    transient: bool = True
+
+    def _fields(self) -> dict:
+        return {"message": self.message, "transient": self.transient}
+
+    def human(self) -> str:
+        return f"error: {self.message}" + (" (will retry)" if self.transient else "")
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class TickOutcome(enum.Enum):
+    """Outcome of one evaluation tick; values double as --once exit codes."""
+
+    SWITCHED = 0
+    ERROR = 1
+    NO_ACTION = 2
+    BLOCKED = 3  # wanted to switch but no viable target / all exhausted
+
+
+def _refresh_fingerprint(credentials: str) -> str | None:
+    data = oauth.extract_oauth_data(credentials)
+    token = data.get("refreshToken") if data else None
+    if not isinstance(token, str) or not token:
+        return None
+    return "sha256:" + hashlib.sha256(token.encode()).hexdigest()
+
+
+def _ref(number: str, email: str) -> dict:
+    return {"number": int(number), "email": email}
+
+
+class AutoSwitchEngine:
+    """Threshold-policy auto-switcher over a :class:`ClaudeAccountSwitcher`.
+
+    ``on_event`` receives every :class:`AutoSwitchEvent`; exceptions it raises
+    are not caught (a broken frontend should fail loudly in tests). ``clock``
+    is wall time (persisted cooldown timestamps must survive processes).
+    """
+
+    def __init__(
+        self,
+        switcher: ClaudeAccountSwitcher,
+        settings: AutoSwitchSettings,
+        on_event: Callable[[AutoSwitchEvent], None],
+        *,
+        dry_run: bool = False,
+        state_path: Path | None = None,
+        clock: Callable[[], float] = time.time,
+    ):
+        self.switcher = switcher
+        self.settings = settings
+        self.on_event = on_event
+        self.dry_run = dry_run
+        self.state_path = state_path or (switcher.backup_dir / STATE_FILENAME)
+        self.clock = clock
+        self._stop = threading.Event()
+        self._unhealthy_ticks = 0
+        # Both set per tick: a known-reset sleep target, and whether a BLOCKED
+        # outcome is static enough (truly exhausted / no candidates) to wait
+        # longer than the normal interval.
+        self._sleep_until_ts: float | None = None
+        self._blocked_wait_long = False
+
+    # -- state file ---------------------------------------------------------
+
+    def _state_lock(self) -> FileLock:
+        return FileLock(self.state_path.parent / ".autoswitch_state.lock")
+
+    def _read_state(self) -> dict:
+        try:
+            raw = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return {}
+        return raw if isinstance(raw, dict) else {}
+
+    def _mutate_state(self, mutator: Callable[[dict], None]) -> dict:
+        """Read-modify-write the state file under its lock; returns new state.
+
+        The lock prevents two concurrent engines (loop + cron ``--once``) from
+        overwriting each other's quarantine/cooldown updates. Never called
+        while any other lock is held.
+        """
+        with self._state_lock():
+            state = self._read_state()
+            state["schemaVersion"] = STATE_SCHEMA_VERSION
+            mutator(state)
+            atomic_write_json(self.state_path, state)
+            return state
+
+    # -- quarantine -----------------------------------------------------------
+
+    def _quarantine(self, number: str, email: str, reason: str) -> None:
+        creds = self.switcher.read_account_credentials(number, email)
+        fingerprint = _refresh_fingerprint(creds) if creds else None
+
+        def add(state: dict) -> None:
+            state.setdefault("quarantine", {})[number] = {
+                "email": email,
+                "reason": reason,
+                "at": _now_iso(),
+                "refreshTokenFingerprint": fingerprint,
+            }
+
+        self._mutate_state(add)
+        self._emit(QuarantineEvent(number=number, email=email, reason=reason))
+
+    def _release_recovered_quarantines(self, state: dict) -> dict:
+        """Drop quarantine entries whose credential was replaced since.
+
+        A changed refresh-token fingerprint (or a removed/re-added slot) means
+        the user re-logged in and re-captured the account — the dead lineage
+        is gone, so it re-enters rotation.
+        """
+        quarantine = state.get("quarantine")
+        if not isinstance(quarantine, dict) or not quarantine:
+            return state
+        to_release: list[tuple[str, str, str]] = []
+        for number, entry in quarantine.items():
+            email_now = self.switcher.account_email(number)
+            if not email_now or email_now != entry.get("email"):
+                to_release.append(
+                    (number, entry.get("email", ""), "account-replaced")
+                )
+                continue
+            creds = self.switcher.read_account_credentials(number, email_now)
+            fingerprint = _refresh_fingerprint(creds) if creds else None
+            if fingerprint != entry.get("refreshTokenFingerprint"):
+                to_release.append((number, email_now, "credentials-replaced"))
+        if not to_release:
+            return state
+
+        def drop(s: dict) -> None:
+            q = s.get("quarantine")
+            if isinstance(q, dict):
+                for number, _, _ in to_release:
+                    q.pop(number, None)
+
+        state = self._mutate_state(drop)
+        for number, email, reason in to_release:
+            self._emit(UnquarantineEvent(number=number, email=email, reason=reason))
+        return state
+
+    # -- freshening -----------------------------------------------------------
+
+    def _freshen_target(self, number: str, email: str) -> str:
+        """Ensure a candidate's stored token outlives Claude Code's 5-min
+        refresh buffer before it gets activated.
+
+        Returns ``"ok"``, ``"invalid_grant"`` (dead lineage — quarantine),
+        ``"transient"`` (network trouble — try again next tick) or
+        ``"skip-live-session"``. Only ever touches the slot's *backup* store;
+        the active credential belongs to Claude Code.
+        """
+        if self.switcher.account_kind_for(number) == "api_key":
+            return "ok"  # API keys don't expire/refresh
+        if self.switcher.live_session_pids_for(number, email):
+            # A live `cswap run` session owns this account's token in its own
+            # profile. Auto-activating it as the default login too would put
+            # one rotating refresh token in two config dirs (the stale-copy
+            # failure class) with nobody reading the warning — and its quota
+            # is already being consumed by that session anyway. Manual
+            # switch_to keeps its warn-and-proceed behavior; auto skips.
+            return "skip-live-session"
+        creds = self.switcher.read_account_credentials(number, email)
+        if not creds:
+            return "transient"
+        data = oauth.extract_oauth_data(creds)
+        if not data:
+            return "invalid_grant"
+        expires_at = data.get("expiresAt")
+        now_ms = self.clock() * 1000
+        near_expiry = (
+            isinstance(expires_at, (int, float))
+            and now_ms + FRESHEN_BUFFER_MS >= expires_at
+        )
+        if not near_expiry:
+            return "ok"
+        outcome = oauth.try_refresh_oauth_credentials(creds)
+        if outcome.error is None and outcome.credentials:
+            self.switcher.persist_backup_credentials(
+                number, email, outcome.credentials
+            )
+            return "ok"
+        if outcome.error in ("invalid_grant", "no_refresh_token"):
+            return "invalid_grant"
+        return "transient"
+
+    # -- tick -----------------------------------------------------------------
+
+    def tick(self) -> TickOutcome:
+        """Evaluate once: poll usage, maybe switch. Never raises."""
+        try:
+            return self._tick_inner()
+        except ClaudeSwitchError as e:
+            self._emit(ErrorEvent(message=str(e), transient=True))
+            return TickOutcome.ERROR
+        except Exception as e:  # pragma: no cover - safety net
+            self._emit(
+                ErrorEvent(message=f"{type(e).__name__}: {e}", transient=True)
+            )
+            return TickOutcome.ERROR
+
+    def _tick_inner(self) -> TickOutcome:
+        self._sleep_until_ts = None
+        self._blocked_wait_long = False
+        settings = self.settings
+        state = self._read_state()
+        if not self.dry_run:
+            # Dry-run must not write anything, so recovered quarantines are
+            # only released (state mutation) on real ticks.
+            state = self._release_recovered_quarantines(state)
+        quarantined = set(
+            state.get("quarantine", {})
+            if isinstance(state.get("quarantine"), dict)
+            else {}
+        )
+
+        current = self.switcher.current_account_number()
+        if current is None:
+            self._emit(
+                PollEvent(active=None, headroom={}, threshold=settings.threshold)
+            )
+            if self.switcher.has_live_login():
+                # Live login exists but cswap doesn't manage it: never act —
+                # a switch would overwrite it without a backup.
+                self._emit(
+                    NoSwitchEvent(
+                        reason="unmanaged-active-account",
+                        detail="run 'cswap --add-account' to include it in rotation",
+                    )
+                )
+            else:
+                self._emit(
+                    NoSwitchEvent(
+                        reason="no-active-account",
+                        detail="log in and run 'cswap --add-account' first",
+                    )
+                )
+            return TickOutcome.NO_ACTION
+
+        current_email = self.switcher.account_email(current)
+        active_ref = _ref(current, current_email) if current_email else {
+            "number": int(current),
+            "email": "",
+        }
+
+        usage = self.switcher.usage_by_account()
+        headroom = {
+            num: oauth.account_headroom(entry if isinstance(entry, dict) else None)
+            for num, entry in usage.items()
+        }
+        self._emit(
+            PollEvent(
+                active=active_ref, headroom=headroom, threshold=settings.threshold
+            )
+        )
+
+        if (
+            self.switcher.account_kind_for(current) == "api_key"
+            and not settings.include_api_key_accounts
+        ):
+            self._emit(
+                NoSwitchEvent(
+                    reason="active-api-key",
+                    detail="API-key accounts have no quota to watch",
+                )
+            )
+            return TickOutcome.NO_ACTION
+
+        active_headroom = headroom.get(current)
+        if active_headroom is not None:
+            self._unhealthy_ticks = 0
+            utilization = 100.0 - active_headroom
+            if utilization < settings.threshold:
+                self._emit(
+                    NoSwitchEvent(
+                        reason="below-threshold",
+                        detail=f"{utilization:.0f}% < {settings.threshold:.0f}%",
+                    )
+                )
+                return TickOutcome.NO_ACTION
+            trigger = "at-limit" if active_headroom <= 0 else "proactive"
+        else:
+            self._unhealthy_ticks += 1
+            if self._unhealthy_ticks < settings.unhealthy_ticks:
+                self._emit(
+                    NoSwitchEvent(
+                        reason="active-usage-unknown",
+                        detail=(
+                            f"{self._unhealthy_ticks}/{settings.unhealthy_ticks} "
+                            "before failover"
+                        ),
+                    )
+                )
+                return TickOutcome.NO_ACTION
+            trigger = "failover"
+
+        if trigger == "proactive" and self._in_cooldown(state):
+            self._emit(NoSwitchEvent(reason="cooldown"))
+            return TickOutcome.NO_ACTION
+
+        # -- candidate selection ------------------------------------------
+        candidates = [
+            num
+            for num in self.switcher.switchable_account_numbers()
+            if num != current and num not in quarantined
+        ]
+        oauth_candidates = [
+            n for n in candidates if self.switcher.account_kind_for(n) != "api_key"
+        ]
+        api_key_candidates = (
+            [n for n in candidates if self.switcher.account_kind_for(n) == "api_key"]
+            if settings.include_api_key_accounts
+            else []
+        )
+        if not oauth_candidates and not api_key_candidates:
+            # Won't change until the user adds/recovers an account — no point
+            # re-polling at full cadence.
+            self._blocked_wait_long = True
+            self._emit(NoSwitchEvent(reason="no-candidates"))
+            return TickOutcome.BLOCKED
+
+        hysteresis_bar = settings.threshold - settings.hysteresis_pct
+        qualifying: list[tuple[float, str]] = []
+        any_known = False
+        for num in oauth_candidates:
+            h = headroom.get(num)
+            if h is None:
+                continue
+            any_known = True
+            if h <= 0:
+                continue  # itself at its limit — never a target
+            if trigger == "proactive":
+                # Hysteresis guards only the proactive case: two accounts
+                # hovering at the line must not ping-pong. At-limit and
+                # failover are escapes — any account with real headroom
+                # beats a blocked or dead one (and you can't flap back onto
+                # an account at 100%).
+                if (100.0 - h) > hysteresis_bar:
+                    continue
+                if active_headroom is not None and h <= active_headroom:
+                    continue  # not provably better than where we are
+            qualifying.append((h, num))
+        # Best headroom first; list order (sequence order) breaks ties.
+        qualifying.sort(key=lambda t: -t[0])
+        ordered = [num for _, num in qualifying]
+        if not ordered and api_key_candidates:
+            # Last resort: metered API-key accounts (unmeasurable headroom).
+            ordered = api_key_candidates
+
+        if not ordered:
+            if not any_known:
+                self._emit(
+                    NoSwitchEvent(
+                        reason="no-comparison",
+                        detail="no candidate has readable usage",
+                    )
+                )
+                return TickOutcome.BLOCKED
+            # "All exhausted" (and its hours-long reset sleep) only when it's
+            # literally true: every candidate's usage is known and at its
+            # limit. A candidate that merely failed the proactive hysteresis
+            # bar, or one whose usage is unreadable this tick, can become
+            # viable at any moment — and the active account can hit 100% and
+            # need the at-limit escape — so those keep the normal cadence.
+            candidate_headrooms = [headroom.get(n) for n in oauth_candidates]
+            truly_exhausted = all(
+                h is not None and h <= 0 for h in candidate_headrooms
+            )
+            if not truly_exhausted:
+                self._emit(
+                    NoSwitchEvent(
+                        reason="no-qualifying-candidate",
+                        detail=(
+                            "candidates are too close to the line or their "
+                            "usage is unreadable this tick"
+                        ),
+                    )
+                )
+                return TickOutcome.BLOCKED
+            self._blocked_wait_long = True
+            earliest = self._earliest_reset(usage)
+            if earliest is not None:
+                self._sleep_until_ts = earliest.timestamp() + RESET_SLACK_S
+            self._emit(
+                AllExhaustedEvent(
+                    earliest_reset_at=(
+                        earliest.isoformat().replace("+00:00", "Z")
+                        if earliest
+                        else None
+                    )
+                )
+            )
+            return TickOutcome.BLOCKED
+
+        # -- freshen + switch ----------------------------------------------
+        transient_failure = False
+        for num in ordered:
+            email = self.switcher.account_email(num)
+            if self.dry_run:
+                # Dry-run stops at the decision: no token refresh, no
+                # quarantine writes — freshening is a mutation.
+                return self._perform(num, email, trigger)
+            status = self._freshen_target(num, email)
+            if status == "invalid_grant":
+                self._quarantine(num, email, "invalid_grant")
+                continue
+            if status == "transient":
+                transient_failure = True
+                continue
+            if status == "skip-live-session":
+                continue
+            return self._perform(num, email, trigger)
+
+        if transient_failure:
+            self._emit(
+                ErrorEvent(
+                    message="could not freshen any candidate (network?)",
+                    transient=True,
+                )
+            )
+            return TickOutcome.ERROR
+        self._emit(NoSwitchEvent(reason="no-viable-target"))
+        return TickOutcome.BLOCKED
+
+    def _perform(self, number: str, email: str, trigger: str) -> TickOutcome:
+        if self.dry_run:
+            current = self.switcher.current_account_number()
+            current_email = self.switcher.account_email(current) if current else ""
+            self._emit(
+                SwitchEvent(
+                    trigger=trigger,
+                    from_ref=_ref(current, current_email) if current else None,
+                    to_ref=_ref(number, email),
+                    dry_run=True,
+                )
+            )
+            return TickOutcome.SWITCHED
+
+        # Hold the state lock across the whole recheck -> switch -> record
+        # sequence so two concurrent engines (loop + cron --once) make one
+        # serialized decision: the loser re-reads the winner's lastSwitchAt
+        # and backs off instead of double-switching. No deadlock cycle: the
+        # switch path (cswap FileLock + Claude Code locks) never takes the
+        # state lock.
+        with self._state_lock():
+            state = self._read_state()
+            if trigger == "proactive" and self._in_cooldown(state):
+                self._emit(NoSwitchEvent(reason="cooldown"))
+                return TickOutcome.NO_ACTION
+
+            result = self.switcher.switch_to(number, json_output=True)
+            if not result or not result.get("switched"):
+                self._emit(
+                    NoSwitchEvent(
+                        reason="already-active",
+                        detail=(result or {}).get("reason", ""),
+                    )
+                )
+                return TickOutcome.NO_ACTION
+
+            state["schemaVersion"] = STATE_SCHEMA_VERSION
+            state["lastSwitchAt"] = self.clock()
+            state["lastSwitchTo"] = number
+            atomic_write_json(self.state_path, state)
+
+        self._emit(
+            SwitchEvent(
+                trigger=trigger,
+                from_ref=result.get("from"),
+                to_ref=result.get("to"),
+                warnings=result.get("warnings", []),
+            )
+        )
+        return TickOutcome.SWITCHED
+
+    # -- helpers --------------------------------------------------------------
+
+    def _in_cooldown(self, state: dict) -> bool:
+        last = state.get("lastSwitchAt")
+        if not isinstance(last, (int, float)):
+            return False
+        return (self.clock() - last) < self.settings.cooldown_seconds
+
+    @staticmethod
+    def _earliest_reset(usage: dict[str, dict | str | None]) -> datetime | None:
+        """Earliest known window reset across all accounts (UTC)."""
+        earliest: datetime | None = None
+        for entry in usage.values():
+            if not isinstance(entry, dict):
+                continue
+            for window in ("five_hour", "seven_day"):
+                resets_at = (entry.get(window) or {}).get("resets_at")
+                if not resets_at:
+                    continue
+                try:
+                    when = datetime.fromisoformat(str(resets_at).replace("Z", "+00:00"))
+                except ValueError:
+                    continue
+                if earliest is None or when < earliest:
+                    earliest = when
+        return earliest
+
+    def _emit(self, event: AutoSwitchEvent) -> None:
+        self.on_event(event)
+
+    # -- loop -------------------------------------------------------------------
+
+    def stop(self) -> None:
+        """Ask ``run_loop`` to exit; wakes it from any sleep."""
+        self._stop.set()
+
+    def _next_delay(self, outcome: TickOutcome) -> float:
+        interval = self.settings.interval_seconds
+        if outcome is TickOutcome.BLOCKED:
+            if self._sleep_until_ts is not None:
+                delay = self._sleep_until_ts - self.clock()
+                return min(max(delay, interval), MAX_SLEEP_S)
+            if self._blocked_wait_long:
+                # Truly exhausted with no reset time known / no candidates.
+                return max(interval, NO_RESET_FALLBACK_S)
+            # Blocked on something that can resolve any tick (hysteresis,
+            # unreadable usage) — keep the normal cadence so the at-limit
+            # escape isn't missed.
+        # ±10% jitter so multiple machines don't synchronize their API hits.
+        return interval * (0.9 + 0.2 * random.random())
+
+    def run_loop(self) -> int:
+        """Tick forever (until :meth:`stop`); a failing tick never kills it."""
+        self._stop.clear()
+        while not self._stop.is_set():
+            try:
+                outcome = self.tick()
+            except Exception as e:  # pragma: no cover - tick() already guards
+                self._emit(
+                    ErrorEvent(message=f"{type(e).__name__}: {e}", transient=True)
+                )
+                outcome = TickOutcome.ERROR
+            delay = self._next_delay(outcome)
+            if delay > self.settings.interval_seconds * 1.5:
+                until = datetime.now(timezone.utc) + timedelta(seconds=delay)
+                self._emit(
+                    SleepEvent(
+                        seconds=delay,
+                        until=until.isoformat(timespec="seconds").replace(
+                            "+00:00", "Z"
+                        ),
+                    )
+                )
+            self._stop.wait(delay)
+        return 0

--- a/src/claude_swap/claude_locks.py
+++ b/src/claude_swap/claude_locks.py
@@ -1,0 +1,147 @@
+"""Cooperate with Claude Code's own advisory locks while mutating its files.
+
+Claude Code guards its OAuth token refresh with the npm ``proper-lockfile``
+package on the config home directory, and its ``~/.claude.json`` writes with
+the same mechanism on the config file. The protocol:
+
+- The lock artifact is a **directory** at ``<target>.lock`` (``~/.claude.lock``,
+  ``~/.claude.json.lock``); ``mkdir`` atomicity is the mutex.
+- A lock is considered stale when its mtime is older than 10s; live holders
+  touch the mtime every 5s to prove liveness, and a stale lock may be removed
+  and taken over.
+- Claude Code retries a held credentials lock 5 times with 1-2s jittered
+  sleeps before giving up, so briefly holding it is fully cooperative.
+
+Holding these locks while swapping credentials closes the one real race with a
+running Claude Code: its refresh reads credentials, refreshes over the network,
+and saves — all under ``~/.claude.lock`` — so a swap landing inside that window
+would be overwritten by the refreshed old-account token (and the just-taken
+backup would keep a pre-rotation refresh token). Under the lock, Claude Code's
+own double-checked re-read sees the swapped (non-expired) credential and aborts
+the refresh instead.
+
+References (claude-code source): utils/auth.ts checkAndRefreshOAuthTokenIfNeededImpl,
+utils/config.ts saveConfigWithLock, utils/lockfile.ts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from claude_swap.exceptions import ClaudeCodeLockTimeout
+from claude_swap.paths import get_claude_config_home, get_global_config_path
+
+# proper-lockfile defaults claude-code runs with: stale after 10s, holder
+# touches every stale/2 = 5s. We touch a little faster for margin.
+STALENESS_S = 10.0
+TOUCH_INTERVAL_S = 3.0
+# Claude Code holds the credentials lock for one token-endpoint round trip
+# (sub-second to a few seconds); its config lock for a local RMW. 9s of
+# bounded waiting comfortably outlasts both without stalling the CLI forever.
+DEFAULT_TIMEOUT_S = 9.0
+
+_logger = logging.getLogger("claude-swap")
+
+
+def credentials_lock_dir() -> Path:
+    """Lock directory guarding the OAuth credential store (``~/.claude.lock``)."""
+    home = get_claude_config_home()
+    return home.parent / (home.name + ".lock")
+
+
+def config_lock_dir() -> Path:
+    """Lock directory guarding the global config file (``~/.claude.json.lock``)."""
+    path = get_global_config_path()
+    return path.parent / (path.name + ".lock")
+
+
+@contextmanager
+def proper_lockfile(
+    lock_dir: Path,
+    *,
+    timeout: float | None = None,
+    staleness: float = STALENESS_S,
+):
+    """Acquire a proper-lockfile-compatible directory lock.
+
+    Blocks up to ``timeout`` seconds (default ``DEFAULT_TIMEOUT_S``, resolved
+    at call time so tests can shorten it), taking over locks whose mtime is
+    older than ``staleness``, touches the directory mtime while held so other
+    holders don't deem us stale, and removes it on exit.
+
+    Raises:
+        ClaudeCodeLockTimeout: The lock stayed held past ``timeout``.
+    """
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT_S
+    lock_dir.parent.mkdir(parents=True, exist_ok=True)
+    start = time.monotonic()
+    while True:
+        try:
+            os.mkdir(lock_dir)
+            break
+        except FileExistsError:
+            pass
+        if time.monotonic() - start > timeout:
+            raise ClaudeCodeLockTimeout(
+                f"Could not acquire {lock_dir.name} — Claude Code appears "
+                "to be refreshing credentials. Retry in a few seconds."
+            )
+        try:
+            held_mtime = os.stat(lock_dir).st_mtime
+        except FileNotFoundError:
+            continue  # holder released between mkdir and stat; retry now
+        if time.time() - held_mtime > staleness:
+            # Dead holder per the protocol: remove and retake. Losing the
+            # rmdir/mkdir race to another waiter just means looping again.
+            try:
+                os.rmdir(lock_dir)
+            except OSError:
+                time.sleep(0.05)  # can't remove it either; don't spin hot
+            continue
+        time.sleep(0.25 + random.random() * 0.25)
+
+    stop_touching = threading.Event()
+
+    def _touch() -> None:
+        while not stop_touching.wait(TOUCH_INTERVAL_S):
+            try:
+                os.utime(lock_dir)
+            except OSError:
+                return  # lock stolen/removed; nothing left to keep alive
+
+    toucher = threading.Thread(target=_touch, daemon=True)
+    toucher.start()
+    try:
+        yield
+    finally:
+        stop_touching.set()
+        toucher.join(timeout=1.0)
+        try:
+            os.rmdir(lock_dir)
+        except FileNotFoundError:
+            _logger.warning(
+                "Lock %s vanished while held (taken over as stale?)", lock_dir
+            )
+        except OSError as e:
+            _logger.warning("Failed to release lock %s: %s", lock_dir, e)
+
+
+@contextmanager
+def claude_credentials_lock(*, timeout: float | None = None):
+    """Hold Claude Code's credential-refresh lock (``~/.claude.lock``)."""
+    with proper_lockfile(credentials_lock_dir(), timeout=timeout):
+        yield
+
+
+@contextmanager
+def claude_config_lock(*, timeout: float | None = None):
+    """Hold Claude Code's global-config write lock (``~/.claude.json.lock``)."""
+    with proper_lockfile(config_lock_dir(), timeout=timeout):
+        yield

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -108,6 +108,157 @@ Examples:
         sys.exit(130)
 
 
+def _auto_command(argv: list[str]) -> None:
+    """Handle `cswap auto [--once] [--json] [...]`.
+
+    Pre-dispatched before the main parser is built, like `run` (and with the
+    same limitation: `auto` must be the first argument). Runs the auto-switch
+    engine — a foreground loop by default, or a single evaluate-and-maybe-
+    switch tick with --once whose exit code reports the outcome (for cron/
+    systemd timers): 0 switched, 1 error, 2 no action needed, 3 blocked
+    (no viable target / all accounts exhausted).
+    """
+    import signal
+    import time as _time
+
+    parser = argparse.ArgumentParser(
+        prog="cswap auto",
+        description=(
+            "Automatically switch accounts when the active one nears its "
+            "5h/7d rate limit. Runs a foreground polling loop; use --once "
+            "for a single tick (cron-friendly)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Exit codes with --once:
+  0  switched to another account
+  1  error (network trouble, lock contention, ...)
+  2  no action needed
+  3  blocked: wanted to switch but no viable target / all exhausted
+
+Examples:
+  cswap auto                       # foreground loop, switch at 90%% used
+  cswap auto --threshold 80        # switch earlier
+  cswap auto --json                # one JSON event per line (for scripts)
+  cswap auto --once; echo $?       # single tick, outcome in exit code
+  cswap auto --dry-run             # log decisions, never actually switch
+
+Defaults live in settings.json in the backup root; flags override them.
+        """,
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Evaluate once, maybe switch, and exit (exit code = outcome)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit one machine-readable JSON event per line on stdout",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        metavar="SECONDS",
+        help="Poll interval in loop mode (min 15; default 60)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        metavar="PCT",
+        help=(
+            "Switch when the active account's binding 5h/7d window reaches "
+            "this utilization (50-99.9; default 90)"
+        ),
+    )
+    parser.add_argument(
+        "--cooldown",
+        type=float,
+        metavar="SECONDS",
+        help="Minimum time between proactive switches (default 300)",
+    )
+    parser.add_argument(
+        "--include-api-key-accounts",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Allow switching onto managed API-key accounts as a last resort "
+            "(they bill per token; default: excluded)"
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Evaluate and report, but never switch or write state",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args(argv)
+
+    from claude_swap.autoswitch import AutoSwitchEngine, AutoSwitchEvent
+    from claude_swap.printer import accent, yellowed
+    from claude_swap.settings import load_settings, merged_with_cli
+
+    def jsonl_emit(event: AutoSwitchEvent) -> None:
+        print(json.dumps(event.to_json()), flush=True)
+
+    def human_emit(event: AutoSwitchEvent) -> None:
+        stamp = _time.strftime("%H:%M:%S")
+        line = event.human()
+        if event.kind == "switch":
+            line = accent(line)
+        elif event.kind in ("error", "account-quarantined"):
+            line = yellowed(line)
+        elif event.kind in ("poll", "no-switch", "sleep"):
+            line = dimmed(line)
+        print(f"{stamp}  {line}", flush=True)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        if sys.platform != "win32":
+            if os.geteuid() == 0 and not switcher._is_running_in_container():
+                error("Error: Do not run this script as root (unless running in a container)")
+                sys.exit(1)
+
+        settings = merged_with_cli(load_settings(switcher.backup_dir), args)
+        engine = AutoSwitchEngine(
+            switcher,
+            settings,
+            jsonl_emit if args.json else human_emit,
+            dry_run=args.dry_run,
+        )
+
+        if args.once:
+            sys.exit(engine.tick().value)
+
+        # Loop mode: SIGTERM (systemd stop) exits the loop cleanly.
+        signal.signal(signal.SIGTERM, lambda *_: engine.stop())
+        if not args.json:
+            print(
+                dimmed(
+                    f"Auto-switch running: threshold {settings.threshold:.0f}%, "
+                    f"every {settings.interval_seconds:.0f}s"
+                    f"{' (dry-run)' if args.dry_run else ''} — Ctrl-C to stop"
+                )
+            )
+        sys.exit(engine.run_loop())
+    except ClaudeSwitchError as e:
+        if args.json:
+            print(json.dumps(error_envelope(e)))
+        else:
+            error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(
+            f"\n{dimmed('Auto-switch stopped')}",
+            file=sys.stderr if args.json else sys.stdout,
+        )
+        sys.exit(130)
+
+
 def _use_native_tls() -> None:
     """Route TLS trust decisions through the OS-native verifier.
 
@@ -139,6 +290,9 @@ def main() -> None:
     if len(sys.argv) > 1 and sys.argv[1] == "run":
         _run_command(sys.argv[2:])
         return  # only reachable in tests where exec/exit is mocked
+    if len(sys.argv) > 1 and sys.argv[1] == "auto":
+        _auto_command(sys.argv[2:])
+        return  # only reachable in tests where sys.exit is mocked
 
     parser = argparse.ArgumentParser(
         description="Multi-Account Switcher for Claude Code",
@@ -159,6 +313,8 @@ Examples:
   %(prog)s --switch-to user@example.com
   %(prog)s run 2                            # run account 2 in this terminal only
   %(prog)s run 2 -- --resume                # forward args after '--' to claude
+  %(prog)s auto                             # auto-switch when nearing rate limits
+  %(prog)s auto --once                      # single auto-switch tick (cron-friendly)
   %(prog)s --remove-account user@example.com
   %(prog)s --status
   %(prog)s --purge

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -49,6 +49,17 @@ class LockError(ClaudeSwitchError):
     pass
 
 
+class ClaudeCodeLockTimeout(LockError):
+    """Timed out acquiring one of Claude Code's own advisory locks.
+
+    Raised when ``~/.claude.lock`` / ``~/.claude.json.lock`` stays held past
+    our bounded wait — usually Claude Code mid-token-refresh. Nothing has been
+    mutated when this raises; the operation is safe to retry.
+    """
+
+    pass
+
+
 class AccountNotFoundError(ClaudeSwitchError):
     """Account not found."""
 

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -7,6 +7,7 @@ import logging
 import urllib.error
 import urllib.request
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from claude_swap.printer import warning as print_warning
@@ -47,21 +48,41 @@ def is_oauth_token_expired(expires_at: object) -> bool:
     return now_ms + OAUTH_EXPIRY_BUFFER_MS >= int(expires_at)
 
 
-def refresh_oauth_credentials(credentials: str) -> str | None:
+@dataclass(frozen=True)
+class RefreshOutcome:
+    """Result of a refresh-token grant attempt.
+
+    ``credentials`` is the full rotated credentials JSON on success, else None.
+    ``error`` classifies failures so callers can distinguish a dead refresh-token
+    lineage (permanent: quarantine, stop retrying) from a network blip
+    (transient: retry later):
+
+    - ``None`` — success (``credentials`` is set)
+    - ``"invalid_grant"`` — the token endpoint rejected the grant; this refresh
+      token is dead and re-login is required
+    - ``"no_refresh_token"`` — the stored credential carries no usable refresh
+      token (also permanent for retry purposes)
+    - ``"transient"`` — network/server error; the token may still be valid
+    """
+
+    credentials: str | None
+    error: str | None
+
+
+def try_refresh_oauth_credentials(credentials: str) -> RefreshOutcome:
     """Refresh an OAuth access token via direct token endpoint POST."""
     try:
         data = json.loads(credentials)
-        oauth = data.get("claudeAiOauth")
-        if not isinstance(oauth, dict):
-            return None
+    except json.JSONDecodeError:
+        return RefreshOutcome(None, "no_refresh_token")
+    oauth = data.get("claudeAiOauth") if isinstance(data, dict) else None
+    if not isinstance(oauth, dict) or not oauth.get("refreshToken"):
+        return RefreshOutcome(None, "no_refresh_token")
 
-        refresh_token = oauth.get("refreshToken")
-        if not refresh_token:
-            return None
-
+    try:
         body = json.dumps({
             "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
+            "refresh_token": oauth["refreshToken"],
             "client_id": OAUTH_CLIENT_ID,
         }).encode()
 
@@ -86,14 +107,27 @@ def refresh_oauth_credentials(credentials: str) -> str | None:
             oauth["scopes"] = resp_data["scope"].split()
 
         data["claudeAiOauth"] = oauth
-        return json.dumps(data)
+        return RefreshOutcome(json.dumps(data), None)
     except urllib.error.HTTPError as e:
         body = e.read().decode(errors="replace") if hasattr(e, "read") else ""
         _logger.debug("OAuth refresh failed: %r, body: %s", e, body[:500])
-        return None
+        # Permanent only when the server itself rejected the grant: a 4xx AND
+        # an explicit marker in the body. Anything ambiguous stays transient —
+        # a misclassified transient costs one retry, a misclassified permanent
+        # would wrongly quarantine a live token.
+        if e.code in (400, 401, 403) and (
+            "invalid_grant" in body or "invalid_client" in body
+        ):
+            return RefreshOutcome(None, "invalid_grant")
+        return RefreshOutcome(None, "transient")
     except Exception as e:
         _logger.debug("OAuth refresh failed: %r", e)
-        return None
+        return RefreshOutcome(None, "transient")
+
+
+def refresh_oauth_credentials(credentials: str) -> str | None:
+    """Refresh an OAuth access token; None on any failure (see RefreshOutcome)."""
+    return try_refresh_oauth_credentials(credentials).credentials
 
 
 

--- a/src/claude_swap/printer.py
+++ b/src/claude_swap/printer.py
@@ -123,6 +123,11 @@ def bold_accent(text: str) -> str:
     return _style(text, _BOLD, _ACCENT)
 
 
+def yellowed(text: str) -> str:
+    """Yellow for warning-toned text (string form; ``warning()`` prints)."""
+    return _style(text, _YELLOW)
+
+
 # --- Line printers (call print() internally) ---
 
 

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -1,0 +1,185 @@
+"""Tool settings persisted at ``<backup_root>/settings.json``.
+
+One versioned JSON file for user-tunable claude-swap preferences, written
+atomically with the backup dir's 0600/0700 modes. v1 carries only the
+``autoswitch`` section; other sections can be added additively. Unknown keys
+(future fields, other tools' experiments) survive a round trip.
+
+Reading is forgiving — a missing or corrupt file yields defaults with a logged
+warning, never a crash — so a bad hand edit degrades to default behavior.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+SETTINGS_SCHEMA_VERSION = 1
+SETTINGS_FILENAME = "settings.json"
+
+_logger = logging.getLogger("claude-swap")
+
+
+@dataclass(frozen=True)
+class AutoSwitchSettings:
+    """Policy knobs for the auto-switch engine (``cswap auto``).
+
+    ``threshold`` is binding-window utilization (max of the 5h/7d percentages):
+    at or above it the engine looks for a better account. 90 rather than 95
+    leaves margin for the macOS ~30s Keychain pickup tail and for heavy
+    subagent turns burning past the mark before a swap lands. A candidate only
+    qualifies while its own utilization sits at least ``hysteresis_pct`` below
+    the threshold, so two accounts hovering at the line never ping-pong.
+    """
+
+    threshold: float = 90.0
+    interval_seconds: float = 60.0
+    cooldown_seconds: float = 300.0
+    hysteresis_pct: float = 10.0
+    strategy: str = "best"  # reserved for future strategies; only "best" in v1
+    include_api_key_accounts: bool = False
+    unhealthy_ticks: int = 3
+
+
+# settings.json uses camelCase (matching the repo's other JSON artifacts);
+# dataclass fields stay snake_case.
+_AUTOSWITCH_KEYS: dict[str, str] = {
+    "threshold": "threshold",
+    "interval_seconds": "intervalSeconds",
+    "cooldown_seconds": "cooldownSeconds",
+    "hysteresis_pct": "hysteresisPct",
+    "strategy": "strategy",
+    "include_api_key_accounts": "includeApiKeyAccounts",
+    "unhealthy_ticks": "unhealthyTicks",
+}
+
+
+def settings_path(backup_root: Path) -> Path:
+    return backup_root / SETTINGS_FILENAME
+
+
+def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:
+    """Clamp values into sane ranges; fall back to the default on bad types."""
+    defaults = AutoSwitchSettings()
+
+    def num(value, default: float, lo: float, hi: float) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return default
+        return float(min(max(value, lo), hi))
+
+    strategy = settings.strategy if settings.strategy == "best" else defaults.strategy
+    if strategy != settings.strategy:
+        _logger.warning(
+            "settings.json: unsupported autoswitch strategy %r; using 'best'",
+            settings.strategy,
+        )
+    return AutoSwitchSettings(
+        threshold=num(settings.threshold, defaults.threshold, 50.0, 99.9),
+        interval_seconds=num(
+            settings.interval_seconds, defaults.interval_seconds, 15.0, 3600.0
+        ),
+        cooldown_seconds=num(
+            settings.cooldown_seconds, defaults.cooldown_seconds, 0.0, 86400.0
+        ),
+        hysteresis_pct=num(settings.hysteresis_pct, defaults.hysteresis_pct, 0.0, 50.0),
+        strategy=strategy,
+        include_api_key_accounts=bool(settings.include_api_key_accounts),
+        unhealthy_ticks=int(
+            num(settings.unhealthy_ticks, defaults.unhealthy_ticks, 1, 100)
+        ),
+    )
+
+
+def _read_raw(path: Path) -> dict:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        _logger.warning("Could not read %s (%s); using defaults", path, e)
+        return {}
+    if not isinstance(raw, dict):
+        _logger.warning("%s is not a JSON object; using defaults", path)
+        return {}
+    return raw
+
+
+def load_settings(backup_root: Path) -> AutoSwitchSettings:
+    """Load the autoswitch section; missing/corrupt file or fields → defaults."""
+    raw = _read_raw(settings_path(backup_root))
+    section = raw.get("autoswitch")
+    if not isinstance(section, dict):
+        return AutoSwitchSettings()
+    kwargs = {}
+    for field, json_key in _AUTOSWITCH_KEYS.items():
+        if json_key in section:
+            kwargs[field] = section[json_key]
+    try:
+        settings = AutoSwitchSettings(**kwargs)
+    except TypeError:
+        settings = AutoSwitchSettings()
+    return _clamped(settings)
+
+
+def save_settings(backup_root: Path, settings: AutoSwitchSettings) -> None:
+    """Write the autoswitch section, preserving unknown keys and sections."""
+    path = settings_path(backup_root)
+    raw = _read_raw(path)
+    raw["schemaVersion"] = raw.get("schemaVersion", SETTINGS_SCHEMA_VERSION)
+    section = raw.get("autoswitch")
+    if not isinstance(section, dict):
+        section = {}
+    for field, json_key in _AUTOSWITCH_KEYS.items():
+        section[json_key] = getattr(settings, field)
+    raw["autoswitch"] = section
+    atomic_write_json(path, raw)
+
+
+def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
+    """Overlay non-None CLI overrides (argparse Namespace) onto settings."""
+    overrides = {}
+    for attr, field in (
+        ("threshold", "threshold"),
+        ("interval", "interval_seconds"),
+        ("cooldown", "cooldown_seconds"),
+        ("include_api_key_accounts", "include_api_key_accounts"),
+    ):
+        value = getattr(args, attr, None)
+        if value is not None:
+            overrides[field] = value
+    if not overrides:
+        return settings
+    return _clamped(dataclasses.replace(settings, **overrides))
+
+
+def atomic_write_json(path: Path, data: dict) -> None:
+    """Atomically write JSON with the backup dir's 0600/0700 modes.
+
+    Shared by settings.json and the autoswitch state file (and any future
+    machine-local state files beside them).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "win32":
+        os.chmod(path.parent, 0o700)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
+        os.close(fd)
+        fd = -1
+        os.replace(tmp_path, str(path))
+        if sys.platform != "win32":
+            os.chmod(str(path), 0o600)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -23,6 +23,7 @@ from claude_swap.exceptions import (
 )
 from claude_swap import oauth
 from claude_swap.cache import MISSING, read_cache, write_cache
+from claude_swap.claude_locks import claude_config_lock, claude_credentials_lock
 from claude_swap.json_output import (
     SCHEMA_VERSION,
     USAGE_API_KEY,
@@ -456,6 +457,67 @@ class ClaudeAccountSwitcher:
     def read_account_config(self, account_num: str, email: str) -> str:
         """Public wrapper for session bootstrap. Empty string when missing."""
         return self._read_account_config(account_num, email)
+
+    # -- public accessors for the auto-switch engine -----------------------
+
+    def usage_by_account(self) -> dict[str, dict | str | None]:
+        """Public wrapper: account number → usage entry (cache-first)."""
+        return self._usage_by_account()
+
+    def switchable_account_numbers(self) -> list[str]:
+        """Account numbers in rotation order that have usable stored backups."""
+        data = self._get_sequence_data() or {}
+        return [
+            str(num)
+            for num in data.get("sequence", [])
+            if self._account_is_switchable(str(num))
+        ]
+
+    def account_kind_for(self, account_num: str) -> str:
+        """Public wrapper: ``"api_key"`` or ``"oauth"`` (setup-tokens read as oauth)."""
+        return self._account_kind(account_num)
+
+    def account_email(self, account_num: str) -> str:
+        """Stored email for a slot; empty string when unknown."""
+        data = self._get_sequence_data() or {}
+        return data.get("accounts", {}).get(str(account_num), {}).get("email", "")
+
+    def current_account_number(self) -> str | None:
+        """Slot of the live login; ``None`` when there is none or it's unmanaged.
+
+        Deliberately no fallback to the recorded ``activeAccountNumber``: an
+        unmanaged live login must return ``None`` — never a guessed slot — so
+        the auto-switch engine can't evaluate the wrong account's usage and
+        overwrite a login cswap doesn't own (``_perform_switch`` would take
+        the no-backup direct-activation path). Use :meth:`has_live_login` to
+        tell the two ``None`` cases apart.
+        """
+        identity = self._get_current_account()
+        if identity is None:
+            return None
+        data = self._get_sequence_data() or {}
+        email, org_uuid = identity
+        return self._find_account_slot(data, email, org_uuid)
+
+    def has_live_login(self) -> bool:
+        """Whether ``~/.claude.json`` carries any live account identity."""
+        return self._get_current_account() is not None
+
+    def live_session_pids_for(self, account_num: str, email: str) -> list[int]:
+        """Public wrapper: PIDs of live ``cswap run`` sessions for a slot."""
+        return self._live_session_pids(account_num, email)
+
+    def persist_backup_credentials(
+        self, account_num: str, email: str, credentials: str
+    ) -> None:
+        """Persist rotated credentials to a slot's backup store, under the lock.
+
+        For inactive accounts only — never routes to the active store. Mirrors
+        the persist callback ``_collect_usage`` uses. The caller must NOT hold
+        ``self.lock_file`` (FileLock is non-reentrant).
+        """
+        with FileLock(self.lock_file):
+            self._write_account_credentials(account_num, email, credentials)
 
     # -- session profile lifecycle ----------------------------------------
 
@@ -1276,36 +1338,49 @@ class ClaudeAccountSwitcher:
 
         def persist_active(num: str, acct_email: str, new_creds: str) -> None:
             nonlocal persist_skipped
-            with FileLock(self.lock_file):
-                live = self._read_credentials() or ""
-                live_oauth = oauth.extract_oauth_data(live) if live else None
-                live_refresh = live_oauth.get("refreshToken") if live_oauth else None
-                # Re-check owners + refresh-token lineage under the lock. If a Claude
-                # Code / session appeared, or an external write (e.g. a user /login)
-                # replaced the credential since we read it, skip rather than clobber a
-                # live process's newer credential. Best effort, not perfectly atomic.
-                if (
-                    self._active_cc_running()
-                    or self._live_session_pids(num, acct_email)
-                    or live_refresh != original_refresh
+            # Failing to acquire any lock means the rotated credential was NOT
+            # persisted — mark it skipped (never show usage for it) before the
+            # error propagates to oauth._persist's warning path. The Claude
+            # Code locks matter here too: _write_credentials touches the
+            # active store and (via _clear_managed_key) possibly ~/.claude.json,
+            # and holding them closes the owner-check-to-write gap.
+            try:
+                with (
+                    FileLock(self.lock_file),
+                    claude_credentials_lock(),
+                    claude_config_lock(),
                 ):
-                    persist_skipped = True
-                    self._logger.warning(
-                        "Active-account refresh for %s (%s): owner appeared or refresh "
-                        "token changed mid-refresh; discarding rotated credential.",
-                        num, acct_email,
+                    live = self._read_credentials() or ""
+                    live_oauth = oauth.extract_oauth_data(live) if live else None
+                    live_refresh = (
+                        live_oauth.get("refreshToken") if live_oauth else None
                     )
-                    return
-                # A write failure leaves the live store holding the now-consumed
-                # original refresh token, so mark the persist as skipped (never show
-                # usage for it) and re-raise — oauth._persist swallows the exception
-                # but logs its "failed to persist" warning first.
-                try:
+                    # Re-check owners + refresh-token lineage under the lock. If a Claude
+                    # Code / session appeared, or an external write (e.g. a user /login)
+                    # replaced the credential since we read it, skip rather than clobber a
+                    # live process's newer credential. Best effort, not perfectly atomic.
+                    if (
+                        self._active_cc_running()
+                        or self._live_session_pids(num, acct_email)
+                        or live_refresh != original_refresh
+                    ):
+                        persist_skipped = True
+                        self._logger.warning(
+                            "Active-account refresh for %s (%s): owner appeared or refresh "
+                            "token changed mid-refresh; discarding rotated credential.",
+                            num, acct_email,
+                        )
+                        return
+                    # A write failure leaves the live store holding the now-consumed
+                    # original refresh token, so mark the persist as skipped (never show
+                    # usage for it) and re-raise — oauth._persist swallows the exception
+                    # but logs its "failed to persist" warning first.
                     self._write_credentials(new_creds)  # active store — Claude Code reads this
                     self._write_account_credentials(num, acct_email, new_creds)  # backup in sync
-                except Exception:
+            except Exception:
+                if not persist_skipped:
                     persist_skipped = True
-                    raise
+                raise
 
         usage = oauth.fetch_usage_for_account(
             account_num, email, creds,
@@ -2216,7 +2291,15 @@ class ClaudeAccountSwitcher:
                 else:
                     warnings_out.append(msg)
 
-        with FileLock(self.lock_file):
+        # Beyond cswap's own lock, hold Claude Code's advisory locks for the
+        # whole mutation (including rollback paths): its token refresh runs
+        # under ~/.claude.lock and re-reads credentials there — holding it
+        # means a mid-refresh Claude Code either finishes before our swap
+        # (backup captures the rotated token) or re-checks after it and aborts.
+        # ~/.claude.json.lock likewise keeps the oauthAccount splice from
+        # interleaving with Claude Code's own config writes. Everything under
+        # here is local I/O — no network while locks are held.
+        with FileLock(self.lock_file), claude_credentials_lock(), claude_config_lock():
             data = self._get_sequence_data()
             active_account = data.get("activeAccountNumber")
             current_account = str(active_account) if active_account is not None else None

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -1,0 +1,695 @@
+"""Tests for the auto-switch engine (autoswitch.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import oauth
+from claude_swap.autoswitch import (
+    AllExhaustedEvent,
+    AutoSwitchEngine,
+    ErrorEvent,
+    NoSwitchEvent,
+    PollEvent,
+    QuarantineEvent,
+    SwitchEvent,
+    TickOutcome,
+    UnquarantineEvent,
+)
+from claude_swap.models import Platform
+from claude_swap.settings import AutoSwitchSettings
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class FakeClock:
+    def __init__(self, now: float = 1_000_000.0):
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _usage(pct: float, resets_at: str | None = None) -> dict:
+    window: dict = {"pct": pct}
+    if resets_at:
+        window["resets_at"] = resets_at
+    return {"five_hour": window, "seven_day": {"pct": 0.0}}
+
+
+class EngineHarness:
+    """Seeded switcher + engine + captured events, on the Linux file backend."""
+
+    def __init__(self, temp_home: Path, **settings_kwargs):
+        self.temp_home = temp_home
+        self.switcher = ClaudeAccountSwitcher()
+        self.switcher.platform = Platform.LINUX
+        self.switcher._setup_directories()
+        self.switcher._init_sequence_file()
+        self.settings = AutoSwitchSettings(**settings_kwargs)
+        self.events: list = []
+        self.clock = FakeClock()
+        self.engine = self._make_engine()
+
+    def _make_engine(self, **kwargs) -> AutoSwitchEngine:
+        return AutoSwitchEngine(
+            self.switcher,
+            self.settings,
+            self.events.append,
+            clock=self.clock,
+            **kwargs,
+        )
+
+    def seed(self, num: int, email: str, *, expires_at: int | None = None) -> None:
+        oauth_blob: dict = {
+            "accessToken": f"sk-{num}",
+            "refreshToken": f"rt-{num}",
+        }
+        if expires_at is not None:
+            oauth_blob["expiresAt"] = expires_at
+        self.switcher._write_account_credentials(
+            str(num), email, json.dumps({"claudeAiOauth": oauth_blob})
+        )
+        self.switcher._write_account_config(
+            str(num),
+            email,
+            json.dumps({
+                "oauthAccount": {"emailAddress": email, "accountUuid": f"uuid-{num}"},
+            }),
+        )
+        data = self.switcher._get_sequence_data()
+        data["accounts"][str(num)] = {
+            "email": email,
+            "uuid": f"uuid-{num}",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+            data["sequence"].sort()
+        if data["activeAccountNumber"] is None:
+            data["activeAccountNumber"] = num
+        self.switcher._write_json(self.switcher.sequence_file, data)
+
+    def make_live(self, email: str, num: int) -> None:
+        (self.temp_home / ".claude" / ".credentials.json").write_text(json.dumps({
+            "claudeAiOauth": {"accessToken": "sk-live", "refreshToken": "rt-live"},
+        }))
+        (self.temp_home / ".claude.json").write_text(json.dumps({
+            "oauthAccount": {"emailAddress": email, "accountUuid": f"uuid-{num}"},
+        }))
+
+    def tick_with_usage(self, usage: dict) -> TickOutcome:
+        with patch.object(self.switcher, "_usage_by_account", return_value=usage):
+            return self.engine.tick()
+
+    def active_number(self) -> int | None:
+        return self.switcher._get_sequence_data()["activeAccountNumber"]
+
+    def kinds(self) -> list[str]:
+        return [e.kind for e in self.events]
+
+    def state(self) -> dict:
+        path = self.switcher.backup_dir / "autoswitch_state.json"
+        if not path.exists():
+            return {}
+        return json.loads(path.read_text())
+
+
+@pytest.fixture
+def harness(temp_home: Path) -> EngineHarness:
+    h = EngineHarness(temp_home)
+    h.seed(1, "a@example.com")
+    h.seed(2, "b@example.com")
+    h.seed(3, "c@example.com")
+    h.make_live("a@example.com", 1)
+    return h
+
+
+class TestDecisionTable:
+    def test_below_threshold_is_no_action(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _usage(50), "2": _usage(10), "3": _usage(10),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert harness.active_number() == 1
+        reasons = [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
+
+    def test_over_threshold_switches_to_max_headroom(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _usage(95), "2": _usage(40), "3": _usage(20),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3
+        switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "proactive"
+        assert switch.to_ref == {"number": 3, "email": "c@example.com"}
+        assert harness.state()["lastSwitchTo"] == "3"
+
+    def test_no_active_account(self, temp_home):
+        h = EngineHarness(temp_home)
+        assert h.engine.tick() is TickOutcome.NO_ACTION
+        assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
+            "no-active-account"
+        ]
+
+    def test_hysteresis_bar_blocks_marginal_candidates(self, harness):
+        # threshold 90, hysteresis 10 → candidates must sit at <= 80% used.
+        # Failing the bar is NOT exhaustion: no all-exhausted event, no
+        # reset-sleep — the next tick must stay at normal cadence so the
+        # at-limit escape isn't missed when the active account tops out.
+        outcome = harness.tick_with_usage({
+            "1": _usage(95), "2": _usage(85), "3": _usage(88),
+        })
+        assert outcome is TickOutcome.BLOCKED
+        assert harness.active_number() == 1
+        assert not any(isinstance(e, AllExhaustedEvent) for e in harness.events)
+        reasons = [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["no-qualifying-candidate"]
+        assert harness.engine._sleep_until_ts is None
+        delay = harness.engine._next_delay(outcome)
+        assert delay <= 1.1 * harness.settings.interval_seconds
+
+    def test_mixed_unknown_and_exhausted_is_not_all_exhausted(self, harness):
+        # One candidate at its limit, the other unreadable this tick: usage
+        # could recover any moment, so no long reset-sleep.
+        outcome = harness.tick_with_usage({
+            "1": _usage(95),
+            "2": _usage(100, "2026-07-03T12:00:00Z"),
+            "3": None,
+        })
+        assert outcome is TickOutcome.BLOCKED
+        assert not any(isinstance(e, AllExhaustedEvent) for e in harness.events)
+        reasons = [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["no-qualifying-candidate"]
+        assert harness.engine._sleep_until_ts is None
+        delay = harness.engine._next_delay(outcome)
+        assert delay <= 1.1 * harness.settings.interval_seconds
+
+    def test_cooldown_suppresses_proactive(self, harness):
+        harness.engine._mutate_state(
+            lambda s: s.update(lastSwitchAt=harness.clock() - 10)
+        )
+        outcome = harness.tick_with_usage({
+            "1": _usage(95), "2": _usage(10), "3": _usage(10),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)] == [
+            "cooldown"
+        ]
+
+    def test_at_limit_bypasses_cooldown(self, harness):
+        harness.engine._mutate_state(
+            lambda s: s.update(lastSwitchAt=harness.clock() - 10)
+        )
+        outcome = harness.tick_with_usage({
+            "1": _usage(100), "2": _usage(10), "3": _usage(50),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "at-limit"
+        assert harness.active_number() == 2
+
+    def test_cooldown_expires(self, harness):
+        harness.engine._mutate_state(
+            lambda s: s.update(lastSwitchAt=harness.clock())
+        )
+        harness.clock.advance(400)  # past the 300s default cooldown
+        outcome = harness.tick_with_usage({
+            "1": _usage(95), "2": _usage(10), "3": _usage(50),
+        })
+        assert outcome is TickOutcome.SWITCHED
+
+    def test_unknown_active_usage_waits_then_fails_over(self, harness):
+        usage = {"1": None, "2": _usage(10), "3": _usage(50)}
+        assert harness.tick_with_usage(usage) is TickOutcome.NO_ACTION
+        assert harness.tick_with_usage(usage) is TickOutcome.NO_ACTION
+        assert harness.tick_with_usage(usage) is TickOutcome.SWITCHED
+        switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "failover"
+        assert harness.active_number() == 2
+
+    def test_known_active_usage_resets_unhealthy_counter(self, harness):
+        unknown = {"1": None, "2": _usage(10), "3": _usage(10)}
+        healthy = {"1": _usage(50), "2": _usage(10), "3": _usage(10)}
+        harness.tick_with_usage(unknown)
+        harness.tick_with_usage(unknown)
+        harness.tick_with_usage(healthy)  # resets the counter
+        assert harness.tick_with_usage(unknown) is TickOutcome.NO_ACTION
+        assert harness.active_number() == 1
+
+    def test_all_candidates_unknown_is_no_comparison(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _usage(95), "2": None, "3": None,
+        })
+        assert outcome is TickOutcome.BLOCKED
+        assert [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)] == [
+            "no-comparison"
+        ]
+
+    def test_tie_resolves_to_earliest_slot(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _usage(95), "2": _usage(30), "3": _usage(30),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2
+
+    def test_candidate_not_better_than_active_is_skipped(self, harness):
+        # Active 91% used (9 headroom); candidates worse or equal → exhausted.
+        outcome = harness.tick_with_usage({
+            "1": _usage(91), "2": _usage(95), "3": _usage(99),
+        })
+        assert outcome is TickOutcome.BLOCKED
+        assert harness.active_number() == 1
+
+    def test_at_limit_escapes_hysteresis_bar(self, harness):
+        # Active hard at 100%; the only room anywhere is a candidate at 85%,
+        # which the proactive hysteresis bar (<=80%) would reject. At-limit is
+        # an escape: any account with real headroom beats a blocked one.
+        outcome = harness.tick_with_usage({
+            "1": _usage(100), "2": _usage(85), "3": _usage(97),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "at-limit"
+        assert harness.active_number() == 2
+
+    def test_at_limit_never_targets_another_at_limit_account(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _usage(100), "2": _usage(100), "3": _usage(100),
+        })
+        assert outcome is TickOutcome.BLOCKED
+        assert harness.active_number() == 1
+
+    def test_failover_ignores_hysteresis_bar(self, harness):
+        # Active usage unreadable (auth likely dead); the only candidate with
+        # room sits above the hysteresis bar — failover takes it anyway.
+        usage = {"1": None, "2": _usage(85), "3": _usage(100)}
+        harness.tick_with_usage(usage)
+        harness.tick_with_usage(usage)
+        outcome = harness.tick_with_usage(usage)
+        assert outcome is TickOutcome.SWITCHED
+        switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "failover"
+        assert harness.active_number() == 2
+
+    def test_unmanaged_live_login_is_never_touched(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        # The user logged in with an account cswap doesn't manage.
+        h.make_live("stranger@example.com", 9)
+        live_before = (temp_home / ".claude" / ".credentials.json").read_text()
+        outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.NO_ACTION
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["unmanaged-active-account"]
+        assert (temp_home / ".claude" / ".credentials.json").read_text() == live_before
+
+    def test_all_exhausted_carries_earliest_reset(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _usage(100, "2026-07-03T12:00:00Z"),
+            "2": _usage(100, "2026-07-03T10:30:00Z"),
+            "3": _usage(100, "2026-07-03T11:00:00Z"),
+        })
+        assert outcome is TickOutcome.BLOCKED
+        event = next(e for e in harness.events if isinstance(e, AllExhaustedEvent))
+        assert event.earliest_reset_at == "2026-07-03T10:30:00Z"
+        assert harness.engine._sleep_until_ts is not None
+
+
+class TestApiKeyAccounts:
+    def _mark_api_key(self, harness, num: int) -> None:
+        data = harness.switcher._get_sequence_data()
+        data["accounts"][str(num)]["kind"] = "api_key"
+        harness.switcher._write_json(harness.switcher.sequence_file, data)
+
+    def test_api_key_candidate_excluded_by_default(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "key@token.local")
+        h.make_live("a@example.com", 1)
+        self._mark_api_key(h, 2)
+        outcome = h.tick_with_usage({"1": _usage(95), "2": "api key"})
+        assert outcome is TickOutcome.BLOCKED
+        assert h.active_number() == 1
+
+    def test_api_key_is_last_resort_when_included(self, temp_home):
+        h = EngineHarness(temp_home, include_api_key_accounts=True)
+        h.seed(1, "a@example.com")
+        h.seed(2, "key@token.local")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        self._mark_api_key(h, 2)
+        # A qualifying OAuth candidate wins over the API key...
+        outcome = h.tick_with_usage({
+            "1": _usage(95), "2": "api key", "3": _usage(10),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+
+    def test_api_key_used_when_oauth_exhausted(self, temp_home):
+        h = EngineHarness(temp_home, include_api_key_accounts=True)
+        h.seed(1, "a@example.com")
+        h.seed(2, "key@token.local")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        self._mark_api_key(h, 2)
+        outcome = h.tick_with_usage({
+            "1": _usage(100), "2": "api key", "3": _usage(100),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_active_api_key_idles_engine(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "key@token.local")
+        h.seed(2, "b@example.com")
+        h.make_live("key@token.local", 1)
+        self._mark_api_key(h, 1)
+        outcome = h.tick_with_usage({"1": "api key", "2": _usage(10)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
+            "active-api-key"
+        ]
+
+
+class TestFreshening:
+    def test_near_expiry_target_is_refreshed_and_persisted(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com", expires_at=int(h.clock() * 1000) + 60_000)
+        h.make_live("a@example.com", 1)
+
+        rotated = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-2-new",
+                "refreshToken": "rt-2-new",
+                "expiresAt": int(h.clock() * 1000) + 3_600_000,
+            }
+        })
+        live_creds_path = temp_home / ".claude" / ".credentials.json"
+        live_before = live_creds_path.read_text()
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(rotated, None),
+        ) as mock_refresh:
+            outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+
+        assert outcome is TickOutcome.SWITCHED
+        mock_refresh.assert_called_once()
+        # Freshening itself never touched the active store (the switch did,
+        # afterwards, via _perform_switch): the rotated token must have gone
+        # through the backup, and now be live.
+        assert "sk-2-new" in live_creds_path.read_text()
+        assert live_creds_path.read_text() != live_before
+
+    def test_fresh_target_is_not_refreshed(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com", expires_at=int(h.clock() * 1000) + 3_600_000)
+        h.make_live("a@example.com", 1)
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials"
+        ) as mock_refresh:
+            outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.SWITCHED
+        mock_refresh.assert_not_called()
+
+    def test_invalid_grant_quarantines_and_tries_next(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com", expires_at=1)  # long expired
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(None, "invalid_grant"),
+        ):
+            outcome = h.tick_with_usage({
+                "1": _usage(95), "2": _usage(10), "3": _usage(20),
+            })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3  # next candidate after 2 was quarantined
+        q = next(e for e in h.events if isinstance(e, QuarantineEvent))
+        assert (q.number, q.reason) == ("2", "invalid_grant")
+        assert "2" in h.state()["quarantine"]
+
+    def test_transient_failure_skips_without_quarantine(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com", expires_at=1)
+        h.make_live("a@example.com", 1)
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(None, "transient"),
+        ):
+            outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.ERROR
+        assert h.active_number() == 1
+        assert not h.state().get("quarantine")
+        assert any(isinstance(e, ErrorEvent) for e in h.events)
+
+    def test_live_session_target_is_skipped_even_with_fresh_token(self, temp_home):
+        # Auto never activates an account that has a live `cswap run` session:
+        # dual refresh-token ownership with nobody reading the warning.
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com", expires_at=int(h.clock() * 1000) + 3_600_000)
+        h.make_live("a@example.com", 1)
+        with patch.object(
+            h.switcher, "live_session_pids_for", return_value=[4242]
+        ), patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials"
+        ) as mock_refresh:
+            outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.BLOCKED
+        mock_refresh.assert_not_called()
+        assert h.active_number() == 1
+
+    def test_live_session_near_expiry_is_skipped(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com", expires_at=1)  # long expired
+        h.make_live("a@example.com", 1)
+        with patch.object(
+            h.switcher, "live_session_pids_for", return_value=[4242]
+        ), patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials"
+        ) as mock_refresh:
+            outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.BLOCKED
+        mock_refresh.assert_not_called()
+        assert h.active_number() == 1
+
+
+class TestQuarantineLifecycle:
+    def test_quarantine_persists_across_engine_instances(self, harness):
+        harness.engine._quarantine("2", "b@example.com", "invalid_grant")
+        harness.events.clear()
+        fresh_engine = harness._make_engine()
+        with patch.object(
+            harness.switcher,
+            "_usage_by_account",
+            return_value={"1": _usage(95), "2": _usage(0), "3": _usage(50)},
+        ):
+            outcome = fresh_engine.tick()
+        # 2 has the most headroom but is quarantined → 3 wins.
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3
+
+    def test_replaced_credentials_lift_quarantine(self, harness):
+        harness.engine._quarantine("2", "b@example.com", "invalid_grant")
+        # User re-logged in and re-captured the slot: new refresh token.
+        harness.switcher._write_account_credentials(
+            "2",
+            "b@example.com",
+            json.dumps({
+                "claudeAiOauth": {"accessToken": "sk-2b", "refreshToken": "rt-2b"},
+            }),
+        )
+        harness.events.clear()
+        outcome = harness.tick_with_usage({
+            "1": _usage(95), "2": _usage(0), "3": _usage(50),
+        })
+        assert any(isinstance(e, UnquarantineEvent) for e in harness.events)
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2
+        assert "2" not in (harness.state().get("quarantine") or {})
+
+    def test_state_lock_preserves_concurrent_writes(self, harness):
+        # Simulate another engine writing between our read and our write: the
+        # RMW under the state lock must preserve its quarantine entry.
+        harness.engine._mutate_state(
+            lambda s: s.setdefault("quarantine", {}).update(
+                {"3": {"email": "c@example.com", "reason": "invalid_grant",
+                       "at": "x", "refreshTokenFingerprint": None}}
+            )
+        )
+        harness.engine._mutate_state(lambda s: s.update(lastSwitchAt=123.0))
+        state = harness.state()
+        assert state["lastSwitchAt"] == 123.0
+        assert "3" in state["quarantine"]
+
+
+class TestDryRunAndNoOp:
+    def test_dry_run_mutates_nothing(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        h.engine = h._make_engine(dry_run=True)
+        live_before = (temp_home / ".claude" / ".credentials.json").read_text()
+
+        outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+
+        assert outcome is TickOutcome.SWITCHED
+        switch = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert switch.dry_run is True
+        assert h.active_number() == 1  # unchanged
+        assert (temp_home / ".claude" / ".credentials.json").read_text() == live_before
+        assert h.state() == {}  # no lastSwitchAt recorded
+
+    def test_dry_run_never_freshens_or_quarantines(self, temp_home):
+        # A near-expiry target would normally be refreshed (a real token
+        # rotation) and a dead one quarantined (a state write). Dry-run must
+        # stop at the decision: no network, no writes of any kind.
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com", expires_at=1)  # long expired
+        h.make_live("a@example.com", 1)
+        h.engine = h._make_engine(dry_run=True)
+        backup_before = h.switcher.read_account_credentials("2", "b@example.com")
+
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials"
+        ) as mock_refresh:
+            outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+
+        assert outcome is TickOutcome.SWITCHED  # reported the would-switch
+        mock_refresh.assert_not_called()
+        assert h.switcher.read_account_credentials("2", "b@example.com") == backup_before
+        assert h.state() == {}  # no quarantine, no lastSwitchAt
+
+    def test_dry_run_does_not_release_quarantines(self, temp_home):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        h.engine._quarantine("2", "b@example.com", "invalid_grant")
+        # Replace the credential — a real tick would lift the quarantine.
+        h.switcher._write_account_credentials(
+            "2", "b@example.com",
+            json.dumps({"claudeAiOauth": {"accessToken": "n", "refreshToken": "n"}}),
+        )
+        h.events.clear()
+        h.engine = h._make_engine(dry_run=True)
+        state_before = h.state()
+
+        outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+
+        assert not any(isinstance(e, UnquarantineEvent) for e in h.events)
+        assert h.state() == state_before  # state file untouched
+        # And the still-recorded quarantine keeps 2 out of the dry-run plan.
+        assert outcome is TickOutcome.BLOCKED
+
+    def test_already_active_result_is_noop(self, harness):
+        with patch.object(
+            harness.switcher,
+            "switch_to",
+            return_value={"switched": False, "reason": "already-active"},
+        ):
+            outcome = harness.tick_with_usage({
+                "1": _usage(95), "2": _usage(10), "3": _usage(50),
+            })
+        assert outcome is TickOutcome.NO_ACTION
+        assert "lastSwitchAt" not in harness.state()
+
+
+class TestEventsShape:
+    def test_every_event_has_envelope(self, harness):
+        harness.tick_with_usage({"1": _usage(95), "2": _usage(10), "3": _usage(50)})
+        assert harness.events
+        for event in harness.events:
+            payload = event.to_json()
+            assert payload["schemaVersion"] == 1
+            assert payload["event"] == event.kind
+            assert payload["ts"].endswith("Z")
+
+    def test_switch_event_refs_match_account_ref_shape(self, harness):
+        harness.tick_with_usage({"1": _usage(95), "2": _usage(10), "3": _usage(50)})
+        switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        payload = switch.to_json()
+        assert payload["from"] == {"number": 1, "email": "a@example.com"}
+        assert payload["to"] == {"number": 2, "email": "b@example.com"}
+
+    def test_poll_event_human_line(self, harness):
+        harness.tick_with_usage({"1": _usage(42), "2": _usage(10), "3": None})
+        poll = next(e for e in harness.events if isinstance(e, PollEvent))
+        line = poll.human()
+        assert "Account-1" in line and "42% used" in line
+
+
+class TestRunLoop:
+    def test_loop_ticks_until_stopped(self, harness):
+        ticks = []
+
+        def fake_tick():
+            ticks.append(1)
+            if len(ticks) >= 2:
+                harness.engine.stop()
+            return TickOutcome.NO_ACTION
+
+        with patch.object(harness.engine, "tick", side_effect=fake_tick), \
+             patch.object(harness.engine._stop, "wait", return_value=None):
+            assert harness.engine.run_loop() == 0
+        assert len(ticks) == 2
+
+    def test_loop_survives_raising_tick(self, harness):
+        calls = []
+
+        def raising_inner():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("boom")
+            harness.engine.stop()
+            return TickOutcome.NO_ACTION
+
+        with patch.object(
+            harness.engine, "_tick_inner", side_effect=raising_inner
+        ), patch.object(harness.engine._stop, "wait", return_value=None):
+            harness.engine.run_loop()
+        assert len(calls) == 2
+        assert any(isinstance(e, ErrorEvent) for e in harness.events)
+
+    def test_blocked_with_reset_sleeps_until_reset(self, harness):
+        harness.engine._sleep_until_ts = harness.clock() + 1800
+        delay = harness.engine._next_delay(TickOutcome.BLOCKED)
+        assert 1700 < delay <= 1800
+
+    def test_blocked_exhausted_without_reset_uses_fallback(self, harness):
+        harness.engine._sleep_until_ts = None
+        harness.engine._blocked_wait_long = True
+        assert harness.engine._next_delay(TickOutcome.BLOCKED) == 300.0
+
+    def test_blocked_on_resolvable_condition_keeps_normal_cadence(self, harness):
+        harness.engine._sleep_until_ts = None
+        harness.engine._blocked_wait_long = False
+        delay = harness.engine._next_delay(TickOutcome.BLOCKED)
+        assert 0.9 * 60 <= delay <= 1.1 * 60
+
+    def test_normal_delay_is_jittered_interval(self, harness):
+        delay = harness.engine._next_delay(TickOutcome.NO_ACTION)
+        assert 0.9 * 60 <= delay <= 1.1 * 60
+
+    def test_sleep_cap(self, harness):
+        harness.engine._sleep_until_ts = harness.clock() + 50 * 3600
+        assert harness.engine._next_delay(TickOutcome.BLOCKED) == 6 * 3600

--- a/tests/test_claude_locks.py
+++ b/tests/test_claude_locks.py
@@ -1,0 +1,99 @@
+"""Tests for the proper-lockfile-compatible Claude Code lock helpers."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from claude_swap import claude_locks
+from claude_swap.claude_locks import (
+    claude_config_lock,
+    claude_credentials_lock,
+    config_lock_dir,
+    credentials_lock_dir,
+    proper_lockfile,
+)
+from claude_swap.exceptions import ClaudeCodeLockTimeout
+
+
+@pytest.fixture
+def lock_dir(tmp_path: Path) -> Path:
+    return tmp_path / "target.lock"
+
+
+class TestProperLockfile:
+    def test_acquire_creates_and_release_removes(self, lock_dir):
+        with proper_lockfile(lock_dir):
+            assert lock_dir.is_dir()
+        assert not lock_dir.exists()
+
+    def test_reacquire_after_release(self, lock_dir):
+        with proper_lockfile(lock_dir):
+            pass
+        with proper_lockfile(lock_dir):
+            assert lock_dir.is_dir()
+
+    def test_contention_times_out(self, lock_dir):
+        lock_dir.mkdir()  # fresh mtime = live holder
+        start = time.monotonic()
+        with pytest.raises(ClaudeCodeLockTimeout):
+            with proper_lockfile(lock_dir, timeout=0.5):
+                pass
+        assert time.monotonic() - start < 5.0
+        assert lock_dir.is_dir()  # the holder's lock is left alone
+
+    def test_stale_lock_is_taken_over(self, lock_dir):
+        lock_dir.mkdir()
+        past = time.time() - 30
+        os.utime(lock_dir, (past, past))
+        with proper_lockfile(lock_dir, timeout=2.0):
+            assert lock_dir.is_dir()
+            # We own it now: mtime is fresh, not the 30s-old corpse.
+            assert time.time() - lock_dir.stat().st_mtime < 5.0
+        assert not lock_dir.exists()
+
+    def test_release_tolerates_stolen_lock(self, lock_dir):
+        with proper_lockfile(lock_dir):
+            os.rmdir(lock_dir)  # simulate a stale-takeover by another process
+        # No exception; nothing left behind.
+        assert not lock_dir.exists()
+
+    def test_toucher_keeps_mtime_fresh(self, lock_dir, monkeypatch):
+        monkeypatch.setattr(claude_locks, "TOUCH_INTERVAL_S", 0.1)
+        with proper_lockfile(lock_dir):
+            past = time.time() - 30
+            os.utime(lock_dir, (past, past))
+            time.sleep(0.4)
+            assert time.time() - lock_dir.stat().st_mtime < 10.0
+
+    def test_creates_missing_parent(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "target.lock"
+        with proper_lockfile(nested):
+            assert nested.is_dir()
+
+
+class TestLockPaths:
+    def test_default_paths(self, temp_home, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        assert credentials_lock_dir() == temp_home / ".claude.lock"
+        assert config_lock_dir() == temp_home / ".claude.json.lock"
+
+    def test_claude_config_dir_is_honored(self, tmp_path, monkeypatch):
+        custom = tmp_path / "custom-claude"
+        custom.mkdir()
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+        assert credentials_lock_dir() == tmp_path / "custom-claude.lock"
+        # ~/.claude.json resolves relative to CLAUDE_CONFIG_DIR too.
+        assert config_lock_dir() == custom / ".claude.json.lock"
+
+    def test_named_helpers_lock_their_dirs(self, temp_home, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        with claude_credentials_lock():
+            assert (temp_home / ".claude.lock").is_dir()
+            with claude_config_lock():
+                assert (temp_home / ".claude.json.lock").is_dir()
+        assert not (temp_home / ".claude.lock").exists()
+        assert not (temp_home / ".claude.json.lock").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -612,3 +612,139 @@ class TestJsonOutputCli:
         envelope = json.loads(captured.out)  # error went to stdout as JSON
         assert envelope["error"] == {"type": "ConfigError", "message": "nope"}
         assert captured.err == ""  # nothing on stderr in JSON mode
+
+
+class TestAutoCommand:
+    """`cswap auto` pre-dispatch: parsing, settings merge, exit codes, JSONL."""
+
+    class FakeEngine:
+        instances: list = []
+        tick_outcome = None  # set per test (TickOutcome)
+
+        def __init__(self, switcher, settings, on_event, *, dry_run=False,
+                     state_path=None, clock=None):
+            self.switcher = switcher
+            self.settings = settings
+            self.on_event = on_event
+            self.dry_run = dry_run
+            type(self).instances.append(self)
+
+        def tick(self):
+            from claude_swap.autoswitch import TickOutcome
+
+            return type(self).tick_outcome or TickOutcome.NO_ACTION
+
+        def run_loop(self):
+            return 0
+
+        def stop(self):
+            pass
+
+    @pytest.fixture(autouse=True)
+    def _fresh_fake(self):
+        self.FakeEngine.instances = []
+        self.FakeEngine.tick_outcome = None
+
+    def _run(self, argv: list[str], temp_home):
+        with patch("claude_swap.autoswitch.AutoSwitchEngine", self.FakeEngine), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "auto", *argv]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        return excinfo.value.code
+
+    def test_once_exit_code_switched(self, temp_home):
+        from claude_swap.autoswitch import TickOutcome
+
+        self.FakeEngine.tick_outcome = TickOutcome.SWITCHED
+        assert self._run(["--once"], temp_home) == 0
+
+    def test_once_exit_code_no_action(self, temp_home):
+        from claude_swap.autoswitch import TickOutcome
+
+        self.FakeEngine.tick_outcome = TickOutcome.NO_ACTION
+        assert self._run(["--once"], temp_home) == 2
+
+    def test_once_exit_code_blocked(self, temp_home):
+        from claude_swap.autoswitch import TickOutcome
+
+        self.FakeEngine.tick_outcome = TickOutcome.BLOCKED
+        assert self._run(["--once"], temp_home) == 3
+
+    def test_loop_mode_returns_loop_exit(self, temp_home):
+        assert self._run([], temp_home) == 0
+        assert self.FakeEngine.instances  # loop path constructed the engine
+
+    def test_flags_override_settings_json(self, temp_home):
+        from claude_swap.paths import get_backup_root
+
+        backup = get_backup_root()
+        backup.mkdir(parents=True, exist_ok=True)
+        (backup / "settings.json").write_text(json.dumps({
+            "schemaVersion": 1,
+            "autoswitch": {"threshold": 80.0, "cooldownSeconds": 42.0},
+        }))
+        self._run(["--once", "--threshold", "60"], temp_home)
+        engine = self.FakeEngine.instances[-1]
+        assert engine.settings.threshold == 60.0     # CLI wins
+        assert engine.settings.cooldown_seconds == 42.0  # settings.json kept
+
+    def test_dry_run_forwarded(self, temp_home):
+        self._run(["--once", "--dry-run"], temp_home)
+        assert self.FakeEngine.instances[-1].dry_run is True
+
+    def test_json_stdout_is_pure_jsonl(self, temp_home, capsys):
+        from claude_swap.autoswitch import NoSwitchEvent, TickOutcome
+
+        class EmittingEngine(self.FakeEngine):
+            def tick(self):
+                self.on_event(NoSwitchEvent(reason="below-threshold"))
+                self.on_event(NoSwitchEvent(reason="cooldown"))
+                return TickOutcome.NO_ACTION
+
+        with patch("claude_swap.autoswitch.AutoSwitchEngine", EmittingEngine), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "auto", "--once", "--json"]):
+            with pytest.raises(SystemExit):
+                cli.main()
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        assert len(lines) == 2
+        for line in lines:
+            payload = json.loads(line)
+            assert payload["event"] == "no-switch"
+            assert payload["schemaVersion"] == 1
+
+    def test_unknown_flag_errors(self, temp_home, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "auto", "--bogus"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+
+    def test_auto_help(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "auto", "--help"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 0
+        out = capsys.readouterr().out
+        assert "--once" in out
+        assert "Exit codes" in out
+
+    def test_main_help_mentions_auto(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "auto" in result.stdout
+
+    def test_switcher_error_exits_1(self, temp_home, capsys):
+        from claude_swap.exceptions import ConfigError
+
+        with patch("claude_swap.cli.ClaudeAccountSwitcher",
+                   side_effect=ConfigError("nope")), \
+             patch.object(sys, "argv", ["claude-swap", "auto", "--once"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 1
+        assert "nope" in capsys.readouterr().err  # printer.error -> stderr

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -319,6 +319,81 @@ class TestRefreshOAuthCredentials:
         assert "scope" not in seen_body
 
 
+class TestTryRefreshOAuthCredentials:
+    """Typed refresh outcomes: permanent vs transient failure classification."""
+
+    _make_credentials = staticmethod(TestRefreshOAuthCredentials._make_credentials)
+
+    @staticmethod
+    def _http_error(code, body: bytes, msg="err"):
+        import io
+
+        return urllib.error.HTTPError(
+            oauth.OAUTH_TOKEN_URL, code, msg, hdrs=None, fp=io.BytesIO(body)
+        )
+
+    def test_success_rotates_and_has_no_error(self):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        }).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen", return_value=mock_response
+        ):
+            outcome = oauth.try_refresh_oauth_credentials(self._make_credentials())
+
+        assert outcome.error is None
+        rotated = json.loads(outcome.credentials)["claudeAiOauth"]
+        assert rotated["accessToken"] == "new-access"
+        assert rotated["refreshToken"] == "new-refresh"
+
+    def test_invalid_grant_body_on_400_is_permanent(self):
+        err = self._http_error(400, b'{"error": "invalid_grant"}')
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            outcome = oauth.try_refresh_oauth_credentials(self._make_credentials())
+        assert outcome.credentials is None
+        assert outcome.error == "invalid_grant"
+
+    def test_400_without_marker_is_transient(self):
+        err = self._http_error(400, b'{"error": "temporarily_unavailable"}')
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            outcome = oauth.try_refresh_oauth_credentials(self._make_credentials())
+        assert outcome.error == "transient"
+
+    def test_5xx_is_transient_even_with_marker(self):
+        err = self._http_error(500, b'{"error": "invalid_grant"}')
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            outcome = oauth.try_refresh_oauth_credentials(self._make_credentials())
+        assert outcome.error == "transient"
+
+    def test_network_error_is_transient(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("dns"),
+        ):
+            outcome = oauth.try_refresh_oauth_credentials(self._make_credentials())
+        assert outcome.error == "transient"
+
+    def test_missing_refresh_token_is_permanent(self):
+        creds = json.dumps({"claudeAiOauth": {"accessToken": "a", "expiresAt": 0}})
+        outcome = oauth.try_refresh_oauth_credentials(creds)
+        assert outcome.error == "no_refresh_token"
+
+    def test_invalid_json_is_permanent(self):
+        outcome = oauth.try_refresh_oauth_credentials("not json")
+        assert outcome.error == "no_refresh_token"
+
+    def test_wrapper_returns_none_on_failure(self):
+        err = self._http_error(400, b'{"error": "invalid_grant"}')
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            assert oauth.refresh_oauth_credentials(self._make_credentials()) is None
+
+
 class TestBuildTokenStatus:
     """Test token status formatting."""
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,128 @@
+"""Tests for settings.json load/save/merge (settings.py)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_swap.settings import (
+    AutoSwitchSettings,
+    load_settings,
+    merged_with_cli,
+    save_settings,
+    settings_path,
+)
+
+
+def _args(**kwargs) -> argparse.Namespace:
+    defaults = {
+        "threshold": None,
+        "interval": None,
+        "cooldown": None,
+        "include_api_key_accounts": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestLoadSettings:
+    def test_missing_file_gives_defaults(self, tmp_path: Path):
+        assert load_settings(tmp_path) == AutoSwitchSettings()
+
+    def test_corrupt_file_gives_defaults(self, tmp_path: Path):
+        settings_path(tmp_path).write_text("{not json")
+        assert load_settings(tmp_path) == AutoSwitchSettings()
+
+    def test_non_object_gives_defaults(self, tmp_path: Path):
+        settings_path(tmp_path).write_text("[1, 2]")
+        assert load_settings(tmp_path) == AutoSwitchSettings()
+
+    def test_partial_section_fills_defaults(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"schemaVersion": 1, "autoswitch": {"threshold": 80}})
+        )
+        loaded = load_settings(tmp_path)
+        assert loaded.threshold == 80.0
+        assert loaded.interval_seconds == AutoSwitchSettings().interval_seconds
+
+    def test_values_are_clamped(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(json.dumps({
+            "autoswitch": {
+                "threshold": 200,
+                "intervalSeconds": 1,
+                "hysteresisPct": -5,
+                "unhealthyTicks": 0,
+            }
+        }))
+        loaded = load_settings(tmp_path)
+        assert loaded.threshold == 99.9
+        assert loaded.interval_seconds == 15.0  # usage-cache TTL floor
+        assert loaded.hysteresis_pct == 0.0
+        assert loaded.unhealthy_ticks == 1
+
+    def test_bad_types_fall_back_to_defaults(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(json.dumps({
+            "autoswitch": {"threshold": "high", "includeApiKeyAccounts": 1}
+        }))
+        loaded = load_settings(tmp_path)
+        assert loaded.threshold == AutoSwitchSettings().threshold
+        assert loaded.include_api_key_accounts is True
+
+    def test_unsupported_strategy_falls_back_to_best(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"autoswitch": {"strategy": "chaos"}})
+        )
+        assert load_settings(tmp_path).strategy == "best"
+
+
+class TestSaveSettings:
+    def test_roundtrip(self, tmp_path: Path):
+        custom = AutoSwitchSettings(threshold=85.0, cooldown_seconds=60.0)
+        save_settings(tmp_path, custom)
+        assert load_settings(tmp_path) == custom
+
+    def test_unknown_keys_survive(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(json.dumps({
+            "schemaVersion": 1,
+            "futureSection": {"x": 1},
+            "autoswitch": {"threshold": 80, "futureKnob": True},
+        }))
+        save_settings(tmp_path, AutoSwitchSettings(threshold=70.0))
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert raw["futureSection"] == {"x": 1}
+        assert raw["autoswitch"]["futureKnob"] is True
+        assert raw["autoswitch"]["threshold"] == 70.0
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+    def test_file_mode_is_0600(self, tmp_path: Path):
+        save_settings(tmp_path, AutoSwitchSettings())
+        mode = stat.S_IMODE(settings_path(tmp_path).stat().st_mode)
+        assert mode == 0o600
+
+
+class TestMergedWithCli:
+    def test_no_flags_returns_settings_unchanged(self):
+        base = AutoSwitchSettings(threshold=80.0)
+        assert merged_with_cli(base, _args()) is base
+
+    def test_cli_beats_settings(self):
+        base = AutoSwitchSettings(threshold=80.0, cooldown_seconds=10.0)
+        merged = merged_with_cli(base, _args(threshold=60.0, interval=30.0))
+        assert merged.threshold == 60.0
+        assert merged.interval_seconds == 30.0
+        assert merged.cooldown_seconds == 10.0  # untouched
+
+    def test_cli_values_are_clamped(self):
+        merged = merged_with_cli(AutoSwitchSettings(), _args(interval=1.0))
+        assert merged.interval_seconds == 15.0
+
+    def test_boolean_override(self):
+        merged = merged_with_cli(
+            AutoSwitchSettings(), _args(include_api_key_accounts=True)
+        )
+        assert merged.include_api_key_accounts is True

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -3197,6 +3197,70 @@ class TestUsageAwareSwitch:
         assert s._get_sequence_data()["activeAccountNumber"] == 3
 
 
+class TestClaudeCodeLockCooperation:
+    """_perform_switch must hold Claude Code's own advisory locks
+    (~/.claude.lock and ~/.claude.json.lock) while mutating credentials/config,
+    and fail cleanly — before any mutation — when Claude Code holds them."""
+
+    _setup = TestUsageAwareSwitch._setup
+    _seed = TestUsageAwareSwitch._seed
+    _make_live = TestUsageAwareSwitch._make_live
+
+    def test_switch_holds_both_cc_locks_at_write_time(self, temp_home: Path):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        creds_lock = temp_home / ".claude.lock"
+        config_lock = temp_home / ".claude.json.lock"
+        seen: list[tuple[bool, bool]] = []
+        original_write = s._write_credentials
+
+        def spying_write(credentials: str) -> None:
+            seen.append((creds_lock.is_dir(), config_lock.is_dir()))
+            original_write(credentials)
+
+        with patch.object(s, "_write_credentials", side_effect=spying_write), \
+             patch.object(s, "list_accounts"):
+            s.switch_to("2")
+
+        assert s._get_sequence_data()["activeAccountNumber"] == 2
+        assert seen and all(pair == (True, True) for pair in seen)
+        # Released after the switch.
+        assert not creds_lock.exists()
+        assert not config_lock.exists()
+
+    def test_preheld_cc_lock_fails_cleanly_without_mutation(
+        self, temp_home: Path, monkeypatch
+    ):
+        from claude_swap import claude_locks
+        from claude_swap.exceptions import ClaudeCodeLockTimeout
+
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._make_live(temp_home, "a@example.com", 1)
+
+        monkeypatch.setattr(claude_locks, "DEFAULT_TIMEOUT_S", 0.3)
+        (temp_home / ".claude.lock").mkdir()  # fresh mtime = live CC refresh
+
+        live_creds_before = (
+            temp_home / ".claude" / ".credentials.json"
+        ).read_text()
+        with pytest.raises(ClaudeCodeLockTimeout):
+            s.switch_to("2")
+
+        # Nothing was mutated: locks acquire before any write.
+        assert s._get_sequence_data()["activeAccountNumber"] == 1
+        live_creds_after = (
+            temp_home / ".claude" / ".credentials.json"
+        ).read_text()
+        assert live_creds_after == live_creds_before
+        # The holder's lock was left alone.
+        assert (temp_home / ".claude.lock").is_dir()
+
+
 class TestMacosKeychainFallback:
     """macOS auto-fallback to file storage when the Keychain is unusable, plus the
     ``.enc``-wins backup reconciliation.


### PR DESCRIPTION
Adds an auto-switch engine and the `cswap auto` command: when the active account's 5h/7d window crosses a threshold (default 90%), cswap switches to the account with the most quota left — proactively, so it works mid-session without a rate-limit error turn.

Related: #38

## What's included

- **`cswap auto`** — foreground loop; `--once` for cron/systemd (outcome in exit code), `--json` JSONL events, `--dry-run`, `--threshold` / `--interval` / `--cooldown`
- **`AutoSwitchEngine`** (`autoswitch.py`) — UI-agnostic policy engine with event callbacks, so future frontends (TUI dashboard, menubar, …) can drive the same logic
- **Policy** — proactive threshold + best-headroom target; cooldown + hysteresis against flip-flopping; failover when the active account's auth dies; quarantine for accounts with dead refresh tokens (auto-released once re-added); sleeps until the earliest quota reset when everything is exhausted
- **Safety** — switches (manual ones too) now hold Claude Code's own advisory locks (`~/.claude.lock` / `~/.claude.json.lock`, proper-lockfile protocol) while writing, closing the one real race with a running Claude Code's token refresh; targets are freshened before activation so Claude Code adopts them without refreshing. API-key accounts are excluded from rotation by default, and unmanaged live logins are never touched
- **`settings.json`** in the backup root for defaults (flags override)

## Testing

- 750 tests pass (90 new: engine decision table, lock protocol, settings, CLI)
- Live-verified on WSL2: engine-driven switch mid-session while Claude Code was actively running (the session continued seamlessly across the swap), lock-contention path (clean error, zero mutation), and `--dry-run` confirmed write-free

Thanks to everyone who explored auto-switching in community PRs — this lands the core machinery those ideas can plug into.
