### PR TITLE
feat(auto): switch on a per-model weekly limit via `--model` / `autoswitch.model`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Let claude-swap watch your usage and switch for you. When the active account's 5
 ```bash
 cswap auto                     # foreground loop, polls every 60s
 cswap auto --threshold 80      # switch earlier
+cswap auto --model Fable       # also switch when the Fable weekly limit is hit
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
 ```
@@ -96,6 +97,7 @@ cswap auto --dry-run           # log what it would do, never switch
 - Usage polling is adaptive — a couple of accounts per check, busy alternates watched more closely, exhausted ones left alone until they reset — so API traffic stays flat no matter how many accounts you manage.
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you log in with it and re-run `cswap add --slot N`. API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
+- By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
 
 For cron/systemd timers, `--once` reports the outcome in its exit code (`0` switched, `1` error, `2` nothing to do, `3` blocked — no viable target), and `--json` emits one JSON event per line:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Let claude-swap watch your usage and switch for you. When the active account's 5
 cswap auto                     # foreground loop, polls every 60s
 cswap auto --threshold 80      # switch earlier
 cswap auto --model Fable       # also switch when the Fable weekly limit is hit
+cswap auto --model Fable,Opus  # ...or any of several models
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
 ```
@@ -97,7 +98,8 @@ cswap auto --dry-run           # log what it would do, never switch
 - Usage polling is adaptive — a couple of accounts per check, busy alternates watched more closely, exhausted ones left alone until they reset — so API traffic stays flat no matter how many accounts you manage.
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you log in with it and re-run `cswap add --slot N`. API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
-- By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
+- By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room. Pass several as a comma-separated list — `--model Fable,Opus` — to switch when **any** of them is maxed.
+  - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap --list` (e.g. a line reading `Fable: 100%`). At the time of writing the values seen are `Fable`, `Opus`, `Sonnet`, and `Haiku`, but the list follows whatever the usage API reports — a name that never matches simply has no effect.
 
 For cron/systemd timers, `--once` reports the outcome in its exit code (`0` switched, `1` error, `2` nothing to do, `3` blocked — no viable target), and `--json` emits one JSON event per line:
 
@@ -195,6 +197,7 @@ Tool preferences live in `settings.json` in the backup root; `cswap config` read
 cswap config                              # list effective settings ("(default)" = not set)
 cswap config get autoswitch.threshold
 cswap config set autoswitch.threshold 80  # validated: rejects out-of-range values loudly
+cswap config set autoswitch.model Fable   # per-model switching (see "auto"); Fable,Opus for several
 cswap config unset autoswitch.threshold   # back to the default
 cswap config path                         # where settings.json lives
 ```

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -398,6 +398,10 @@ class AutoSwitchEngine:
     ):
         self.switcher = switcher
         self.settings = settings
+        # Model whose per-model weekly limit also binds the switch decision
+        # (empty = account-wide 5h/7d only). Passed to every account_headroom
+        # call so active and candidates are judged on the same axes.
+        self._models = (settings.model,) if settings.model else ()
         self.on_event = on_event
         self.dry_run = dry_run
         self.state_path = state_path or (switcher.backup_dir / STATE_FILENAME)
@@ -870,7 +874,7 @@ class AutoSwitchEngine:
 
         active_value = usage.get(current)
         active_headroom = oauth.account_headroom(
-            active_value if isinstance(active_value, dict) else None
+            active_value if isinstance(active_value, dict) else None, self._models
         )
         escalate = bool(candidates) and (
             (active_headroom is None and active_value != USAGE_TOKEN_EXPIRED)
@@ -887,7 +891,9 @@ class AutoSwitchEngine:
             usage = {num: entry.decision_value() for num, entry in entries.items()}
 
         headroom = {
-            num: oauth.account_headroom(value if isinstance(value, dict) else None)
+            num: oauth.account_headroom(
+                value if isinstance(value, dict) else None, self._models
+            )
             for num, value in usage.items()
         }
         if not self.dry_run:

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -398,10 +398,14 @@ class AutoSwitchEngine:
     ):
         self.switcher = switcher
         self.settings = settings
-        # Model whose per-model weekly limit also binds the switch decision
-        # (empty = account-wide 5h/7d only). Passed to every account_headroom
-        # call so active and candidates are judged on the same axes.
-        self._models = (settings.model,) if settings.model else ()
+        # Model(s) whose per-model weekly limit also binds the switch decision
+        # (empty = account-wide 5h/7d only). ``settings.model`` is a comma-
+        # separated list ("Fable", "Opus,Sonnet", ...); split once here and
+        # pass to every account_headroom call so active and candidates are
+        # judged on the same axes.
+        self._models = tuple(
+            m.strip() for m in (settings.model or "").split(",") if m.strip()
+        )
         self.on_event = on_event
         self.dry_run = dry_run
         self.state_path = state_path or (switcher.backup_dir / STATE_FILENAME)

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -210,6 +210,7 @@ Exit codes with --once:
 Examples:
   cswap auto                       # foreground loop, switch at 90%% used
   cswap auto --threshold 80        # switch earlier
+  cswap auto --model Fable         # also switch when the Fable weekly limit is hit
   cswap auto --json                # one JSON event per line (for scripts)
   cswap auto --once; echo $?       # single tick, outcome in exit code
   cswap auto --dry-run             # log decisions, never actually switch
@@ -247,6 +248,14 @@ Defaults live in settings.json in the backup root; flags override them.
         type=float,
         metavar="SECONDS",
         help="Minimum time between proactive switches (default 300)",
+    )
+    parser.add_argument(
+        "--model",
+        metavar="NAME",
+        help=(
+            "Also switch when this model's weekly limit is hit (e.g. Fable), "
+            "not just the account-wide 5h/7d windows"
+        ),
     )
     parser.add_argument(
         "--include-api-key-accounts",

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -251,10 +251,11 @@ Defaults live in settings.json in the backup root; flags override them.
     )
     parser.add_argument(
         "--model",
-        metavar="NAME",
+        metavar="NAMES",
         help=(
-            "Also switch when this model's weekly limit is hit (e.g. Fable), "
-            "not just the account-wide 5h/7d windows"
+            "Also switch when a per-model weekly limit is hit, not just the "
+            "account-wide 5h/7d windows. One name or a comma-separated list "
+            "(e.g. Fable, Opus, Sonnet, Haiku, or 'Fable,Opus')"
         ),
     )
     parser.add_argument(

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -6,7 +6,7 @@ import json
 import logging
 import urllib.error
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -335,15 +335,21 @@ def build_usage_result(data: dict) -> dict | None:
     return result if result else None
 
 
-def account_headroom(usage: dict | None) -> float | None:
+def account_headroom(
+    usage: dict | None, models: Sequence[str] = ()
+) -> float | None:
     """Remaining percentage before this account hits a rate-limit window.
 
-    Considers only the 5-hour and 7-day utilization windows — the two that
-    actually gate requests. ``spend`` (pay-as-you-go extra-usage credits) is a
-    separate axis and is deliberately ignored. Returns the headroom of the
-    *binding* window (``100 - max(pct)``), so ``<= 0`` means the account is at
-    or over a limit. Returns ``None`` when usage is unavailable or carries no
-    window data, which callers treat as "unknown" (never auto-skipped).
+    Considers the 5-hour and 7-day utilization windows — the two that always
+    gate requests. When ``models`` is non-empty, each named per-model weekly
+    ``scoped`` window (matched case-insensitively on ``display_name``, e.g.
+    "Fable") is folded in too: a model maxed at 100% blocks that model's work
+    even with 5h/7d headroom, so for someone pinned to that model it binds
+    just as hard. ``spend`` (pay-as-you-go extra-usage credits) is a separate
+    axis and is deliberately ignored. Returns the headroom of the *binding*
+    window (``100 - max(pct)``), so ``<= 0`` means the account is at or over a
+    limit. Returns ``None`` when usage is unavailable or carries no window
+    data, which callers treat as "unknown" (never auto-skipped).
     """
     if not isinstance(usage, dict):
         return None
@@ -352,6 +358,18 @@ def account_headroom(usage: dict | None) -> float | None:
         for window in (usage.get("five_hour"), usage.get("seven_day"))
         if isinstance(window, dict) and isinstance(window.get("pct"), (int, float))
     ]
+    if models:
+        wanted = {m.lower() for m in models}
+        scoped = usage.get("scoped")
+        if isinstance(scoped, list):
+            pcts += [
+                s["pct"]
+                for s in scoped
+                if isinstance(s, dict)
+                and isinstance(s.get("pct"), (int, float))
+                and isinstance(s.get("name"), str)
+                and s["name"].lower() in wanted
+            ]
     if not pcts:
         return None
     return 100.0 - max(pcts)

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -47,6 +47,11 @@ class AutoSwitchSettings:
     strategy: str = "best"  # reserved for future strategies; only "best" in v1
     include_api_key_accounts: bool = False
     unhealthy_ticks: int = 3
+    # When set to a model display name (e.g. "Fable"), that model's per-model
+    # weekly limit is folded into the binding window, so the engine switches
+    # off an account whose model quota is exhausted even while its 5h/7d
+    # windows still have headroom. None = account-wide 5h/7d only (default).
+    model: str | None = None
 
 
 @dataclass(frozen=True)
@@ -109,6 +114,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
             "autoswitch", "unhealthyTicks", "unhealthy_ticks", "int", 1, 100,
             help="Consecutive failed polls before an account is unhealthy",
         ),
+        SettingSpec(
+            "autoswitch", "model", "model", "string",
+            help="Also switch when this model's weekly limit is hit (e.g. Fable)",
+        ),
     )
 }
 
@@ -137,6 +146,10 @@ def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:
             kwargs[spec.field] = int(clamped) if spec.kind == "int" else clamped
         elif spec.kind == "bool":
             kwargs[spec.field] = bool(value)
+        elif spec.kind == "string":
+            # A non-empty string keeps as-is; anything else reverts to default
+            # (None) so a null/garbage settings.json value disables the filter.
+            kwargs[spec.field] = value if isinstance(value, str) and value else spec.default
         else:  # choice
             if value not in spec.choices:
                 _logger.warning(
@@ -232,6 +245,14 @@ def parse_setting_value(spec: SettingSpec, raw_value: str):
                 f"{spec.dotted} must be one of: {', '.join(spec.choices)}"
             )
         return raw_value
+    if spec.kind == "string":
+        value = raw_value.strip()
+        if not value:
+            raise ConfigError(
+                f"{spec.dotted} expects a non-empty value; use "
+                f"'cswap config unset {spec.dotted}' to clear it"
+            )
+        return value
     try:
         value = int(raw_value) if spec.kind == "int" else float(raw_value)
     except ValueError:
@@ -249,6 +270,8 @@ def parse_setting_value(spec: SettingSpec, raw_value: str):
 
 def format_setting_value(value) -> str:
     """Render a settings value the way settings.json writes it."""
+    if value is None:
+        return "(none)"
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, float) and value.is_integer():
@@ -347,6 +370,7 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
         ("interval", "interval_seconds"),
         ("cooldown", "cooldown_seconds"),
         ("include_api_key_accounts", "include_api_key_accounts"),
+        ("model", "model"),
     ):
         value = getattr(args, attr, None)
         if value is not None:

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -47,10 +47,11 @@ class AutoSwitchSettings:
     strategy: str = "best"  # reserved for future strategies; only "best" in v1
     include_api_key_accounts: bool = False
     unhealthy_ticks: int = 3
-    # When set to a model display name (e.g. "Fable"), that model's per-model
-    # weekly limit is folded into the binding window, so the engine switches
-    # off an account whose model quota is exhausted even while its 5h/7d
-    # windows still have headroom. None = account-wide 5h/7d only (default).
+    # Comma-separated model display name(s) (e.g. "Fable" or "Fable,Opus").
+    # Each named model's per-model weekly limit is folded into the binding
+    # window, so the engine switches off an account whose model quota is
+    # exhausted even while its 5h/7d windows still have headroom. None =
+    # account-wide 5h/7d only (default).
     model: str | None = None
 
 
@@ -116,7 +117,7 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         ),
         SettingSpec(
             "autoswitch", "model", "model", "string",
-            help="Also switch when this model's weekly limit is hit (e.g. Fable)",
+            help="Also switch on these models' weekly limits (e.g. Fable or Fable,Opus)",
         ),
     )
 }

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -1172,3 +1172,26 @@ class TestModelAwareSwitch:
         })
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2  # lowest binding (max of 5h, Fable)
+
+    def test_comma_separated_models_switch_on_any(self, temp_home):
+        # Configured for "Fable,Opus"; active #1 is fine on Fable but maxed on
+        # Opus → must leave. Candidate scoped windows carry both models.
+        h = self._seed(temp_home, model="Fable,Opus")
+
+        def usage(five_h, fable, opus):
+            return {
+                "five_hour": {"pct": five_h},
+                "seven_day": {"pct": 0.0},
+                "scoped": [
+                    {"name": "Fable", "pct": fable},
+                    {"name": "Opus", "pct": opus},
+                ],
+            }
+
+        outcome = h.tick_with_usage({
+            "1": usage(5, 20, 100),   # Opus maxed
+            "2": usage(5, 20, 30),    # most headroom
+            "3": usage(5, 20, 70),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -1114,3 +1114,61 @@ class TestRunLoop:
     def test_sleep_cap(self, harness):
         harness.engine._sleep_until_ts = harness.clock() + 50 * 3600
         assert harness.engine._next_delay(TickOutcome.BLOCKED) == 6 * 3600
+
+
+def _model_usage(five_h: float, fable: float) -> dict:
+    """Usage with a low 5h/7d but a per-model (Fable) weekly window."""
+    return {
+        "five_hour": {"pct": five_h},
+        "seven_day": {"pct": 0.0},
+        "scoped": [{"name": "Fable", "pct": fable}],
+    }
+
+
+class TestModelAwareSwitch:
+    """`autoswitch.model` folds a per-model weekly limit into the decision."""
+
+    def _seed(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, **kw)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_model_maxed_switches_despite_session_headroom(self, temp_home):
+        # Active #1: 5h only 5% used, but Fable is maxed → must leave.
+        h = self._seed(temp_home, model="Fable")
+        outcome = h.tick_with_usage({
+            "1": _model_usage(5, 100),
+            "2": _model_usage(5, 30),
+            "3": _model_usage(5, 60),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2  # most Fable headroom
+        switch = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert switch.to_ref == {"number": 2, "email": "b@example.com"}
+
+    def test_without_model_setting_the_same_usage_holds(self, temp_home):
+        # Default engine ignores scoped windows → #1 reads 5% used, no switch.
+        h = self._seed(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _model_usage(5, 100),
+            "2": _model_usage(5, 30),
+            "3": _model_usage(5, 60),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
+
+    def test_model_headroom_still_gated_by_session_window(self, temp_home):
+        # Fable has room on every account, but #1's 5h is maxed → still leaves.
+        h = self._seed(temp_home, model="Fable")
+        outcome = h.tick_with_usage({
+            "1": _model_usage(100, 40),
+            "2": _model_usage(10, 40),
+            "3": _model_usage(20, 40),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2  # lowest binding (max of 5h, Fable)

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -47,9 +47,10 @@ class TestConfigList:
             "autoswitch.strategy",
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
+            "autoswitch.model",
         ):
             assert key in out
-        assert out.count("(default)") == 7
+        assert out.count("(default)") == 8
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -76,7 +77,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 7
+        assert len(by_key) == 8
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -87,6 +87,23 @@ class TestAccountHeadroom:
         usage = {"five_hour": {"pct": 10.0}, "scoped": [{"name": "Opus", "pct": 100.0}]}
         assert oauth.account_headroom(usage, ["Fable"]) == 90.0
 
+    def test_multiple_models_take_the_worst(self):
+        usage = {
+            "five_hour": {"pct": 10.0},
+            "scoped": [
+                {"name": "Fable", "pct": 30.0},
+                {"name": "Opus", "pct": 95.0},
+                {"name": "Haiku", "pct": 50.0},
+            ],
+        }
+        # Opus binds (95%); Sonnet is absent and simply contributes nothing.
+        assert oauth.account_headroom(usage, ["Fable", "Opus", "Sonnet"]) == 5.0
+
+    def test_works_for_any_model_name(self):
+        for name in ("Opus", "Sonnet", "Haiku"):
+            usage = {"scoped": [{"name": name, "pct": 100.0}]}
+            assert oauth.account_headroom(usage, [name]) == 0.0
+
     def test_only_scoped_and_named_yields_headroom(self):
         # No 5h/7d at all (the live shape when the API returns only limits).
         assert oauth.account_headroom({"scoped": [{"name": "Fable", "pct": 100.0}]}, ["Fable"]) == 0.0

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -61,6 +61,40 @@ class TestAccountHeadroom:
     def test_malformed_pct_is_ignored(self):
         assert oauth.account_headroom({"five_hour": {"pct": None}}) is None
 
+    def test_scoped_ignored_without_models_arg(self):
+        # Default behavior is unchanged: per-model windows never bind.
+        usage = {"five_hour": {"pct": 10.0}, "scoped": [{"name": "Fable", "pct": 100.0}]}
+        assert oauth.account_headroom(usage) == 90.0
+
+    def test_named_model_folds_into_binding_window(self):
+        usage = {"five_hour": {"pct": 10.0}, "scoped": [{"name": "Fable", "pct": 95.0}]}
+        assert oauth.account_headroom(usage, ["Fable"]) == 5.0
+
+    def test_maxed_model_is_at_limit_despite_session_headroom(self):
+        # The exact motivating case: 5h/7d fine, but the model is exhausted.
+        usage = {
+            "five_hour": {"pct": 1.0},
+            "seven_day": {"pct": 40.0},
+            "scoped": [{"name": "Fable", "pct": 100.0}],
+        }
+        assert oauth.account_headroom(usage, ["Fable"]) == 0.0
+
+    def test_model_match_is_case_insensitive(self):
+        usage = {"scoped": [{"name": "Fable", "pct": 70.0}]}
+        assert oauth.account_headroom(usage, ["fable"]) == 30.0
+
+    def test_unlisted_model_does_not_bind(self):
+        usage = {"five_hour": {"pct": 10.0}, "scoped": [{"name": "Opus", "pct": 100.0}]}
+        assert oauth.account_headroom(usage, ["Fable"]) == 90.0
+
+    def test_only_scoped_and_named_yields_headroom(self):
+        # No 5h/7d at all (the live shape when the API returns only limits).
+        assert oauth.account_headroom({"scoped": [{"name": "Fable", "pct": 100.0}]}, ["Fable"]) == 0.0
+
+    def test_scoped_without_5h7d_and_unlisted_model_is_unknown(self):
+        usage = {"scoped": [{"name": "Opus", "pct": 100.0}]}
+        assert oauth.account_headroom(usage, ["Fable"]) is None
+
 
 class TestFormatReset:
     """Test format_reset."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -145,6 +145,23 @@ class TestSetUnsetSetting:
         with pytest.raises(ConfigError, match="unknown setting"):
             set_setting(tmp_path, "autoswitch.bogus", "1")
 
+    def test_set_string_kind_round_trips(self, tmp_path: Path):
+        assert set_setting(tmp_path, "autoswitch.model", "Fable") == "Fable"
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert raw["autoswitch"]["model"] == "Fable"
+        assert load_settings(tmp_path).model == "Fable"
+
+    def test_set_string_kind_rejects_empty(self, tmp_path: Path):
+        with pytest.raises(ConfigError, match="unset"):
+            set_setting(tmp_path, "autoswitch.model", "   ")
+        assert not settings_path(tmp_path).exists()
+
+    def test_garbage_model_value_falls_back_to_none(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"autoswitch": {"model": 123}})
+        )
+        assert load_settings(tmp_path).model is None
+
     def test_set_rejects_bool_words_strictly(self, tmp_path: Path):
         assert set_setting(tmp_path, "autoswitch.includeApiKeyAccounts", "FALSE") is False
         with pytest.raises(ConfigError, match="true or false"):
@@ -209,3 +226,7 @@ class TestMergedWithCli:
             AutoSwitchSettings(), _args(include_api_key_accounts=True)
         )
         assert merged.include_api_key_accounts is True
+
+    def test_model_override(self):
+        merged = merged_with_cli(AutoSwitchSettings(), _args(model="Fable"))
+        assert merged.model == "Fable"


### PR DESCRIPTION
## Problem

`account_headroom` — the single function that decides *when* `cswap auto` switches and *which* account it picks — only looks at the account-wide **5h/7d** windows. Anthropic now also enforces **per-model weekly limits**, which the usage layer already parses into `scoped` windows (e.g. `{"name": "Fable", "pct": 100}`). Those were never consulted, so:

- An account whose **model quota is exhausted** but whose 5h/7d still have headroom reads as "plenty left" → `cswap auto` **never switches off it**, even though every request for that model is blocked.
- On the live shape where the usage API returns **only** a per-model window (no 5h/7d yet), `account_headroom` returns `None` → the engine reads the active account as **"usage unknown"** and sits there.

I hit this working exclusively on one model: the account was model-maxed for a day while cswap happily stayed on it.

## What this does

Adds an **opt-in** model filter — off by default, so nothing changes for anyone who doesn't set it (a per-model cap must not evict users who don't use that model).

- `oauth.account_headroom(usage, models=())` — when `models` is non-empty, each named `scoped` window is folded into the binding `max(pct)` alongside 5h/7d (case-insensitive `display_name` match). Empty tuple = today's behavior, byte-for-byte.
- `AutoSwitchSettings.model` + a new `"string"` `SettingSpec` kind — validated, round-trips through `cswap config set/get/unset autoswitch.model`; a null/garbage value in `settings.json` disables the filter rather than crashing.
- `cswap auto --model NAME` flag (overrides the setting, like the other `auto` flags).
- Threaded through the **engine only** — so both the leave-decision and target-selection agree. Manual `--switch --strategy best` and the poll-cadence heuristics deliberately stay on 5h/7d (noted in code); happy to extend those in a follow-up if you'd like.

## Example

```bash
cswap auto --model Fable
# or persist it:
cswap config set autoswitch.model Fable
```

Now an account with `5h 1% · 7d 40% · Fable 100%` is treated as at-limit and the engine moves to the account with the most model headroom.

## Tests

- `test_oauth.py`: the `models` math — folds a named window, ignores unlisted models, case-insensitive, only-scoped shape, still `None` when nothing matches.
- `test_settings.py`: string-kind set/get/unset round-trip, empty-value rejection, garbage→`None` clamp; the existing registry/defaults tests cover the new field automatically.
- `test_config_cli.py`: key-count assertions bumped 7→8.
- `test_autoswitch.py`: new `TestModelAwareSwitch` — switches when the model is maxed despite session headroom, **stays put** with no model configured on the same usage, and still respects a maxed 5h window.

Full suite: **921 passed, 3 skipped**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)