### PR TITLE
feat: cswap config subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ For cron/systemd timers, `--once` reports the outcome in its exit code (`0` swit
 */5 * * * * cswap auto --once --json >> ~/.cswap-auto.log 2>&1
 ```
 
-Defaults are configurable in `settings.json` in the backup root (see [Data locations](#data-locations)) — flags override it:
+Defaults are configurable with `cswap config` (see [Configuration](#configuration)) — flags override them:
 
-```json
-{ "schemaVersion": 1, "autoswitch": { "threshold": 90, "intervalSeconds": 60, "cooldownSeconds": 300 } }
+```bash
+cswap config set autoswitch.threshold 80
 ```
 
 </details>
@@ -132,6 +132,7 @@ This will update the stored credentials without creating a duplicate.
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
 cswap auto                      # Auto-switch when nearing rate limits (see above)
+cswap config                    # Show or edit settings (see Configuration below)
 cswap --list                    # Show all accounts with 5h/7d usage and reset times
 cswap --status                  # Show current account
 cswap --add-account --slot 3    # Add account to a specific slot (prompts before overwrite)
@@ -167,6 +168,25 @@ Session-mode profiles (`cswap run`) live under the backup directory in `sessions
 On Linux/WSL, set `XDG_DATA_HOME` to override the default location. Data from older installs under `~/.claude-swap-backup/` is migrated automatically on first run.
 
 ## Advanced
+
+### Configuration
+
+Tool preferences live in `settings.json` in the backup root; `cswap config` reads and edits it with validation, so you never have to find the file or guess valid ranges.
+
+<details>
+<summary>Commands & usage</summary>
+
+```bash
+cswap config                              # list effective settings ("(default)" = not set)
+cswap config get autoswitch.threshold
+cswap config set autoswitch.threshold 80  # validated: rejects out-of-range values loudly
+cswap config unset autoswitch.threshold   # back to the default
+cswap config path                         # where settings.json lives
+```
+
+`cswap config --help` lists every key with its valid range and default. Hand-editing the file still works — `cswap config` is just a safer front door. `list` and `get` take `--json` for scripting.
+
+</details>
 
 ### Backup and migration
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -259,6 +259,151 @@ Defaults live in settings.json in the backup root; flags override them.
         sys.exit(130)
 
 
+def _config_command(argv: list[str]) -> None:
+    """Handle `cswap config [list|get KEY|set KEY VALUE|unset KEY|path]`.
+
+    Pre-dispatched before the main parser is built, like `run` and `auto`
+    (same limitation: `config` must be the first argument). Edits
+    settings.json in the backup root with strict validation — unlike loading,
+    which forgivingly clamps — so a typo'd key or out-of-range value errors
+    loudly here instead of silently degrading at `cswap auto` time.
+    """
+    from claude_swap.settings import (
+        SETTING_SPECS,
+        effective_settings,
+        format_setting_value,
+        set_setting,
+        setting_spec,
+        settings_path,
+        unset_setting,
+    )
+
+    key_lines = "\n".join(
+        f"  {spec.dotted:<34}{spec.help} (default {format_setting_value(spec.default)})"
+        for spec in SETTING_SPECS.values()
+    )
+    parser = argparse.ArgumentParser(
+        prog="cswap config",
+        description=(
+            "Read and edit claude-swap settings (settings.json in the "
+            "backup root)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Keys:
+{key_lines}
+
+Examples:
+  cswap config                              # list effective settings
+  cswap config get autoswitch.threshold
+  cswap config set autoswitch.threshold 80
+  cswap config unset autoswitch.threshold   # back to the default
+  cswap config path                         # where settings.json lives
+        """,
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON to stdout (with list or get)",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    sub = parser.add_subparsers(dest="action", metavar="{list,get,set,unset,path}")
+
+    p_list = sub.add_parser("list", help="Show all effective settings (the default)")
+    p_get = sub.add_parser("get", help="Print one setting's effective value")
+    p_get.add_argument("key", metavar="KEY", help="Dotted key, e.g. autoswitch.threshold")
+    for p in (p_list, p_get):
+        # SUPPRESS: without it the subparser's False default would clobber a
+        # pre-verb `cswap config --json` in the shared namespace.
+        p.add_argument(
+            "--json",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help="Emit machine-readable JSON to stdout",
+        )
+    p_set = sub.add_parser("set", help="Validate and persist one setting")
+    p_set.add_argument("key", metavar="KEY")
+    p_set.add_argument("value", metavar="VALUE")
+    p_unset = sub.add_parser("unset", help="Remove one setting (revert to the default)")
+    p_unset.add_argument("key", metavar="KEY")
+    sub.add_parser("path", help="Print the settings.json location")
+
+    args = parser.parse_args(argv)
+    json_mode = bool(getattr(args, "json", False))
+    action = args.action or "list"
+    if json_mode and action not in ("list", "get"):
+        parser.error("--json can only be used with list or get")
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        if sys.platform != "win32":
+            if os.geteuid() == 0 and not switcher._is_running_in_container():
+                error("Error: Do not run this script as root (unless running in a container)")
+                sys.exit(1)
+        root = switcher.backup_dir
+
+        if action == "path":
+            print(settings_path(root))
+        elif action == "list":
+            rows = effective_settings(root)
+            if json_mode:
+                payload = {
+                    "schemaVersion": 1,
+                    "path": str(settings_path(root)),
+                    "settings": [
+                        {"key": spec.dotted, "value": value, "isSet": is_set}
+                        for spec, value, is_set in rows
+                    ],
+                }
+                print(json.dumps(payload, indent=2))
+            else:
+                key_w = max(len(spec.dotted) for spec, _, _ in rows)
+                val_w = max(len(format_setting_value(v)) for _, v, _ in rows)
+                for spec, value, is_set in rows:
+                    line = f"{spec.dotted:<{key_w}}  {format_setting_value(value):<{val_w}}"
+                    print(line if is_set else f"{line}  {dimmed('(default)')}")
+        elif action == "get":
+            spec = setting_spec(args.key)
+            value, is_set = next(
+                (v, s) for sp, v, s in effective_settings(root) if sp is spec
+            )
+            if json_mode:
+                payload = {
+                    "schemaVersion": 1,
+                    "key": spec.dotted,
+                    "value": value,
+                    "isSet": is_set,
+                }
+                print(json.dumps(payload, indent=2))
+            else:
+                print(format_setting_value(value))
+        elif action == "set":
+            value = set_setting(root, args.key, args.value)
+            print(f"{args.key} = {format_setting_value(value)}")
+        elif action == "unset":
+            if unset_setting(root, args.key):
+                default = setting_spec(args.key).default
+                print(f"{args.key} unset (default: {format_setting_value(default)})")
+            else:
+                print(muted(f"{args.key} is not set; nothing to do"), file=sys.stderr)
+    except ClaudeSwitchError as e:
+        if json_mode:
+            print(json.dumps(error_envelope(e), indent=2))
+        else:
+            error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(
+            f"\n{dimmed('Operation cancelled')}",
+            file=sys.stderr if json_mode else sys.stdout,
+        )
+        sys.exit(130)
+
+
 def _use_native_tls() -> None:
     """Route TLS trust decisions through the OS-native verifier.
 
@@ -293,6 +438,9 @@ def main() -> None:
     if len(sys.argv) > 1 and sys.argv[1] == "auto":
         _auto_command(sys.argv[2:])
         return  # only reachable in tests where sys.exit is mocked
+    if len(sys.argv) > 1 and sys.argv[1] == "config":
+        _config_command(sys.argv[2:])
+        return
 
     parser = argparse.ArgumentParser(
         description="Multi-Account Switcher for Claude Code",
@@ -315,6 +463,8 @@ Examples:
   %(prog)s run 2 -- --resume                # forward args after '--' to claude
   %(prog)s auto                             # auto-switch when nearing rate limits
   %(prog)s auto --once                      # single auto-switch tick (cron-friendly)
+  %(prog)s config                           # show settings (settings.json)
+  %(prog)s config set autoswitch.threshold 80
   %(prog)s --remove-account user@example.com
   %(prog)s --status
   %(prog)s --purge

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -314,6 +314,7 @@ def unset_setting(backup_root: Path, dotted_key: str) -> bool:
     section = raw.get(spec.section)
     if not isinstance(section, dict) or spec.json_key not in section:
         return False
+    raw["schemaVersion"] = raw.get("schemaVersion", SETTINGS_SCHEMA_VERSION)
     del section[spec.json_key]
     if not section:
         del raw[spec.section]

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -20,6 +20,8 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from claude_swap.exceptions import ConfigError
+
 SETTINGS_SCHEMA_VERSION = 1
 SETTINGS_FILENAME = "settings.json"
 
@@ -47,16 +49,71 @@ class AutoSwitchSettings:
     unhealthy_ticks: int = 3
 
 
+@dataclass(frozen=True)
+class SettingSpec:
+    """Metadata for one user-tunable settings.json key.
+
+    Single source of truth for bounds/choices: both the lenient clamp on load
+    (`_clamped`) and the strict validation in `cswap config set`
+    (`parse_setting_value`) read from here, so the two can't drift.
+    """
+
+    section: str  # top-level JSON section ("autoswitch")
+    json_key: str  # camelCase key inside the section
+    field: str  # snake_case AutoSwitchSettings field
+    kind: str  # "float" | "int" | "bool" | "choice"
+    lo: float | None = None
+    hi: float | None = None
+    choices: tuple[str, ...] = ()
+    help: str = ""
+
+    @property
+    def dotted(self) -> str:
+        return f"{self.section}.{self.json_key}"
+
+    @property
+    def default(self):
+        return getattr(AutoSwitchSettings(), self.field)
+
+
 # settings.json uses camelCase (matching the repo's other JSON artifacts);
 # dataclass fields stay snake_case.
+SETTING_SPECS: dict[str, SettingSpec] = {
+    spec.dotted: spec
+    for spec in (
+        SettingSpec(
+            "autoswitch", "threshold", "threshold", "float", 50.0, 99.9,
+            help="Switch when the binding 5h/7d window reaches this pct",
+        ),
+        SettingSpec(
+            "autoswitch", "intervalSeconds", "interval_seconds", "float", 15.0, 3600.0,
+            help="Poll interval for the cswap auto loop, in seconds",
+        ),
+        SettingSpec(
+            "autoswitch", "cooldownSeconds", "cooldown_seconds", "float", 0.0, 86400.0,
+            help="Minimum seconds between proactive switches",
+        ),
+        SettingSpec(
+            "autoswitch", "hysteresisPct", "hysteresis_pct", "float", 0.0, 50.0,
+            help="A target must sit this many pct below the threshold",
+        ),
+        SettingSpec(
+            "autoswitch", "strategy", "strategy", "choice", choices=("best",),
+            help="How auto-switch picks the target account",
+        ),
+        SettingSpec(
+            "autoswitch", "includeApiKeyAccounts", "include_api_key_accounts", "bool",
+            help="Allow rotating onto managed API-key accounts (bill per token)",
+        ),
+        SettingSpec(
+            "autoswitch", "unhealthyTicks", "unhealthy_ticks", "int", 1, 100,
+            help="Consecutive failed polls before an account is unhealthy",
+        ),
+    )
+}
+
 _AUTOSWITCH_KEYS: dict[str, str] = {
-    "threshold": "threshold",
-    "interval_seconds": "intervalSeconds",
-    "cooldown_seconds": "cooldownSeconds",
-    "hysteresis_pct": "hysteresisPct",
-    "strategy": "strategy",
-    "include_api_key_accounts": "includeApiKeyAccounts",
-    "unhealthy_ticks": "unhealthyTicks",
+    spec.field: spec.json_key for spec in SETTING_SPECS.values()
 }
 
 
@@ -65,35 +122,30 @@ def settings_path(backup_root: Path) -> Path:
 
 
 def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:
-    """Clamp values into sane ranges; fall back to the default on bad types."""
-    defaults = AutoSwitchSettings()
+    """Clamp values into the SETTING_SPECS ranges; bad types → the default."""
 
     def num(value, default: float, lo: float, hi: float) -> float:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             return default
         return float(min(max(value, lo), hi))
 
-    strategy = settings.strategy if settings.strategy == "best" else defaults.strategy
-    if strategy != settings.strategy:
-        _logger.warning(
-            "settings.json: unsupported autoswitch strategy %r; using 'best'",
-            settings.strategy,
-        )
-    return AutoSwitchSettings(
-        threshold=num(settings.threshold, defaults.threshold, 50.0, 99.9),
-        interval_seconds=num(
-            settings.interval_seconds, defaults.interval_seconds, 15.0, 3600.0
-        ),
-        cooldown_seconds=num(
-            settings.cooldown_seconds, defaults.cooldown_seconds, 0.0, 86400.0
-        ),
-        hysteresis_pct=num(settings.hysteresis_pct, defaults.hysteresis_pct, 0.0, 50.0),
-        strategy=strategy,
-        include_api_key_accounts=bool(settings.include_api_key_accounts),
-        unhealthy_ticks=int(
-            num(settings.unhealthy_ticks, defaults.unhealthy_ticks, 1, 100)
-        ),
-    )
+    kwargs = {}
+    for spec in SETTING_SPECS.values():
+        value = getattr(settings, spec.field)
+        if spec.kind in ("float", "int"):
+            clamped = num(value, spec.default, spec.lo, spec.hi)
+            kwargs[spec.field] = int(clamped) if spec.kind == "int" else clamped
+        elif spec.kind == "bool":
+            kwargs[spec.field] = bool(value)
+        else:  # choice
+            if value not in spec.choices:
+                _logger.warning(
+                    "settings.json: unsupported %s %r; using %r",
+                    spec.dotted, value, spec.default,
+                )
+                value = spec.default
+            kwargs[spec.field] = value
+    return AutoSwitchSettings(**kwargs)
 
 
 def _read_raw(path: Path) -> dict:
@@ -139,6 +191,151 @@ def save_settings(backup_root: Path, settings: AutoSwitchSettings) -> None:
         section[json_key] = getattr(settings, field)
     raw["autoswitch"] = section
     atomic_write_json(path, raw)
+
+
+def setting_spec(dotted_key: str) -> SettingSpec:
+    """Look up a spec by dotted key; unknown keys raise with the valid list."""
+    spec = SETTING_SPECS.get(dotted_key)
+    if spec is None:
+        raise ConfigError(
+            f"unknown setting '{dotted_key}'\n"
+            f"Valid keys: {', '.join(SETTING_SPECS)}"
+        )
+    return spec
+
+
+_BOOL_WORDS = {
+    "true": True, "1": True, "yes": True,
+    "false": False, "0": False, "no": False,
+}
+
+
+def parse_setting_value(spec: SettingSpec, raw_value: str):
+    """Strictly parse a CLI-provided string for `cswap config set`.
+
+    Unlike the forgiving clamp on load, out-of-range or mistyped values raise
+    ConfigError so the user learns about the problem when setting the value,
+    not by silently degraded behavior at `cswap auto` time.
+    """
+    if spec.kind == "bool":
+        # Never bool(str): bool("false") is True.
+        parsed = _BOOL_WORDS.get(raw_value.strip().lower())
+        if parsed is None:
+            raise ConfigError(
+                f"{spec.dotted} expects true or false (or 1/0, yes/no), "
+                f"got '{raw_value}'"
+            )
+        return parsed
+    if spec.kind == "choice":
+        if raw_value not in spec.choices:
+            raise ConfigError(
+                f"{spec.dotted} must be one of: {', '.join(spec.choices)}"
+            )
+        return raw_value
+    try:
+        value = int(raw_value) if spec.kind == "int" else float(raw_value)
+    except ValueError:
+        noun = "an integer" if spec.kind == "int" else "a number"
+        raise ConfigError(
+            f"{spec.dotted} expects {noun}, got '{raw_value}'"
+        ) from None
+    if not spec.lo <= value <= spec.hi:
+        raise ConfigError(
+            f"{spec.dotted} must be between {format_setting_value(spec.lo)} "
+            f"and {format_setting_value(spec.hi)}"
+        )
+    return value
+
+
+def format_setting_value(value) -> str:
+    """Render a settings value the way settings.json writes it."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _read_raw_for_write(path: Path) -> dict:
+    """Raw read for the config write path: a corrupt file errors, never {}.
+
+    ``_read_raw``'s degrade-to-defaults is right for reads, but a
+    read-modify-write starting from ``{}`` would replace a malformed (and
+    maybe hand-recoverable) file with a near-empty one.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except (OSError, UnicodeDecodeError) as e:
+        raise ConfigError(f"could not read {path}: {e}") from e
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ConfigError(
+            f"{path} is not valid JSON ({e}); fix or delete it before "
+            "changing settings"
+        ) from e
+    if not isinstance(raw, dict):
+        raise ConfigError(
+            f"{path} is not a JSON object; fix or delete it before "
+            "changing settings"
+        )
+    return raw
+
+
+def set_setting(backup_root: Path, dotted_key: str, raw_value: str):
+    """Validate and persist one key for `cswap config set`; returns the value.
+
+    Writes only the given key (plus schemaVersion) — deliberately not
+    ``save_settings``, which writes every known key and would freeze the
+    current defaults into the file, pinning users to them if a later version
+    changes a default. Unknown keys and sections in the file survive.
+    """
+    spec = setting_spec(dotted_key)
+    value = parse_setting_value(spec, raw_value)
+    path = settings_path(backup_root)
+    raw = _read_raw_for_write(path)
+    raw["schemaVersion"] = raw.get("schemaVersion", SETTINGS_SCHEMA_VERSION)
+    section = raw.get(spec.section)
+    if not isinstance(section, dict):
+        section = {}
+    section[spec.json_key] = value
+    raw[spec.section] = section
+    atomic_write_json(path, raw)
+    return value
+
+
+def unset_setting(backup_root: Path, dotted_key: str) -> bool:
+    """Remove one key from settings.json; False if it wasn't set (no write)."""
+    spec = setting_spec(dotted_key)
+    path = settings_path(backup_root)
+    raw = _read_raw_for_write(path)
+    section = raw.get(spec.section)
+    if not isinstance(section, dict) or spec.json_key not in section:
+        return False
+    del section[spec.json_key]
+    if not section:
+        del raw[spec.section]
+    atomic_write_json(path, raw)
+    return True
+
+
+def effective_settings(backup_root: Path) -> list[tuple[SettingSpec, object, bool]]:
+    """(spec, effective value, explicitly set?) per key, in registry order.
+
+    "Set" means the key is present in the raw file — an explicit value equal
+    to the default still counts — so `cswap config`'s "(default)" marker
+    reflects the file, not value equality.
+    """
+    raw = _read_raw(settings_path(backup_root))
+    effective = load_settings(backup_root)
+    rows = []
+    for spec in SETTING_SPECS.values():
+        section = raw.get(spec.section)
+        is_set = isinstance(section, dict) and spec.json_key in section
+        rows.append((spec, getattr(effective, spec.field), is_set))
+    return rows
 
 
 def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -1,0 +1,268 @@
+"""Tests for the `cswap config` subcommand (get/set/unset/list/path)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import cli
+
+
+def _run(argv: list[str], capsys) -> tuple[int, str, str]:
+    """Run `cswap config <argv>`; returns (exit_code, stdout, stderr).
+
+    Success returns normally from main() (no sys.exit), errors raise
+    SystemExit — normalize both to an exit code.
+    """
+    with patch("os.geteuid", return_value=1000, create=True), \
+         patch.object(sys, "argv", ["claude-swap", "config", *argv]):
+        code = 0
+        try:
+            cli.main()
+        except SystemExit as e:
+            code = e.code or 0
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+def _settings_file(capsys) -> Path:
+    code, out, _ = _run(["path"], capsys)
+    assert code == 0
+    return Path(out.strip())
+
+
+class TestConfigList:
+    def test_lists_all_keys_as_defaults(self, temp_home, capsys):
+        code, out, _ = _run([], capsys)
+        assert code == 0
+        for key in (
+            "autoswitch.threshold",
+            "autoswitch.intervalSeconds",
+            "autoswitch.cooldownSeconds",
+            "autoswitch.hysteresisPct",
+            "autoswitch.strategy",
+            "autoswitch.includeApiKeyAccounts",
+            "autoswitch.unhealthyTicks",
+        ):
+            assert key in out
+        assert out.count("(default)") == 7
+
+    def test_set_key_not_marked_default(self, temp_home, capsys):
+        _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
+        code, out, _ = _run([], capsys)
+        assert code == 0
+        cooldown_line = next(
+            ln for ln in out.splitlines() if "cooldownSeconds" in ln
+        )
+        assert "600" in cooldown_line
+        assert "(default)" not in cooldown_line
+
+    def test_set_equal_to_default_still_counts_as_set(self, temp_home, capsys):
+        _run(["set", "autoswitch.threshold", "90"], capsys)
+        _, out, _ = _run([], capsys)
+        threshold_line = next(
+            ln for ln in out.splitlines() if "threshold" in ln
+        )
+        assert "(default)" not in threshold_line
+
+    def test_json_list(self, temp_home, capsys):
+        code, out, _ = _run(["--json"], capsys)
+        assert code == 0
+        payload = json.loads(out)
+        assert payload["schemaVersion"] == 1
+        assert payload["path"].endswith("settings.json")
+        by_key = {entry["key"]: entry for entry in payload["settings"]}
+        assert len(by_key) == 7
+        assert by_key["autoswitch.threshold"]["value"] == 90.0
+        assert by_key["autoswitch.threshold"]["isSet"] is False
+        assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False
+
+
+class TestConfigSetGet:
+    def test_set_then_get(self, temp_home, capsys):
+        code, out, _ = _run(["set", "autoswitch.threshold", "80"], capsys)
+        assert code == 0
+        assert "autoswitch.threshold = 80" in out
+        code, out, _ = _run(["get", "autoswitch.threshold"], capsys)
+        assert code == 0
+        assert out.strip() == "80"
+
+    def test_set_writes_only_that_key(self, temp_home, capsys):
+        """The trap guard: no other defaults get materialized into the file."""
+        _run(["set", "autoswitch.threshold", "80"], capsys)
+        raw = json.loads(_settings_file(capsys).read_text())
+        assert set(raw) == {"schemaVersion", "autoswitch"}
+        assert set(raw["autoswitch"]) == {"threshold"}
+        assert raw["autoswitch"]["threshold"] == 80.0
+
+    def test_set_bool_words(self, temp_home, capsys):
+        code, out, _ = _run(
+            ["set", "autoswitch.includeApiKeyAccounts", "no"], capsys
+        )
+        assert code == 0
+        assert "= false" in out
+        raw = json.loads(_settings_file(capsys).read_text())
+        assert raw["autoswitch"]["includeApiKeyAccounts"] is False
+
+    def test_set_preserves_unknown_keys(self, temp_home, capsys):
+        path = _settings_file(capsys)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "schemaVersion": 1,
+            "futureSection": {"x": 1},
+            "autoswitch": {"threshold": 80, "futureKnob": True},
+        }))
+        code, _, _ = _run(["set", "autoswitch.threshold", "70"], capsys)
+        assert code == 0
+        raw = json.loads(path.read_text())
+        assert raw["futureSection"] == {"x": 1}
+        assert raw["autoswitch"]["futureKnob"] is True
+        assert raw["autoswitch"]["threshold"] == 70.0
+
+    def test_get_json_trailing_and_leading_flag(self, temp_home, capsys):
+        _run(["set", "autoswitch.threshold", "80"], capsys)
+        for argv in (
+            ["get", "autoswitch.threshold", "--json"],
+            ["--json", "get", "autoswitch.threshold"],
+        ):
+            code, out, _ = _run(argv, capsys)
+            assert code == 0
+            payload = json.loads(out)
+            assert payload == {
+                "schemaVersion": 1,
+                "key": "autoswitch.threshold",
+                "value": 80.0,
+                "isSet": True,
+            }
+
+
+class TestConfigValidation:
+    def test_out_of_range_exits_1(self, temp_home, capsys):
+        code, _, err = _run(["set", "autoswitch.threshold", "30"], capsys)
+        assert code == 1
+        assert "between 50 and 99.9" in err
+
+    def test_unknown_key_exits_1_and_lists_valid_keys(self, temp_home, capsys):
+        code, _, err = _run(["set", "autoswitch.bogus", "1"], capsys)
+        assert code == 1
+        assert "unknown setting" in err
+        assert "autoswitch.threshold" in err
+
+    def test_bad_bool_exits_1(self, temp_home, capsys):
+        code, _, err = _run(
+            ["set", "autoswitch.includeApiKeyAccounts", "falsy"], capsys
+        )
+        assert code == 1
+        assert "true or false" in err
+
+    def test_bad_number_exits_1(self, temp_home, capsys):
+        code, _, err = _run(["set", "autoswitch.threshold", "high"], capsys)
+        assert code == 1
+        assert "expects a number" in err
+
+    def test_int_key_rejects_float(self, temp_home, capsys):
+        code, _, err = _run(["set", "autoswitch.unhealthyTicks", "3.5"], capsys)
+        assert code == 1
+        assert "expects an integer" in err
+
+    def test_bad_strategy_exits_1(self, temp_home, capsys):
+        code, _, err = _run(["set", "autoswitch.strategy", "chaos"], capsys)
+        assert code == 1
+        assert "must be one of: best" in err
+
+    def test_unknown_key_json_error_envelope(self, temp_home, capsys):
+        code, out, _ = _run(["--json", "get", "autoswitch.bogus"], capsys)
+        assert code == 1
+        payload = json.loads(out)
+        assert payload["schemaVersion"] == 1
+        assert "unknown setting" in payload["error"]["message"]
+
+    def test_corrupt_file_set_exits_1_and_leaves_file_untouched(
+        self, temp_home, capsys
+    ):
+        path = _settings_file(capsys)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json")
+        code, _, err = _run(["set", "autoswitch.threshold", "80"], capsys)
+        assert code == 1
+        assert "not valid JSON" in err
+        assert path.read_text() == "{not json"
+
+    def test_missing_value_usage_error_exits_2(self, temp_home, capsys):
+        code, _, _ = _run(["set", "autoswitch.threshold"], capsys)
+        assert code == 2
+
+    def test_unknown_action_exits_2(self, temp_home, capsys):
+        code, _, _ = _run(["frobnicate"], capsys)
+        assert code == 2
+
+    def test_json_with_set_rejected(self, temp_home, capsys):
+        code, _, _ = _run(
+            ["--json", "set", "autoswitch.threshold", "80"], capsys
+        )
+        assert code == 2
+
+
+class TestConfigUnset:
+    def test_unset_restores_default(self, temp_home, capsys):
+        _run(["set", "autoswitch.threshold", "80"], capsys)
+        code, out, _ = _run(["unset", "autoswitch.threshold"], capsys)
+        assert code == 0
+        assert "default: 90" in out
+        code, out, _ = _run(["get", "autoswitch.threshold"], capsys)
+        assert out.strip() == "90"
+        # The emptied autoswitch section is removed entirely.
+        raw = json.loads(_settings_file(capsys).read_text())
+        assert "autoswitch" not in raw
+
+    def test_unset_when_not_set_is_a_noop(self, temp_home, capsys):
+        code, _, err = _run(["unset", "autoswitch.threshold"], capsys)
+        assert code == 0
+        assert "not set" in err
+
+
+class TestConfigMisc:
+    def test_path_prints_settings_location(self, temp_home, capsys):
+        code, out, _ = _run(["path"], capsys)
+        assert code == 0
+        assert out.strip().endswith("settings.json")
+
+    def test_config_help(self, temp_home, capsys):
+        code, out, _ = _run(["--help"], capsys)
+        assert code == 0
+        assert "autoswitch.threshold" in out
+        assert "unset" in out
+
+    def test_main_help_mentions_config(self, temp_home, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "--help"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 0
+        assert "config" in capsys.readouterr().out
+
+    def test_auto_picks_up_configured_threshold(self, temp_home, capsys):
+        """End-to-end: a value set via config drives `cswap auto`."""
+        _run(["set", "autoswitch.threshold", "77"], capsys)
+
+        captured = {}
+
+        class FakeEngine:
+            def __init__(self, switcher, settings, on_event, *, dry_run=False,
+                         state_path=None, clock=None):
+                captured["settings"] = settings
+
+            def tick(self):
+                from claude_swap.autoswitch import TickOutcome
+
+                return TickOutcome.NO_ACTION
+
+        with patch("claude_swap.autoswitch.AutoSwitchEngine", FakeEngine), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "auto", "--once"]):
+            with pytest.raises(SystemExit):
+                cli.main()
+        assert captured["settings"].threshold == 77.0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,12 +10,17 @@ from pathlib import Path
 
 import pytest
 
+from claude_swap.exceptions import ConfigError
 from claude_swap.settings import (
+    SETTING_SPECS,
     AutoSwitchSettings,
+    effective_settings,
     load_settings,
     merged_with_cli,
     save_settings,
+    set_setting,
     settings_path,
+    unset_setting,
 )
 
 
@@ -103,6 +108,76 @@ class TestSaveSettings:
         save_settings(tmp_path, AutoSwitchSettings())
         mode = stat.S_IMODE(settings_path(tmp_path).stat().st_mode)
         assert mode == 0o600
+
+
+class TestSettingSpecs:
+    def test_registry_covers_every_dataclass_field(self):
+        spec_fields = {spec.field for spec in SETTING_SPECS.values()}
+        dataclass_fields = {
+            f.name for f in AutoSwitchSettings.__dataclass_fields__.values()
+        }
+        assert spec_fields == dataclass_fields
+
+    def test_defaults_match_dataclass(self):
+        defaults = AutoSwitchSettings()
+        for spec in SETTING_SPECS.values():
+            assert spec.default == getattr(defaults, spec.field)
+
+
+class TestSetUnsetSetting:
+    def test_set_writes_minimal_file(self, tmp_path: Path):
+        value = set_setting(tmp_path, "autoswitch.threshold", "80")
+        assert value == 80.0
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert raw == {"schemaVersion": 1, "autoswitch": {"threshold": 80.0}}
+
+    def test_set_int_kind_coerces_and_rejects_floats(self, tmp_path: Path):
+        assert set_setting(tmp_path, "autoswitch.unhealthyTicks", "5") == 5
+        with pytest.raises(ConfigError, match="integer"):
+            set_setting(tmp_path, "autoswitch.unhealthyTicks", "3.5")
+
+    def test_set_rejects_out_of_range_without_writing(self, tmp_path: Path):
+        with pytest.raises(ConfigError, match="between 50 and 99.9"):
+            set_setting(tmp_path, "autoswitch.threshold", "200")
+        assert not settings_path(tmp_path).exists()
+
+    def test_set_rejects_unknown_key(self, tmp_path: Path):
+        with pytest.raises(ConfigError, match="unknown setting"):
+            set_setting(tmp_path, "autoswitch.bogus", "1")
+
+    def test_set_rejects_bool_words_strictly(self, tmp_path: Path):
+        assert set_setting(tmp_path, "autoswitch.includeApiKeyAccounts", "FALSE") is False
+        with pytest.raises(ConfigError, match="true or false"):
+            set_setting(tmp_path, "autoswitch.includeApiKeyAccounts", "falsy")
+
+    def test_set_on_corrupt_file_raises_and_preserves_it(self, tmp_path: Path):
+        settings_path(tmp_path).write_text("{not json")
+        with pytest.raises(ConfigError, match="not valid JSON"):
+            set_setting(tmp_path, "autoswitch.threshold", "80")
+        assert settings_path(tmp_path).read_text() == "{not json"
+
+    def test_unset_removes_key_and_empty_section(self, tmp_path: Path):
+        set_setting(tmp_path, "autoswitch.threshold", "80")
+        assert unset_setting(tmp_path, "autoswitch.threshold") is True
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert "autoswitch" not in raw
+
+    def test_unset_absent_key_is_noop(self, tmp_path: Path):
+        assert unset_setting(tmp_path, "autoswitch.threshold") is False
+        assert not settings_path(tmp_path).exists()
+
+
+class TestEffectiveSettings:
+    def test_missing_file_reports_all_defaults(self, tmp_path: Path):
+        rows = effective_settings(tmp_path)
+        assert len(rows) == len(SETTING_SPECS)
+        assert all(not is_set for _, _, is_set in rows)
+
+    def test_presence_not_value_equality_marks_set(self, tmp_path: Path):
+        set_setting(tmp_path, "autoswitch.threshold", "90")  # equals default
+        by_key = {spec.dotted: is_set for spec, _, is_set in effective_settings(tmp_path)}
+        assert by_key["autoswitch.threshold"] is True
+        assert by_key["autoswitch.intervalSeconds"] is False
 
 
 class TestMergedWithCli:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -162,6 +162,14 @@ class TestSetUnsetSetting:
         raw = json.loads(settings_path(tmp_path).read_text())
         assert "autoswitch" not in raw
 
+    def test_unset_stamps_schema_version_on_unversioned_file(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"autoswitch": {"threshold": 80}})
+        )
+        assert unset_setting(tmp_path, "autoswitch.threshold") is True
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert raw["schemaVersion"] == 1
+
     def test_unset_absent_key_is_noop(self, tmp_path: Path):
         assert unset_setting(tmp_path, "autoswitch.threshold") is False
         assert not settings_path(tmp_path).exists()


### PR DESCRIPTION
Adds a git-style `cswap config` subcommand for reading and editing `settings.json`, so users no longer have to find the file or hand-edit JSON that fails silently.

## What's included

- `cswap config` / `list` — show effective settings, marking values not in the file as `(default)` (based on key presence, not value equality)
- `cswap config get|set|unset <key>` — dotted camelCase keys matching the JSON (`autoswitch.threshold`); `set` validates strictly and rejects out-of-range values, unknown keys, and bad booleans loudly (exit 1), unlike the lenient clamp-on-load which is unchanged
- `cswap config path` — prints the platform-dependent settings.json location
- `--json` on `list`/`get` for scripting (works before or after the verb)

## Implementation notes

- New `SETTING_SPECS` registry in `settings.py` is the single source of truth for keys, bounds, and defaults; `_clamped` now derives from it so load-clamping and set-validation can't drift
- `set`/`unset` write only the touched key via `atomic_write_json` (never `save_settings`, which would freeze all current defaults into the file); unknown keys/sections round-trip untouched
- Writes against a corrupt settings.json error out instead of silently replacing it
- Exit codes follow the existing convention: 0 success, 1 handled errors, 2 usage errors

## Testing

- New `tests/test_config_cli.py` covering the full surface, including regression guards: a `set` never materializes unrelated defaults, and a corrupt file is left byte-for-byte untouched
- Module-level tests for the new helpers in `tests/test_settings.py`
- Verified end-to-end in an isolated home: values set via `cswap config` are picked up by `cswap auto`