### PR TITLE
fix(switch): never back up an empty current credential (Keychain timeout)

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -2743,6 +2743,16 @@ class ClaudeAccountSwitcher:
                 original_creds = self._read_credentials()
                 if original_creds is None:
                     raise CredentialReadError("Failed to read current credentials")
+                if not original_creds:
+                    # An empty read (e.g. a macOS Keychain `security` timeout,
+                    # which returns "" rather than raising) must NOT be written
+                    # over the departing account's backup — that would destroy
+                    # its stored credential. Fail the switch; the backup stays
+                    # intact and the caller can retry once the Keychain settles.
+                    raise CredentialReadError(
+                        "Current account credential is empty (Keychain unreadable?); "
+                        "refusing to overwrite its backup"
+                    )
                 original_config = config_path.read_text(encoding="utf-8")
             except FileNotFoundError:
                 raise ConfigError("Claude config file not found")

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -1345,6 +1345,38 @@ class TestPerformSwitchPostDisplay:
         )
         assert backup_oauth["accessToken"] == "sk-rotated-1"
 
+    def test_switch_refuses_to_overwrite_backup_with_empty_current_creds(
+        self,
+        temp_home: Path,
+        mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        """A Keychain read that times out returns "" (not None); the switch must
+        refuse to back up that empty credential over the departing account's
+        good backup and fail instead — otherwise a transient Keychain hiccup
+        destroys the stored credential. Regression for empty-backup cred loss."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        good_backup = json.dumps({
+            "claudeAiOauth": {"accessToken": "sk-good-1", "refreshToken": "rt-good-1"},
+        })
+        creds_store[("1", "test@example.com")] = good_backup
+        # Live read returns empty, exactly as a `security find-generic-password`
+        # timeout does (Keychain fail → falls through to an absent file → "").
+        live_state = {"creds": ""}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with pytest.raises(CredentialReadError):
+                switcher._perform_switch("2")
+        finally:
+            for p in patches:
+                p.stop()
+        # The departing account's good backup is untouched (not wiped to empty).
+        assert creds_store[("1", "test@example.com")] == good_backup
+
     def test_switch_survives_post_display_failure(
         self,
         temp_home: Path,


### PR DESCRIPTION
## The bug (credential loss)
On macOS a Keychain read that times out (`security find-generic-password timed out after 5.0s`) returns `""` rather than raising, so `_read_credentials()` yields an empty string. `_perform_switch` only rejected a `None` read (`if original_creds is None`), then wrote the empty value over the **departing** account's backup — destroying its stored credential.

I hit this in the wild running the menu bar's auto-switch: two accounts' backups were wiped to **0 bytes** during background switches while the Keychain was timing out, and re-adding them from a terminal was immediately undone by the next background switch-away.

```
13:29:37  Added account 2          ← restored
13:30:31  Switched from 2 to 3     ← backed up account 2 EMPTY (Keychain timeout) → wiped
13:30:56  Added account 1          ← restored
13:31:38  Switched from 1 to 3     ← backed up account 1 EMPTY → wiped
13:31:46  Switch failed: Account-2 has no stored credentials
```

## The fix
Reject an **empty** current-credential read too, before the backup step, so the switch fails harmlessly (leaving the good backup intact) instead of overwriting it. The caller retries once the Keychain settles. One-line guard alongside the existing `is None` check.

## Test
`test_switch_refuses_to_overwrite_backup_with_empty_current_creds`: a switch whose current-credential read returns `""` (as a Keychain timeout does) now raises `CredentialReadError` and leaves the departing account's backup byte-for-byte intact. Fails on `main`, passes with the fix. Full suite: 908 passed, 3 skipped.

## Note
This only guards the normal (backup-then-switch) path — the direct-activation path already snapshots for rollback only and never writes a backup. A separate follow-up could re-probe the Keychain on a transient timeout so the switch can succeed rather than defer, but preventing the data loss is the priority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)