### PR TITLE
feat: show per-model weekly usage (e.g. Fable) in --list (#82)

### DIFF
--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -37,6 +37,13 @@ def _window_to_json(entry: dict) -> dict:
     return out
 
 
+def _scoped_window_to_json(entry: dict) -> dict:
+    """Project a per-model scoped weekly window, carrying its model name."""
+    out = _window_to_json(entry)
+    out["name"] = entry["name"]
+    return out
+
+
 def usage_to_json(usage: dict) -> dict:
     """Convert the internal usage dict to its camelCase JSON projection.
 
@@ -63,6 +70,8 @@ def usage_to_json(usage: dict) -> dict:
         if "clock" in spend:
             spend_out["clock"] = spend["clock"]
         out["spend"] = spend_out
+    if "scoped" in usage:
+        out["scoped"] = [_scoped_window_to_json(w) for w in usage["scoped"]]
     return out
 
 

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -238,6 +238,31 @@ def build_usage_result(data: dict) -> dict | None:
             except (TypeError, ValueError) as e:
                 _logger.debug("extra_usage parse failed: %r", e)
 
+    # Per-model weekly limits live in the newer ``limits`` array as
+    # ``weekly_scoped`` entries carrying a ``scope.model.display_name`` (e.g.
+    # "Fable"). The legacy five_hour/seven_day keys above never expose these, so
+    # surface each scoped window separately. Absent/older responses (no
+    # ``limits``) simply yield no ``scoped`` key.
+    limits = data.get("limits")
+    if isinstance(limits, list):
+        scoped: list[dict] = []
+        for lim in limits:
+            if not isinstance(lim, dict):
+                continue
+            scope = lim.get("scope")
+            model = scope.get("model") if isinstance(scope, dict) else None
+            name = model.get("display_name") if isinstance(model, dict) else None
+            pct = lim.get("percent")
+            if not name or not isinstance(pct, (int, float)):
+                continue
+            scoped_entry: dict = {"name": name, "pct": float(pct)}
+            if lim.get("resets_at"):
+                scoped_entry["resets_at"] = lim["resets_at"]
+                scoped_entry["countdown"], scoped_entry["clock"] = format_reset(lim["resets_at"])
+            scoped.append(scoped_entry)
+        if scoped:
+            result["scoped"] = scoped
+
     return result if result else None
 
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -104,6 +104,14 @@ def _format_usage_lines(usage: dict) -> list[str]:
             lines.append(f"7d: {d7['pct']:>3.0f}%   resets {d7['clock']:<12}  in {d7['countdown']}")
         else:
             lines.append(f"7d: {d7['pct']:>3.0f}%")
+    for w in usage.get("scoped") or []:
+        # Per-model weekly limits (e.g. Fable). Flag ones at/over the limit so a
+        # maxed model — the usual reason to switch — stands out.
+        marker = "  (!)" if w["pct"] >= 100 else ""
+        if "clock" in w:
+            lines.append(f"{w['name']}: {w['pct']:>3.0f}%   resets {w['clock']:<12}  in {w['countdown']}{marker}")
+        else:
+            lines.append(f"{w['name']}: {w['pct']:>3.0f}%{marker}")
     return lines
 
 

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -42,6 +42,20 @@ class TestJsonHelpers:
         assert out["spend"]["used"] == 12.5
         assert out["spend"]["resetsAt"] == "2026-07-01T00:00:00Z"
 
+    def test_usage_to_json_projects_scoped_windows(self):
+        usage = {
+            "five_hour": {"pct": 7.0},
+            "scoped": [
+                {"name": "Fable", "pct": 100.0, "resets_at": "2026-07-03T21:59:59Z",
+                 "countdown": "3h", "clock": "21:59"},
+            ],
+        }
+        out = usage_to_json(usage)
+        assert out["scoped"] == [
+            {"name": "Fable", "pct": 100.0, "resetsAt": "2026-07-03T21:59:59Z",
+             "countdown": "3h", "clock": "21:59"},
+        ]
+
     def test_usage_fields_variants(self):
         from claude_swap.json_output import (
             USAGE_KEYCHAIN_UNAVAILABLE,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -277,6 +277,55 @@ class TestFetchUsage:
         assert result["seven_day"]["pct"] == 61.0
         assert "spend" not in result
 
+    def test_scoped_per_model_limits(self):
+        """weekly_scoped entries in limits[] surface as result['scoped'] by model name."""
+        from datetime import timedelta
+        fixed_now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        future = fixed_now + timedelta(hours=3)
+        response_data = {
+            "five_hour": {"utilization": 7.0, "resets_at": None},
+            "seven_day": {"utilization": 72.0, "resets_at": None},
+            "seven_day_opus": None,
+            "limits": [
+                {"kind": "session", "group": "session", "percent": 7,
+                 "resets_at": None, "scope": None, "is_active": False},
+                {"kind": "weekly_all", "group": "weekly", "percent": 72,
+                 "resets_at": None, "scope": None, "is_active": False},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 100,
+                 "severity": "critical", "resets_at": future.isoformat(),
+                 "scope": {"model": {"id": None, "display_name": "Fable"}, "surface": None},
+                 "is_active": True},
+            ],
+        }
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(response_data).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        with patch("claude_swap.oauth.urllib.request.urlopen", return_value=mock_response), \
+             patch("claude_swap.oauth.datetime") as mock_dt:
+            mock_dt.fromisoformat = datetime.fromisoformat
+            mock_dt.now.return_value = fixed_now
+            result = oauth.fetch_usage("sk-test-token")
+
+        assert result is not None
+        # Only the model-scoped entry is surfaced; session/weekly_all (scope=None) are not.
+        assert len(result["scoped"]) == 1
+        fable = result["scoped"][0]
+        assert fable["name"] == "Fable"
+        assert fable["pct"] == 100.0
+        assert fable["resets_at"] == future.isoformat()
+        assert fable["countdown"] == "3h 0m"
+        assert "clock" in fable
+
+    def test_no_limits_no_scoped_key(self):
+        """A response without a limits array yields no 'scoped' key (backward compat)."""
+        result = self._fetch_with_response({
+            "five_hour": {"utilization": 22.0, "resets_at": None},
+            "seven_day": {"utilization": 61.0, "resets_at": None},
+        })
+        assert result is not None
+        assert "scoped" not in result
+
 
 class TestRefreshOAuthCredentials:
     """Test direct OAuth refresh requests."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -27,6 +27,7 @@ from claude_swap.switcher import (
     ClaudeAccountSwitcher,
     SECURITY_SERVICE,
     SETUP_TOKEN_SCOPES,
+    _format_usage_lines,
 )
 
 
@@ -3606,3 +3607,43 @@ class TestMacosKeychainFallback:
         s._last_active_credentials_backend = "keychain"
         s._print_switch_followup()
         assert "30 seconds" in capsys.readouterr().out
+
+
+class TestFormatUsageLines:
+    """Test _format_usage_lines rendering, including per-model scoped windows."""
+
+    def test_scoped_lines_render_per_model_with_at_limit_marker(self):
+        usage = {
+            "five_hour": {"pct": 7.0, "clock": "20:39", "countdown": "1h 30m"},
+            "seven_day": {"pct": 72.0, "clock": "21:59", "countdown": "3h"},
+            "scoped": [
+                {"name": "Fable", "pct": 100.0, "clock": "21:59", "countdown": "3h"},
+            ],
+        }
+        lines = _format_usage_lines(usage)
+        assert lines[0].startswith("5h:")
+        assert lines[1].startswith("7d:")
+        fable = lines[2]
+        assert fable.startswith("Fable:")
+        assert "100%" in fable
+        assert fable.rstrip().endswith("(!)")  # at/over limit marker
+
+    def test_scoped_under_limit_has_no_marker(self):
+        usage = {"scoped": [{"name": "Fable", "pct": 40.0, "clock": "21:59", "countdown": "3h"}]}
+        lines = _format_usage_lines(usage)
+        assert len(lines) == 1
+        assert lines[0].startswith("Fable:")
+        assert "40%" in lines[0]
+        assert "resets 21:59" in lines[0]
+        assert "in 3h" in lines[0]
+        assert not lines[0].rstrip().endswith("(!)")
+
+    def test_scoped_without_clock_renders_pct_only(self):
+        usage = {"scoped": [{"name": "Fable", "pct": 100.0}]}
+        lines = _format_usage_lines(usage)
+        assert lines == ["Fable: 100%  (!)"]
+
+    def test_no_scoped_key_renders_only_standard_windows(self):
+        usage = {"five_hour": {"pct": 7.0}, "seven_day": {"pct": 72.0}}
+        lines = _format_usage_lines(usage)
+        assert all(not line.startswith("Fable:") for line in lines)


### PR DESCRIPTION
## What

Adds per-model weekly usage windows (e.g. **Fable**) to `cswap --list`, closing #82.

## Why

The `/api/oauth/usage` endpoint now returns a `limits` array whose `weekly_scoped` entries carry `scope.model.display_name` (e.g. `"Fable"`), alongside the legacy `five_hour`/`seven_day` keys. `build_usage_result()` only kept `five_hour`/`seven_day`/`extra_usage`, so the per-model data was fetched and then discarded — never shown. Switching accounts to dodge a per-model (Fable) limit is exactly the use case #82 describes, but the number that drives the switch wasn't visible.

## What changed

- **`oauth.build_usage_result()`** — parse `weekly_scoped` entries from `limits[]` into `result["scoped"]` (a list of `{name, pct, resets_at, countdown, clock}`).
- **`switcher._format_usage_lines()`** — render one line per model; a `(!)` flags a model at/over its limit.
- **`json_output.usage_to_json()`** — project `scoped` into the `--json` output (camelCase, carrying `name`).

## Compatibility

Additive and backward-compatible: responses without a `limits` array yield no `scoped` key, and existing `5h`/`7d`/`spend` output is unchanged.

## Example (verified against live accounts; emails/names redacted)

`cswap --list`:

```
Accounts:
  1: user1@example.com [Personal]
     ├ 5h:   0%
     ├ 7d:  62%   resets Jul 5 08:59   in 1d 19h
     └ Fable: 100%   resets Jul 5 08:59   in 1d 19h  (!)

  2: user2@example.com [Work] (active)
     ├ 5h:  10%   resets 16:39         in 3h 28m
     ├ 7d:  72%   resets 17:59         in 4h 48m
     └ Fable: 100%   resets 17:59         in 4h 48m  (!)
```

`cswap --list --json` (per account):

```json
"scoped": [
  { "pct": 100.0, "resetsAt": "…", "countdown": "1d 19h", "clock": "Jul 5 08:59", "name": "Fable" }
]
```

## Not included (happy to add if wanted)

- `account_headroom()` (used by `cswap auto`) still considers only `five_hour`/`seven_day`, so auto-rotate won't trigger on a Fable-only limit. Left out to keep this PR display-only; scoped windows could be wired into headroom in a follow-up.
- `severity` / `is_active` from `limits[]` aren't surfaced, to keep the diff minimal.

## Tests

`757 passed, 3 skipped`. New coverage: `build_usage_result` scoped extraction + a no-`limits` negative (`test_oauth.py`), `_format_usage_lines` per-model rendering incl. the marker (`test_switcher.py`), and the `--json` scoped projection (`test_json_output.py`).
