### PR TITLE
Stale-on-error usage store, idle-hold, and adaptive polling for auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ cswap auto --dry-run           # log what it would do, never switch
 
 - Switches cooperate with Claude Code's own credential locks, so a swap can never collide with a token refresh mid-session.
 - A cooldown (default 5 min) and a hysteresis margin keep it from flip-flopping between accounts near the line; when every account is exhausted it sleeps until the earliest quota reset.
+- Usage polling is adaptive: each check polls the active account plus one alternate (whichever has the stalest data), and only refreshes everything when a switch is actually near — so API traffic stays flat no matter how many accounts you manage. An alternate whose usage is moving (in use on another machine or in session mode) gets watched more closely, an unchanging one backs off, and an exhausted one isn't polled again until its window resets.
+- A failed usage fetch doesn't blind it: the last-known usage keeps being trusted for a few minutes while retries back off (honoring the server's `Retry-After`), so a network blip can't trigger a spurious failover.
+- If the active account's token expires while Claude Code sits idle (typical after the PC wakes from sleep), auto holds and slows down instead of failing over — Claude Code refreshes the token itself on your next message, and nothing consumes quota in the meantime.
 - An account whose refresh token has died is quarantined — taken out of rotation and reported — until you log in with it and re-run `cswap --add-account --slot N`.
 - API-key accounts are never rotated onto unless you pass `--include-api-key-accounts` (they bill per token).
 
@@ -211,6 +214,8 @@ cswap --switch-to 2 --json
 ```
 
 Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
+
+Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is.
 
 </details>
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import enum
 import hashlib
 import json
+import logging
 import random
 import threading
 import time
@@ -43,13 +44,15 @@ from typing import ClassVar
 
 from claude_swap import oauth
 from claude_swap.exceptions import ClaudeSwitchError
-from claude_swap.json_output import SCHEMA_VERSION
+from claude_swap.json_output import SCHEMA_VERSION, USAGE_TOKEN_EXPIRED
 from claude_swap.locking import FileLock
 from claude_swap.settings import AutoSwitchSettings, atomic_write_json
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 STATE_FILENAME = "autoswitch_state.json"
 STATE_SCHEMA_VERSION = 1
+
+_logger = logging.getLogger("claude-swap")
 
 # Freshen targets whose access token expires within this window: twice Claude
 # Code's own 5-minute refresh buffer, so its post-lock "abort refresh if not
@@ -62,6 +65,13 @@ FRESHEN_BUFFER_MS = 10 * 60 * 1000
 RESET_SLACK_S = 60.0
 MAX_SLEEP_S = 6 * 3600.0
 NO_RESET_FALLBACK_S = 300.0
+
+# Idle-hold cap (elapsed, not ticks — the hold itself slows the cadence to
+# NO_RESET_FALLBACK_S): an owned-and-expired token normally means Claude Code
+# is idle and will self-heal on next use, but a *dead* refresh token with an
+# active user would look identical forever, so after this long the engine
+# falls back to normal unhealthy counting.
+IDLE_HOLD_MAX_S = 30 * 60.0
 
 
 def _now_iso() -> str:
@@ -305,6 +315,12 @@ class AutoSwitchEngine:
         # longer than the normal interval.
         self._sleep_until_ts: float | None = None
         self._blocked_wait_long = False
+        # Idle-hold: when the active token expired while Claude Code owns it
+        # (and is therefore idle), crawl instead of counting unhealthy ticks.
+        # ``_idle_hold_since`` survives across ticks (elapsed-time cap);
+        # ``_idle_hold_slow`` is per-tick like ``_blocked_wait_long``.
+        self._idle_hold_since: float | None = None
+        self._idle_hold_slow = False
 
     # -- state file ---------------------------------------------------------
 
@@ -448,6 +464,7 @@ class AutoSwitchEngine:
     def _tick_inner(self) -> TickOutcome:
         self._sleep_until_ts = None
         self._blocked_wait_long = False
+        self._idle_hold_slow = False
         settings = self.settings
         state = self._read_state()
         if not self.dry_run:
@@ -515,6 +532,7 @@ class AutoSwitchEngine:
         active_headroom = headroom.get(current)
         if active_headroom is not None:
             self._unhealthy_ticks = 0
+            self._idle_hold_since = None
             utilization = 100.0 - active_headroom
             if utilization < settings.threshold:
                 self._emit(
@@ -526,6 +544,39 @@ class AutoSwitchEngine:
                 return TickOutcome.NO_ACTION
             trigger = "at-limit" if active_headroom <= 0 else "proactive"
         else:
+            if usage.get(current) == USAGE_TOKEN_EXPIRED:
+                # Expired while an owner (Claude Code / live session) holds the
+                # credential: CC refreshes on every API request, so expired +
+                # owner present proves Claude has been idle since expiry — no
+                # quota burn, nothing to switch for. Self-heals on next use;
+                # crawl slowly instead of burning failover ticks (Finding 2 of
+                # the usage-lapse investigation).
+                now = self.clock()
+                if self._idle_hold_since is None:
+                    self._idle_hold_since = now
+                if now - self._idle_hold_since <= IDLE_HOLD_MAX_S:
+                    self._unhealthy_ticks = 0
+                    self._idle_hold_slow = True
+                    self._emit(
+                        NoSwitchEvent(
+                            reason="active-idle",
+                            detail=(
+                                "token expired while Claude Code is idle; "
+                                "resumes on next use"
+                            ),
+                        )
+                    )
+                    return TickOutcome.NO_ACTION
+                # Held far longer than any idle nap should need — likely a
+                # dead refresh token with an *active* user. Fall through to
+                # normal unhealthy counting so failover can still happen.
+                _logger.warning(
+                    "Active token expired and owned for over %.0f minutes; "
+                    "resuming unhealthy counting (dead refresh token?)",
+                    IDLE_HOLD_MAX_S / 60,
+                )
+            else:
+                self._idle_hold_since = None
             self._unhealthy_ticks += 1
             if self._unhealthy_ticks < settings.unhealthy_ticks:
                 self._emit(
@@ -767,6 +818,11 @@ class AutoSwitchEngine:
             # Blocked on something that can resolve any tick (hysteresis,
             # unreadable usage) — keep the normal cadence so the at-limit
             # escape isn't missed.
+        elif outcome is TickOutcome.NO_ACTION and self._idle_hold_slow:
+            # Idle-hold: Claude is idle on an expired token — nothing changes
+            # until the user comes back, so crawl. Worst case protection
+            # resumes one slow tick after they do.
+            return max(interval, NO_RESET_FALLBACK_S)
         # ±10% jitter so multiple machines don't synchronize their API hits.
         return interval * (0.9 + 0.2 * random.random())
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -73,6 +73,19 @@ NO_RESET_FALLBACK_S = 300.0
 # falls back to normal unhealthy counting.
 IDLE_HOLD_MAX_S = 30 * 60.0
 
+# Adaptive scheduler: the baseline request volume is O(1) per tick — the
+# active account plus ONE due candidate (stalest data first) — instead of
+# every account in parallel. Candidates far from mattering are served stale
+# from the usage store. The engine escalates to a full refresh only when a
+# switch could actually be near: active utilization within this margin of the
+# threshold, or active usage unknown (failover needs fresh candidate data).
+ESCALATION_MARGIN_PCT = 15.0
+# A candidate whose binding pct moved at least this much between polls is
+# being used elsewhere (another PC / session mode) → poll it more closely;
+# an unmoved one backs off, up to the cap.
+MOVEMENT_DELTA_PCT = 1.0
+CANDIDATE_MAX_INTERVAL_S = 600.0
+
 
 def _now_iso() -> str:
     return (
@@ -116,23 +129,40 @@ class PollEvent(AutoSwitchEvent):
     active: dict | None  # account_ref shape, or None
     headroom: dict[str, float | None]  # account number → headroom pct (None=unknown)
     threshold: float
+    # account number → last fetch-error cause ("http-429", "timeout", ...) for
+    # accounts whose usage is unknown this tick. Additive field.
+    fetch_errors: dict[str, str] = field(default_factory=dict)
 
     def _fields(self) -> dict:
-        return {
+        fields = {
             "active": self.active,
             "headroomPct": self.headroom,
             "threshold": self.threshold,
         }
+        if self.fetch_errors:
+            fields["fetchErrors"] = self.fetch_errors
+        return fields
+
+    def _describe(self, num: str) -> str:
+        h = self.headroom.get(num)
+        if h is not None:
+            return f"{100 - h:.0f}%"
+        err = self.fetch_errors.get(num)
+        return f"? ({err})" if err else "?"
 
     def human(self) -> str:
         if self.active is None:
             return "poll: no active account"
         num = self.active.get("number")
         h = self.headroom.get(str(num))
-        used = f"{100 - h:.0f}% used" if h is not None else "usage unknown"
+        if h is not None:
+            used = f"{100 - h:.0f}% used"
+        else:
+            err = self.fetch_errors.get(str(num))
+            used = f"usage unknown ({err})" if err else "usage unknown"
         others = ", ".join(
-            f"#{n}: {100 - v:.0f}%" if v is not None else f"#{n}: ?"
-            for n, v in self.headroom.items()
+            f"#{n}: {self._describe(n)}"
+            for n in self.headroom
             if n != str(num)
         )
         tail = f" | others: {others}" if others else ""
@@ -278,6 +308,38 @@ def _refresh_fingerprint(credentials: str) -> str | None:
     if not isinstance(token, str) or not token:
         return None
     return "sha256:" + hashlib.sha256(token.encode()).hexdigest()
+
+
+def _binding_pct(usage: dict | None) -> float | None:
+    """Utilization of the binding (higher) 5h/7d window, or None."""
+    headroom = oauth.account_headroom(usage)
+    return None if headroom is None else 100.0 - headroom
+
+
+def _limiting_reset_ts(usage: dict | None) -> float | None:
+    """Epoch when the last of the ≥100% windows resets (account usable again)."""
+    if not isinstance(usage, dict):
+        return None
+    latest: float | None = None
+    for key in ("five_hour", "seven_day"):
+        window = usage.get(key)
+        if not isinstance(window, dict):
+            continue
+        pct = window.get("pct")
+        if not isinstance(pct, (int, float)) or pct < 100.0:
+            continue
+        resets_at = window.get("resets_at")
+        if not resets_at:
+            continue
+        try:
+            ts = datetime.fromisoformat(
+                str(resets_at).replace("Z", "+00:00")
+            ).timestamp()
+        except ValueError:
+            continue
+        if latest is None or ts > latest:
+            latest = ts
+    return latest
 
 
 def _ref(number: str, email: str) -> dict:
@@ -506,14 +568,17 @@ class AutoSwitchEngine:
             "email": "",
         }
 
-        usage = self.switcher.usage_by_account()
-        headroom = {
-            num: oauth.account_headroom(entry if isinstance(entry, dict) else None)
-            for num, entry in usage.items()
-        }
+        entries, usage, headroom = self._collect_scheduled_usage(current)
         self._emit(
             PollEvent(
-                active=active_ref, headroom=headroom, threshold=settings.threshold
+                active=active_ref,
+                headroom=headroom,
+                threshold=settings.threshold,
+                fetch_errors={
+                    num: entry.last_error
+                    for num, entry in entries.items()
+                    if usage.get(num) is None and entry.last_error
+                },
             )
         )
 
@@ -718,6 +783,142 @@ class AutoSwitchEngine:
             return TickOutcome.ERROR
         self._emit(NoSwitchEvent(reason="no-viable-target"))
         return TickOutcome.BLOCKED
+
+    # -- adaptive usage scheduling ---------------------------------------------
+
+    def _collect_scheduled_usage(
+        self, current: str
+    ) -> tuple[dict, dict[str, dict | str | None], dict[str, float | None]]:
+        """Two-phase usage collection with an O(1) baseline.
+
+        Phase A fetches the active account plus ONE due candidate (the one
+        with the stalest data — never-fetched first, then oldest fetch);
+        everyone else is served from the usage store. Phase B refetches ALL
+        candidates and recomputes before any switch decision when a switch
+        could be near: active utilization within ``ESCALATION_MARGIN_PCT`` of
+        the threshold, or active usage unknown (failover must not run on
+        stale candidate data). Candidate selection never runs on the
+        pre-escalation snapshot.
+
+        Stalest-first needs no rotation cursor: it reads the persisted store,
+        so the loop and cron-driven ``--once`` runs schedule identically.
+        Backoff (``backoffUntil``) is enforced by the collector even for the
+        active account — a Retry-After must never be defeated — and during an
+        idle-hold no candidate is polled at all (slow crawl for everything).
+
+        Returns ``(entries, usage, headroom)`` where ``usage`` carries
+        decision values and ``headroom`` the derived headroom per account.
+        """
+        now = self.clock()
+        candidates = [
+            n for n in self.switcher.switchable_account_numbers() if n != current
+        ]
+
+        pre = self.switcher.usage_entries_by_account(fetch=set())
+        plan: set[str] = {current}
+        if self._idle_hold_since is None:
+            pick = self._due_candidate(candidates, pre, now)
+            if pick is not None:
+                plan.add(pick)
+        entries = self.switcher.usage_entries_by_account(fetch=plan)
+        usage = {num: entry.decision_value() for num, entry in entries.items()}
+
+        active_value = usage.get(current)
+        active_headroom = oauth.account_headroom(
+            active_value if isinstance(active_value, dict) else None
+        )
+        escalate = bool(candidates) and (
+            (active_headroom is None and active_value != USAGE_TOKEN_EXPIRED)
+            or (
+                active_headroom is not None
+                and 100.0 - active_headroom
+                >= self.settings.threshold - ESCALATION_MARGIN_PCT
+            )
+        )
+        if escalate:
+            entries = self.switcher.usage_entries_by_account(
+                fetch={current, *candidates}
+            )
+            usage = {num: entry.decision_value() for num, entry in entries.items()}
+
+        headroom = {
+            num: oauth.account_headroom(value if isinstance(value, dict) else None)
+            for num, value in usage.items()
+        }
+        if not self.dry_run:
+            self._update_poll_plans(candidates, pre, entries, now)
+        return entries, usage, headroom
+
+    @staticmethod
+    def _due_candidate(
+        candidates: list[str], entries: dict, now: float
+    ) -> str | None:
+        """The due candidate with the stalest data, or None.
+
+        Due = past its ``nextPollAt`` and not in failure backoff. Sentinel
+        accounts (api-key / no credentials) have nothing to fetch. A
+        perpetually failing account can't monopolize the slot: its backoff
+        removes it from the due set between attempts.
+        """
+        due: list[tuple[int, float, str]] = []
+        for num in candidates:
+            entry = entries.get(num)
+            if entry is None:
+                due.append((0, 0.0, num))
+                continue
+            if entry.sentinel is not None:
+                continue
+            if entry.in_backoff(now):
+                continue
+            if entry.next_poll_at is not None and now < entry.next_poll_at:
+                continue
+            if entry.fetched_at is None:
+                due.append((0, 0.0, num))
+            else:
+                due.append((1, entry.fetched_at, num))
+        if not due:
+            return None
+        due.sort()
+        return due[0][2]
+
+    def _update_poll_plans(
+        self, candidates: list[str], pre: dict, post: dict, now: float
+    ) -> None:
+        """Adapt each just-fetched candidate's poll cadence, persisted in the
+        store (survives ``--once`` engine restarts).
+
+        Movement (binding pct changed ≥ ``MOVEMENT_DELTA_PCT`` since its
+        previous poll — someone is using it elsewhere) halves the interval,
+        floored at the engine interval; no movement backs it off ×1.5 up to
+        ``CANDIDATE_MAX_INTERVAL_S``. A candidate at its limit skips straight
+        to its window reset (``nextPollAt`` only — the learned interval is
+        kept for when it comes back).
+        """
+        plans: dict[str, tuple[float | None, float | None]] = {}
+        for num in candidates:
+            before, after = pre.get(num), post.get(num)
+            if before is None or after is None or after.sentinel is not None:
+                continue
+            if after.fetched_at is None or after.fetched_at == before.fetched_at:
+                continue  # not fetched this pass
+            base = before.poll_interval_s or self.settings.interval_seconds
+            prev_pct = _binding_pct(before.last_good)
+            new_pct = _binding_pct(after.last_good)
+            if prev_pct is None or new_pct is None:
+                interval = self.settings.interval_seconds
+            elif abs(new_pct - prev_pct) >= MOVEMENT_DELTA_PCT:
+                interval = max(self.settings.interval_seconds, base / 2)
+            else:
+                interval = min(CANDIDATE_MAX_INTERVAL_S, base * 1.5)
+            next_poll = now + interval
+            headroom = oauth.account_headroom(after.last_good)
+            if headroom is not None and headroom <= 0:
+                reset_ts = _limiting_reset_ts(after.last_good)
+                if reset_ts is not None and reset_ts > next_poll:
+                    next_poll = reset_ts
+            plans[num] = (next_poll, interval)
+        if plans:
+            self.switcher.set_usage_poll_plan(plans)
 
     def _perform(self, number: str, email: str, trigger: str) -> TickOutcome:
         if self.dry_run:

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -568,7 +568,7 @@ class AutoSwitchEngine:
             "email": "",
         }
 
-        entries, usage, headroom = self._collect_scheduled_usage(current)
+        entries, usage, headroom = self._collect_scheduled_usage(current, quarantined)
         self._emit(
             PollEvent(
                 active=active_ref,
@@ -787,7 +787,7 @@ class AutoSwitchEngine:
     # -- adaptive usage scheduling ---------------------------------------------
 
     def _collect_scheduled_usage(
-        self, current: str
+        self, current: str, quarantined: set[str] = frozenset()
     ) -> tuple[dict, dict[str, dict | str | None], dict[str, float | None]]:
         """Two-phase usage collection with an O(1) baseline.
 
@@ -810,8 +810,12 @@ class AutoSwitchEngine:
         decision values and ``headroom`` the derived headroom per account.
         """
         now = self.clock()
+        # Quarantined accounts can never be switch targets, so spending the
+        # single alternate poll slot (or an escalation fetch) on one is wasted.
         candidates = [
-            n for n in self.switcher.switchable_account_numbers() if n != current
+            n
+            for n in self.switcher.switchable_account_numbers()
+            if n != current and n not in quarantined
         ]
 
         pre = self.switcher.usage_entries_by_account(fetch=set())

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -8,6 +8,8 @@ the single ``json.dumps`` (see cli.py).
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 # Bump only on a breaking change to any payload shape. Scripts key off this.
 SCHEMA_VERSION = 1
 
@@ -102,6 +104,26 @@ def account_ref(number: int | None, email: str) -> dict:
     return {"number": number, "email": email}
 
 
+def usage_freshness_fields(
+    fetched_at: float | None, age_s: float | None
+) -> dict:
+    """Additive ``usageFetchedAt``/``usageAgeSeconds`` fields describing how
+    old the served ``usage`` measurement is (the store may serve last-good
+    data on fetch failure). Emitted only alongside a non-null ``usage``."""
+    if fetched_at is None:
+        return {}
+    fields: dict = {
+        "usageFetchedAt": (
+            datetime.fromtimestamp(fetched_at, tz=timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+    }
+    if age_s is not None:
+        fields["usageAgeSeconds"] = round(age_s, 1)
+    return fields
+
+
 def account_row(
     number: int,
     email: str,
@@ -109,10 +131,13 @@ def account_row(
     org_uuid: str,
     active: bool,
     usage_entry: dict | str | None,
+    *,
+    usage_fetched_at: float | None = None,
+    usage_age_s: float | None = None,
 ) -> dict:
     """A full account row for ``--list``."""
     status, usage = usage_fields(usage_entry)
-    return {
+    row = {
         "number": number,
         "email": email,
         "organizationName": org_name,
@@ -122,6 +147,9 @@ def account_row(
         "usageStatus": status,
         "usage": usage,
     }
+    if usage is not None:
+        row.update(usage_freshness_fields(usage_fetched_at, usage_age_s))
+    return row
 
 
 def error_envelope(exc: Exception) -> dict:

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -191,6 +191,44 @@ def request_usage_data(access_token: str) -> dict:
         return json.loads(resp.read().decode())
 
 
+def _classify_usage_error(e: Exception) -> tuple[str, float | None]:
+    """Map a usage-fetch exception to ``(kind, retry_after_s)``.
+
+    ``kind`` is a short stable token for logs and backoff decisions
+    (``"http-429"``, ``"timeout"``, ``"network"``, ``"bad-response"``, or the
+    exception type name as a fallback). ``retry_after_s`` is the parsed
+    ``Retry-After`` header when the server sent one (seconds form only — the
+    HTTP-date form is rare enough to ignore).
+    """
+    if isinstance(e, urllib.error.HTTPError):
+        retry_after = None
+        raw = e.headers.get("Retry-After") if e.headers else None
+        if raw:
+            try:
+                retry_after = max(0.0, float(raw.strip()))
+            except ValueError:
+                pass
+        return f"http-{e.code}", retry_after
+    if isinstance(e, TimeoutError):  # socket.timeout is an alias since 3.10
+        return "timeout", None
+    if isinstance(e, urllib.error.URLError):
+        if isinstance(e.reason, TimeoutError):
+            return "timeout", None
+        return "network", None
+    if isinstance(e, json.JSONDecodeError):
+        return "bad-response", None
+    return type(e).__name__, None
+
+
+def _log_usage_failure(context: str, e: Exception, kind: str) -> None:
+    """One WARNING line with the cause so it lands in the default log file
+    (issue #85 was undiagnosable with failures swallowed at DEBUG); the full
+    exception repr stays at DEBUG."""
+    where = f" {context}" if context else ""
+    _logger.warning("Usage fetch failed%s: %s", where, kind)
+    _logger.debug("Usage fetch failure detail%s: %r", where, e)
+
+
 
 def build_usage_result(data: dict) -> dict | None:
     """Normalize raw usage API data into the structure used by the CLI."""
@@ -288,31 +326,49 @@ def account_headroom(usage: dict | None) -> float | None:
     return 100.0 - max(pcts)
 
 
+@dataclass(frozen=True)
+class UsageOutcome:
+    """Result of a usage-API fetch attempt.
+
+    ``usage`` is the normalized usage dict on success (it can also be ``None``
+    on a successful round trip whose response carried no window data).
+    ``error`` is ``None`` on success, else a ``_classify_usage_error`` kind
+    (plus ``"no-access-token"`` / ``"refresh-failed"`` for pre-request
+    failures). ``retry_after_s`` carries the server's Retry-After when sent.
+    """
+
+    usage: dict | None
+    error: str | None = None
+    retry_after_s: float | None = None
+
+
 def fetch_usage(access_token: str) -> dict | None:
     """Fetch 5-hour and 7-day utilization from the Anthropic usage API."""
     try:
         data = request_usage_data(access_token)
         return build_usage_result(data)
     except Exception as e:
-        _logger.debug("Usage fetch failed: %r", e)
+        kind, _ = _classify_usage_error(e)
+        _log_usage_failure("", e, kind)
         return None
 
 
-def fetch_usage_for_account(
+def try_fetch_usage_for_account(
     account_num: str,
     email: str,
     credentials: str,
     is_active: bool,
     persist_credentials: Callable[[str, str, str], None] | None = None,
-) -> dict | None:
+) -> UsageOutcome:
     """Fetch usage for an account, refreshing expired tokens for inactive accounts only.
 
     Active accounts are never refreshed — Claude Code owns those credentials.
     """
+    context = f"for account {account_num} ({email})"
     oauth = extract_oauth_data(credentials)
     access_token = oauth.get("accessToken") if oauth else None
     if not access_token:
-        return None
+        return UsageOutcome(None, error="no-access-token")
 
     working_credentials = credentials
 
@@ -330,38 +386,55 @@ def fetch_usage_for_account(
 
     try:
         data = request_usage_data(access_token)
-        return build_usage_result(data)
+        return UsageOutcome(build_usage_result(data))
     except urllib.error.HTTPError as e:
-        _logger.debug("Usage fetch failed: %r", e)
+        kind, retry_after = _classify_usage_error(e)
         if (
             e.code != 401
             or is_active
             or not oauth
             or not oauth.get("refreshToken")
         ):
-            return None
+            _log_usage_failure(context, e, kind)
+            return UsageOutcome(None, error=kind, retry_after_s=retry_after)
 
         # Retry once after refreshing on 401 (inactive accounts only).
         refreshed = refresh_oauth_credentials(working_credentials)
         if not refreshed:
-            return None
+            _log_usage_failure(context, e, kind)
+            return UsageOutcome(None, error="refresh-failed")
 
         working_credentials = refreshed
         _persist(persist_credentials, account_num, email, working_credentials)
         refreshed_oauth = extract_oauth_data(working_credentials)
         new_token = refreshed_oauth.get("accessToken") if refreshed_oauth else None
         if not new_token:
-            return None
+            return UsageOutcome(None, error="refresh-failed")
 
         try:
             data = request_usage_data(new_token)
-            return build_usage_result(data)
+            return UsageOutcome(build_usage_result(data))
         except Exception as retry_error:
-            _logger.debug("Usage fetch failed after refresh: %r", retry_error)
-            return None
+            kind, retry_after = _classify_usage_error(retry_error)
+            _log_usage_failure(context + " after refresh", retry_error, kind)
+            return UsageOutcome(None, error=kind, retry_after_s=retry_after)
     except Exception as e:
-        _logger.debug("Usage fetch failed: %r", e)
-        return None
+        kind, retry_after = _classify_usage_error(e)
+        _log_usage_failure(context, e, kind)
+        return UsageOutcome(None, error=kind, retry_after_s=retry_after)
+
+
+def fetch_usage_for_account(
+    account_num: str,
+    email: str,
+    credentials: str,
+    is_active: bool,
+    persist_credentials: Callable[[str, str, str], None] | None = None,
+) -> dict | None:
+    """Usage dict or None (see try_fetch_usage_for_account for the cause)."""
+    return try_fetch_usage_for_account(
+        account_num, email, credentials, is_active, persist_credentials
+    ).usage
 
 
 def _persist(

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1427,6 +1427,11 @@ class ClaudeAccountSwitcher:
             self._live_session_pids(account_num, email)
         )
         if owned:
+            if oauth.is_oauth_token_expired(oauth_data.get("expiresAt")):
+                # The request would just 401 (an owned credential may not be
+                # refreshed), so skip it — Claude Code's own /usage does the
+                # same on a locally-expired token.
+                return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
             outcome = oauth.try_fetch_usage_for_account(
                 account_num, email, creds, is_active=True,
             )

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -22,7 +23,6 @@ from claude_swap.exceptions import (
     ValidationError,
 )
 from claude_swap import oauth
-from claude_swap.cache import MISSING, read_cache, write_cache
 from claude_swap.claude_locks import claude_config_lock, claude_credentials_lock
 from claude_swap.json_output import (
     SCHEMA_VERSION,
@@ -33,6 +33,7 @@ from claude_swap.json_output import (
     account_ref,
     account_row,
     usage_fields,
+    usage_freshness_fields,
 )
 from claude_swap.credentials import (  # noqa: F401  (constants re-exported for migrations/tests)
     CLAUDE_CODE_KEYCHAIN_SERVICE,
@@ -64,6 +65,12 @@ from claude_swap.paths import (
     migrate_legacy_backup_dir,
 )
 from claude_swap.process_detection import get_running_instances
+from claude_swap.usage_store import (
+    FetchRecord,
+    UsageEntry,
+    UsageStore,
+    with_sentinel,
+)
 
 # Service name under which the legacy ``keyring`` backend stored per-account
 # backup credentials on macOS (kept for the one-time keyring → security migration
@@ -77,8 +84,14 @@ KEYRING_SERVICE = "claude-code"
 # on profile endpoints. Matches Claude Code's CLAUDE_CODE_OAUTH_TOKEN path.
 SETUP_TOKEN_SCOPES = ("user:inference",)
 
-# Usage cache
-_USAGE_CACHE_TTL = 15  # seconds
+# Delay between successive usage-request launches in one collect pass, so N
+# accounts never burst the shared usage endpoint from one IP in the same
+# instant (request hygiene; see issue #85).
+_FETCH_STAGGER_S = 0.25
+
+# Show a "· Xm ago" age note on displayed usage older than this. Below it the
+# data is essentially current (auto refreshes every tick; --list on demand).
+_USAGE_AGE_NOTE_S = 90.0
 
 
 def _format_usage_lines(usage: dict) -> list[str]:
@@ -110,6 +123,61 @@ def _format_usage_lines(usage: dict) -> list[str]:
             rows.append((w["name"], f"{w['pct']:>3.0f}%{marker}"))
     width = max((len(label) for label, _ in rows), default=0) + 1  # label + ':'
     return [f"{label + ':':<{width}} {body}" for label, body in rows]
+
+
+# Human notes for sentinel usage states (fallback: the raw sentinel string).
+_SENTINEL_NOTES = {
+    USAGE_TOKEN_EXPIRED: "token expired — Claude Code refreshes the active account",
+    USAGE_API_KEY: "API key (no quota)",
+    USAGE_KEYCHAIN_UNAVAILABLE: "keychain unavailable — locked or in use; try again",
+}
+
+
+def _last_seen_note(entry: UsageEntry) -> str | None:
+    """"last seen 53% used · 12m ago" from an entry's last-good measurement."""
+    if entry.last_good is None or entry.fetched_at is None:
+        return None
+    headroom = oauth.account_headroom(entry.last_good)
+    if headroom is None:
+        return None
+    return (
+        f"last seen {100 - headroom:.0f}% used · "
+        f"{format_age(int(entry.fetched_at * 1000))}"
+    )
+
+
+def _usage_entry_lines(entry: UsageEntry) -> list[str]:
+    """Styled usage lines (sans indent) for one account's entry.
+
+    Sentinel states render their note first, with a supplementary "last seen"
+    line when an older measurement exists. Measurements render as usual, age-
+    annotated once older than ``_USAGE_AGE_NOTE_S`` (stale-served); an account
+    with no measurement at all shows "usage unavailable" plus the last fetch
+    error, so a failing endpoint is visible instead of a silent blank.
+    """
+    if entry.sentinel is not None:
+        out = [dimmed(_SENTINEL_NOTES.get(entry.sentinel, entry.sentinel))]
+        last_seen = _last_seen_note(entry)
+        if last_seen is not None and entry.sentinel != USAGE_API_KEY:
+            out.append(f"{dimmed('└')} {muted(last_seen)}")
+        return out
+    if entry.last_good is not None:
+        lines = _format_usage_lines(entry.last_good)
+        if (
+            lines
+            and entry.age_s is not None
+            and entry.age_s > _USAGE_AGE_NOTE_S
+            and entry.fetched_at is not None
+        ):
+            lines[-1] += f" · {format_age(int(entry.fetched_at * 1000))}"
+        return [
+            f"{dimmed('└' if j == len(lines) - 1 else '├')} {muted(line)}"
+            for j, line in enumerate(lines)
+        ]
+    detail = "usage unavailable"
+    if entry.last_error:
+        detail += f" ({entry.last_error})"
+    return [dimmed(detail)]
 
 
 def _sweep_legacy_keyring(usernames: list[str], removed_items: list[str]) -> None:
@@ -157,6 +225,7 @@ class ClaudeAccountSwitcher:
         self.credentials_dir = self.backup_dir / "credentials"
         self.lock_file = self.backup_dir / ".lock"
         self._logger = setup_logging(self.backup_dir, debug=debug)
+        self._usage_store = UsageStore(self.backup_dir / "cache")
 
         # The credential storage layer (active + per-account backup stores, macOS
         # Keychain-vs-file routing, the per-process capability cache). Reads its
@@ -466,8 +535,40 @@ class ClaudeAccountSwitcher:
     # -- public accessors for the auto-switch engine -----------------------
 
     def usage_by_account(self) -> dict[str, dict | str | None]:
-        """Public wrapper: account number → usage entry (cache-first)."""
+        """Public wrapper: account number → decision-grade usage value.
+
+        Each value is a usage dict (last-good, trusted while ≤
+        ``usage_store.STALE_OK_S`` old), a sentinel string, or ``None``
+        (unknown).
+        """
         return self._usage_by_account()
+
+    def usage_entries_by_account(
+        self, fetch: set[str] | None = None
+    ) -> dict[str, UsageEntry]:
+        """Store-backed usage entries (ages, errors, poll state) per account.
+
+        ``fetch`` restricts which accounts *may* be fetched this pass (the
+        auto engine's scheduler); ``None`` means every stale account is
+        eligible (on-demand callers).
+        """
+        accounts_info = self._build_accounts_info()
+        return self._collect_usage_entries(accounts_info, fetch=fetch)
+
+    def set_usage_poll_plan(
+        self, plans: dict[str, tuple[float | None, float | None]]
+    ) -> None:
+        """Persist the auto engine's per-slot ``(nextPollAt, pollIntervalS)``."""
+        data = self._get_sequence_data() or {}
+        accounts = data.get("accounts", {})
+        identities = {
+            num: (
+                accounts.get(num, {}).get("email", ""),
+                accounts.get(num, {}).get("organizationUuid", "") or "",
+            )
+            for num in plans
+        }
+        self._usage_store.set_poll_plan(plans, identities)
 
     def switchable_account_numbers(self) -> list[str]:
         """Account numbers in rotation order that have usable stored backups."""
@@ -518,8 +619,8 @@ class ClaudeAccountSwitcher:
         """Persist rotated credentials to a slot's backup store, under the lock.
 
         For inactive accounts only — never routes to the active store. Mirrors
-        the persist callback ``_collect_usage`` uses. The caller must NOT hold
-        ``self.lock_file`` (FileLock is non-reentrant).
+        the persist callback ``_fetch_account_usage`` uses. The caller must NOT
+        hold ``self.lock_file`` (FileLock is non-reentrant).
         """
         with FileLock(self.lock_file):
             self._write_account_credentials(account_num, email, credentials)
@@ -1267,8 +1368,8 @@ class ClaudeAccountSwitcher:
 
         accounts_info: list[tuple[int, str, str, str, bool, str]] = []
         # Reset each build; set below only when the active slot's OAuth Keychain
-        # read failed with no fallback. Read by _collect_usage.fetch (main thread
-        # writes it here before the fetch pool starts → no data race).
+        # read failed with no fallback. Read by _static_usage_sentinel (main
+        # thread writes it here before the fetch pool starts → no data race).
         self._active_keychain_unavailable = False
         for num in data.get("sequence", []):
             account = data.get("accounts", {}).get(str(num), {})
@@ -1302,8 +1403,9 @@ class ClaudeAccountSwitcher:
 
     def _fetch_active_usage(
         self, account_num: str, email: str, creds: str
-    ) -> dict | str | None:
-        """Usage for the active/default account, refreshing its token only when safe.
+    ) -> FetchRecord:
+        """Usage fetch for the active/default account, refreshing its token only
+        when safe.
 
         The active credential is the one Claude Code concurrently owns, so cswap
         normally leaves it alone (issue #62). But when no *owner* is detected —
@@ -1319,18 +1421,24 @@ class ClaudeAccountSwitcher:
         """
         oauth_data = oauth.extract_oauth_data(creds)
         if not oauth_data or not oauth_data.get("accessToken"):
-            return USAGE_NO_CREDENTIALS
+            return FetchRecord(sentinel=USAGE_NO_CREDENTIALS)
 
         owned = self._active_cc_running() or bool(
             self._live_session_pids(account_num, email)
         )
         if owned:
-            usage = oauth.fetch_usage_for_account(
+            outcome = oauth.try_fetch_usage_for_account(
                 account_num, email, creds, is_active=True,
             )
-            if usage is None and oauth.is_oauth_token_expired(oauth_data.get("expiresAt")):
-                return USAGE_TOKEN_EXPIRED
-            return usage
+            if outcome.usage is None and oauth.is_oauth_token_expired(
+                oauth_data.get("expiresAt")
+            ):
+                return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
+            return FetchRecord(
+                usage=outcome.usage,
+                error=outcome.error,
+                retry_after_s=outcome.retry_after_s,
+            )
 
         # No owner detected → safe to refresh the active token. Reuse the inactive
         # refresh machinery (proactive refresh + 401 retry), persisting the rotated
@@ -1387,7 +1495,7 @@ class ClaudeAccountSwitcher:
                     persist_skipped = True
                 raise
 
-        usage = oauth.fetch_usage_for_account(
+        outcome = oauth.try_fetch_usage_for_account(
             account_num, email, creds,
             is_active=False, persist_credentials=persist_active,
         )
@@ -1395,78 +1503,147 @@ class ClaudeAccountSwitcher:
         # a credential we didn't keep — surface the expired state and let Claude Code
         # settle it.
         if persist_skipped:
-            return USAGE_TOKEN_EXPIRED
-        if usage is None and oauth.is_oauth_token_expired(oauth_data.get("expiresAt")):
-            return USAGE_TOKEN_EXPIRED
-        return usage
+            return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
+        if outcome.usage is None and oauth.is_oauth_token_expired(
+            oauth_data.get("expiresAt")
+        ):
+            return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
+        return FetchRecord(
+            usage=outcome.usage,
+            error=outcome.error,
+            retry_after_s=outcome.retry_after_s,
+        )
 
-    def _collect_usage(
-        self, accounts_info: list[tuple[int, str, str, str, bool, str]]
-    ) -> list[dict | str | None]:
-        """Fetch usage for each account (cache-first), returning one entry per row.
+    def _static_usage_sentinel(
+        self, account_info: tuple[int, str, str, str, bool, str]
+    ) -> str | None:
+        """Sentinel state derivable without any network call, or ``None``.
 
-        Each entry is a usage dict, the string ``"no credentials"``, or ``None``
-        when the API call failed. Results are cached under
-        ``<backup_dir>/cache/usage.json`` for ``_USAGE_CACHE_TTL`` seconds and
-        reused only when the cache covers exactly the same set of accounts.
+        Re-derived on every collect pass (never persisted), so it can't
+        outlive the condition that produced it.
         """
-        def fetch(
-            account_info: tuple[int, str, str, str, bool, str]
-        ) -> dict | str | None:
-            num, email, _, _, is_active, creds = account_info
-            if looks_like_api_key(creds):
-                # Managed API-key account: no subscription quota to fetch.
-                return USAGE_API_KEY
-            if not creds or not oauth.extract_access_token(creds):
-                if is_active and self._active_keychain_unavailable:
-                    return USAGE_KEYCHAIN_UNAVAILABLE
-                return USAGE_NO_CREDENTIALS
+        _num, _email, _, _, is_active, creds = account_info
+        if looks_like_api_key(creds):
+            # Managed API-key account: no subscription quota to fetch.
+            return USAGE_API_KEY
+        if not creds or not oauth.extract_access_token(creds):
+            if is_active and self._active_keychain_unavailable:
+                return USAGE_KEYCHAIN_UNAVAILABLE
+            return USAGE_NO_CREDENTIALS
+        return None
 
-            # The active/default account owns the live credential — route it through
-            # the owner-aware path that refreshes only when no Claude Code/session is
-            # running and writes the rotated credential back to the active store.
-            if is_active:
-                return self._fetch_active_usage(str(num), email, creds)
+    def _fetch_account_usage(
+        self, account_info: tuple[int, str, str, str, bool, str]
+    ) -> FetchRecord:
+        """One network fetch for one account. Never raises."""
+        num, email, _, _, is_active, creds = account_info
 
-            def persist(acct_num: str, acct_email: str, new_creds: str) -> None:
-                with FileLock(self.lock_file):
-                    self._write_account_credentials(acct_num, acct_email, new_creds)
+        # The active/default account owns the live credential — route it through
+        # the owner-aware path that refreshes only when no Claude Code/session is
+        # running and writes the rotated credential back to the active store.
+        if is_active:
+            return self._fetch_active_usage(str(num), email, creds)
 
-            # An account running in session mode is "inactive" here but live
-            # in its own config dir, where claude manages the token. Treat it
-            # like the active account (no proactive refresh / 401-retry):
-            # refreshing the backup copy could rotate the refresh token out
-            # from under the live session. Worst case its usage shows as
-            # unavailable until the session exits.
-            has_live_session = bool(self._live_session_pids(str(num), email))
+        def persist(acct_num: str, acct_email: str, new_creds: str) -> None:
+            with FileLock(self.lock_file):
+                self._write_account_credentials(acct_num, acct_email, new_creds)
 
-            return oauth.fetch_usage_for_account(
-                str(num), email, creds,
-                is_active=has_live_session,
-                persist_credentials=persist,
-            )
+        # An account running in session mode is "inactive" here but live
+        # in its own config dir, where claude manages the token. Treat it
+        # like the active account (no proactive refresh / 401-retry):
+        # refreshing the backup copy could rotate the refresh token out
+        # from under the live session. Worst case its usage shows as
+        # unavailable until the session exits.
+        has_live_session = bool(self._live_session_pids(str(num), email))
 
-        usage_cache_path = self.backup_dir / "cache" / "usage.json"
-        cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
-        account_keys = {str(info[0]) for info in accounts_info}
-        if cached is not MISSING and isinstance(cached, dict) and cached.keys() == account_keys:
-            return [cached.get(str(info[0])) for info in accounts_info]
+        outcome = oauth.try_fetch_usage_for_account(
+            str(num), email, creds,
+            is_active=has_live_session,
+            persist_credentials=persist,
+        )
+        return FetchRecord(
+            usage=outcome.usage,
+            error=outcome.error,
+            retry_after_s=outcome.retry_after_s,
+        )
+
+    def _run_usage_fetches(
+        self, infos: list[tuple[int, str, str, str, bool, str]]
+    ) -> dict[str, FetchRecord]:
+        """Fetch the given accounts in parallel, staggering request starts so
+        N accounts never hit the endpoint in the same instant."""
+        def fetch_one(
+            idx_info: tuple[int, tuple[int, str, str, str, bool, str]]
+        ) -> tuple[str, FetchRecord]:
+            idx, info = idx_info
+            if idx and _FETCH_STAGGER_S:
+                time.sleep(idx * _FETCH_STAGGER_S)
+            return str(info[0]), self._fetch_account_usage(info)
 
         with ThreadPoolExecutor() as executor:
-            usages = list(executor.map(fetch, accounts_info))
-        write_cache(usage_cache_path, {
-            str(info[0]): usage
-            for info, usage in zip(accounts_info, usages)
-        })
-        return usages
+            return dict(executor.map(fetch_one, enumerate(infos)))
+
+    def _collect_usage_entries(
+        self,
+        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        fetch: set[str] | None = None,
+    ) -> dict[str, UsageEntry]:
+        """Store-backed usage collection: one :class:`UsageEntry` per account.
+
+        ``fetch=None`` (on-demand callers: ``--list``/``--status``/switch
+        strategies) makes every account eligible; the auto engine passes an
+        explicit set to restrict which accounts *may* be fetched this pass.
+        Either way an account is skipped — its stored entry served instead —
+        when a sentinel state applies, its entry is fresh (≤ ``SERVE_TTL_S``),
+        it is inside failure backoff, or another collector claimed it moments
+        ago. A failed fetch only updates the entry's error/backoff fields, so
+        the last-good measurement keeps being served (stale-on-error).
+        """
+        store = self._usage_store
+        now = store.clock()
+        identities = {
+            str(num): (email, org_uuid or "")
+            for num, email, _org_name, org_uuid, _active, _creds in accounts_info
+        }
+        info_by_num = {str(info[0]): info for info in accounts_info}
+        sentinels: dict[str, str] = {}
+        for num, info in info_by_num.items():
+            static = self._static_usage_sentinel(info)
+            if static is not None:
+                sentinels[num] = static
+
+        entries = store.entries(identities)
+        to_fetch = [
+            num
+            for num in info_by_num
+            if num not in sentinels
+            and (fetch is None or num in fetch)
+            and not entries[num].fresh(now)
+            and not entries[num].in_backoff(now)
+            and not entries[num].claimed(now)
+        ]
+
+        if to_fetch:
+            store.claim(to_fetch, identities)
+            records = self._run_usage_fetches(
+                [info_by_num[num] for num in to_fetch]
+            )
+            store.record(records, identities)
+            for num, record in records.items():
+                if record.sentinel is not None:
+                    sentinels[num] = record.sentinel
+            entries = store.entries(identities)
+
+        return {
+            num: with_sentinel(entries[num], sentinels.get(num))
+            for num in info_by_num
+        }
 
     def _usage_by_account(self) -> dict[str, dict | str | None]:
-        """Map account number → usage entry (cache-first) for managed accounts."""
+        """Map account number → decision-grade usage value for managed accounts."""
         accounts_info = self._build_accounts_info()
-        usages = self._collect_usage(accounts_info)
-        return {
-            str(info[0]): usage for info, usage in zip(accounts_info, usages)
-        }
+        entries = self._collect_usage_entries(accounts_info)
+        return {num: entry.decision_value() for num, entry in entries.items()}
 
     def _select_best_switchable(
         self, current_num: str | None
@@ -1532,18 +1709,22 @@ class ClaudeAccountSwitcher:
     def _build_list_payload(
         self,
         accounts_info: list[tuple[int, str, str, str, bool, str]],
-        usages: list[dict | str | None],
+        entries: dict[str, UsageEntry],
     ) -> dict:
         """Build the ``--list --json`` payload from gathered account + usage data."""
         active_num: int | None = None
         accounts = []
-        for (num, email, org_name, org_uuid, is_active, _), usage in zip(
-            accounts_info, usages
-        ):
+        for num, email, org_name, org_uuid, is_active, _ in accounts_info:
             if is_active:
                 active_num = num
+            entry = entries[str(num)]
             accounts.append(
-                account_row(num, email, org_name, org_uuid, is_active, usage)
+                account_row(
+                    num, email, org_name, org_uuid, is_active,
+                    entry.sentinel if entry.sentinel is not None else entry.last_good,
+                    usage_fetched_at=entry.fetched_at,
+                    usage_age_s=entry.age_s,
+                )
             )
         return {
             "schemaVersion": SCHEMA_VERSION,
@@ -1575,34 +1756,21 @@ class ClaudeAccountSwitcher:
             return None
 
         accounts_info = self._build_accounts_info()
-        usages = self._collect_usage(accounts_info)
+        entries = self._collect_usage_entries(accounts_info)
 
         if json_output:
-            return self._build_list_payload(accounts_info, usages)
+            return self._build_list_payload(accounts_info, entries)
 
         print(bolded("Accounts:"))
-        for i, ((num, email, org_name, org_uuid, is_active, _), usage) in enumerate(zip(accounts_info, usages)):
+        for i, (num, email, org_name, org_uuid, is_active, _) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
             if is_active:
                 marker = f" {bold_accent('(active)')}"
                 print(f"  {num}: {email} {muted(f'[{tag}]')}{marker}")
             else:
                 print(f"  {num}: {email} {muted(f'[{tag}]')}")
-            if usage == USAGE_TOKEN_EXPIRED:
-                print(f"     {dimmed('token expired — Claude Code refreshes the active account')}")
-            elif usage == USAGE_API_KEY:
-                print(f"     {dimmed('API key (no quota)')}")
-            elif usage == USAGE_KEYCHAIN_UNAVAILABLE:
-                print(f"     {dimmed('keychain unavailable — locked or in use; try again')}")
-            elif isinstance(usage, str):
-                print(f"     {dimmed(usage)}")
-            elif usage is None:
-                print(f"     {dimmed('usage unavailable')}")
-            else:
-                lines = _format_usage_lines(usage)
-                for j, line in enumerate(lines):
-                    connector = "└" if j == len(lines) - 1 else "├"
-                    print(f"     {dimmed(connector)} {muted(line)}")
+            for line in _usage_entry_lines(entries[str(num)]):
+                print(f"     {line}")
 
             if show_token_status:
                 token_status = oauth.build_token_status(accounts_info[i][5])
@@ -1645,36 +1813,20 @@ class ClaudeAccountSwitcher:
             self._logger.debug("Failed to detect running instances", exc_info=True)
 
     def _active_account_usage(
-        self, account_num: str, current_email: str
-    ) -> dict | str | None:
-        """Usage for the active account as a ``_collect_usage``-style entry.
+        self, account_num: str, current_email: str, org_uuid: str
+    ) -> UsageEntry:
+        """Store-backed usage entry for just the active account.
 
-        Returns ``USAGE_NO_CREDENTIALS`` when the live store has no usable token,
-        ``USAGE_KEYCHAIN_UNAVAILABLE`` when the OAuth Keychain read failed with no
-        fallback, a usage dict on success, ``USAGE_TOKEN_EXPIRED`` when the token is
-        expired and Claude Code owns it, or ``None`` when the fetch fails. Reuses the
-        same ``cache/usage.json`` list_accounts writes — cache-first — and delegates
-        the owner-aware refresh decision to ``_fetch_active_usage``.
+        Builds a single-account info row instead of the full accounts list
+        (``--status`` touches one slot) and runs it through the shared
+        collector, so freshness/backoff/claim gating and the shared
+        ``cache/usage.json`` table behave exactly as in ``--list``.
         """
         active = self._read_active_credentials()
         creds = active.value or ""
-        if looks_like_api_key(creds):
-            # Managed API-key account: no subscription quota to fetch.
-            return USAGE_API_KEY
-        if not creds or not oauth.extract_access_token(creds):
-            if active.keychain_unavailable:
-                return USAGE_KEYCHAIN_UNAVAILABLE
-            return USAGE_NO_CREDENTIALS
-        usage_cache_path = self.backup_dir / "cache" / "usage.json"
-        cached = read_cache(usage_cache_path, _USAGE_CACHE_TTL)
-        if (cached is not MISSING and isinstance(cached, dict)
-                and account_num in cached):
-            return cached[account_num]
-        usage = self._fetch_active_usage(account_num, current_email, creds)
-        existing = cached if (cached is not MISSING and isinstance(cached, dict)) else {}
-        existing[account_num] = usage
-        write_cache(usage_cache_path, existing)
-        return usage
+        self._active_keychain_unavailable = active.keychain_unavailable
+        info = (int(account_num), current_email, "", org_uuid or "", True, creds)
+        return self._collect_usage_entries([info])[str(account_num)]
 
     def _build_status_payload(self) -> dict:
         """Build the ``--status --json`` payload (no active / unmanaged / managed)."""
@@ -1700,21 +1852,25 @@ class ClaudeAccountSwitcher:
         acct = data["accounts"][account_num]
         org_name = acct.get("organizationName", "") or ""
         org_uuid = acct.get("organizationUuid", "") or ""
+        entry = self._active_account_usage(account_num, current_email, org_uuid)
         status, usage = usage_fields(
-            self._active_account_usage(account_num, current_email)
+            entry.sentinel if entry.sentinel is not None else entry.last_good
         )
+        active: dict = {
+            "number": int(account_num),
+            "email": current_email,
+            "organizationName": org_name,
+            "organizationUuid": org_uuid,
+            "isOrganization": bool(org_uuid),
+            "managed": True,
+            "usageStatus": status,
+            "usage": usage,
+        }
+        if usage is not None:
+            active.update(usage_freshness_fields(entry.fetched_at, entry.age_s))
         return {
             "schemaVersion": SCHEMA_VERSION,
-            "active": {
-                "number": int(account_num),
-                "email": current_email,
-                "organizationName": org_name,
-                "organizationUuid": org_uuid,
-                "isOrganization": bool(org_uuid),
-                "managed": True,
-                "usageStatus": status,
-                "usage": usage,
-            },
+            "active": active,
             "totalManagedAccounts": len(data.get("accounts", {})),
         }
 
@@ -1747,18 +1903,11 @@ class ClaudeAccountSwitcher:
                 f"({current_email} {muted(f'[{tag}]')})"
             )
             print(f"  {dimmed(f'Total managed accounts: {total}')}")
-            usage = self._active_account_usage(account_num, current_email)
-            if isinstance(usage, dict):
-                lines = _format_usage_lines(usage)
-                for j, line in enumerate(lines):
-                    connector = "└" if j == len(lines) - 1 else "├"
-                    print(f"  {dimmed(connector)} {muted(line)}")
-            elif usage == USAGE_TOKEN_EXPIRED:
-                print(f"  {dimmed('token expired — Claude Code refreshes the active account')}")
-            elif usage == USAGE_API_KEY:
-                print(f"  {dimmed('API key (no quota)')}")
-            elif usage == USAGE_KEYCHAIN_UNAVAILABLE:
-                print(f"  {dimmed('keychain unavailable — locked or in use; try again')}")
+            entry = self._active_account_usage(
+                account_num, current_email, current_org_uuid
+            )
+            for line in _usage_entry_lines(entry):
+                print(f"  {line}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")
         return None

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1527,7 +1527,7 @@ class ClaudeAccountSwitcher:
         Re-derived on every collect pass (never persisted), so it can't
         outlive the condition that produced it.
         """
-        _num, _email, _, _, is_active, creds = account_info
+        num, email, _, _, is_active, creds = account_info
         if looks_like_api_key(creds):
             # Managed API-key account: no subscription quota to fetch.
             return USAGE_API_KEY
@@ -1535,6 +1535,23 @@ class ClaudeAccountSwitcher:
             if is_active and self._active_keychain_unavailable:
                 return USAGE_KEYCHAIN_UNAVAILABLE
             return USAGE_NO_CREDENTIALS
+        if is_active:
+            # Owned + locally expired must be visible even when the fetch is
+            # gated (fresh entry, failure backoff, concurrent claim) — the
+            # auto engine's idle-hold keys on this sentinel, and it is provable
+            # locally: only an owner (Claude Code / live session) may refresh
+            # this credential, and it hasn't. The expiry check gates the
+            # process scan, so the common non-expired path pays nothing.
+            oauth_data = oauth.extract_oauth_data(creds)
+            if (
+                oauth_data
+                and oauth.is_oauth_token_expired(oauth_data.get("expiresAt"))
+                and (
+                    self._active_cc_running()
+                    or self._live_session_pids(str(num), email)
+                )
+            ):
+                return USAGE_TOKEN_EXPIRED
         return None
 
     def _fetch_account_usage(
@@ -1723,10 +1740,14 @@ class ClaudeAccountSwitcher:
             if is_active:
                 active_num = num
             entry = entries[str(num)]
+            # JSON carries the decision-grade value: last-good only while it is
+            # recent enough to act on (≤ STALE_OK_S), else unavailable. Showing
+            # older measurements is a human-display affordance only — scripts
+            # keying on usageStatus == "ok" must not act on arbitrarily old data.
             accounts.append(
                 account_row(
                     num, email, org_name, org_uuid, is_active,
-                    entry.sentinel if entry.sentinel is not None else entry.last_good,
+                    entry.decision_value(),
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
                 )
@@ -1858,9 +1879,9 @@ class ClaudeAccountSwitcher:
         org_name = acct.get("organizationName", "") or ""
         org_uuid = acct.get("organizationUuid", "") or ""
         entry = self._active_account_usage(account_num, current_email, org_uuid)
-        status, usage = usage_fields(
-            entry.sentinel if entry.sentinel is not None else entry.last_good
-        )
+        # Decision-grade projection, same rule as the --list payload: stale
+        # beyond STALE_OK_S reports unavailable, not "ok" with old numbers.
+        status, usage = usage_fields(entry.decision_value())
         active: dict = {
             "number": int(account_num),
             "email": current_email,

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -324,8 +324,9 @@ def _do_watch(stdscr, switcher: ClaudeAccountSwitcher) -> None:
 def _watch_loop(stdscr, switcher: ClaudeAccountSwitcher, interval: int = 5) -> None:
     """Re-capture ``list_accounts()`` every ``interval`` seconds and redraw.
 
-    Usage is cache-gated at switcher._USAGE_CACHE_TTL (15s), so sub-15s
-    intervals re-render cached usage rather than re-fetching from the network.
+    Usage comes from the per-account store (usage_store.SERVE_TTL_S, 30s):
+    redraws inside that window re-render stored usage rather than re-fetching
+    from the network.
     """
     stdscr.timeout(250)  # non-blocking getch, 250ms tick
     try:

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -1,0 +1,294 @@
+"""Per-account usage table: last-known-good measurements + fetch/backoff state.
+
+Replaces the all-or-nothing 15s snapshot that previously lived in
+``cache/usage.json`` (now ``schemaVersion: 2``; a version-less legacy file is
+treated as empty — its data had a 15s shelf life anyway). One failed round
+trip no longer blanks every account: a failure updates the error/backoff
+fields and never touches the last-good measurement (stale-on-error). The
+table is shared by ``--list``/``--status`` (on-demand refresh of stale
+entries) and ``cswap auto`` (scheduled polling), so each learns from the
+other's fetches.
+
+The store persists only *measurements* (``lastGood``) and *fetch state*
+(failures, backoff, poll schedule). Sentinel states ("api key",
+"token expired", ...) are derived fresh by the collector on every pass and
+overlaid on the read model (``UsageEntry.sentinel``) — never written to disk,
+so a stale sentinel can't outlive the condition that produced it.
+
+Locking protocol (never holds the lock across network I/O):
+(a) lock → read, decide/claim the fetch set (stamp ``lastAttemptAt``) → unlock;
+(b) fetch with no lock held;
+(c) lock → re-read, merge outcomes, write → unlock.
+The claim stamp lets concurrent collectors skip accounts another process
+started fetching moments ago; a crashed claimer just ages out.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from claude_swap.locking import FileLock
+from claude_swap.settings import atomic_write_json
+
+SCHEMA_VERSION = 2
+
+# Freshness is the reader's judgment per purpose, not a global TTL:
+SERVE_TTL_S = 30.0  # fresher than this → serve without fetching
+STALE_OK_S = 300.0  # trusted for switch decisions; older → headroom unknown
+CLAIM_TTL_S = 10.0  # in-flight claim window: skip just-claimed accounts
+
+# Failure backoff when the server sent no Retry-After: 30s · 2^(n-1), capped.
+# Conservative placeholders until issue #85's debug logs settle the real cause.
+BACKOFF_BASE_S = 30.0
+BACKOFF_CAP_S = 600.0
+
+# (email, organizationUuid) — the identity a slot number currently maps to.
+Identity = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class FetchRecord:
+    """Outcome of one fetch attempt, as handed to :meth:`UsageStore.record`.
+
+    Exactly one of three shapes:
+    - success: ``error`` and ``sentinel`` are None (``usage`` may still be
+      None when the response carried no window data);
+    - failure: ``error`` set (with optional ``retry_after_s``);
+    - sentinel: ``sentinel`` set — a derived state ("token expired" with an
+      owner present, ...), recorded as a no-op: sentinels are re-derived every
+      pass and never persisted.
+    """
+
+    usage: dict | None = None
+    error: str | None = None
+    retry_after_s: float | None = None
+    sentinel: str | None = None
+
+
+@dataclass(frozen=True)
+class UsageEntry:
+    """Read model of one account's usage state at collect time.
+
+    ``sentinel`` is the collector's live overlay (never persisted); all other
+    fields mirror the stored row. ``age_s`` is the age of ``last_good``.
+    """
+
+    sentinel: str | None = None
+    last_good: dict | None = None
+    fetched_at: float | None = None
+    age_s: float | None = None
+    last_attempt_at: float | None = None
+    consecutive_failures: int = 0
+    last_error: str | None = None
+    backoff_until: float | None = None
+    next_poll_at: float | None = None
+    poll_interval_s: float | None = None
+
+    def fresh(self, now: float, ttl: float = SERVE_TTL_S) -> bool:
+        return self.fetched_at is not None and (now - self.fetched_at) <= ttl
+
+    def in_backoff(self, now: float) -> bool:
+        return self.backoff_until is not None and now < self.backoff_until
+
+    def claimed(self, now: float) -> bool:
+        """A collector stamped this entry moments ago (fetch may be in flight)."""
+        return (
+            self.last_attempt_at is not None
+            and (now - self.last_attempt_at) < CLAIM_TTL_S
+        )
+
+    def decision_value(self) -> dict | str | None:
+        """The ``dict | sentinel | None`` value switch decisions run on.
+
+        Sentinel wins; else last-good while it is recent enough to trust
+        (≤ ``STALE_OK_S``); else None (unknown). Display code reads
+        ``last_good``/``age_s`` directly instead — it may show older data,
+        annotated with its age.
+        """
+        if self.sentinel is not None:
+            return self.sentinel
+        if (
+            self.last_good is not None
+            and self.age_s is not None
+            and self.age_s <= STALE_OK_S
+        ):
+            return self.last_good
+        return None
+
+
+def _failure_backoff_s(consecutive_failures: int, retry_after_s: float | None) -> float:
+    computed = min(
+        BACKOFF_BASE_S * (2 ** max(0, consecutive_failures - 1)), BACKOFF_CAP_S
+    )
+    if retry_after_s is None:
+        return computed
+    # The server's word is the floor; our own curve may wait longer.
+    return max(retry_after_s, computed)
+
+
+class UsageStore:
+    """The ``cache/usage.json`` table. All writes go read-modify-write under
+    ``cache/.usage.lock``; reads are lock-free (writes are atomic replaces).
+
+    Every method takes the caller's current ``identities`` map (slot number →
+    ``(email, organizationUuid)``) and only ever touches rows for those slots:
+    a row whose stored identity differs is invisible to reads and replaced on
+    write, so slot reuse never serves the previous account's usage. Rows for
+    slots outside the map are left alone (callers like ``--status`` operate
+    on a single slot).
+    """
+
+    def __init__(self, cache_dir: Path, clock: Callable[[], float] = time.time):
+        self.path = cache_dir / "usage.json"
+        self._lock_path = cache_dir / ".usage.lock"
+        self.clock = clock
+
+    # -- raw I/O ------------------------------------------------------------
+
+    def _lock(self) -> FileLock:
+        return FileLock(self._lock_path)
+
+    def _read_rows(self) -> dict[str, dict]:
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return {}
+        if not isinstance(raw, dict) or raw.get("schemaVersion") != SCHEMA_VERSION:
+            return {}  # legacy snapshot or future schema: start empty
+        rows = raw.get("accounts")
+        return rows if isinstance(rows, dict) else {}
+
+    def _write_rows(self, rows: dict[str, dict]) -> None:
+        atomic_write_json(
+            self.path, {"schemaVersion": SCHEMA_VERSION, "accounts": rows}
+        )
+
+    @staticmethod
+    def _matches(row: object, identity: Identity) -> bool:
+        return (
+            isinstance(row, dict)
+            and row.get("email") == identity[0]
+            and row.get("organizationUuid", "") == identity[1]
+        )
+
+    def _fresh_row(self, identity: Identity) -> dict:
+        return {"email": identity[0], "organizationUuid": identity[1]}
+
+    # -- read model -----------------------------------------------------------
+
+    def entries(self, identities: dict[str, Identity]) -> dict[str, UsageEntry]:
+        """Identity-guarded snapshot for the given slots (empty entry when the
+        row is missing or belongs to a different account)."""
+        now = self.clock()
+        rows = self._read_rows()
+        out: dict[str, UsageEntry] = {}
+        for num, identity in identities.items():
+            row = rows.get(num)
+            if not self._matches(row, identity):
+                out[num] = UsageEntry()
+                continue
+            fetched_at = row.get("fetchedAt")
+            if not isinstance(fetched_at, (int, float)):
+                fetched_at = None
+            last_good = row.get("lastGood")
+            out[num] = UsageEntry(
+                last_good=last_good if isinstance(last_good, dict) else None,
+                fetched_at=fetched_at,
+                age_s=(now - fetched_at) if fetched_at is not None else None,
+                last_attempt_at=_num_or_none(row.get("lastAttemptAt")),
+                consecutive_failures=int(row.get("consecutiveFailures") or 0),
+                last_error=row.get("lastError"),
+                backoff_until=_num_or_none(row.get("backoffUntil")),
+                next_poll_at=_num_or_none(row.get("nextPollAt")),
+                poll_interval_s=_num_or_none(row.get("pollIntervalS")),
+            )
+        return out
+
+    # -- writes ---------------------------------------------------------------
+
+    def _mutate(
+        self,
+        identities: dict[str, Identity],
+        nums: Iterable[str],
+        mutator: Callable[[str, dict], None],
+    ) -> None:
+        """Read-modify-write rows for ``nums`` under the lock. A row whose
+        stored identity mismatches is replaced with a fresh one first."""
+        with self._lock():
+            rows = self._read_rows()
+            for num in nums:
+                identity = identities[num]
+                if not self._matches(rows.get(num), identity):
+                    rows[num] = self._fresh_row(identity)
+                mutator(num, rows[num])
+            self._write_rows(rows)
+
+    def claim(self, nums: Iterable[str], identities: dict[str, Identity]) -> None:
+        """Stamp ``lastAttemptAt`` on the slots about to be fetched."""
+        nums = list(nums)
+        if not nums:
+            return
+        now = self.clock()
+        self._mutate(identities, nums, lambda _n, row: row.update(lastAttemptAt=now))
+
+    def record(
+        self, outcomes: dict[str, FetchRecord], identities: dict[str, Identity]
+    ) -> None:
+        """Merge fetch outcomes. Success and failure are mutually exclusive
+        writers: success resets the failure fields, failure never touches
+        ``lastGood``/``fetchedAt``. Sentinel records are no-ops (derived state
+        lives only in the collector's overlay)."""
+        effective = {n: r for n, r in outcomes.items() if r.sentinel is None}
+        if not effective:
+            return
+        now = self.clock()
+
+        def apply(num: str, row: dict) -> None:
+            rec = effective[num]
+            row["lastAttemptAt"] = now
+            if rec.error is None:
+                row["lastGood"] = rec.usage
+                row["fetchedAt"] = now
+                row["consecutiveFailures"] = 0
+                row["lastError"] = None
+                row["backoffUntil"] = None
+            else:
+                failures = int(row.get("consecutiveFailures") or 0) + 1
+                row["consecutiveFailures"] = failures
+                row["lastError"] = rec.error
+                row["backoffUntil"] = now + _failure_backoff_s(
+                    failures, rec.retry_after_s
+                )
+
+        self._mutate(identities, effective.keys(), apply)
+
+    def set_poll_plan(
+        self,
+        plans: dict[str, tuple[float | None, float | None]],
+        identities: dict[str, Identity],
+    ) -> None:
+        """Persist the scheduler's per-slot ``(nextPollAt, pollIntervalS)``."""
+        if not plans:
+            return
+
+        def apply(num: str, row: dict) -> None:
+            next_poll_at, interval = plans[num]
+            row["nextPollAt"] = next_poll_at
+            row["pollIntervalS"] = interval
+
+        self._mutate(identities, plans.keys(), apply)
+
+
+def _num_or_none(value: object) -> float | None:
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def with_sentinel(entry: UsageEntry, sentinel: str | None) -> UsageEntry:
+    """Overlay a derived sentinel state on a stored entry (read model only)."""
+    if sentinel is None:
+        return entry
+    return replace(entry, sentinel=sentinel)

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -230,14 +230,18 @@ class TestUsageDisplay:
     def test_collect_usage_short_circuits(self, temp_home: Path):
         s = _linux_switcher()
         info = [(2, "api-key-2@token.local", "", "", False, API_KEY)]
-        assert s._collect_usage(info) == [USAGE_API_KEY]
+        entries = s._collect_usage_entries(info)
+        assert entries["2"].sentinel == USAGE_API_KEY
+        assert entries["2"].decision_value() == USAGE_API_KEY
 
     def test_active_account_usage_short_circuits(self, temp_home: Path):
         s = _linux_switcher()
         get_global_config_path().write_text(
             json.dumps({"primaryApiKey": API_KEY}), encoding="utf-8"
         )
-        assert s._active_account_usage("2", "api-key-2@token.local") == USAGE_API_KEY
+        entry = s._active_account_usage("2", "api-key-2@token.local", "")
+        assert entry.sentinel == USAGE_API_KEY
+        assert entry.decision_value() == USAGE_API_KEY
 
 
 class TestStrategyBehaviour:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -10,6 +10,8 @@ import pytest
 
 from claude_swap import oauth
 from claude_swap.autoswitch import (
+    IDLE_HOLD_MAX_S,
+    NO_RESET_FALLBACK_S,
     AllExhaustedEvent,
     AutoSwitchEngine,
     ErrorEvent,
@@ -20,6 +22,7 @@ from claude_swap.autoswitch import (
     TickOutcome,
     UnquarantineEvent,
 )
+from claude_swap.json_output import USAGE_TOKEN_EXPIRED
 from claude_swap.models import Platform
 from claude_swap.settings import AutoSwitchSettings
 from claude_swap.switcher import ClaudeAccountSwitcher
@@ -324,6 +327,58 @@ class TestDecisionTable:
         event = next(e for e in harness.events if isinstance(e, AllExhaustedEvent))
         assert event.earliest_reset_at == "2026-07-03T10:30:00Z"
         assert harness.engine._sleep_until_ts is not None
+
+
+class TestIdleHold:
+    """Active token expired while Claude Code owns it → hold, don't fail over."""
+
+    _HELD = {"1": USAGE_TOKEN_EXPIRED, "2": _usage(10), "3": _usage(20)}
+
+    def test_token_expired_holds_instead_of_failover(self, harness):
+        for _ in range(6):  # far past unhealthy_ticks (3)
+            assert harness.tick_with_usage(self._HELD) is TickOutcome.NO_ACTION
+            harness.clock.advance(60)
+        assert harness.active_number() == 1
+        assert not any(isinstance(e, SwitchEvent) for e in harness.events)
+        reasons = {e.reason for e in harness.events if isinstance(e, NoSwitchEvent)}
+        assert reasons == {"active-idle"}
+        assert harness.engine._unhealthy_ticks == 0
+
+    def test_idle_hold_slows_cadence(self, harness):
+        outcome = harness.tick_with_usage(self._HELD)
+        assert outcome is TickOutcome.NO_ACTION
+        assert harness.engine._next_delay(outcome) >= NO_RESET_FALLBACK_S
+
+    def test_idle_hold_cap_escalates_to_failover(self, harness):
+        assert harness.tick_with_usage(self._HELD) is TickOutcome.NO_ACTION
+        harness.clock.advance(IDLE_HOLD_MAX_S + 1)
+        # Past the cap the sentinel counts as unhealthy again → failover after
+        # unhealthy_ticks (3) consecutive ticks.
+        assert harness.tick_with_usage(self._HELD) is TickOutcome.NO_ACTION
+        assert harness.tick_with_usage(self._HELD) is TickOutcome.NO_ACTION
+        assert harness.tick_with_usage(self._HELD) is TickOutcome.SWITCHED
+        switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "failover"
+
+    def test_recovery_resets_the_hold_clock(self, harness):
+        healthy = {"1": _usage(50), "2": _usage(10), "3": _usage(20)}
+        harness.tick_with_usage(self._HELD)
+        harness.clock.advance(IDLE_HOLD_MAX_S - 60)
+        harness.tick_with_usage(healthy)  # user came back; token refreshed
+        harness.clock.advance(120)
+        # New expiry long after: the hold clock restarted, so still held.
+        assert harness.tick_with_usage(self._HELD) is TickOutcome.NO_ACTION
+        assert harness.engine._unhealthy_ticks == 0
+        assert harness.active_number() == 1
+
+    def test_plain_fetch_failure_still_counts_unhealthy(self, harness):
+        # A None (network failure / dead creds) is NOT the idle sentinel:
+        # unhealthy counting and the hold clock reset both apply.
+        harness.tick_with_usage(self._HELD)
+        unknown = {"1": None, "2": _usage(10), "3": _usage(20)}
+        assert harness.tick_with_usage(unknown) is TickOutcome.NO_ACTION
+        assert harness.engine._unhealthy_ticks == 1
+        assert harness.engine._idle_hold_since is None
 
 
 class TestApiKeyAccounts:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -23,6 +23,7 @@ from claude_swap.autoswitch import (
     UnquarantineEvent,
 )
 from claude_swap.json_output import USAGE_TOKEN_EXPIRED
+from claude_swap.usage_store import UsageEntry
 from claude_swap.models import Platform
 from claude_swap.settings import AutoSwitchSettings
 from claude_swap.switcher import ClaudeAccountSwitcher
@@ -46,6 +47,15 @@ def _usage(pct: float, resets_at: str | None = None) -> dict:
     return {"five_hour": window, "seven_day": {"pct": 0.0}}
 
 
+def _entry_for(value: dict | str | None, now: float) -> UsageEntry:
+    """Synthesize the store entry a live fetch would have produced."""
+    if isinstance(value, dict):
+        return UsageEntry(last_good=value, fetched_at=now, age_s=0.0)
+    if isinstance(value, str):
+        return UsageEntry(sentinel=value)
+    return UsageEntry()
+
+
 class EngineHarness:
     """Seeded switcher + engine + captured events, on the Linux file backend."""
 
@@ -58,6 +68,9 @@ class EngineHarness:
         self.settings = AutoSwitchSettings(**settings_kwargs)
         self.events: list = []
         self.clock = FakeClock()
+        # Keep the usage store on the same fake clock as the engine so
+        # freshness/claims/poll scheduling are deterministic in tests.
+        self.switcher._usage_store.clock = self.clock
         self.engine = self._make_engine()
 
     def _make_engine(self, **kwargs) -> AutoSwitchEngine:
@@ -110,7 +123,12 @@ class EngineHarness:
         }))
 
     def tick_with_usage(self, usage: dict) -> TickOutcome:
-        with patch.object(self.switcher, "_usage_by_account", return_value=usage):
+        entries = {
+            num: _entry_for(value, self.clock.now) for num, value in usage.items()
+        }
+        with patch.object(
+            self.switcher, "usage_entries_by_account", return_value=entries
+        ):
             return self.engine.tick()
 
     def active_number(self) -> int | None:
@@ -381,6 +399,150 @@ class TestIdleHold:
         assert harness.engine._idle_hold_since is None
 
 
+class TestAdaptiveScheduler:
+    """End-to-end through the real store: O(1) baseline, escalations,
+    skip-to-reset, movement-based cadence."""
+
+    def _harness(self, temp_home, monkeypatch, accounts=3, **settings_kwargs):
+        monkeypatch.setattr("claude_swap.switcher._FETCH_STAGGER_S", 0)
+        h = EngineHarness(temp_home, **settings_kwargs)
+        emails = ["a@example.com", "b@example.com", "c@example.com"]
+        for num in range(1, accounts + 1):
+            h.seed(num, emails[num - 1])
+        h.make_live("a@example.com", 1)
+        # Deterministic owner detection: Claude Code "running" → the active
+        # account is fetched hands-off (is_active=True), never refreshed.
+        monkeypatch.setattr(h.switcher, "_active_cc_running", lambda: True)
+        monkeypatch.setattr(h.switcher, "_live_session_pids", lambda *a: [])
+        return h
+
+    @staticmethod
+    def _counting_fetch(counts, usage_by_num, errors_by_num=None):
+        def fake(num, email, creds, is_active=False, persist_credentials=None):
+            counts[num] = counts.get(num, 0) + 1
+            error = (errors_by_num or {}).get(num)
+            if error:
+                return oauth.UsageOutcome(None, error=error)
+            value = usage_by_num.get(num)
+            return oauth.UsageOutcome(dict(value) if value else None)
+        return fake
+
+    def _tick(self, h, counts, usage_by_num, errors_by_num=None):
+        with patch(
+            "claude_swap.oauth.try_fetch_usage_for_account",
+            side_effect=self._counting_fetch(counts, usage_by_num, errors_by_num),
+        ):
+            return h.engine.tick()
+
+    def test_baseline_fetches_active_plus_one_candidate(self, temp_home, monkeypatch):
+        h = self._harness(temp_home, monkeypatch)
+        usage = {"1": _usage(50), "2": _usage(10), "3": _usage(20)}
+        counts: dict[str, int] = {}
+        for expected in ({"1": 1, "2": 1}, {"1": 2, "2": 1, "3": 1},
+                         {"1": 3, "2": 2, "3": 1}):
+            self._tick(h, counts, usage)
+            assert counts == expected, "one candidate per tick, stalest first"
+            h.clock.advance(60)
+
+    def test_near_threshold_escalates_to_full_refresh(self, temp_home, monkeypatch):
+        # threshold 90, margin 15 → active at 80% is within the escalation band.
+        h = self._harness(temp_home, monkeypatch)
+        counts: dict[str, int] = {}
+        outcome = self._tick(
+            h, counts, {"1": _usage(80), "2": _usage(10), "3": _usage(20)}
+        )
+        assert outcome is TickOutcome.NO_ACTION  # still below the threshold
+        assert counts == {"1": 1, "2": 1, "3": 1}  # but everyone got refreshed
+
+    def test_active_unknown_escalates_before_failover(self, temp_home, monkeypatch):
+        h = self._harness(temp_home, monkeypatch, unhealthy_ticks=1)
+        counts: dict[str, int] = {}
+        outcome = self._tick(
+            h, counts,
+            {"2": _usage(10), "3": _usage(50)},
+            errors_by_num={"1": "timeout"},
+        )
+        # Candidate data was refreshed in the same tick the failover ran on.
+        assert counts == {"1": 1, "2": 1, "3": 1}
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_exhausted_candidate_skips_to_its_reset(self, temp_home, monkeypatch):
+        from datetime import datetime, timezone
+
+        h = self._harness(temp_home, monkeypatch)
+        reset_iso = "2026-07-05T12:00:00Z"
+        reset_ts = datetime(2026, 7, 5, 12, tzinfo=timezone.utc).timestamp()
+        usage = {"1": _usage(50), "2": _usage(100, reset_iso), "3": _usage(20)}
+        counts: dict[str, int] = {}
+        for _ in range(3):
+            self._tick(h, counts, usage)
+            h.clock.advance(60)
+        assert counts["2"] == 1  # fetched once, then parked until its reset
+        entry = h.switcher._usage_store.entries(
+            {"2": ("b@example.com", "")}
+        )["2"]
+        assert entry.next_poll_at == pytest.approx(reset_ts)
+
+    def test_movement_adapts_poll_interval(self, temp_home, monkeypatch):
+        h = self._harness(temp_home, monkeypatch, accounts=2)
+        usage = {"1": _usage(50), "2": _usage(10)}
+        counts: dict[str, int] = {}
+
+        def interval() -> float | None:
+            return h.switcher._usage_store.entries(
+                {"2": ("b@example.com", "")}
+            )["2"].poll_interval_s
+
+        self._tick(h, counts, usage)          # first data point → base interval
+        assert interval() == 60.0
+        h.clock.advance(60)
+        self._tick(h, counts, usage)          # unmoved → backs off ×1.5
+        assert interval() == 90.0
+        assert counts["2"] == 2
+        h.clock.advance(60)
+        self._tick(h, counts, usage)          # not due yet (90s interval)
+        assert counts["2"] == 2
+        h.clock.advance(60)
+        usage["2"] = _usage(20)               # moved 10 pts on another machine
+        self._tick(h, counts, usage)
+        assert counts["2"] == 3
+        assert interval() == 60.0             # halved (floored at engine interval)
+
+    def test_idle_hold_skips_candidate_polling(self, temp_home, monkeypatch):
+        h = self._harness(temp_home, monkeypatch)
+        # Active token locally expired while "Claude Code is running" (owner
+        # patched True) → sentinel without any request.
+        (h.temp_home / ".claude" / ".credentials.json").write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-live", "refreshToken": "rt-live",
+                "expiresAt": 1000,
+            },
+        }))
+        usage = {"2": _usage(10), "3": _usage(20)}
+        counts: dict[str, int] = {}
+        assert self._tick(h, counts, usage) is TickOutcome.NO_ACTION
+        h.clock.advance(60)
+        counts.clear()
+        # Hold established → the next tick polls nothing at all: the active
+        # fetch short-circuits locally and no candidate slot is spent.
+        assert self._tick(h, counts, usage) is TickOutcome.NO_ACTION
+        assert counts == {}
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert set(reasons) == {"active-idle"}
+
+    def test_poll_event_carries_fetch_errors(self, temp_home, monkeypatch):
+        h = self._harness(temp_home, monkeypatch, accounts=2, unhealthy_ticks=3)
+        counts: dict[str, int] = {}
+        self._tick(
+            h, counts, {"2": _usage(10)}, errors_by_num={"1": "http-429"}
+        )
+        poll = next(e for e in h.events if isinstance(e, PollEvent))
+        assert poll.fetch_errors.get("1") == "http-429"
+        assert "http-429" in poll.human()
+        assert poll.to_json()["fetchErrors"] == {"1": "http-429"}
+
+
 class TestApiKeyAccounts:
     def _mark_api_key(self, harness, num: int) -> None:
         data = harness.switcher._get_sequence_data()
@@ -551,10 +713,14 @@ class TestQuarantineLifecycle:
         harness.engine._quarantine("2", "b@example.com", "invalid_grant")
         harness.events.clear()
         fresh_engine = harness._make_engine()
+        usage = {"1": _usage(95), "2": _usage(0), "3": _usage(50)}
         with patch.object(
             harness.switcher,
-            "_usage_by_account",
-            return_value={"1": _usage(95), "2": _usage(0), "3": _usage(50)},
+            "usage_entries_by_account",
+            return_value={
+                num: _entry_for(value, harness.clock.now)
+                for num, value in usage.items()
+            },
         ):
             outcome = fresh_engine.tick()
         # 2 has the most headroom but is quarantined → 3 wins.

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -542,6 +542,49 @@ class TestAdaptiveScheduler:
         assert "http-429" in poll.human()
         assert poll.to_json()["fetchErrors"] == {"1": "http-429"}
 
+    def test_quarantined_candidate_never_consumes_the_poll_slot(
+        self, temp_home, monkeypatch
+    ):
+        h = self._harness(temp_home, monkeypatch)
+        h.engine._quarantine("2", "b@example.com", "invalid_grant")
+        usage = {"1": _usage(50), "2": _usage(10), "3": _usage(20)}
+        counts: dict[str, int] = {}
+        for _ in range(3):
+            self._tick(h, counts, usage)
+            h.clock.advance(60)
+        # The alternate slot always went to account 3; 2 is dead weight.
+        assert "2" not in counts
+        assert counts["3"] >= 1
+
+    def test_expired_active_enters_idle_hold_even_during_backoff(
+        self, temp_home, monkeypatch
+    ):
+        """Finding-2 regression: the owned+expired sentinel must not be hidden
+        by the active row's failure backoff (e.g. a Retry-After window), or
+        the engine would count unhealthy ticks toward a spurious failover."""
+        from claude_swap.usage_store import FetchRecord
+
+        h = self._harness(temp_home, monkeypatch)
+        # Active token locally expired while an owner is present.
+        (h.temp_home / ".claude" / ".credentials.json").write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-live", "refreshToken": "rt-live",
+                "expiresAt": 1000,
+            },
+        }))
+        # Active row sits in a long failure backoff → the fetch path (and its
+        # own expired short-circuit) is unreachable this tick.
+        h.switcher._usage_store.record(
+            {"1": FetchRecord(error="http-429", retry_after_s=600.0)},
+            {"1": ("a@example.com", "")},
+        )
+        counts: dict[str, int] = {}
+        outcome = self._tick(h, counts, {"2": _usage(10), "3": _usage(20)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.engine._unhealthy_ticks == 0
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["active-idle"]
+
 
 class TestApiKeyAccounts:
     def _mark_api_key(self, harness, num: int) -> None:

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from claude_swap import oauth
 from claude_swap.exceptions import ConfigError, SwitchError
 from claude_swap.json_output import (
     SCHEMA_VERSION,
@@ -116,7 +117,7 @@ class TestListJson:
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage):
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(usage)):
             payload = switcher.list_accounts(json_output=True)
 
         # Method itself prints nothing — the CLI serializes.
@@ -144,7 +145,7 @@ class TestListJson:
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
              patch.object(switcher, "_read_account_credentials", return_value=""), \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
             payload = switcher.list_accounts(json_output=True)
 
         by_num = {a["number"]: a for a in payload["accounts"]}
@@ -184,7 +185,7 @@ class TestStatusJson:
 
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage):
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(usage)):
             payload = switcher.status(json_output=True)
 
         assert capsys.readouterr().out == ""
@@ -242,7 +243,7 @@ def _install_patches(switcher, creds_store, configs_store, live_state):
         patch.object(switcher, "_write_credentials",
                      side_effect=lambda c: live_state.__setitem__("creds", c)),
         # Don't make network calls from the (suppressed) post-switch usage path.
-        patch("claude_swap.oauth.fetch_usage_for_account", return_value=None),
+        patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)),
     ]
     for p in patches:
         p.start()

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -153,6 +153,56 @@ class TestListJson:
         assert by_num[1]["usage"] is None
         assert by_num[2]["usageStatus"] == "no_credentials"
 
+    @pytest.mark.parametrize(
+        "age_s,expected_status", [(100.0, "ok"), (400.0, "unavailable")]
+    )
+    def test_stale_usage_is_decision_gated_in_json(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict, age_s: float, expected_status: str,
+    ):
+        """JSON serves last-good only while decision-grade (≤ STALE_OK_S).
+
+        A script keying on usageStatus == "ok" must never act on arbitrarily
+        old data; past the trust window the row reports unavailable even
+        though the human view still shows the last-seen numbers with age.
+        """
+        import time as time_mod
+
+        from claude_swap.usage_store import FetchRecord, UsageStore
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        backdated = UsageStore(
+            switcher.backup_dir / "cache", clock=lambda: time_mod.time() - age_s
+        )
+        backdated.record(
+            {"1": FetchRecord(usage={"five_hour": {"pct": 25.0}})},
+            {"1": ("test@example.com", "")},
+        )
+
+        # The stale entry is due for a refetch, but the fetch fails — the
+        # store keeps serving the old measurement.
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
+             patch.object(switcher, "_read_account_credentials", return_value=""), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None, error="timeout")):
+            payload = switcher.list_accounts(json_output=True)
+
+        row = next(a for a in payload["accounts"] if a["number"] == 1)
+        assert row["usageStatus"] == expected_status
+        if expected_status == "ok":
+            assert row["usage"]["fiveHour"]["pct"] == 25.0
+            assert row["usageAgeSeconds"] >= age_s
+        else:
+            assert row["usage"] is None
+            assert "usageFetchedAt" not in row
+
 
 # --------------------------------------------------------------------------- #
 # --status --json

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -777,3 +777,143 @@ class TestFetchUsageForAccount:
         output = capsys.readouterr().out
         assert "failed to save refreshed token" in output
         assert "cswap --add-account" in output
+
+
+class TestClassifyUsageError:
+    """Test _classify_usage_error kinds and Retry-After parsing."""
+
+    @staticmethod
+    def _http_error(code: int, headers: dict | None = None):
+        import email.message
+        hdrs = None
+        if headers is not None:
+            hdrs = email.message.Message()
+            for k, v in headers.items():
+                hdrs[k] = v
+        return urllib.error.HTTPError(
+            url="https://api.anthropic.com/api/oauth/usage",
+            code=code, msg="err", hdrs=hdrs, fp=None,
+        )
+
+    def test_http_codes(self):
+        assert oauth._classify_usage_error(self._http_error(429))[0] == "http-429"
+        assert oauth._classify_usage_error(self._http_error(500))[0] == "http-500"
+        assert oauth._classify_usage_error(self._http_error(401))[0] == "http-401"
+
+    def test_retry_after_seconds(self):
+        kind, retry = oauth._classify_usage_error(
+            self._http_error(429, {"Retry-After": "30"})
+        )
+        assert kind == "http-429"
+        assert retry == 30.0
+
+    def test_retry_after_date_form_ignored(self):
+        _, retry = oauth._classify_usage_error(
+            self._http_error(429, {"Retry-After": "Fri, 04 Jul 2026 12:00:00 GMT"})
+        )
+        assert retry is None
+
+    def test_retry_after_negative_clamped(self):
+        _, retry = oauth._classify_usage_error(
+            self._http_error(429, {"Retry-After": "-5"})
+        )
+        assert retry == 0.0
+
+    def test_no_headers(self):
+        kind, retry = oauth._classify_usage_error(self._http_error(429))
+        assert (kind, retry) == ("http-429", None)
+
+    def test_timeout(self):
+        import socket
+        assert oauth._classify_usage_error(TimeoutError())[0] == "timeout"
+        assert oauth._classify_usage_error(socket.timeout())[0] == "timeout"
+        assert oauth._classify_usage_error(
+            urllib.error.URLError(TimeoutError())
+        )[0] == "timeout"
+
+    def test_network(self):
+        assert oauth._classify_usage_error(
+            urllib.error.URLError(ConnectionRefusedError())
+        )[0] == "network"
+
+    def test_bad_response(self):
+        try:
+            json.loads("not json")
+        except json.JSONDecodeError as e:
+            assert oauth._classify_usage_error(e)[0] == "bad-response"
+
+    def test_fallback_type_name(self):
+        assert oauth._classify_usage_error(ValueError("x"))[0] == "ValueError"
+
+
+class TestTryFetchUsageOutcome:
+    """Test try_fetch_usage_for_account outcome classification."""
+
+    @staticmethod
+    def _make_credentials() -> str:
+        from datetime import timedelta
+        future_ms = int(
+            (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp() * 1000
+        )
+        return json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "old-access",
+                "refreshToken": "old-refresh",
+                "expiresAt": future_ms,
+            }
+        })
+
+    def test_success_outcome(self):
+        resp = MagicMock()
+        resp.read.return_value = json.dumps(
+            {"five_hour": {"utilization": 12.0, "resets_at": None}}
+        ).encode()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("claude_swap.oauth.urllib.request.urlopen", return_value=resp):
+            outcome = oauth.try_fetch_usage_for_account(
+                "1", "a@b.c", self._make_credentials(), is_active=False,
+            )
+        assert outcome.error is None
+        assert outcome.usage["five_hour"]["pct"] == 12.0
+
+    def test_429_outcome_carries_retry_after(self, caplog):
+        import email.message
+        import logging
+        hdrs = email.message.Message()
+        hdrs["Retry-After"] = "42"
+        err = urllib.error.HTTPError(
+            "https://api.anthropic.com/api/oauth/usage", 429, "Too Many",
+            hdrs=hdrs, fp=None,
+        )
+        with (
+            patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err),
+            caplog.at_level(logging.WARNING, logger="claude-swap"),
+        ):
+            outcome = oauth.try_fetch_usage_for_account(
+                "1", "a@b.c", self._make_credentials(), is_active=False,
+            )
+        assert outcome.usage is None
+        assert outcome.error == "http-429"
+        assert outcome.retry_after_s == 42.0
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("http-429" in m and "a@b.c" in m for m in warnings)
+
+    def test_timeout_outcome(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            side_effect=urllib.error.URLError(TimeoutError()),
+        ):
+            outcome = oauth.try_fetch_usage_for_account(
+                "1", "a@b.c", self._make_credentials(), is_active=False,
+            )
+        assert outcome.error == "timeout"
+
+    def test_no_access_token_outcome(self):
+        outcome = oauth.try_fetch_usage_for_account(
+            "1", "a@b.c", json.dumps({"claudeAiOauth": {}}), is_active=False,
+        )
+        assert outcome.error == "no-access-token"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from claude_swap import oauth
 from claude_swap import session as session_mod
 from claude_swap.exceptions import AccountNotFoundError, SessionError
 from claude_swap.models import Platform
@@ -936,10 +937,10 @@ class TestGuards:
 
         def fake_fetch(num, email, creds, is_active=False, persist_credentials=None):
             seen[num] = is_active
-            return None
+            return oauth.UsageOutcome(None)
 
         monkeypatch.setattr(
-            "claude_swap.oauth.fetch_usage_for_account", fake_fetch
+            "claude_swap.oauth.try_fetch_usage_for_account", fake_fetch
         )
         seeded_switcher.list_accounts()
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -13,6 +13,7 @@ import pytest
 
 from claude_swap import macos_keychain
 from claude_swap import oauth
+from claude_swap.json_output import USAGE_TOKEN_EXPIRED
 from claude_swap.exceptions import (
     AccountNotFoundError,
     ConfigError,
@@ -816,12 +817,12 @@ class TestActiveAccountRefresh:
              patch.object(switcher, "_active_cc_running", return_value=True), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials") as write_live, \
-             patch("claude_swap.oauth.try_fetch_usage_for_account",
-                   return_value=oauth.UsageOutcome(None)) as mock_fetch:
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
             result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
         assert result.sentinel == USAGE_TOKEN_EXPIRED
-        assert mock_fetch.call_args.kwargs.get("is_active") is True
+        # Owned + locally expired → the request would just 401, so none is made.
+        mock_fetch.assert_not_called()
         write_live.assert_not_called()
 
     def test_live_session_blocks_refresh(
@@ -834,11 +835,13 @@ class TestActiveAccountRefresh:
              patch.object(switcher, "_active_cc_running", return_value=False), \
              patch.object(switcher, "_live_session_pids", return_value=[4242]), \
              patch.object(switcher, "_write_credentials") as write_live, \
-             patch("claude_swap.oauth.try_fetch_usage_for_account",
-                   return_value=oauth.UsageOutcome(None)) as mock_fetch:
-            switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
-        assert mock_fetch.call_args.kwargs.get("is_active") is True
+        # Session owns the credential + token expired → sentinel, no request,
+        # and certainly no refresh write.
+        assert result.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_not_called()
         write_live.assert_not_called()
 
     def test_lineage_mismatch_skips_write_and_reports_token_expired(
@@ -912,11 +915,13 @@ class TestActiveAccountRefresh:
              patch("claude_swap.switcher.get_running_instances", side_effect=OSError("boom")), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials") as write_live, \
-             patch("claude_swap.oauth.try_fetch_usage_for_account",
-                   return_value=oauth.UsageOutcome(None)) as mock_fetch:
-            switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
-        assert mock_fetch.call_args.kwargs.get("is_active") is True
+        # Fails closed: assumed owner + expired token → sentinel, no request,
+        # no refresh write.
+        assert result.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_not_called()
         write_live.assert_not_called()
 
     def test_refresh_network_call_does_not_hold_the_lock(

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -12,12 +12,14 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from claude_swap import macos_keychain
+from claude_swap import oauth
 from claude_swap.exceptions import (
     AccountNotFoundError,
     ConfigError,
     CredentialReadError,
     ValidationError,
 )
+from claude_swap.usage_store import FetchRecord, UsageStore
 from claude_swap.macos_keychain import KeychainError
 from claude_swap.models import Platform
 from claude_swap.paths import get_backup_root, get_credentials_path
@@ -430,9 +432,7 @@ class TestStatusCache:
     def test_status_uses_cached_usage(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
     ):
-        """A fresh cache entry for the active account skips the API call."""
-        from claude_swap.cache import write_cache
-
+        """A fresh store entry for the active account skips the API call."""
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
         active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
 
@@ -440,15 +440,17 @@ class TestStatusCache:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        cached_usage = {
-            "1": {"five_hour": {"pct": 25, "clock": "Jan 1 03:00", "countdown": "1h"},
-                  "seven_day": {"pct": 60, "clock": "Jan 2 03:00", "countdown": "2d"}},
-        }
-        write_cache(switcher.backup_dir / "cache" / "usage.json", cached_usage)
+        UsageStore(switcher.backup_dir / "cache").record(
+            {"1": FetchRecord(usage={
+                "five_hour": {"pct": 25, "clock": "Jan 1 03:00", "countdown": "1h"},
+                "seven_day": {"pct": 60, "clock": "Jan 2 03:00", "countdown": "2d"},
+            })},
+            {"1": ("test@example.com", "")},
+        )
 
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
             switcher.status()
 
         mock_fetch.assert_not_called()
@@ -460,8 +462,6 @@ class TestStatusCache:
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
     ):
         """When Claude Code is running, fetch with is_active=True (never refresh live creds)."""
-        from claude_swap.cache import read_cache, MISSING
-
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
         active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
 
@@ -477,7 +477,8 @@ class TestStatusCache:
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
              patch.object(switcher, "_active_cc_running", return_value=True), \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage_result) as mock_fetch:
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(usage_result)) as mock_fetch:
             switcher.status()
 
         mock_fetch.assert_called_once()
@@ -486,17 +487,15 @@ class TestStatusCache:
         output = capsys.readouterr().out
         assert "10%" in output
 
-        cache_path = switcher.backup_dir / "cache" / "usage.json"
-        cached = read_cache(cache_path, 300)
-        assert cached is not MISSING
-        assert cached["1"] == usage_result
+        entry = UsageStore(switcher.backup_dir / "cache").entries(
+            {"1": ("test@example.com", "")}
+        )["1"]
+        assert entry.last_good == usage_result
 
     def test_status_preserves_other_accounts_in_cache(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
     ):
-        """A cache miss for the active account merges into existing entries instead of clobbering."""
-        from claude_swap.cache import read_cache, write_cache, MISSING
-
+        """Fetching the active account merges into the store without clobbering others."""
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
         active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
 
@@ -504,22 +503,26 @@ class TestStatusCache:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        # Cache has only account "2"; status() runs for account "1"
-        existing = {"2": {"five_hour": {"pct": 80}}}
-        cache_path = switcher.backup_dir / "cache" / "usage.json"
-        write_cache(cache_path, existing)
+        # Store has only account "2"; status() runs for account "1"
+        store = UsageStore(switcher.backup_dir / "cache")
+        store.record(
+            {"2": FetchRecord(usage={"five_hour": {"pct": 80}})},
+            {"2": ("account2@example.com", "")},
+        )
 
         usage_result = {"five_hour": {"pct": 10, "clock": "Jan 1 03:00", "countdown": "0m"}}
 
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage_result):
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(usage_result)):
             switcher.status()
 
-        cached = read_cache(cache_path, 300)
-        assert cached is not MISSING
-        assert cached["1"] == usage_result
-        assert cached["2"] == {"five_hour": {"pct": 80}}
+        entries = store.entries(
+            {"1": ("test@example.com", ""), "2": ("account2@example.com", "")}
+        )
+        assert entries["1"].last_good == usage_result
+        assert entries["2"].last_good == {"five_hour": {"pct": 80}}
 
 
 class TestListAccountsUsage:
@@ -632,14 +635,14 @@ class TestListAccountsUsage:
             # Simulate a refresh on the inactive account only.
             if not is_active and persist_credentials is not None:
                 persist_credentials(account_num, email, refreshed_creds)
-            return None
+            return oauth.UsageOutcome(None)
 
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
              patch.object(switcher, "_active_cc_running", return_value=True), \
              patch.object(switcher, "_write_credentials") as write_live, \
              patch.object(switcher, "_write_account_credentials") as write_backup, \
-             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+             patch("claude_swap.oauth.try_fetch_usage_for_account", side_effect=mock_fetch):
             switcher.list_accounts()
 
         # Live creds must never be written while Claude Code is running.
@@ -660,7 +663,7 @@ class TestListAccountsUsage:
 
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)), \
              patch("claude_swap.oauth.build_token_status", return_value="oauth: fresh, refresh token yes"):
             switcher.list_accounts(show_token_status=True)
 
@@ -670,10 +673,7 @@ class TestListAccountsUsage:
     def test_list_uses_cached_usage(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
     ):
-        """When a fresh usage cache exists, list_accounts skips API calls."""
-        import time
-        from claude_swap.cache import write_cache
-
+        """When fresh store entries exist, list_accounts skips API calls."""
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
         active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
         backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
@@ -682,31 +682,38 @@ class TestListAccountsUsage:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        # Pre-populate cache with usage data for both accounts
-        cached_usage = {
-            "1": {"five_hour": {"pct": 25, "clock": "Jan 1 03:00", "countdown": "1h"},
-                   "seven_day": {"pct": 60, "clock": "Jan 2 03:00", "countdown": "2d"}},
-            "2": {"five_hour": {"pct": 80, "clock": "Jan 1 04:00", "countdown": "30m"},
-                   "seven_day": {"pct": 90, "clock": "Jan 3 03:00", "countdown": "3d"}},
-        }
-        write_cache(switcher.backup_dir / "cache" / "usage.json", cached_usage)
+        # Pre-populate the store with fresh usage data for both accounts
+        UsageStore(switcher.backup_dir / "cache").record(
+            {
+                "1": FetchRecord(usage={
+                    "five_hour": {"pct": 25, "clock": "Jan 1 03:00", "countdown": "1h"},
+                    "seven_day": {"pct": 60, "clock": "Jan 2 03:00", "countdown": "2d"},
+                }),
+                "2": FetchRecord(usage={
+                    "five_hour": {"pct": 80, "clock": "Jan 1 04:00", "countdown": "30m"},
+                    "seven_day": {"pct": 90, "clock": "Jan 3 03:00", "countdown": "3d"},
+                }),
+            },
+            {"1": ("test@example.com", ""), "2": ("account2@example.com", "")},
+        )
 
-        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
-             patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
             switcher.list_accounts()
 
-        # API should NOT have been called — data came from cache
+        # API should NOT have been called — data came from the store
         mock_fetch.assert_not_called()
         output = capsys.readouterr().out
         assert "25%" in output
         assert "80%" in output
 
-    def test_list_ignores_cache_when_accounts_change(
+    def test_list_refetches_stale_entries(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
     ):
-        """Cache is invalidated when the account set doesn't match."""
-        from claude_swap.cache import write_cache
+        """Entries older than the serve TTL are refetched, not served."""
+        import time as time_mod
 
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
         active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
@@ -716,25 +723,34 @@ class TestListAccountsUsage:
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
-        # Cache has only account "1" but the switcher has accounts "1" and "2"
-        cached_usage = {
-            "1": {"five_hour": {"pct": 25}},
-        }
-        write_cache(switcher.backup_dir / "cache" / "usage.json", cached_usage)
+        # Store has a 100s-old entry for account "1" (past SERVE_TTL_S) and
+        # nothing for "2" — both must be fetched live.
+        backdated = UsageStore(
+            switcher.backup_dir / "cache", clock=lambda: time_mod.time() - 100
+        )
+        backdated.record(
+            {"1": FetchRecord(usage={"five_hour": {"pct": 25}})},
+            {"1": ("test@example.com", "")},
+        )
 
         usage_result = {
             "five_hour": {"pct": 10, "clock": "Jan 1 03:00", "countdown": "0m"},
             "seven_day": {"pct": 50, "clock": "Jan 2 03:00", "countdown": "0m"},
         }
 
-        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=usage_result):
+             patch.object(switcher, "_active_cc_running", return_value=True), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(usage_result)) as mock_fetch:
             switcher.list_accounts()
 
+        assert mock_fetch.call_count == 2
         output = capsys.readouterr().out
-        # Should show live data (10%), not cached data (25%)
+        # Should show live data (10%), not the stale 25%
         assert "10%" in output
+        assert "25%" not in output
 
 
 class TestActiveAccountRefresh:
@@ -773,17 +789,18 @@ class TestActiveAccountRefresh:
         def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
             assert is_active is False  # no owner → refresh enabled
             persist_credentials(account_num, email, self._REFRESHED)
-            return usage_result
+            return oauth.UsageOutcome(usage_result)
 
         with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
              patch.object(switcher, "_active_cc_running", return_value=False), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials") as write_live, \
              patch.object(switcher, "_write_account_credentials") as write_backup, \
-             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+             patch("claude_swap.oauth.try_fetch_usage_for_account", side_effect=mock_fetch):
             result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
-        assert result == usage_result
+        assert result.usage == usage_result
+        assert result.sentinel is None
         write_live.assert_called_once_with(self._REFRESHED)
         write_backup.assert_called_once_with("1", "test@example.com", self._REFRESHED)
 
@@ -799,10 +816,11 @@ class TestActiveAccountRefresh:
              patch.object(switcher, "_active_cc_running", return_value=True), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials") as write_live, \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None) as mock_fetch:
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None)) as mock_fetch:
             result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
-        assert result == USAGE_TOKEN_EXPIRED
+        assert result.sentinel == USAGE_TOKEN_EXPIRED
         assert mock_fetch.call_args.kwargs.get("is_active") is True
         write_live.assert_not_called()
 
@@ -816,7 +834,8 @@ class TestActiveAccountRefresh:
              patch.object(switcher, "_active_cc_running", return_value=False), \
              patch.object(switcher, "_live_session_pids", return_value=[4242]), \
              patch.object(switcher, "_write_credentials") as write_live, \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None) as mock_fetch:
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None)) as mock_fetch:
             switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
         assert mock_fetch.call_args.kwargs.get("is_active") is True
@@ -837,18 +856,18 @@ class TestActiveAccountRefresh:
 
         def mock_fetch(account_num, email, credentials, is_active, persist_credentials):
             persist_credentials(account_num, email, self._REFRESHED)
-            return usage_result  # in-memory token would fetch fine...
+            return oauth.UsageOutcome(usage_result)  # in-memory token would fetch fine...
 
         with patch.object(switcher, "_read_credentials", return_value=live_changed), \
              patch.object(switcher, "_active_cc_running", return_value=False), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials") as write_live, \
              patch.object(switcher, "_write_account_credentials") as write_backup, \
-             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+             patch("claude_swap.oauth.try_fetch_usage_for_account", side_effect=mock_fetch):
             result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
         # ...but we discarded the rotated credential, so never show its usage.
-        assert result == USAGE_TOKEN_EXPIRED
+        assert result.sentinel == USAGE_TOKEN_EXPIRED
         write_live.assert_not_called()
         write_backup.assert_not_called()
 
@@ -867,17 +886,17 @@ class TestActiveAccountRefresh:
                 persist_credentials(account_num, email, self._REFRESHED)
             except Exception:
                 pass
-            return usage_result  # refreshed in-memory token still fetches fine
+            return oauth.UsageOutcome(usage_result)  # refreshed in-memory token still fetches fine
 
         with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
              patch.object(switcher, "_active_cc_running", return_value=False), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials", side_effect=OSError("disk full")), \
              patch.object(switcher, "_write_account_credentials"), \
-             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+             patch("claude_swap.oauth.try_fetch_usage_for_account", side_effect=mock_fetch):
             result = switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
-        assert result == USAGE_TOKEN_EXPIRED
+        assert result.sentinel == USAGE_TOKEN_EXPIRED
 
     def test_detection_failure_fails_closed(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
@@ -893,7 +912,8 @@ class TestActiveAccountRefresh:
              patch("claude_swap.switcher.get_running_instances", side_effect=OSError("boom")), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials") as write_live, \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None) as mock_fetch:
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None)) as mock_fetch:
             switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
         assert mock_fetch.call_args.kwargs.get("is_active") is True
@@ -914,14 +934,14 @@ class TestActiveAccountRefresh:
             if lock_free_during_fetch["ok"]:
                 probe.release()
             persist_credentials(account_num, email, self._REFRESHED)
-            return {"five_hour": {"pct": 10}}
+            return oauth.UsageOutcome({"five_hour": {"pct": 10}})
 
         with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
              patch.object(switcher, "_active_cc_running", return_value=False), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials"), \
              patch.object(switcher, "_write_account_credentials"), \
-             patch("claude_swap.oauth.fetch_usage_for_account", side_effect=mock_fetch):
+             patch("claude_swap.oauth.try_fetch_usage_for_account", side_effect=mock_fetch):
             switcher._fetch_active_usage("1", "test@example.com", self._EXPIRED)
 
         assert lock_free_during_fetch["ok"] is True
@@ -933,9 +953,9 @@ class TestActiveAccountRefresh:
         from claude_swap.json_output import USAGE_NO_CREDENTIALS
 
         switcher = self._switcher(sample_sequence_data)
-        with patch("claude_swap.oauth.fetch_usage_for_account") as mock_fetch:
+        with patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
             result = switcher._fetch_active_usage("1", "test@example.com", "")
-        assert result == USAGE_NO_CREDENTIALS
+        assert result.sentinel == USAGE_NO_CREDENTIALS
         mock_fetch.assert_not_called()
 
     def test_list_renders_token_expired_line(
@@ -950,7 +970,8 @@ class TestActiveAccountRefresh:
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
              patch.object(switcher, "_active_cc_running", return_value=True), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
-             patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None)):
             switcher.list_accounts()
 
         output = capsys.readouterr().out
@@ -1915,7 +1936,7 @@ class TestListAccountsOrgDisplay:
         }))
 
         switcher = ClaudeAccountSwitcher()
-        with patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
+        with patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
             switcher.list_accounts()
 
         out = capsys.readouterr().out
@@ -1942,7 +1963,7 @@ class TestListAccountsOrgDisplay:
         }))
 
         switcher = ClaudeAccountSwitcher()
-        with patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
+        with patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
             switcher.list_accounts()
 
         out = capsys.readouterr().out
@@ -1973,7 +1994,7 @@ class TestBackwardCompatibility:
         (temp_home / ".claude" / ".credentials.json").write_text('{"accessToken": "tok"}')
 
         switcher = ClaudeAccountSwitcher()
-        with patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
+        with patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
             switcher.list_accounts()
 
         out = capsys.readouterr().out
@@ -2053,7 +2074,7 @@ class TestUpgradeMigration:
         )
 
         switcher = ClaudeAccountSwitcher()
-        with patch("claude_swap.oauth.fetch_usage_for_account", return_value=None):
+        with patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
             switcher.list_accounts()
 
         out = capsys.readouterr().out

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -982,6 +982,28 @@ class TestActiveAccountRefresh:
         output = capsys.readouterr().out
         assert "token expired — Claude Code refreshes the active account" in output
 
+    def test_expired_owned_sentinel_wins_over_stored_entry(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """The owned+expired sentinel is derived statically, so a fresh store
+        entry (or a backoff/claim gate skipping the fetch) can't hide it."""
+        switcher = self._switcher(sample_sequence_data)
+        UsageStore(switcher.backup_dir / "cache").record(
+            {"1": FetchRecord(usage={"five_hour": {"pct": 25.0}})},
+            {"1": ("test@example.com", "")},
+        )
+        info = (1, "test@example.com", "", "", True, self._EXPIRED)
+
+        with patch.object(switcher, "_active_cc_running", return_value=True), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            entry = switcher._collect_usage_entries([info])["1"]
+
+        assert entry.sentinel == USAGE_TOKEN_EXPIRED
+        assert entry.decision_value() == USAGE_TOKEN_EXPIRED
+        assert entry.last_good == {"five_hour": {"pct": 25.0}}  # last-seen kept
+        mock_fetch.assert_not_called()
+
 
 class TestPerformSwitchPostDisplay:
     """Regression tests for the post-switch display running outside the lock."""

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -1,0 +1,233 @@
+"""Tests for the per-account usage store."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from claude_swap import usage_store
+from claude_swap.usage_store import (
+    BACKOFF_BASE_S,
+    BACKOFF_CAP_S,
+    CLAIM_TTL_S,
+    SERVE_TTL_S,
+    STALE_OK_S,
+    FetchRecord,
+    UsageEntry,
+    UsageStore,
+    with_sentinel,
+)
+
+IDENT = {"1": ("a@x.com", ""), "2": ("b@x.com", "org-2")}
+USAGE = {"five_hour": {"pct": 25.0}, "seven_day": {"pct": 10.0}}
+
+
+class FakeClock:
+    def __init__(self, start: float = 1_000_000.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock():
+    return FakeClock()
+
+
+@pytest.fixture
+def store(tmp_path, clock):
+    return UsageStore(tmp_path / "cache", clock=clock)
+
+
+class TestSchema:
+    def test_empty_when_missing(self, store):
+        entries = store.entries(IDENT)
+        assert entries["1"] == UsageEntry()
+        assert entries["1"].decision_value() is None
+
+    def test_versionless_legacy_snapshot_ignored(self, store):
+        store.path.parent.mkdir(parents=True)
+        store.path.write_text(
+            json.dumps({"timestamp": 123, "data": {"1": USAGE}}), encoding="utf-8"
+        )
+        assert store.entries(IDENT)["1"].last_good is None
+
+    def test_corrupt_file_ignored(self, store):
+        store.path.parent.mkdir(parents=True)
+        store.path.write_text("{not json", encoding="utf-8")
+        assert store.entries(IDENT)["1"] == UsageEntry()
+
+    def test_round_trip(self, store, clock):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        raw = json.loads(store.path.read_text(encoding="utf-8"))
+        assert raw["schemaVersion"] == 2
+        row = raw["accounts"]["1"]
+        assert row["email"] == "a@x.com"
+        assert row["lastGood"] == USAGE
+        assert row["fetchedAt"] == clock.now
+        entry = store.entries(IDENT)["1"]
+        assert entry.last_good == USAGE
+        assert entry.age_s == 0.0
+        assert entry.decision_value() == USAGE
+
+
+class TestStaleOnError:
+    def test_failure_preserves_last_good(self, store, clock):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        clock.advance(60)
+        store.record({"1": FetchRecord(error="http-429")}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.last_good == USAGE
+        assert entry.age_s == 60.0
+        assert entry.last_error == "http-429"
+        assert entry.consecutive_failures == 1
+        # Still trusted for decisions while within STALE_OK_S.
+        assert entry.decision_value() == USAGE
+
+    def test_too_stale_is_unknown_for_decisions(self, store, clock):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        clock.advance(STALE_OK_S + 1)
+        entry = store.entries(IDENT)["1"]
+        assert entry.decision_value() is None
+        # ... but display still sees the measurement + its age.
+        assert entry.last_good == USAGE
+        assert entry.age_s == STALE_OK_S + 1
+
+    def test_success_clears_failure_state(self, store, clock):
+        store.record({"1": FetchRecord(error="timeout")}, IDENT)
+        clock.advance(5)
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.consecutive_failures == 0
+        assert entry.last_error is None
+        assert entry.backoff_until is None
+        assert entry.decision_value() == USAGE
+
+    def test_success_with_no_windows(self, store):
+        store.record({"1": FetchRecord(usage=None)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.last_error is None
+        assert entry.fetched_at is not None
+        assert entry.decision_value() is None
+
+
+class TestBackoff:
+    def test_exponential_backoff(self, store, clock):
+        expected = [30.0, 60.0, 120.0, 240.0, 480.0, 600.0, 600.0]
+        for i, want in enumerate(expected):
+            store.record({"1": FetchRecord(error="http-500")}, IDENT)
+            entry = store.entries(IDENT)["1"]
+            assert entry.consecutive_failures == i + 1
+            assert entry.backoff_until == pytest.approx(clock.now + want)
+            clock.advance(want + 1)
+
+    def test_backoff_cap(self):
+        assert usage_store._failure_backoff_s(50, None) == BACKOFF_CAP_S
+
+    def test_retry_after_is_the_floor(self, store, clock):
+        store.record(
+            {"1": FetchRecord(error="http-429", retry_after_s=90.0)}, IDENT
+        )
+        entry = store.entries(IDENT)["1"]
+        # First failure computes 30s, but the server asked for 90s.
+        assert entry.backoff_until == pytest.approx(clock.now + 90.0)
+        assert entry.in_backoff(clock.now + 89)
+        assert not entry.in_backoff(clock.now + 91)
+
+    def test_own_curve_may_exceed_retry_after(self):
+        assert usage_store._failure_backoff_s(5, 10.0) == pytest.approx(480.0)
+        assert BACKOFF_BASE_S * 2**4 == 480.0
+
+
+class TestIdentityGuard:
+    def test_slot_reuse_hides_old_usage(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        rebound = {"1": ("new@x.com", "")}
+        assert store.entries(rebound)["1"] == UsageEntry()
+
+    def test_same_email_different_org_is_a_different_account(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        rebound = {"1": ("a@x.com", "org-9")}
+        assert store.entries(rebound)["1"] == UsageEntry()
+
+    def test_write_replaces_mismatched_row(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        rebound = {"1": ("new@x.com", "")}
+        store.record({"1": FetchRecord(error="timeout")}, rebound)
+        entry = store.entries(rebound)["1"]
+        assert entry.last_good is None  # old account's data did not survive
+        assert entry.consecutive_failures == 1
+
+    def test_untouched_slots_survive_subset_writes(self, store):
+        store.record(
+            {"1": FetchRecord(usage=USAGE), "2": FetchRecord(usage=USAGE)}, IDENT
+        )
+        store.record({"1": FetchRecord(error="timeout")}, {"1": IDENT["1"]})
+        assert store.entries(IDENT)["2"].last_good == USAGE
+
+
+class TestClaims:
+    def test_claim_marks_in_flight(self, store, clock):
+        store.claim(["1"], IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.claimed(clock.now)
+        clock.advance(CLAIM_TTL_S + 1)
+        assert not store.entries(IDENT)["1"].claimed(clock.now)
+
+    def test_claim_does_not_touch_measurement(self, store, clock):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        clock.advance(100)
+        store.claim(["1"], IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.last_good == USAGE
+        assert entry.age_s == 100.0
+
+
+class TestSentinels:
+    def test_sentinel_record_is_a_store_noop(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        store.record({"1": FetchRecord(sentinel="token expired")}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.sentinel is None  # never persisted
+        assert entry.last_good == USAGE
+
+    def test_overlay_wins_decisions_but_not_display(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        entry = with_sentinel(store.entries(IDENT)["1"], "token expired")
+        assert entry.decision_value() == "token expired"
+        assert entry.last_good == USAGE  # display can still show last-seen
+
+    def test_with_sentinel_none_is_identity(self):
+        entry = UsageEntry(last_good=USAGE)
+        assert with_sentinel(entry, None) is entry
+
+
+class TestFreshness:
+    def test_fresh_within_serve_ttl(self, store, clock):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.fresh(clock.now)
+        assert entry.fresh(clock.now + SERVE_TTL_S)
+        assert not entry.fresh(clock.now + SERVE_TTL_S + 1)
+
+
+class TestPollPlan:
+    def test_set_and_read_poll_plan(self, store, clock):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        store.set_poll_plan({"1": (clock.now + 120.0, 120.0)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.next_poll_at == clock.now + 120.0
+        assert entry.poll_interval_s == 120.0
+        assert entry.last_good == USAGE  # untouched
+
+    def test_poll_plan_clear(self, store, clock):
+        store.set_poll_plan({"1": (clock.now + 120.0, 120.0)}, IDENT)
+        store.set_poll_plan({"1": (None, None)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.next_poll_at is None
+        assert entry.poll_interval_s is None


### PR DESCRIPTION
Related to #85.

One failed usage round trip currently blanks every account at once ("usage unknown"), and three such ticks trigger a spurious failover away from a healthy account. The same blindness hits after PC sleep, when the active token expires while Claude Code sits idle. On top of that, request volume was O(N accounts) in parallel bursts, sustained forever.

### What changed

- **Failures are diagnosable now**: usage-fetch failures log one WARNING line with a classified cause (`http-429`, `timeout`, `network`, ...) in the normal log file instead of being swallowed at DEBUG. `Retry-After` headers are parsed and honored.
- **Per-account usage store** (`usage_store.py`, `cache/usage.json` schema v2): last-known-good usage per account with fetch/backoff state. A failed fetch updates only the error fields — the measurement survives, so `--list`, `--status`, and `cswap auto` serve slightly stale data ("53% · 2m ago") instead of going blind. Entries are identity-guarded (email + org), so slot reuse never shows the previous account's numbers. Exponential backoff (30s doubling, capped 10m) with `Retry-After` as the floor.
- **Request hygiene**: refreshes are staggered ~250ms apart instead of one synchronized burst per tick; concurrent collectors (`--list` vs `auto`) skip accounts the other just claimed.
- **Idle-hold**: when the active token is expired and Claude Code owns it (typical after wake-from-sleep), no doomed 401 request is fired and `auto` emits `active-idle` and slows to a crawl instead of counting toward failover — Claude Code refreshes the token itself on the next message. A 30-minute cap still escalates genuinely dead tokens.
- **Adaptive polling in `cswap auto`**: each tick fetches the active account plus one candidate (stalest data first), escalating to a full refresh only when a switch is near or failover needs fresh data — request volume is O(1) regardless of account count. Exhausted candidates aren't polled again until their window resets; a candidate whose usage moves (used on another machine / session mode) gets watched more closely, an unchanging one backs off.
- JSON output gains additive `usageFetchedAt` / `usageAgeSeconds` on rows with usage, and `poll` events gain `fetchErrors`; existing fields and `schemaVersion` are unchanged.

### Verification

- 808 tests pass (31 new: store semantics, idle-hold incl. the elapsed cap, scheduler baseline/escalation/skip-to-reset/movement adaptation).
- Verified live: warm `--list` makes zero API calls; with the network down, `--list` shows last-good usage with its age and the WARNING cause lands in the log; backoff blocks the immediate retry; a real `auto --once` parks a 100%-used candidate exactly until its 5h reset.

Backoff/timeout constants are conservative placeholders — final tuning waits for the debug output requested in #85.
