### PR TITLE
feat: add detailed menu bar usage and login startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ cswap --menubar
 
 Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / remove / refresh actions. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
 
+Install it as a per-user LaunchAgent to start automatically at login:
+
+```bash
+cswap --install-menubar
+cswap --menubar-status
+cswap --uninstall-menubar  # stop and remove automatic startup
+```
+
 </details>
 
 ## Advanced

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -707,6 +707,21 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         help="Launch the macOS menu bar app (macOS only)",
     )
     group.add_argument(
+        "--install-menubar",
+        action="store_true",
+        help="Install and start the macOS menu bar at login",
+    )
+    group.add_argument(
+        "--uninstall-menubar",
+        action="store_true",
+        help="Stop and remove the macOS menu bar login agent",
+    )
+    group.add_argument(
+        "--menubar-status",
+        action="store_true",
+        help="Show whether the macOS menu bar login agent is running",
+    )
+    group.add_argument(
         "--upgrade",
         action="store_true",
         help="Upgrade claude-swap to the latest version on PyPI",
@@ -766,6 +781,29 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         except KeyboardInterrupt:
             print(f"\n{dimmed('Upgrade cancelled')}")
             sys.exit(130)
+
+    # LaunchAgent management does not need account/config initialization. Keep
+    # it ahead of switcher construction so status and cleanup still work when
+    # the user's Claude configuration is temporarily unavailable.
+    if args.install_menubar or args.uninstall_menubar or args.menubar_status:
+        try:
+            from claude_swap.menubar_launch_agent import (
+                install,
+                is_installed,
+                uninstall,
+            )
+
+            if args.install_menubar:
+                print(f"Menu bar startup installed: {install()}")
+            elif args.uninstall_menubar:
+                uninstall()
+                print("Menu bar startup removed")
+            else:
+                print("running" if is_installed() else "not running")
+            return
+        except ClaudeSwitchError as e:
+            error(f"Error: {e}")
+            sys.exit(1)
 
     # Initialize switcher and dispatch under a single error handler so
     # init-time failures (e.g. MigrationError on a backup-dir collision)

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from pathlib import Path
 
 from claude_swap.exceptions import ClaudeSwitchError, CredentialReadError
-from claude_swap.switcher import SENTINEL_NOTES
+from claude_swap.switcher import SENTINEL_NOTES, _format_usage_lines
 
 ICON = "⇄"
 REFRESH_CHOICES: tuple[int, ...] = (30, 60, 300)
@@ -167,6 +167,15 @@ def format_account_label(
 ) -> str:
     """Build one account row's menu label."""
     return f"{num}  {email}  {usage_summary(usage, now)}"
+
+
+def account_detail_lines(usage: dict | str | None) -> tuple[str, ...]:
+    """Detailed account rows matching the usage portion of ``cswap --list``."""
+    if isinstance(usage, str):
+        return (usage,)
+    if isinstance(usage, dict):
+        return tuple(_format_usage_lines(usage))
+    return ("usage unavailable",)
 
 
 def _local_part(email: str, limit: int = 12) -> str:
@@ -489,6 +498,12 @@ def run(switcher) -> int:
                 )
                 item.state = 1 if is_active else 0
                 account_items.append(item)
+                details = account_detail_lines(display)
+                for index, detail in enumerate(details):
+                    branch = "└" if index == len(details) - 1 else "├"
+                    account_items.append(
+                        rumps.MenuItem(f"    {branch} {detail}", callback=None)
+                    )
             if not account_items:
                 account_items.append(rumps.MenuItem("No managed accounts", callback=None))
 

--- a/src/claude_swap/menubar_launch_agent.py
+++ b/src/claude_swap/menubar_launch_agent.py
@@ -1,0 +1,85 @@
+"""Install the macOS menu bar as a per-user LaunchAgent."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+from claude_swap.exceptions import ClaudeSwitchError
+
+LABEL = "com.claude-swap.menubar"
+
+
+def plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def _domain() -> str:
+    return f"gui/{os.getuid()}"
+
+
+def _service() -> str:
+    return f"{_domain()}/{LABEL}"
+
+
+def _launchctl(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            ["/bin/launchctl", *args],
+            check=check,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise ClaudeSwitchError(f"launchctl failed: {detail.strip()}") from exc
+
+
+def install() -> Path:
+    """Write and immediately load the per-user LaunchAgent."""
+    if sys.platform != "darwin":
+        raise ClaudeSwitchError("Menu bar startup is only available on macOS.")
+
+    path = plist_path()
+    log_dir = Path.home() / "Library" / "Logs" / "ClaudeSwap"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Do not resolve the virtualenv symlink: its base interpreter cannot see
+    # packages installed in the uv/pipx environment when launchd starts it.
+    python = str(Path(sys.executable).absolute())
+    payload = {
+        "Label": LABEL,
+        "ProgramArguments": [python, "-m", "claude_swap", "--menubar"],
+        "RunAtLoad": True,
+        "ProcessType": "Interactive",
+        "StandardOutPath": str(log_dir / "menubar.log"),
+        "StandardErrorPath": str(log_dir / "menubar-error.log"),
+    }
+    temporary = path.with_suffix(".plist.tmp")
+    temporary.write_bytes(plistlib.dumps(payload, sort_keys=True))
+    os.chmod(temporary, 0o644)
+    os.replace(temporary, path)
+
+    _launchctl("bootout", _service(), check=False)
+    _launchctl("bootstrap", _domain(), str(path))
+    return path
+
+
+def uninstall() -> None:
+    """Stop and remove the LaunchAgent, if present."""
+    if sys.platform != "darwin":
+        raise ClaudeSwitchError("Menu bar startup is only available on macOS.")
+    _launchctl("bootout", _service(), check=False)
+    plist_path().unlink(missing_ok=True)
+
+
+def is_installed() -> bool:
+    """Return whether launchd currently knows the installed service."""
+    if sys.platform != "darwin" or not plist_path().exists():
+        return False
+    return _launchctl("print", _service(), check=False).returncode == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -378,6 +378,32 @@ class TestCLI:
             cli.main()
         assert exc.value.code == 0
         assert called.get("ran") is True
+
+    @pytest.mark.parametrize(
+        ("flag", "target", "output"),
+        [
+            ("--install-menubar", "install", "Menu bar startup installed"),
+            ("--uninstall-menubar", "uninstall", "Menu bar startup removed"),
+            ("--menubar-status", "is_installed", "running"),
+        ],
+    )
+    def test_menubar_launch_agent_dispatches(
+        self, flag, target, output, monkeypatch, capsys
+    ):
+        switcher_cls = MagicMock()
+        monkeypatch.setattr(cli, "ClaudeAccountSwitcher", switcher_cls)
+        monkeypatch.setattr(sys, "argv", ["cswap", flag])
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(cli.os, "geteuid", lambda: 1000, raising=False)
+
+        result = Path("/tmp/com.claude-swap.menubar.plist")
+        if target == "is_installed":
+            result = True
+        with patch(f"claude_swap.menubar_launch_agent.{target}", return_value=result):
+            cli.main()
+
+        assert output in capsys.readouterr().out
+        switcher_cls.assert_not_called()
 
 
 class TestCLICommands:

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -100,6 +100,26 @@ def test_format_account_label():
     assert label == "2  loc@papaya.asia  5h 42% · 7d 18% · $ 30%"
 
 
+def test_account_detail_lines_matches_list_rows():
+    usage = {
+        "five_hour": {"pct": 93.0},
+        "seven_day": {"pct": 49.0},
+        "scoped": [{"name": "Fable", "pct": 100.0}],
+    }
+    lines = menubar.account_detail_lines(usage)
+    assert lines[0].startswith("5h:") and "93%" in lines[0]
+    assert lines[1].startswith("7d:") and "49%" in lines[1]
+    assert lines[2].startswith("Fable:") and "100%" in lines[2]
+    assert lines[2].endswith("(!)")
+
+
+def test_account_detail_lines_handles_sentinel_and_missing_usage():
+    assert menubar.account_detail_lines("API key (no quota)") == (
+        "API key (no quota)",
+    )
+    assert menubar.account_detail_lines(None) == ("usage unavailable",)
+
+
 # --- usage logging -------------------------------------------------------------
 
 def test_format_usage_log_full():

--- a/tests/test_menubar_launch_agent.py
+++ b/tests/test_menubar_launch_agent.py
@@ -1,0 +1,78 @@
+"""Tests for macOS menu bar LaunchAgent management."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from claude_swap import menubar_launch_agent
+
+
+def test_install_writes_virtualenv_python_and_bootstraps(tmp_path):
+    completed = subprocess.CompletedProcess([], 0, "", "")
+    with (
+        patch.object(sys, "platform", "darwin"),
+        patch.object(Path, "home", return_value=tmp_path),
+        patch.object(
+            menubar_launch_agent, "_launchctl", return_value=completed
+        ) as launchctl,
+    ):
+        path = menubar_launch_agent.install()
+
+    payload = plistlib.loads(path.read_bytes())
+    assert payload["Label"] == menubar_launch_agent.LABEL
+    assert payload["ProgramArguments"] == [
+        sys.executable,
+        "-m",
+        "claude_swap",
+        "--menubar",
+    ]
+    assert payload["RunAtLoad"] is True
+    assert launchctl.call_args_list[-1].args[:2] == (
+        "bootstrap",
+        f"gui/{os.getuid()}",
+    )
+
+
+def test_uninstall_is_idempotent(tmp_path):
+    path = (
+        tmp_path
+        / "Library"
+        / "LaunchAgents"
+        / f"{menubar_launch_agent.LABEL}.plist"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text("placeholder", encoding="utf-8")
+    completed = subprocess.CompletedProcess([], 0, "", "")
+    with (
+        patch.object(sys, "platform", "darwin"),
+        patch.object(Path, "home", return_value=tmp_path),
+        patch.object(
+            menubar_launch_agent, "_launchctl", return_value=completed
+        ),
+    ):
+        menubar_launch_agent.uninstall()
+        menubar_launch_agent.uninstall()
+    assert not path.exists()
+
+
+def test_status_requires_plist_and_loaded_service(tmp_path):
+    completed = subprocess.CompletedProcess([], 0, "", "")
+    with (
+        patch.object(sys, "platform", "darwin"),
+        patch.object(Path, "home", return_value=tmp_path),
+        patch.object(
+            menubar_launch_agent, "_launchctl", return_value=completed
+        ) as launchctl,
+    ):
+        assert menubar_launch_agent.is_installed() is False
+        launchctl.assert_not_called()
+
+        path = menubar_launch_agent.plist_path()
+        path.parent.mkdir(parents=True)
+        path.write_text("placeholder", encoding="utf-8")
+        assert menubar_launch_agent.is_installed() is True

--- a/uv.lock
+++ b/uv.lock
@@ -49,6 +49,11 @@ dependencies = [
     { name = "truststore" },
 ]
 
+[package.optional-dependencies]
+menubar = [
+    { name = "rumps" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -58,9 +63,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "keyring", specifier = ">=25.0.0" },
+    { name = "rumps", marker = "extra == 'menubar'", specifier = ">=0.4.0" },
     { name = "textual", specifier = ">=8.2.8,<9" },
     { name = "truststore", specifier = ">=0.10.4" },
 ]
+provides-extras = ["menubar"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -294,6 +301,39 @@ wheels = [
 ]
 
 [[package]]
+name = "pyobjc-core"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b1/729f7458a63758bd21716648a8abcd9a0c8f2d2e9897763c8a1a1c7fd31b/pyobjc_core-12.2.1.tar.gz", hash = "sha256:7a7b9b018402342cf32bf1956366896350fbe5c0478cb3ef59778f77abed7f07", size = 1063383, upload-time = "2026-06-19T16:19:39.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/88/300ad283bed0c971c52dcac6f70113e138169d4ce6d856ddd03d16081e51/pyobjc_core-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a64232bb27ed101d4adc7d42b0e64a6d3331aac7bee7861c037a6777a163f10b", size = 6433347, upload-time = "2026-06-19T16:04:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/b9b0ddffae66996b8779f1f7958adc9f21c13a0448cd3be8d7fe589b5b0f/pyobjc_core-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:af101222762665a4125157906cb4b23f5d5a63d3851d5e0504f72a1eaaa2cfd2", size = 6436004, upload-time = "2026-06-19T16:04:53.257Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/bd309ede07784c6e5fac4b440c90a5f72a66da7859ed303a9392fe8a5f3f/pyobjc_core-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:efe465e3ecc6fc73f7c7622620345d134a8d34564ab1c29d8247e45f4ed55071", size = 6687044, upload-time = "2026-06-19T16:04:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8a/cfa4f56939d554dbb342ec6e5226a441e2f552bc2002a0ddf7705bb11bef/pyobjc_core-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2b8fc0531c27277325e113ac00b8a72a82e6145f0a88175b9425d8de814ff69a", size = 6429289, upload-time = "2026-06-19T16:05:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/42/74/446c89bc18103aaa4a00d1fb85ff8acace9a0dc3f362d9678ebf7571e275/pyobjc_core-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9bef500f979e22d54f9da3aaebf6a48f873234b324858bd69256055a318955c7", size = 6690181, upload-time = "2026-06-19T16:05:06.201Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c7/0121ee4c616af07ad2de8cd1a286f6978dc9a227eb58b7c2e875cb68a1df/pyobjc_core-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:047c226eeb58a2993ace5e8904e71cc9426ee20d064c617f8fbf32717d37093e", size = 6487078, upload-time = "2026-06-19T16:05:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a8/cb9fcc150f97d0bf22a2028f88b24cc35949beb1bcc7b8bc5c17d4401677/pyobjc_core-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1188613805336270279570467e4455b74cb6c0f60913ac74c917ee1c37cfaecb", size = 6733064, upload-time = "2026-06-19T16:05:14.313Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/cf/1b3b32b2f28f66cc053c3438ef4e6df36a1591945bf05e7399da18d74553/pyobjc_framework_cocoa-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:28b9b8bab1c36efb94744786918752d0c1842f5fbb67e7d5ca97b5f736512080", size = 388113, upload-time = "2026-06-19T16:07:38.9Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/46/68e8e4d926a2f70fed0437047bc3f9fe08af8fe620d94d80656ebc3cfa9b/pyobjc_framework_cocoa-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b74a78fa7803e547b32e5e8ec1b49987b52fe318383e793bc6cd49b80efbd9f", size = 388183, upload-time = "2026-06-19T16:07:40.483Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f3/dfc9af4c9eb2e5389c860ad5ef252be9fe456db09f39d537555dc5057aa1/pyobjc_framework_cocoa-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc2eaca2f13c7bcd8e41e51a372e47825dea9dd3126108760eed7ba883d2945c", size = 392275, upload-time = "2026-06-19T16:07:42.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c8/b90baa8f3592eded79b4be98fb59d2b8dc16b62361e34292bd95806ebd9f/pyobjc_framework_cocoa-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b386c324d64ae565c1f6b7dfb77be68f640a1c7c23caa6966ab661131f519561", size = 388357, upload-time = "2026-06-19T16:07:43.364Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/64a94651b9294702d55e748d94de30e25bc59d0784526be7643f4467eccd/pyobjc_framework_cocoa-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a6c584e2af0813cb2f6103b184e632665a26f58c1bd5b08ffd6e95a19c617f7b", size = 392404, upload-time = "2026-06-19T16:07:44.955Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/cc/26e8a7bf1f5e8caa38b7f80d486296f9fd3c97e71ad7e5444ef22e802758/pyobjc_framework_cocoa-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b6023657b8d6cc049a21bd6b4752425f2f53c42f9f0b02d64c7608cc484bf103", size = 388589, upload-time = "2026-06-19T16:07:46.276Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/eedf743a303ea742b8e082afe3613fb4d6618bc1a48cf2568b004ce906f7/pyobjc_framework_cocoa-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c685ccd8e266a07cf912a2c5a13b1f2eff2a868a1aff163b4801b4687bd425e1", size = 392691, upload-time = "2026-06-19T16:07:47.477Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -343,6 +383,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
+
+[[package]]
+name = "rumps"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e2/2e6a47951290bd1a2831dcc50aec4b25d104c0cf00e8b7868cbd29cf3bfe/rumps-0.4.0.tar.gz", hash = "sha256:17fb33c21b54b1e25db0d71d1d793dc19dc3c0b7d8c79dc6d833d0cffc8b1596", size = 39257, upload-time = "2022-10-15T05:15:10.386Z" }
 
 [[package]]
 name = "secretstorage"


### PR DESCRIPTION
## Summary

- expand each menu bar account with the same detailed 5h, 7d, spend, and scoped-model rows shown by cswap --list
- add macOS LaunchAgent install, status, and uninstall commands for automatic startup at login
- preserve the virtualenv interpreter path so uv and pipx installations remain importable under launchd
- update the uv lockfile for the recently added menubar extra

## Commands

- cswap --install-menubar
- cswap --menubar-status
- cswap --uninstall-menubar

## Validation

- uv run pytest -q
- 954 passed, 3 skipped
- manually validated the LaunchAgent on macOS and confirmed the service remains running from the project virtualenv

## Context

This is a focused follow-up to #65. It builds on the menu bar implementation now in main instead of introducing a second GUI path.