### PR TITLE
Quick-switch accounts from the Watch view

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1790,6 +1790,10 @@ class ClaudeAccountSwitcher:
         print(bolded("Accounts:"))
         for i, (num, email, org_name, org_uuid, is_active, _) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
+            # NOTE: the TUI watch view (tui._watch_account_rows) parses this
+            # output to map rows to accounts for quick-switch: it relies on the
+            # uncolored ``  {num}: `` prefix and the ``(active)`` marker below.
+            # Keep them intact when tweaking this line, or update that parser.
             if is_active:
                 marker = f" {bold_accent('(active)')}"
                 print(f"  {num}: {email} {muted(f'[{tag}]')}{marker}")

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -386,12 +386,17 @@ def _watch_loop(stdscr, switcher: ClaudeAccountSwitcher, interval: int = 5) -> N
                     selected = (selected + 1) % len(acct_rows)
                 elif key in (curses.KEY_ENTER, 10, 13):
                     num = acct_rows[selected][1]
-                    # Apply the switch silently and stay in the watch view — no
-                    # intermediate pager. The forced refresh below re-renders
-                    # with the new active account.
-                    _capture(lambda: switcher.switch_to(num))
+                    # Apply the switch and stay in the watch view on success —
+                    # no intermediate pager. On failure (lock timeout, keychain,
+                    # account removed meanwhile) switch_to's output would be
+                    # swallowed, so surface it in the pager like _do_switch.
+                    out = _capture(lambda: switcher.switch_to(num))
                     selecting = False
                     last_refresh = 0.0  # re-fetch to show the new active account
+                    if _capture_has_error(out):
+                        stdscr.timeout(-1)  # pager expects blocking input
+                        _pager(stdscr, "Switch account", out.splitlines())
+                        stdscr.timeout(250)
                 elif key in (27, ord("q"), ord("s")):
                     selecting = False
             elif key in (ord("q"), 27):
@@ -399,7 +404,7 @@ def _watch_loop(stdscr, switcher: ClaudeAccountSwitcher, interval: int = 5) -> N
             elif key == ord("s"):
                 if acct_rows:
                     selecting = True
-                    selected = 0
+                    selected = _watch_active_index(acct_rows, body)
             elif key in (ord("+"), ord("=")):
                 interval = _clamp_interval(interval + 1)
             elif key in (ord("-"), ord("_")):
@@ -432,6 +437,28 @@ def _watch_account_rows(body: list[str]) -> list[tuple[int, str]]:
         if m:
             rows.append((i, m.group(1)))
     return rows
+
+
+def _watch_active_index(acct_rows: list[tuple[int, str]], body: list[str]) -> int:
+    """Index into ``acct_rows`` of the account shown as active, else 0.
+
+    Matches the ``(active)`` marker ``list_accounts()`` prints so quick-switch
+    selection starts on the row the user is currently on.
+    """
+    for i, (line_idx, _num) in enumerate(acct_rows):
+        if "(active)" in body[line_idx]:
+            return i
+    return 0
+
+
+def _capture_has_error(captured: str) -> bool:
+    """True if ``_capture`` output signals a failure (an ``Error:`` line).
+
+    ``_capture`` renders a swallowed ClaudeSwitchError/EOFError as ``Error: …``
+    (uncolored); a successful switch never prints that, so this cleanly tells
+    the two apart without inspecting exceptions.
+    """
+    return any(line.startswith("Error:") for line in captured.splitlines())
 
 
 def _status_line(switcher: ClaudeAccountSwitcher) -> str:

--- a/src/claude_swap/tui.py
+++ b/src/claude_swap/tui.py
@@ -146,8 +146,15 @@ def _style_to_attr(flags: int) -> int:
     return attr
 
 
-def _addstr_ansi(stdscr, y: int, x: int, text: str, max_width: int) -> None:
-    """Draw an ANSI-styled line clipped to ``max_width`` visible characters."""
+def _addstr_ansi(
+    stdscr, y: int, x: int, text: str, max_width: int, extra: int = 0
+) -> None:
+    """Draw an ANSI-styled line clipped to ``max_width`` visible characters.
+
+    ``extra`` is OR-ed into every segment's attribute, so callers can layer a
+    whole-line effect (e.g. ``curses.A_REVERSE`` to highlight a selected row)
+    on top of the text's own styling.
+    """
     remaining = max_width
     cx = x
     for seg_text, flags in _ansi_segments(text):
@@ -155,7 +162,7 @@ def _addstr_ansi(stdscr, y: int, x: int, text: str, max_width: int) -> None:
             break
         chunk = seg_text[:remaining]
         try:
-            stdscr.addstr(y, cx, chunk, _style_to_attr(flags))
+            stdscr.addstr(y, cx, chunk, _style_to_attr(flags) | extra)
         except curses.error:
             pass
         cx += len(chunk)
@@ -332,21 +339,32 @@ def _watch_loop(stdscr, switcher: ClaudeAccountSwitcher, interval: int = 5) -> N
     try:
         last_refresh = 0.0
         body: list[str] = []
+        selecting = False  # arrow-key quick-switch overlay (paused refresh)
+        selected = 0
         while True:
             now = time.monotonic()
-            if now - last_refresh >= interval:
+            # Freeze the view while selecting so rows don't shift under the cursor.
+            if not selecting and now - last_refresh >= interval:
                 body = _capture(lambda: switcher.list_accounts()).splitlines()
                 now = time.monotonic()  # recompute after the (possibly slow) fetch
                 last_refresh = now
 
+            acct_rows = _watch_account_rows(body)
+            if selecting and acct_rows:
+                selected %= len(acct_rows)  # keep in range if the list shrank
+            sel_line = acct_rows[selected][0] if (selecting and acct_rows) else -1
+
             stdscr.erase()
             rows, cols = stdscr.getmaxyx()
             _draw_header(stdscr, "Watch", _status_line(switcher), cols)
-            age = int(now - last_refresh)
-            meta = (
-                f"every {interval}s · updated {age}s ago · "
-                f"[+/-] interval  [r] refresh  [q] back"
-            )
+            if selecting:
+                meta = "switch to · [↑/↓] move  [Enter] select  [Esc] cancel"
+            else:
+                age = int(now - last_refresh)
+                meta = (
+                    f"every {interval}s · updated {age}s ago · "
+                    f"[s] switch  [+/-] interval  [r] refresh  [q] back"
+                )
             try:
                 stdscr.addstr(3, 2, meta[: cols - 4], curses.A_DIM)
             except curses.error:
@@ -356,12 +374,32 @@ def _watch_loop(stdscr, switcher: ClaudeAccountSwitcher, interval: int = 5) -> N
                 y = body_top + i
                 if y >= rows - 1:
                     break
-                _addstr_ansi(stdscr, y, 2, line, cols - 4)
+                extra = curses.A_REVERSE if i == sel_line else 0
+                _addstr_ansi(stdscr, y, 2, line, cols - 4, extra)
             stdscr.refresh()
 
             key = stdscr.getch()
-            if key in (ord("q"), 27):
+            if selecting:
+                if key in (curses.KEY_UP, ord("k")):
+                    selected = (selected - 1) % len(acct_rows)
+                elif key in (curses.KEY_DOWN, ord("j")):
+                    selected = (selected + 1) % len(acct_rows)
+                elif key in (curses.KEY_ENTER, 10, 13):
+                    num = acct_rows[selected][1]
+                    # Apply the switch silently and stay in the watch view — no
+                    # intermediate pager. The forced refresh below re-renders
+                    # with the new active account.
+                    _capture(lambda: switcher.switch_to(num))
+                    selecting = False
+                    last_refresh = 0.0  # re-fetch to show the new active account
+                elif key in (27, ord("q"), ord("s")):
+                    selecting = False
+            elif key in (ord("q"), 27):
                 return
+            elif key == ord("s"):
+                if acct_rows:
+                    selecting = True
+                    selected = 0
             elif key in (ord("+"), ord("=")):
                 interval = _clamp_interval(interval + 1)
             elif key in (ord("-"), ord("_")):
@@ -375,6 +413,25 @@ def _watch_loop(stdscr, switcher: ClaudeAccountSwitcher, interval: int = 5) -> N
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+# Account header lines in ``list_accounts()`` output look like ``  1: email …``.
+# The numeric prefix is printed without color, so matching the raw (still-ANSI)
+# captured line works.
+_WATCH_ACCT_RE = re.compile(r"^  (\d+): ")
+
+
+def _watch_account_rows(body: list[str]) -> list[tuple[int, str]]:
+    """Locate account header lines in captured ``list_accounts()`` output.
+
+    Returns ``(line_index, account_number)`` for each account block so the watch
+    view can highlight and quick-switch to a selected account.
+    """
+    rows: list[tuple[int, str]] = []
+    for i, line in enumerate(body):
+        m = _WATCH_ACCT_RE.match(line)
+        if m:
+            rows.append((i, m.group(1)))
+    return rows
 
 
 def _status_line(switcher: ClaudeAccountSwitcher) -> str:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -600,6 +600,61 @@ class TestWatch:
             tui._watch_loop(screen, switcher, interval=5)
         mock_switch.assert_not_called()
 
+    def test_active_index_finds_active_row(self):
+        body = ["Accounts:", "  1: a [x]", "  2: b [x] (active)", "  3: c [x]"]
+        rows = tui._watch_account_rows(body)
+        assert tui._watch_active_index(rows, body) == 1  # row for account 2
+
+    def test_active_index_defaults_to_zero(self):
+        body = ["Accounts:", "  1: a [x]", "  2: b [x]"]
+        rows = tui._watch_account_rows(body)
+        assert tui._watch_active_index(rows, body) == 0
+
+    def test_selection_starts_on_active_row(self, temp_home: Path):
+        _make_seq(temp_home, [("1", "a@x.com"), ("2", "b@x.com")])
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+
+        def _print_accounts():
+            print("Accounts:")
+            print("  1: a@x.com [personal]")
+            print("  2: b@x.com [personal] (active)")  # account 2 is active
+
+        # s → select starts on the active row (account 2), Enter → switch to 2.
+        screen.getch.side_effect = [ord("s"), 10, ord("q")]
+        with patch.object(switcher, "list_accounts", side_effect=_print_accounts), \
+             patch.object(switcher, "switch_to") as mock_switch, \
+             patch("claude_swap.tui.time.monotonic", return_value=100.0):
+            tui._watch_loop(screen, switcher, interval=5)
+        mock_switch.assert_called_once_with("2")
+
+    def test_capture_has_error(self):
+        assert tui._capture_has_error("Error: could not acquire lock\n")
+        assert not tui._capture_has_error("Switched to Account-2 (b@x.com)\n")
+        assert not tui._capture_has_error("")
+
+    def test_switch_failure_surfaces_in_pager(self, temp_home: Path):
+        _make_seq(temp_home, [("1", "a@x.com"), ("2", "b@x.com")])
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+
+        def _print_accounts():
+            print("Accounts:")
+            print("  1: a@x.com [personal] (active)")
+            print("  2: b@x.com [personal]")
+
+        # s → select, Enter → switch fails → its error is paged (not swallowed).
+        screen.getch.side_effect = [ord("s"), 10, ord("q")]
+        with patch.object(switcher, "list_accounts", side_effect=_print_accounts), \
+             patch.object(switcher, "switch_to",
+                          side_effect=ClaudeSwitchError("lock timeout")), \
+             patch("claude_swap.tui._pager") as mock_pager, \
+             patch("claude_swap.tui.time.monotonic", return_value=100.0):
+            tui._watch_loop(screen, switcher, interval=5)
+        mock_pager.assert_called_once()
+        paged_lines = mock_pager.call_args.args[2]
+        assert any("lock timeout" in line for line in paged_lines)
+
 
 class TestInitColors:
     def test_initializes_pairs_when_color_supported(self):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -412,6 +412,15 @@ class TestAddstrAnsi:
         # Must not raise.
         tui._addstr_ansi(screen, 4, 2, "x", max_width=10)
 
+    def test_extra_attr_ored_into_every_run(self):
+        screen = _stub_screen()
+        tui._addstr_ansi(
+            screen, 4, 2, "\x1b[1mAB\x1b[0mCD", max_width=10,
+            extra=tui.curses.A_REVERSE,
+        )
+        for c in screen.addstr.call_args_list:
+            assert c.args[-1] & tui.curses.A_REVERSE
+
 
 class TestPager:
     def test_returns_on_q(self):
@@ -525,6 +534,71 @@ class TestWatch:
              patch("claude_swap.tui.time.monotonic", return_value=100.0):
             tui._watch_loop(screen, switcher, interval=5)
         assert mock_list.call_count == 1
+
+    def test_account_rows_locates_headers(self):
+        body = [
+            "Accounts:",
+            "  1: a@x.com [personal] (active)",
+            "     5h: 12%",
+            "  2: b@x.com [personal]",
+            "     5h: 40%",
+            "Running instances:",
+            "  ● claude   ~/proj  (1 session)",
+        ]
+        assert tui._watch_account_rows(body) == [(1, "1"), (3, "2")]
+
+    def test_account_rows_empty_without_headers(self):
+        assert tui._watch_account_rows(["Accounts:", "  none yet"]) == []
+
+    def test_s_selects_row_and_switches(self, temp_home: Path):
+        _make_seq(temp_home, [("1", "a@x.com"), ("2", "b@x.com")])
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+
+        def _print_accounts():
+            print("Accounts:")
+            print("  1: a@x.com [personal] (active)")
+            print("  2: b@x.com [personal]")
+
+        # s → enter select, ↓ → row 2, Enter → switch (stays in watch, no
+        # pager), q → quit watch.
+        screen.getch.side_effect = [
+            ord("s"), tui.curses.KEY_DOWN, 10, ord("q"),
+        ]
+        with patch.object(switcher, "list_accounts", side_effect=_print_accounts), \
+             patch.object(switcher, "switch_to") as mock_switch, \
+             patch("claude_swap.tui.time.monotonic", return_value=100.0):
+            tui._watch_loop(screen, switcher, interval=5)
+        mock_switch.assert_called_once_with("2")
+
+    def test_select_cancel_does_not_switch(self, temp_home: Path):
+        _make_seq(temp_home, [("1", "a@x.com"), ("2", "b@x.com")])
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+
+        def _print_accounts():
+            print("Accounts:")
+            print("  1: a@x.com [personal] (active)")
+            print("  2: b@x.com [personal]")
+
+        screen.getch.side_effect = [ord("s"), 27, ord("q")]  # s, Esc, q
+        with patch.object(switcher, "list_accounts", side_effect=_print_accounts), \
+             patch.object(switcher, "switch_to") as mock_switch, \
+             patch("claude_swap.tui.time.monotonic", return_value=100.0):
+            tui._watch_loop(screen, switcher, interval=5)
+        mock_switch.assert_not_called()
+
+    def test_s_is_noop_without_accounts(self, temp_home: Path):
+        _make_seq(temp_home, [("1", "a@x.com")])
+        switcher = ClaudeAccountSwitcher()
+        screen = _stub_screen()
+        # list_accounts prints nothing → no header rows → 's' cannot enter select.
+        screen.getch.side_effect = [ord("s"), ord("q")]
+        with patch.object(switcher, "list_accounts"), \
+             patch.object(switcher, "switch_to") as mock_switch, \
+             patch("claude_swap.tui.time.monotonic", return_value=100.0):
+            tui._watch_loop(screen, switcher, interval=5)
+        mock_switch.assert_not_called()
 
 
 class TestInitColors:


### PR DESCRIPTION
Adds `[s]` to the Watch view so you can switch accounts without leaving it.

- `s` → select mode: ↑/↓ highlight an account row, **Enter** switches and stays in Watch, **Esc/q/s** cancels.
- Auto-refresh pauses while selecting so rows don't shift under the cursor; a forced refresh after the switch shows the new active account.
- Reuses `switcher.switch_to`; no account logic added. Selection is derived from the existing `list_accounts()` output (a small `_watch_account_rows` helper) and highlighted via an optional `extra` attr on `_addstr_ansi`.
- Tests added; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)