### PR TITLE
Fetch usage for session-owned accounts from the session profile's credentials (#96)

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -182,6 +182,36 @@ def delete_macos_keychain_entry(session_dir: Path) -> None:
         pass  # best-effort; absent entry is already success (rc 44)
 
 
+def read_session_credentials(session_dir: Path) -> str | None:
+    """Best-effort read of a session profile's *current* credential JSON.
+
+    Once a session has run, the profile — not the backup store — holds the
+    newest generation of the account's token family: claude rotates tokens
+    in place, and nothing syncs them back to backup. On macOS the rotated
+    credential lives in the profile's hashed keychain entry (which shadows
+    the plaintext seed from the moment claude first writes it), elsewhere in
+    the profile's ``.credentials.json``. Read-only by design: writing either
+    location stays claude's job (see the module docstring on why cswap never
+    writes the hashed entry). Returns ``None`` when the profile has no
+    readable credential material.
+    """
+    if not session_dir.is_dir():
+        return None
+    if Platform.detect() == Platform.MACOS:
+        try:
+            creds = macos_keychain.get_password(
+                keychain_service_name(session_dir), _keychain_account_name()
+            )
+            if creds:
+                return creds
+        except KeychainError:
+            pass  # locked/denied/timeout — the plaintext seed is the next-best truth
+    try:
+        return (session_dir / ".credentials.json").read_text()
+    except OSError:
+        return None
+
+
 def live_sessions_for(session_dir: Path) -> list[ClaudeSession]:
     """Live Claude instances running against a session profile."""
     if not session_dir.exists():

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1650,13 +1650,41 @@ class ClaudeAccountSwitcher:
             with FileLock(self.lock_file):
                 self._write_account_credentials(acct_num, acct_email, new_creds)
 
-        # An account running in session mode is "inactive" here but live
-        # in its own config dir, where claude manages the token. Treat it
-        # like the active account (no proactive refresh / 401-retry):
-        # refreshing the backup copy could rotate the refresh token out
-        # from under the live session. Worst case its usage shows as
-        # unavailable until the session exits.
+        from claude_swap.session import read_session_credentials
+
         has_live_session = bool(self._live_session_pids(str(num), email))
+
+        # A session profile supersedes the backup copy as this account's
+        # credential truth: claude rotates the token family inside the profile
+        # and nothing syncs it back, so once a session has run, the backup's
+        # refresh token is a consumed generation the server 401s forever —
+        # usage would silently freeze at the last pre-session measurement.
+        # Fetch with the profile's newest credential, strictly read-only
+        # (is_active=True: no refresh, no persist): rotating the profile's
+        # family here would log the next `cswap run` out the same way.
+        session_creds = read_session_credentials(self._session_dir(str(num), email))
+        if session_creds:
+            session_oauth = oauth.extract_oauth_data(session_creds)
+            if session_oauth and session_oauth.get("accessToken"):
+                if not oauth.is_oauth_token_expired(session_oauth.get("expiresAt")):
+                    outcome = oauth.try_fetch_usage_for_account(
+                        str(num), email, session_creds, is_active=True,
+                    )
+                    return FetchRecord(
+                        usage=outcome.usage,
+                        error=outcome.error,
+                        retry_after_s=outcome.retry_after_s,
+                    )
+                if has_live_session:
+                    # The live claude refreshes lazily on its next API call;
+                    # requesting now would just 401 (same rule as the owned
+                    # active account in _fetch_active_usage).
+                    return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
+                # Expired profile credential and no live session: fall through
+                # to the backup path — cswap must not rotate the profile's
+                # family, but a backup family that is still alive (e.g. the
+                # account was re-added after the profile last ran) can serve
+                # and heal via the normal refresh machinery below.
 
         outcome = oauth.try_fetch_usage_for_account(
             str(num), email, creds,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1164,3 +1164,50 @@ class TestShareHistoryWindows:
 
         with pytest.raises(SessionError, match="Windows"):
             mgr.run(ACCOUNT_NUM, [], share=True, share_history=True)
+
+
+class TestReadSessionCredentials:
+    """The profile's current credential JSON: keychain first, then plaintext."""
+
+    def test_missing_dir_returns_none(self, tmp_path):
+        assert session_mod.read_session_credentials(tmp_path / "absent") is None
+
+    def test_reads_plaintext_file_off_macos(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            Platform, "detect", classmethod(lambda cls: Platform.LINUX)
+        )
+        session_dir = tmp_path / "sess"
+        session_dir.mkdir()
+        (session_dir / ".credentials.json").write_text(
+            '{"claudeAiOauth": {"accessToken": "sk-file"}}'
+        )
+        assert "sk-file" in session_mod.read_session_credentials(session_dir)
+
+    def test_keychain_shadows_plaintext_on_macos(
+        self, tmp_path, macos_platform, block_real_keychain
+    ):
+        """Claude migrates the seed into its hashed keychain entry on first
+        write and rotates it there — the entry is the newest generation."""
+        session_dir = tmp_path / "sess"
+        session_dir.mkdir()
+        (session_dir / ".credentials.json").write_text(
+            '{"claudeAiOauth": {"accessToken": "sk-stale-seed"}}'
+        )
+        block_real_keychain.set_password(
+            keychain_service_name(session_dir),
+            session_mod._keychain_account_name(),
+            '{"claudeAiOauth": {"accessToken": "sk-rotated"}}',
+        )
+        creds = session_mod.read_session_credentials(session_dir)
+        assert creds is not None and "sk-rotated" in creds
+
+    def test_macos_falls_back_to_file_without_keychain_entry(
+        self, tmp_path, macos_platform, block_real_keychain
+    ):
+        session_dir = tmp_path / "sess"
+        session_dir.mkdir()
+        (session_dir / ".credentials.json").write_text(
+            '{"claudeAiOauth": {"accessToken": "sk-seed"}}'
+        )
+        creds = session_mod.read_session_credentials(session_dir)
+        assert creds is not None and "sk-seed" in creds

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -6,6 +6,7 @@ import base64
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -524,6 +525,104 @@ class TestStatusCache:
         )
         assert entries["1"].last_good == usage_result
         assert entries["2"].last_good == {"five_hour": {"pct": 80}}
+
+
+def _oauth_creds(token: str, expires_in_s: float) -> str:
+    """Credential JSON with an access token expiring ``expires_in_s`` from now."""
+    return json.dumps({"claudeAiOauth": {
+        "accessToken": token,
+        "refreshToken": f"rt-{token}",
+        "expiresAt": int((time.time() + expires_in_s) * 1000),
+    }})
+
+
+class TestFetchAccountUsageSessionProfile:
+    """Inactive-account fetches source credentials from the session profile.
+
+    Claude rotates the token family inside a session profile and nothing
+    syncs it back, so the backup copy's refresh token is a consumed
+    generation once a session has run — fetching with it 401s forever and
+    usage silently freezes at the last pre-session measurement.
+    """
+
+    def _info(self, backup_creds: str) -> tuple:
+        return (2, "test@example.com", "Org", "org-uuid", False, backup_creds)
+
+    def test_fresh_session_credentials_fetch_read_only(self, temp_home: Path):
+        """Profile creds are used with is_active=True (no refresh, no persist)."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", 7200)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 5}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.usage == {"five_hour": {"pct": 5}}
+        mock_fetch.assert_called_once()
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == session
+        assert kwargs.get("is_active") is True
+        assert "persist_credentials" not in kwargs
+
+    def test_expired_session_credentials_with_live_session_is_sentinel(
+        self, temp_home: Path
+    ):
+        """Live claude refreshes lazily — don't burn a request that would 401."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", -60)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_not_called()
+
+    def test_expired_session_credentials_without_live_session_falls_back(
+        self, temp_home: Path
+    ):
+        """No live session: the backup path (with refresh machinery) still runs."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+        session = _oauth_creds("sk-session", -60)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 9}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.usage == {"five_hour": {"pct": 9}}
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == backup
+        assert kwargs.get("is_active") is False
+        assert kwargs.get("persist_credentials") is not None
+
+    def test_no_session_profile_uses_backup_path(self, temp_home: Path):
+        """Accounts without a session profile behave exactly as before."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=None), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 9}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.usage == {"five_hour": {"pct": 9}}
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == backup
+        assert kwargs.get("is_active") is False
+        assert kwargs.get("persist_credentials") is not None
 
 
 class TestListAccountsUsage:


### PR DESCRIPTION
Fixes #96 — full root-cause analysis there. Short version: once `cswap run` has bootstrapped a profile, claude rotates the token family inside the profile and nothing syncs it back, so the backup's refresh token is a consumed generation the server 401s forever. Usage for that account then freezes silently at the last pre-session measurement.

## Change

- **session.py**: new `read_session_credentials(session_dir)` — best-effort read of the profile's *current* credential JSON: the hashed keychain entry first (it shadows the plaintext seed from claude's first write; the service name comes from the existing `keychain_service_name`), then the plaintext `.credentials.json`. Read-only by design — cswap keeps never writing the hashed entry.
- **switcher.py** `_fetch_account_usage`: for inactive accounts, prefer the session profile's credential and fetch with `is_active=True` (no refresh, no persist) — rotating the profile's family would log the next `cswap run` out the same way the backup got burned. Two edges:
  - profile credential locally expired + live session → `USAGE_TOKEN_EXPIRED` sentinel instead of burning a request that would 401 (mirrors the owned-active rule in `_fetch_active_usage`; the running claude refreshes lazily on its next API call, after which fetches succeed again);
  - profile credential expired + no live session → fall through to the existing backup path unchanged, so a backup family that is still alive keeps serving and healing exactly as before.

Accounts without a session profile are untouched (covered by a regression test).

## Verified

On the affected setup from #96: the profile's keychain entry is found and used; a live-but-idle session now reports the honest token-expired sentinel instead of frozen bars, and flips to live data as soon as the session's claude refreshes. Full suite: 907 passed, 3 skipped.