### PR TITLE
feat(autoswitch): add consume-first strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ cswap auto --threshold 80      # switch earlier
 cswap auto --model Fable       # also switch when the Fable weekly limit is hit
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
+cswap auto --strategy consume-first   # burn the soonest-resetting account first
 ```
 
 <details>
@@ -95,6 +96,7 @@ cswap auto --dry-run           # log what it would do, never switch
 
 - Runs safely alongside Claude Code: switches take the same credential locks Claude Code uses, so a swap never collides with a token refresh.
 - A cooldown (default 5 min) and a hysteresis margin stop it flip-flopping near the threshold: a proactive switch only lands on an account that's below the threshold *and* better than the current one by the margin — a candidate that clears the margin is always taken, but two accounts hovering at the line never ping-pong. When every account is exhausted it sleeps until the first one becomes usable again.
+- **Strategies** (`--strategy`, or `cswap config set autoswitch.strategy`): `best` (default) stays put until the active account nears its limit, then moves to the account with the most quota left. `consume-first` proactively keeps you on the account whose **weekly window resets soonest** — use-it-or-lose-it — switching to a sooner-resetting account (with room to spare) even below the threshold, so perishable weekly quota isn't wasted.
 - Usage polling is adaptive — a couple of accounts per check, busy alternates watched more closely, exhausted ones left alone until they reset — so API traffic stays flat no matter how many accounts you manage.
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you log in with it and re-run `cswap add --slot N`. API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -369,6 +369,20 @@ _earliest_future_reset_ts = poll_policy.earliest_future_reset_ts
 _parse_reset_ts = poll_policy.parse_reset_ts
 
 
+def _seven_day_reset_ts(usage: dict | str | None) -> float | None:
+    """Epoch of an account's 7-day (weekly) window reset, or None if unknown.
+
+    The consume-first strategy ranks by this — the weekly window is the
+    perishable quota (the 5-hour one recycles too fast to be worth planning
+    around).
+    """
+    if isinstance(usage, dict):
+        window = usage.get("seven_day")
+        if isinstance(window, dict):
+            return _parse_reset_ts(window.get("resets_at"))
+    return None
+
+
 def _ref(number: str, email: str) -> dict:
     return {"number": int(number), "email": email}
 
@@ -709,19 +723,26 @@ class AutoSwitchEngine:
             self._idle_hold_since = None
             utilization = 100.0 - active_headroom
             if utilization < settings.threshold:
-                self._emit(
-                    NoSwitchEvent(
-                        reason="below-threshold",
-                        # Both sides through pct_label: .0f utilization could
-                        # display an impossible "100% < 99.9%".
-                        detail=(
-                            f"{pct_label(utilization)}% < "
-                            f"{pct_label(settings.threshold)}%"
-                        ),
+                if settings.strategy != "consume-first":
+                    self._emit(
+                        NoSwitchEvent(
+                            reason="below-threshold",
+                            # Both sides through pct_label: .0f utilization could
+                            # display an impossible "100% < 99.9%".
+                            detail=(
+                                f"{pct_label(utilization)}% < "
+                                f"{pct_label(settings.threshold)}%"
+                            ),
+                        )
                     )
-                )
-                return TickOutcome.NO_ACTION
-            trigger = "at-limit" if active_headroom <= 0 else "proactive"
+                    return TickOutcome.NO_ACTION
+                # consume-first: below the threshold we still proactively move to
+                # whichever account's weekly window resets soonest, to burn the
+                # most-perishable quota first. Candidate selection decides whether
+                # a sooner-resetting account with room actually exists.
+                trigger = "consume-first"
+            else:
+                trigger = "at-limit" if active_headroom <= 0 else "proactive"
         else:
             if usage.get(current) == USAGE_TOKEN_EXPIRED:
                 # Expired while an owner (Claude Code / live session) holds the
@@ -770,7 +791,7 @@ class AutoSwitchEngine:
                 return TickOutcome.NO_ACTION
             trigger = "failover"
 
-        if trigger == "proactive" and self._in_cooldown(state):
+        if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
             self._emit(NoSwitchEvent(reason="cooldown"))
             return TickOutcome.NO_ACTION
 
@@ -795,7 +816,13 @@ class AutoSwitchEngine:
             self._emit(NoSwitchEvent(reason="no-candidates"))
             return TickOutcome.BLOCKED
 
-        qualifying: list[tuple[float, str]] = []
+        consume_first = settings.strategy == "consume-first"
+        # consume-first ranks by soonest weekly reset; a proactive (below-
+        # threshold) target must reset strictly sooner than where we are.
+        active_reset_ts = (
+            _seven_day_reset_ts(usage.get(current)) if consume_first else None
+        )
+        qualifying: list[tuple[tuple, str]] = []
         any_known = False
         for num in oauth_candidates:
             h = headroom.get(num)
@@ -804,29 +831,59 @@ class AutoSwitchEngine:
             any_known = True
             if h <= 0:
                 continue  # itself at its limit — never a target
-            if trigger == "proactive" and active_headroom is not None:
-                # Hysteresis guards only the proactive case: two accounts
-                # hovering at the line must not ping-pong. The gate is
-                # relative — the candidate must beat the active account by
-                # the full margin (a one-way move like 99%→89% qualifies;
-                # near-line pairs can't flap back) — and the landing must be
-                # healthy: an account at/over the threshold would re-trigger
-                # on the very next tick. At-limit and failover are escapes —
-                # any account with real headroom beats a blocked or dead one
-                # (and you can't flap back onto an account at 100%).
+            reset_ts = _seven_day_reset_ts(usage.get(num)) if consume_first else None
+            if trigger in ("proactive", "consume-first"):
+                # Landing must be healthy: an account at/over the threshold
+                # would re-trigger on the very next tick. At-limit and failover
+                # are escapes that skip this whole block — any account with real
+                # headroom beats a blocked or dead one.
                 if (100.0 - h) >= settings.threshold:
                     continue
-                if h - active_headroom < settings.hysteresis_pct:
-                    continue  # not provably better than where we are
-            qualifying.append((h, num))
-        # Best headroom first; list order (sequence order) breaks ties.
-        qualifying.sort(key=lambda t: -t[0])
+                if consume_first:
+                    # Purely proactive on reset ordering: below the threshold,
+                    # only move to accounts whose weekly window resets sooner
+                    # than the active one (above the threshold we must move, so
+                    # any healthy account qualifies and the sort picks soonest).
+                    if trigger == "consume-first" and (
+                        reset_ts is None
+                        or active_reset_ts is None
+                        or reset_ts >= active_reset_ts
+                    ):
+                        continue
+                elif active_headroom is not None:
+                    # best: the candidate must beat the active account by the
+                    # full hysteresis margin (a one-way move like 99%→89%
+                    # qualifies; near-line pairs can't flap back).
+                    if h - active_headroom < settings.hysteresis_pct:
+                        continue
+            if consume_first:
+                # Soonest weekly reset first (unknown resets sort last), most
+                # headroom breaks ties, then sequence order.
+                key: tuple = (reset_ts if reset_ts is not None else float("inf"), -h)
+            else:
+                key = (-h,)
+            qualifying.append((key, num))
+        # Ascending by the strategy's key; list order (sequence order) breaks ties.
+        qualifying.sort(key=lambda t: t[0])
         ordered = [num for _, num in qualifying]
-        if not ordered and api_key_candidates:
-            # Last resort: metered API-key accounts (unmeasurable headroom).
+        if not ordered and api_key_candidates and trigger != "consume-first":
+            # Last resort when we must move: metered API-key accounts
+            # (unmeasurable headroom). Never for a below-threshold consume-first
+            # nudge — those API-key accounts have no weekly window to consume.
             ordered = api_key_candidates
 
         if not ordered:
+            if trigger == "consume-first":
+                # Active already holds the soonest-resetting quota (or no sooner
+                # account has room) — nothing to consume elsewhere yet. Staying
+                # put is the correct outcome, not a block.
+                self._emit(
+                    NoSwitchEvent(
+                        reason="already-consuming-soonest",
+                        detail="active account's weekly window resets first",
+                    )
+                )
+                return TickOutcome.NO_ACTION
             if not any_known:
                 self._emit(
                     NoSwitchEvent(

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -498,6 +498,16 @@ Defaults live in settings.json in the backup root; flags override them.
         ),
     )
     parser.add_argument(
+        "--strategy",
+        choices=("best", "consume-first"),
+        default=None,
+        help=(
+            "Target selection: 'best' (most quota left; default) or "
+            "'consume-first' (proactively use the account whose weekly window "
+            "resets soonest)"
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Evaluate and report, but never switch or write state",

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -46,7 +46,7 @@ class AutoSwitchSettings:
     interval_seconds: float = 60.0
     cooldown_seconds: float = 300.0
     hysteresis_pct: float = 10.0
-    strategy: str = "best"  # reserved for future strategies; only "best" in v1
+    strategy: str = "best"  # "best" (most headroom) or "consume-first" (soonest weekly reset)
     include_api_key_accounts: bool = False
     unhealthy_ticks: int = 3
     # Comma-separated model display name(s) (e.g. "Fable" or "Fable,Opus"),
@@ -107,7 +107,8 @@ SETTING_SPECS: dict[str, SettingSpec] = {
             help="A target must beat the active account by this many pct",
         ),
         SettingSpec(
-            "autoswitch", "strategy", "strategy", "choice", choices=("best",),
+            "autoswitch", "strategy", "strategy", "choice",
+            choices=("best", "consume-first"),
             help="How auto-switch picks the target account",
         ),
         SettingSpec(
@@ -389,6 +390,7 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
         ("cooldown", "cooldown_seconds"),
         ("include_api_key_accounts", "include_api_key_accounts"),
         ("model", "model"),
+        ("strategy", "strategy"),
     ):
         value = getattr(args, attr, None)
         if value is not None:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -1876,3 +1876,114 @@ class TestModelAwareSwitch:
             "3": _model_usage(5, 10),
         })
         assert not any(isinstance(e, ConfigWarningEvent) for e in h.events)
+
+
+# --- consume-first strategy ----------------------------------------------------
+
+# Weekly-reset instants in ascending order (all valid ISO-8601, absolute).
+_R_SOON = "2024-01-05T00:00:00Z"
+_R_LATER = "2024-01-08T00:00:00Z"
+_R_LATEST = "2024-01-10T00:00:00Z"
+
+
+def _usage7(pct5: float, pct7: float, reset7: str | None = None) -> dict:
+    """Usage with an explicit 7-day window (utilization + optional reset)."""
+    seven: dict = {"pct": pct7}
+    if reset7:
+        seven["resets_at"] = reset7
+    return {"five_hour": {"pct": pct5}, "seven_day": seven}
+
+
+class TestConsumeFirstStrategy:
+    def _harness(self, temp_home: Path) -> EngineHarness:
+        h = EngineHarness(temp_home, strategy="consume-first")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_below_threshold_switches_to_soonest_weekly_reset(self, temp_home):
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATER),    # active resets later
+            "2": _usage7(10, 10, _R_SOON),     # soonest -> consume first
+            "3": _usage7(10, 10, _R_LATEST),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "consume-first"
+        assert sw.to_ref == {"number": 2, "email": "b@example.com"}
+
+    def test_stays_when_active_already_resets_soonest(self, temp_home):
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20, _R_SOON),     # active is soonest -> stay
+            "2": _usage7(10, 10, _R_LATER),
+            "3": _usage7(10, 10, _R_LATEST),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["already-consuming-soonest"]
+
+    def test_over_threshold_prefers_soonest_reset_over_max_headroom(self, temp_home):
+        h = self._harness(temp_home)
+        # Active over threshold -> must move. #2 has LESS headroom but resets
+        # sooner; #3 has more headroom but resets latest. consume-first -> #2.
+        outcome = h.tick_with_usage({
+            "1": _usage7(95, 20, _R_LATER),
+            "2": _usage7(50, 40, _R_SOON),
+            "3": _usage7(10, 10, _R_LATEST),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_respects_cooldown(self, temp_home):
+        h = self._harness(temp_home)  # default cooldown 300s
+        h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATER),
+            "2": _usage7(10, 10, _R_SOON),
+            "3": _usage7(10, 10, _R_LATEST),
+        })
+        assert h.active_number() == 2  # switched to soonest
+        h.events.clear()
+        # Now a sooner account (#3) appears, but we're within cooldown.
+        outcome = h.tick_with_usage({
+            "2": _usage7(20, 20, _R_LATER),
+            "1": _usage7(10, 10, _R_LATEST),
+            "3": _usage7(10, 10, _R_SOON),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 2
+        assert "cooldown" in [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+
+    def test_skips_sooner_account_that_is_exhausted(self, temp_home):
+        h = self._harness(temp_home)
+        # #2 resets soonest but is itself at its limit (no headroom) -> ignored;
+        # #3 resets later but has room and is sooner than active -> switch there.
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATEST),   # active resets latest
+            "2": _usage7(100, 100, _R_SOON),   # soonest but exhausted
+            "3": _usage7(10, 10, _R_LATER),    # sooner than active, has room
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+
+    def test_best_strategy_unaffected_below_threshold(self, temp_home):
+        # Regression: default (best) still holds below threshold even when a
+        # peer resets sooner — consume-first behavior must be opt-in.
+        h = EngineHarness(temp_home)  # strategy defaults to "best"
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATER),
+            "2": _usage7(10, 10, _R_SOON),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
+            "below-threshold"
+        ]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,7 @@ def _args(**kwargs) -> argparse.Namespace:
         "interval": None,
         "cooldown": None,
         "include_api_key_accounts": None,
+        "strategy": None,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -83,6 +84,16 @@ class TestLoadSettings:
             json.dumps({"autoswitch": {"strategy": "chaos"}})
         )
         assert load_settings(tmp_path).strategy == "best"
+
+    def test_consume_first_is_a_valid_strategy(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"autoswitch": {"strategy": "consume-first"}})
+        )
+        assert load_settings(tmp_path).strategy == "consume-first"
+
+    def test_set_strategy_consume_first(self, tmp_path: Path):
+        set_setting(tmp_path, "autoswitch.strategy", "consume-first")
+        assert load_settings(tmp_path).strategy == "consume-first"
 
 
 class TestSaveSettings:
@@ -230,3 +241,7 @@ class TestMergedWithCli:
     def test_model_override(self):
         merged = merged_with_cli(AutoSwitchSettings(), _args(model="Fable"))
         assert merged.model == "Fable"
+
+    def test_strategy_override(self):
+        merged = merged_with_cli(AutoSwitchSettings(), _args(strategy="consume-first"))
+        assert merged.strategy == "consume-first"


### PR DESCRIPTION
Follow-up to #65 (as discussed there): brings the menu bar's **consume-first** idea into the core auto-switch engine as a selectable `--strategy`, so it works from the CLI/TUI too — not buried in the GUI.

## What it does
A second target-selection strategy alongside the default `best` (most headroom). `consume-first` proactively keeps you on the account whose **weekly (7d) window resets soonest** — use-it-or-lose-it — so perishable quota isn't wasted.

- **Below the threshold:** switches to a candidate whose weekly window resets *strictly sooner* than the active account's (with room to spare, past the hysteresis bar, respecting the cooldown). Once you're on the soonest-resetting account it stays put (`already-consuming-soonest`).
- **At/over the threshold or on failover:** must move, and picks the soonest-resetting candidate *with headroom* instead of the most-headroom one.

The engine now honors `settings.strategy` (previously `"best"` was effectively hardcoded — the field existed but wasn't read).

## Interface
- `cswap auto --strategy consume-first`
- `cswap config set autoswitch.strategy consume-first`

## Tests
- Engine: below-threshold switch to soonest reset, stay-when-already-soonest, at-limit prefers soonest over max-headroom, skips exhausted-but-sooner accounts, cooldown suppression, and a `best`-strategy regression guard.
- Settings: `consume-first` is a valid strategy (load + `set`), `merged_with_cli` override.

Full suite green (896 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)