### PR TITLE
Fix stale reset countdown in list/status: recompute from resets_at at render time

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -100,6 +100,27 @@ _FETCH_STAGGER_S = 0.25
 _USAGE_AGE_NOTE_S = 90.0
 
 
+def _reset_cell(window: dict) -> tuple[str, str] | None:
+    """``(clock, countdown)`` for one usage window, or None when unknown.
+
+    Recomputed from ``resets_at`` at render time: the strings cached at fetch
+    time drift as the measurement ages (a countdown frozen 2h ago overstates
+    the remaining wait by those 2h, and a same-day "15:30" clock silently
+    starts meaning yesterday). Entries persisted without ``resets_at`` fall
+    back to the fetch-time strings — stale beats blank.
+    """
+    resets_at = window.get("resets_at")
+    if resets_at:
+        try:
+            countdown, clock = oauth.format_reset(resets_at)
+            return clock, countdown
+        except (ValueError, TypeError):
+            pass  # unparseable cached value — fall back below
+    if "clock" in window:
+        return window["clock"], window.get("countdown", "?")
+    return None
+
+
 def _format_usage_lines(usage: dict) -> list[str]:
     # Collect (label, body) rows first, then pad every label to the widest one so
     # per-model names (e.g. "Fable") don't shift the columns of the other lines.
@@ -109,22 +130,27 @@ def _format_usage_lines(usage: dict) -> list[str]:
         used = spend["used"]
         limit = spend["limit"]
         pct = spend["pct"]
-        if "clock" in spend:
-            rows.append(("$$", f"{pct:>3.0f}%   resets {spend['clock']:<12}  ${used:,.2f} / ${limit:,.2f}"))
+        cell = _reset_cell(spend)
+        if cell:
+            rows.append(("$$", f"{pct:>3.0f}%   resets {cell[0]:<12}  ${used:,.2f} / ${limit:,.2f}"))
         else:
             rows.append(("$$", f"{pct:>3.0f}%   ${used:,.2f} / ${limit:,.2f}"))
     for label, w in (("5h", usage.get("five_hour")), ("7d", usage.get("seven_day"))):
         if w:
-            if "clock" in w:
-                rows.append((label, f"{w['pct']:>3.0f}%   resets {w['clock']:<12}  in {w['countdown']}"))
+            cell = _reset_cell(w)
+            if cell:
+                clock, countdown = cell
+                rows.append((label, f"{w['pct']:>3.0f}%   resets {clock:<12}  in {countdown}"))
             else:
                 rows.append((label, f"{w['pct']:>3.0f}%"))
     for w in usage.get("scoped") or []:
         # Per-model weekly limits (e.g. Fable). Flag ones at/over the limit so a
         # maxed model — the usual reason to switch — stands out.
         marker = "  (!)" if w["pct"] >= 100 else ""
-        if "clock" in w:
-            rows.append((w["name"], f"{w['pct']:>3.0f}%   resets {w['clock']:<12}  in {w['countdown']}{marker}"))
+        cell = _reset_cell(w)
+        if cell:
+            clock, countdown = cell
+            rows.append((w["name"], f"{w['pct']:>3.0f}%   resets {clock:<12}  in {countdown}{marker}"))
         else:
             rows.append((w["name"], f"{w['pct']:>3.0f}%{marker}"))
     width = max((len(label) for label, _ in rows), default=0) + 1  # label + ':'

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -3808,6 +3808,67 @@ class TestFormatUsageLines:
         lines = _format_usage_lines(usage)
         assert lines == ["Fable: 100%  (!)"]
 
+    def test_countdown_recomputed_from_resets_at_not_cached_strings(self):
+        # A measurement served from the store hours after its fetch still
+        # carries the countdown frozen at fetch time; rendering must derive
+        # the live value from resets_at instead (issue: "resets 15:59 in 17h"
+        # printed when the reset was 15h away).
+        from datetime import datetime, timedelta, timezone
+
+        resets_at = (datetime.now(timezone.utc) + timedelta(hours=2, minutes=30)).isoformat()
+        usage = {
+            "seven_day": {
+                "pct": 62.0,
+                "resets_at": resets_at,
+                "clock": "15:59",
+                "countdown": "17h 0m",
+            }
+        }
+        line = _format_usage_lines(usage)[0]
+        assert "in 2h" in line
+        assert "17h" not in line
+
+    def test_reset_falls_back_to_cached_strings_without_resets_at(self):
+        # Entries persisted by older versions have no resets_at — the
+        # fetch-time strings are the best available then.
+        usage = {"seven_day": {"pct": 62.0, "clock": "15:59", "countdown": "17h 0m"}}
+        line = _format_usage_lines(usage)[0]
+        assert "resets 15:59" in line
+        assert "in 17h 0m" in line
+
+    def test_reset_falls_back_on_unparseable_resets_at(self):
+        usage = {
+            "seven_day": {
+                "pct": 62.0,
+                "resets_at": "not-a-date",
+                "clock": "15:59",
+                "countdown": "17h 0m",
+            }
+        }
+        line = _format_usage_lines(usage)[0]
+        assert "resets 15:59" in line
+        assert "in 17h 0m" in line
+
+    def test_spend_clock_recomputed_from_resets_at(self):
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc)
+        resets_at = (now + timedelta(hours=2)).isoformat()
+        expected_clock = oauth.format_reset(resets_at)[1]
+        usage = {
+            "spend": {
+                "used": 1.0,
+                "limit": 10.0,
+                "pct": 10.0,
+                "currency": "USD",
+                "resets_at": resets_at,
+                "clock": "stale-clock",
+            }
+        }
+        line = _format_usage_lines(usage)[0]
+        assert f"resets {expected_clock}" in line
+        assert "stale-clock" not in line
+
     def test_no_scoped_key_renders_only_standard_windows(self):
         usage = {"five_hour": {"pct": 7.0}, "seven_day": {"pct": 72.0}}
         lines = _format_usage_lines(usage)


### PR DESCRIPTION
## Bug

`cswap list` can print a reset countdown that contradicts the reset clock on the same line:

```
7d:     62%   resets Jul 6 15:59   in 17h 0m   (!) · 2h ago
```

At the time of that output the reset was ~15h away, not 17h. The clock (`Jul 6 15:59`) was correct; the countdown was frozen.

## Root cause

`build_usage_result()` computes the `countdown` and `clock` display strings once at **fetch** time and stores them with the measurement. When the usage store serves last-good data later (stale-served entries, e.g. inactive accounts), `_format_usage_lines()` prints those frozen strings verbatim — so the countdown is off by exactly the measurement's age. The `clock` string has the same issue in a subtler form: a same-day `resets 15:30` silently starts meaning *yesterday* 15:30 once the date rolls over, and a reset that already passed still renders as pending.

The TUI already solved exactly this (`tui/data.py::reset_text`, "the countdown the API sent was correct at *fetch* time and drifts as the measurement ages") — the CLI list/status path just never got the same treatment.

## Fix

`_format_usage_lines()` now derives both strings from the stored `resets_at` at render time via the existing `format_reset()`, for the 5h/7d windows, per-model scoped windows, and the spend row. Entries persisted without `resets_at` (older versions) fall back to the fetch-time strings, so old cache files keep rendering.

Before/after with a measurement fetched 2h ago (reset 15h away):

```
before: 7d:  62%   resets 18:31  in 17h 0m
after:  7d:  62%   resets 16:31  in 14h 59m
```

## Tests

- countdown/clock recomputed from `resets_at` (stale cached strings ignored)
- fallback to cached strings when `resets_at` is absent (old persisted entries)
- fallback on unparseable `resets_at`
- spend row clock recomputed

Full suite: 891 passed, 3 skipped.
