### PR TITLE
fix(usage): global 429 backoff so the rate limiter can recover

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1710,15 +1710,23 @@ class ClaudeAccountSwitcher:
                 sentinels[num] = static
 
         entries = store.entries(identities)
-        to_fetch = [
-            num
-            for num in info_by_num
-            if num not in sentinels
-            and (fetch is None or num in fetch)
-            and not entries[num].fresh(now)
-            and not entries[num].in_backoff(now)
-            and not entries[num].claimed(now)
-        ]
+        # A prior 429 stands *all* usage fetching down for a growing interval:
+        # the endpoint rate-limits per IP, so quieting every account (not just
+        # the one that saw the 429) is what lets the limiter recover. Last-good
+        # is served meanwhile.
+        to_fetch = (
+            []
+            if store.in_global_backoff(now)
+            else [
+                num
+                for num in info_by_num
+                if num not in sentinels
+                and (fetch is None or num in fetch)
+                and not entries[num].fresh(now)
+                and not entries[num].in_backoff(now)
+                and not entries[num].claimed(now)
+            ]
+        )
 
         if to_fetch:
             store.claim(to_fetch, identities)

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -54,6 +54,10 @@ TRUST_MAX_AGE_S = 3600.0
 BACKOFF_BASE_S = 30.0
 BACKOFF_CAP_S = 600.0
 
+# The fetch-error kind (from oauth._classify_usage_error) that means the usage
+# endpoint rate-limited us — an IP-wide signal, hence the global backoff.
+RATE_LIMIT_ERROR = "http-429"
+
 # (email, organizationUuid) — the identity a slot number currently maps to.
 Identity = tuple[str, str]
 
@@ -202,20 +206,41 @@ class UsageStore:
     def _lock(self) -> FileLock:
         return FileLock(self._lock_path)
 
-    def _read_rows(self) -> dict[str, dict]:
+    def _read_doc(self) -> dict:
+        """The whole document: per-account ``accounts`` plus the ``rateLimit``
+        meta (the shared 429 gate). Tolerant of missing/corrupt/legacy files."""
         try:
             raw = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-            return {}
+            raw = None
         if not isinstance(raw, dict) or raw.get("schemaVersion") != SCHEMA_VERSION:
-            return {}  # legacy snapshot or future schema: start empty
-        rows = raw.get("accounts")
-        return rows if isinstance(rows, dict) else {}
+            return {"accounts": {}, "rateLimit": {}}  # legacy/future: start empty
+        accounts = raw.get("accounts")
+        meta = raw.get("rateLimit")
+        return {
+            "accounts": accounts if isinstance(accounts, dict) else {},
+            "rateLimit": meta if isinstance(meta, dict) else {},
+        }
+
+    def _write_doc(self, doc: dict) -> None:
+        out: dict = {
+            "schemaVersion": SCHEMA_VERSION,
+            "accounts": doc.get("accounts") or {},
+        }
+        meta = doc.get("rateLimit")
+        if meta:  # omit when empty so the file stays clean and legacy-comparable
+            out["rateLimit"] = meta
+        atomic_write_json(self.path, out)
+
+    def _read_rows(self) -> dict[str, dict]:
+        return self._read_doc()["accounts"]
 
     def _write_rows(self, rows: dict[str, dict]) -> None:
-        atomic_write_json(
-            self.path, {"schemaVersion": SCHEMA_VERSION, "accounts": rows}
-        )
+        # Preserve the rateLimit meta a concurrent/other writer set (this runs
+        # under the caller's lock, so the re-read is consistent).
+        doc = self._read_doc()
+        doc["accounts"] = rows
+        self._write_doc(doc)
 
     @staticmethod
     def _matches(row: object, identity: Identity) -> bool:
@@ -329,6 +354,47 @@ class UsageStore:
                 )
 
         self._mutate(identities, effective.keys(), apply)
+        self._note_global_rate_limit(effective.values(), now)
+
+    def _note_global_rate_limit(self, records: Iterable[FetchRecord], now: float) -> None:
+        """Update the shared 429 gate from one fetch pass's outcomes.
+
+        A 429 is an IP-wide signal, so it stands *all* usage fetching down for a
+        growing interval (``in_global_backoff``) — per-account backoff alone
+        can't quiet a per-IP limit when N accounts poll on staggered schedules.
+        Any 429 in the pass extends the gate (even if another account succeeded
+        — the IP is still limiting); a pass with a clean success and no 429
+        clears it. Non-429 errors (timeouts) leave it untouched.
+        """
+        records = list(records)
+        saw_rate_limit = any(r.error == RATE_LIMIT_ERROR for r in records)
+        had_success = any(r.error is None for r in records)
+        if not (saw_rate_limit or had_success):
+            return
+        retry_after = max(
+            (
+                r.retry_after_s
+                for r in records
+                if r.error == RATE_LIMIT_ERROR and r.retry_after_s is not None
+            ),
+            default=None,
+        )
+        with self._lock():
+            doc = self._read_doc()
+            if saw_rate_limit:
+                n = int((doc["rateLimit"] or {}).get("consecutive") or 0) + 1
+                doc["rateLimit"] = {
+                    "consecutive": n,
+                    "blockedUntil": now + _failure_backoff_s(n, retry_after),
+                }
+            else:  # clean success, no 429 → the IP is clear
+                doc["rateLimit"] = {}
+            self._write_doc(doc)
+
+    def in_global_backoff(self, now: float) -> bool:
+        """Whether a shared 429 backoff is currently gating all usage fetches."""
+        blocked_until = (self._read_doc()["rateLimit"] or {}).get("blockedUntil")
+        return isinstance(blocked_until, (int, float)) and now < blocked_until
 
     def set_poll_plan(
         self,

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -597,8 +597,11 @@ class TestAdaptiveScheduler:
         outcome = self._tick(h, counts, usage)
         assert outcome is TickOutcome.NO_ACTION
         assert h.engine._unhealthy_ticks == 0
-        assert "1" not in counts  # backoff respected
-        assert sum(counts.values()) == 1  # baseline slot only, no escalate-all
+        # The 429 also raised the shared global gate (Retry-After 600s, only
+        # 400s elapsed), so this tick fetches *nothing* — not even the baseline
+        # candidate. Quieting the whole IP is the point; headroom stays trusted
+        # from deliberate-stale last-good, so still no unhealthy ticks / burst.
+        assert sum(counts.values()) == 0
 
     def test_exhausted_candidate_skips_to_its_reset(self, temp_home, monkeypatch):
         from datetime import datetime, timezone

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -1063,6 +1063,29 @@ class TestActiveAccountRefresh:
         assert entry.last_good == {"five_hour": {"pct": 25.0}}  # last-seen kept
         mock_fetch.assert_not_called()
 
+    def test_global_backoff_skips_all_fetching(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """While the shared 429 gate is up, the collector serves last-good and
+        never calls the usage endpoint — even for an otherwise-eligible account
+        (fresh token, no per-account backoff)."""
+        switcher = self._switcher(sample_sequence_data)
+        UsageStore(switcher.backup_dir / "cache").record(
+            {"1": FetchRecord(usage={"five_hour": {"pct": 25.0}})},
+            {"1": ("test@example.com", "")},
+        )
+        info = (1, "test@example.com", "", "", True, self._REFRESHED)
+
+        with patch.object(
+                 switcher._usage_store, "in_global_backoff", return_value=True), \
+             patch.object(switcher, "_active_cc_running", return_value=True), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            entry = switcher._collect_usage_entries([info])["1"]
+
+        mock_fetch.assert_not_called()
+        assert entry.last_good == {"five_hour": {"pct": 25.0}}  # served from store
+
 
 class TestPerformSwitchPostDisplay:
     """Regression tests for the post-switch display running outside the lock."""

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -325,3 +325,70 @@ class TestDueCandidate:
 
     def test_none_when_no_candidates(self):
         assert due_candidate([], {}, self.NOW) is None
+
+
+class TestGlobalRateLimitBackoff:
+    """A 429 is an IP-wide signal: it must stand *all* fetching down for a
+    growing interval, not just back off the one account that saw it."""
+
+    def test_not_blocked_initially(self, store, clock):
+        assert store.in_global_backoff(clock.now) is False
+
+    def test_429_trips_global_backoff(self, store, clock):
+        store.record({"1": FetchRecord(error="http-429", retry_after_s=0.0)}, IDENT)
+        assert store.in_global_backoff(clock.now) is True
+
+    def test_backoff_grows_on_repeated_429(self, store, clock):
+        store.record({"1": FetchRecord(error="http-429")}, IDENT)
+        first = store._read_doc()["rateLimit"]["blockedUntil"] - clock.now
+        store.record({"1": FetchRecord(error="http-429")}, IDENT)
+        second = store._read_doc()["rateLimit"]["blockedUntil"] - clock.now
+        assert second > first
+
+    def test_clean_success_clears_backoff(self, store, clock):
+        store.record({"1": FetchRecord(error="http-429")}, IDENT)
+        assert store.in_global_backoff(clock.now)
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        assert store.in_global_backoff(clock.now) is False
+
+    def test_mixed_pass_with_a_429_still_backs_off(self, store, clock):
+        # One account 429s while another succeeds in the same pass: the IP is
+        # still limiting, so an intermittent success must not defeat the gate.
+        store.record(
+            {"1": FetchRecord(error="http-429"), "2": FetchRecord(usage=USAGE)},
+            IDENT,
+        )
+        assert store.in_global_backoff(clock.now) is True
+
+    def test_non_429_error_does_not_trip(self, store, clock):
+        store.record({"1": FetchRecord(error="timeout")}, IDENT)
+        assert store.in_global_backoff(clock.now) is False
+
+    def test_retry_after_is_a_floor(self, store, clock):
+        store.record(
+            {"1": FetchRecord(error="http-429", retry_after_s=5000.0)}, IDENT
+        )
+        # server's Retry-After (5000s) beats the exponential base, and outlives
+        # the per-attempt cap the way _failure_backoff_s treats the server's word
+        assert store._read_doc()["rateLimit"]["blockedUntil"] - clock.now >= 5000.0
+
+    def test_persists_across_instances(self, tmp_path, clock):
+        s1 = UsageStore(tmp_path / "cache", clock=clock)
+        s1.record({"1": FetchRecord(error="http-429")}, IDENT)
+        s2 = UsageStore(tmp_path / "cache", clock=clock)
+        assert s2.in_global_backoff(clock.now) is True
+
+    def test_backoff_expires(self, store, clock):
+        store.record({"1": FetchRecord(error="http-429")}, IDENT)
+        assert store.in_global_backoff(clock.now)
+        clock.advance(BACKOFF_CAP_S + 1)
+        assert store.in_global_backoff(clock.now) is False
+
+    def test_coexists_with_per_account_state(self, store, clock):
+        # A 429 updates BOTH the per-account row and the global gate, and neither
+        # write clobbers the other.
+        store.record({"1": FetchRecord(error="http-429")}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.consecutive_failures == 1
+        assert entry.in_backoff(clock.now) is True
+        assert store.in_global_backoff(clock.now) is True


### PR DESCRIPTION
Addresses the recurring `http-429` loop on the usage endpoint (related to #85).

## Problem
The usage endpoint rate-limits **per IP**, but the store's backoff is **per-account only**. With multiple accounts polling on staggered schedules, whichever account's backoff just expired keeps poking the shared limit — so it never quiets. Observed live: all accounts cycling through 429s every ~2 minutes indefinitely. A single account's occasional success also resets its `consecutiveFailures`, keeping its backoff pinned at the 30s floor.

## Fix
A **shared 429 gate** in `UsageStore`:
- Any `http-429` in a fetch pass sets `rateLimit.blockedUntil = now + expo(consecutive429)` (server `Retry-After` as a floor), and the collector (`_collect_usage_entries`) skips **all** fetching until it passes — serving last-known-good meanwhile.
- A pass with a clean success **and no 429** clears it; a **mixed** pass (one 429 + one success) still backs off, so an intermittent success can't defeat the gate.
- It grows on each re-trip until it outlasts the IP window, then a probe succeeds and clears it.
- Persisted in `usage.json` (`rateLimit`) so the menubar engine, TUI, and cron `cswap auto --once` all honor one backoff.
- Per-account backoff stays for genuinely per-account errors.

## Tests
- `TestGlobalRateLimitBackoff` (10 cases): trips on 429, grows, clears on clean success, mixed-pass still backs off, non-429 ignored, Retry-After floor, persistence across instances, expiry, coexistence with per-account state.
- Collector: `test_global_backoff_skips_all_fetching` — no endpoint call while gated, last-good served.
- Updated `test_active_in_backoff_keeps_trusted_headroom` to the new semantics (a 429 quiets all polling, not just the one account).

Full suite: 898 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)