### PR TITLE
fix(keychain): re-probe after a cooldown so a daemon recovers from timeouts

### DIFF
--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -161,7 +161,10 @@ class CredentialStore:
             result = fn(*args)
         except macos_keychain.KEYCHAIN_ERRORS:
             self._keychain_usable_cache = False
-            self._keychain_disabled_until = time.time() + KEYCHAIN_RECHECK_COOLDOWN_S
+            # Monotonic so a wall-clock jump can't expire the cooldown early/late.
+            self._keychain_disabled_until = (
+                time.monotonic() + KEYCHAIN_RECHECK_COOLDOWN_S
+            )
             raise
         if self._keychain_usable_cache is None:
             self._keychain_usable_cache = True
@@ -176,18 +179,33 @@ class CredentialStore:
         never passes, so a command can't split-brain between backends, but a
         long-running daemon re-probes once the cooldown elapses so a transient
         ``security`` timeout self-heals instead of sticking for the whole process.
-        A directly-forced ``False`` with no deadline (0.0) stays sticky.
+        A pinned file mode with no deadline (0.0) stays sticky — see
+        :meth:`_pin_file_mode` for why a write fallback must never re-probe.
         """
         if self._host.platform != Platform.MACOS:
             return False
         if (
             self._keychain_usable_cache is False
             and self._keychain_disabled_until
-            and time.time() >= self._keychain_disabled_until
+            and time.monotonic() >= self._keychain_disabled_until
         ):
             self._keychain_usable_cache = None  # cooldown elapsed → re-probe
             self._keychain_disabled_until = 0.0
         return self._keychain_usable_cache is not False
+
+    def _pin_file_mode(self) -> None:
+        """Pin file mode for the rest of the process — no Keychain re-probe.
+
+        A read timeout is safe to recover from (re-probe on cooldown), but an
+        active-credential *write* that falls back to the file is not: its
+        best-effort delete of the old Keychain item may have failed, leaving a
+        stale entry. Re-probing later could read that residual and show the wrong
+        account, so once a write falls back we never re-probe onto a Keychain we
+        could not verify-clear. Clears any re-probe deadline a prior read
+        scheduled, which could otherwise still be pending.
+        """
+        self._keychain_usable_cache = False
+        self._keychain_disabled_until = 0.0
 
     def _read_credentials(self) -> str | None:
         """Read Claude Code's active credential — OAuth *or* managed API key (value).
@@ -563,6 +581,11 @@ class CredentialStore:
         except Exception as e:
             raise CredentialWriteError(f"Failed to write credentials: {e}")
         self._delete_active_keychain_entry()
+        if self._host.platform == Platform.MACOS:
+            # The delete above is best-effort; a stale Keychain item may remain.
+            # Pin file mode so a later read-timeout cooldown can't re-probe onto
+            # that residual and resurrect the wrong account (see _pin_file_mode).
+            self._pin_file_mode()
         self._last_active_credentials_backend = "file"
 
     def _refresh_stale_credentials_file(self, credentials: str) -> None:

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -61,6 +61,14 @@ CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE = "Claude Code"
 _ACTIVE_READ_ATTEMPTS = 2
 _ACTIVE_READ_RETRY_DELAY = 0.3  # seconds between attempts
 
+# After a Keychain failure the store drops to file mode so one CLI invocation
+# can't split-brain between backends. A long-running daemon (menu bar / TUI)
+# instead re-probes this long after the last failure: far longer than any CLI
+# command runs (so the guarantee holds — a sub-second command never re-probes),
+# short enough that a transient `security` timeout self-heals within a minute
+# instead of disabling the Keychain for the whole process lifetime.
+KEYCHAIN_RECHECK_COOLDOWN_S = 60.0
+
 
 class ActiveCredentials(NamedTuple):
     """Outcome of reading Claude Code's active credential.
@@ -129,6 +137,10 @@ class CredentialStore:
         # most recent active-credential write landed ("keychain" | "file"), for the
         # post-switch follow-up message.
         self._keychain_usable_cache: bool | None = None
+        # When file mode was entered by a real failure, the epoch after which to
+        # re-probe the Keychain (see KEYCHAIN_RECHECK_COOLDOWN_S). 0.0 = no
+        # pending re-probe (never failed, or forced to file mode deliberately).
+        self._keychain_disabled_until: float = 0.0
         self._last_active_credentials_backend: str | None = None
 
     def _kc_call(self, fn, *args):
@@ -149,20 +161,32 @@ class CredentialStore:
             result = fn(*args)
         except macos_keychain.KEYCHAIN_ERRORS:
             self._keychain_usable_cache = False
+            self._keychain_disabled_until = time.time() + KEYCHAIN_RECHECK_COOLDOWN_S
             raise
         if self._keychain_usable_cache is None:
             self._keychain_usable_cache = True
         return result
 
     def _use_keychain(self) -> bool:
-        """Whether credential *writes* should target the macOS Keychain this run.
+        """Whether credential ops should target the macOS Keychain right now.
 
-        ``False`` off macOS. On macOS, ``True`` until a Keychain op has failed this
-        process (the cache flips to ``False`` and sticks). Unknown (``None``) is
-        optimistic — the first real op tries the Keychain and records the outcome.
+        ``False`` off macOS. On macOS, ``True`` until a Keychain op fails, which
+        drops to file mode. That failure records a re-probe deadline
+        (``KEYCHAIN_RECHECK_COOLDOWN_S``): within one CLI invocation the deadline
+        never passes, so a command can't split-brain between backends, but a
+        long-running daemon re-probes once the cooldown elapses so a transient
+        ``security`` timeout self-heals instead of sticking for the whole process.
+        A directly-forced ``False`` with no deadline (0.0) stays sticky.
         """
         if self._host.platform != Platform.MACOS:
             return False
+        if (
+            self._keychain_usable_cache is False
+            and self._keychain_disabled_until
+            and time.time() >= self._keychain_disabled_until
+        ):
+            self._keychain_usable_cache = None  # cooldown elapsed → re-probe
+            self._keychain_disabled_until = 0.0
         return self._keychain_usable_cache is not False
 
     def _read_credentials(self) -> str | None:

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -486,6 +486,13 @@ class CredentialStore:
 
         # Mutual exclusion: drop the OAuth credential so it can't shadow the key.
         self._clear_oauth_credential()
+        if self._host.platform == Platform.MACOS and not wrote_to_keychain:
+            # Same stale-Keychain resurrection guard as the OAuth path: the key
+            # fell back to plaintext ``primaryApiKey`` while a stale "Claude Code"
+            # Keychain item may remain, and managed-key reads check the Keychain
+            # before ``primaryApiKey``. Pin file mode so a cooldown re-probe can't
+            # read that residual over the fresh fallback value.
+            self._pin_file_mode()
         self._last_active_credentials_backend = (
             "keychain" if wrote_to_keychain else "file"
         )

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -370,6 +370,14 @@ class ClaudeAccountSwitcher:
         self._store._keychain_usable_cache = value
 
     @property
+    def _keychain_disabled_until(self) -> float:
+        return self._store._keychain_disabled_until
+
+    @_keychain_disabled_until.setter
+    def _keychain_disabled_until(self, value: float) -> None:
+        self._store._keychain_disabled_until = value
+
+    @property
     def _last_active_credentials_backend(self) -> str | None:
         return self._store._last_active_credentials_backend
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -3542,7 +3542,7 @@ class TestMacosKeychainFallback:
     def test_kc_call_failure_schedules_a_recheck(self, temp_home: Path, monkeypatch):
         s = self._macos_switcher()
         monkeypatch.setattr(macos_keychain, "get_password", _raise_locked)
-        before = time.time()
+        before = time.monotonic()
         with pytest.raises(KeychainError):
             s._kc_call(macos_keychain.get_password, "svc", "acct")
         assert s._keychain_disabled_until > before  # a re-probe is scheduled
@@ -3553,7 +3553,7 @@ class TestMacosKeychainFallback:
         # whole process — the stuck-in-file-mode "no credentials" display bug.
         s = self._macos_switcher()
         s._keychain_usable_cache = False
-        s._keychain_disabled_until = time.time() - 1  # cooldown already elapsed
+        s._keychain_disabled_until = time.monotonic() - 1  # cooldown already elapsed
         assert s._use_keychain() is True             # re-probes
         assert s._keychain_usable_cache is None       # re-armed for a fresh op
         assert s._keychain_disabled_until == 0.0
@@ -3561,7 +3561,37 @@ class TestMacosKeychainFallback:
     def test_keychain_stays_file_mode_during_cooldown(self, temp_home: Path):
         s = self._macos_switcher()
         s._keychain_usable_cache = False
-        s._keychain_disabled_until = time.time() + 100  # still within cooldown
+        s._keychain_disabled_until = time.monotonic() + 100  # still within cooldown
+        assert s._use_keychain() is False
+
+    def test_write_keychain_failure_pins_file_mode(self, temp_home: Path, monkeypatch):
+        # An active write whose Keychain attempt fails falls back to the file; the
+        # stale-item delete is best-effort. Even though the failed op scheduled a
+        # re-probe, the write must pin file mode so a later cooldown can't re-probe
+        # onto the residual Keychain item and resurrect the wrong account.
+        s = self._macos_switcher()
+        store = s._store
+        monkeypatch.setattr(macos_keychain, "set_password", _raise_locked)
+        monkeypatch.setattr(macos_keychain, "delete_password", _raise_locked)
+        monkeypatch.setattr(store, "_write_active_credentials_file", lambda creds: None)
+        store._write_oauth_credentials('{"claudeAiOauth": {"accessToken": "x"}}')
+        assert store._last_active_credentials_backend == "file"
+        assert s._keychain_disabled_until == 0.0   # no re-probe scheduled
+        assert s._use_keychain() is False          # pinned, stays file mode
+
+    def test_write_fallback_clears_pending_read_reprobe(self, temp_home: Path, monkeypatch):
+        # The owner's edge: already in file mode from a read timeout with a
+        # re-probe still pending, then a write leaves a stale item behind. The
+        # write must clear that pending re-probe (pin) so it never resurrects.
+        s = self._macos_switcher()
+        store = s._store
+        s._keychain_usable_cache = False
+        s._keychain_disabled_until = time.monotonic() + 100  # pending read re-probe
+        monkeypatch.setattr(macos_keychain, "delete_password", _raise_locked)
+        monkeypatch.setattr(store, "_write_active_credentials_file", lambda creds: None)
+        store._write_oauth_credentials('{"claudeAiOauth": {"accessToken": "x"}}')
+        assert store._last_active_credentials_backend == "file"
+        assert s._keychain_disabled_until == 0.0   # pending re-probe cleared
         assert s._use_keychain() is False
 
     def test_item_exists_is_capability_neutral(

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -3539,6 +3539,31 @@ class TestMacosKeychainFallback:
         s._kc_call(macos_keychain.get_password, "svc", "acct")
         assert s._use_keychain() is False
 
+    def test_kc_call_failure_schedules_a_recheck(self, temp_home: Path, monkeypatch):
+        s = self._macos_switcher()
+        monkeypatch.setattr(macos_keychain, "get_password", _raise_locked)
+        before = time.time()
+        with pytest.raises(KeychainError):
+            s._kc_call(macos_keychain.get_password, "svc", "acct")
+        assert s._keychain_disabled_until > before  # a re-probe is scheduled
+
+    def test_keychain_recovers_after_cooldown(self, temp_home: Path):
+        # A long-running daemon (menu bar / TUI) must re-probe after the cooldown
+        # so a transient `security` timeout doesn't disable the Keychain for the
+        # whole process — the stuck-in-file-mode "no credentials" display bug.
+        s = self._macos_switcher()
+        s._keychain_usable_cache = False
+        s._keychain_disabled_until = time.time() - 1  # cooldown already elapsed
+        assert s._use_keychain() is True             # re-probes
+        assert s._keychain_usable_cache is None       # re-armed for a fresh op
+        assert s._keychain_disabled_until == 0.0
+
+    def test_keychain_stays_file_mode_during_cooldown(self, temp_home: Path):
+        s = self._macos_switcher()
+        s._keychain_usable_cache = False
+        s._keychain_disabled_until = time.time() + 100  # still within cooldown
+        assert s._use_keychain() is False
+
     def test_item_exists_is_capability_neutral(
         self, temp_home: Path, block_real_keychain
     ):

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -3594,6 +3594,21 @@ class TestMacosKeychainFallback:
         assert s._keychain_disabled_until == 0.0   # pending re-probe cleared
         assert s._use_keychain() is False
 
+    def test_managed_key_write_fallback_pins_file_mode(self, temp_home: Path, monkeypatch):
+        # Managed API-key variant of the same guard: a failed Keychain write
+        # falls back to plaintext primaryApiKey, and managed-key reads check the
+        # Keychain first — so the fallback must pin file mode too, or a cooldown
+        # re-probe could read a stale "Claude Code" Keychain item over the key.
+        s = self._macos_switcher()
+        store = s._store
+        monkeypatch.setattr(macos_keychain, "set_password", _raise_locked)
+        monkeypatch.setattr(store, "_update_global_config", lambda mutate: None)
+        monkeypatch.setattr(store, "_clear_oauth_credential", lambda: None)
+        store._write_managed_credentials("sk-ant-api03-" + "x" * 40)
+        assert store._last_active_credentials_backend == "file"
+        assert s._keychain_disabled_until == 0.0   # pinned, no re-probe
+        assert s._use_keychain() is False
+
     def test_item_exists_is_capability_neutral(
         self, temp_home: Path, block_real_keychain
     ):


### PR DESCRIPTION
## Problem
The macOS Keychain capability cache drops to file mode on the first `security` failure and **sticks for the whole process** (so one CLI invocation can't split-brain between backends — correct for a sub-second command). But in a long-running daemon (the menu bar, `cswap watch`), a single transient `security find-generic-password timed out after 5.0s` disables the Keychain **permanently**: the active account's credential becomes unreadable and the dashboard shows "keychain unavailable" / "no credentials" indefinitely — while a fresh `cswap list` in a terminal reads it fine.

Observed running the menu bar: a timeout cluster left the active account stuck showing the error until the app was relaunched.

## Fix
Record a re-probe deadline when a failure drops to file mode (`KEYCHAIN_RECHECK_COOLDOWN_S = 60s`). `_use_keychain()` re-probes once the cooldown elapses:
- A CLI command runs far shorter than the cooldown → it never re-probes mid-invocation, so the no-split-brain guarantee is preserved.
- A daemon self-heals within a minute of the Keychain recovering.
- A directly-forced file mode with no deadline stays sticky (unchanged).

## Tests
- `test_kc_call_failure_schedules_a_recheck`, `test_keychain_recovers_after_cooldown`, `test_keychain_stays_file_mode_during_cooldown`.
- Existing `test_capability_cache_sticky_false` / `_is_process_local` still pass (a forced `False` with no deadline stays sticky). Full suite: 910 passed.

Pairs with #99 (empty-credential backup guard): #99 stops a Keychain timeout from *destroying* credentials on a switch; this stops it from making them *unreadable* for the daemon's lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)