### PR TITLE
Recover the display faster from edge-429s, then throttle a saturated account (#103)

### DIFF
--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -58,14 +58,21 @@ BACKOFF_CAP_S = 600.0
 # Retry-After value:
 # - "Retry-After: 0" = the sustained/edge rule: the account's overall Claude
 #   Code activity has its budget at the edge; retries are penalty-free and
-#   ~every other one succeeds. Long exponential backoff only costs freshness
-#   during exactly the heavy-burn periods where it matters most, so edge
-#   backoff is capped low.
+#   ~every other one succeeds. So the first few retries stay very short
+#   (EDGE_BACKOFF_FAST_S) to keep the display fresh during exactly the
+#   heavy-burn periods where it matters most; only after EDGE_FAST_RETRIES
+#   consecutive misses — the account is genuinely saturated, not just busy —
+#   does the wait ramp up (toward EDGE_BACKOFF_CAP_S) so we stop hammering a
+#   limit that clearly isn't clearing. This ramp also throttles the active
+#   account, which is polled every pass and would otherwise poll straight into
+#   the wall.
 # - "Retry-After: N>0" = the burst rule (~5 rapid requests on one account →
 #   hard 300s block; measured: accurate, counts down, not extended by
 #   probing). Honored as the wait, up to a safety cap so a pathological
 #   header can never park an account for hours.
-EDGE_BACKOFF_CAP_S = 120.0
+EDGE_BACKOFF_FAST_S = 15.0   # the short retry cadence for the first edge misses
+EDGE_FAST_RETRIES = 3        # this many fast retries before the wait ramps up
+EDGE_BACKOFF_CAP_S = 90.0    # ceiling once a saturated account keeps refusing
 RETRY_AFTER_FLOOR_CAP_S = 900.0
 
 # (email, organizationUuid) — the identity a slot number currently maps to.
@@ -191,8 +198,14 @@ def _failure_backoff_s(consecutive_failures: int, retry_after_s: float | None) -
     if retry_after_s is None:
         return computed
     if retry_after_s == 0:
-        # Edge rule: retrying is penalty-free, so keep the cadence tight.
-        return min(computed, EDGE_BACKOFF_CAP_S)
+        # Edge rule: retries are penalty-free and ~half succeed. Keep the first
+        # few very short so the display recovers in seconds, then ramp up once
+        # the account is clearly saturated so we neither hammer a stuck limit
+        # nor let the active account poll into the wall every pass.
+        if consecutive_failures <= EDGE_FAST_RETRIES:
+            return EDGE_BACKOFF_FAST_S
+        steps = consecutive_failures - EDGE_FAST_RETRIES + 1
+        return min(EDGE_BACKOFF_FAST_S * steps, EDGE_BACKOFF_CAP_S)
     # Burst rule: wait at least what the server asked (up to the safety cap);
     # our own curve may wait longer.
     return max(min(retry_after_s, RETRY_AFTER_FLOOR_CAP_S), computed)

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -193,11 +193,13 @@ class TestBackoff:
         assert usage_store._failure_backoff_s(5, 10.0) == pytest.approx(480.0)
         assert BACKOFF_BASE_S * 2**4 == 480.0
 
-    def test_edge_429_backoff_capped(self, store, clock):
+    def test_edge_429_backoff_fast_then_ramps(self, store, clock):
         # "Retry-After: 0" is the sustained/edge rule: retries are penalty-free
-        # and ~every other one succeeds, so backoff must stay tight instead of
-        # doubling to BACKOFF_CAP_S — freshness matters most during heavy burn.
-        expected = [30.0, 60.0, 120.0, 120.0, 120.0]
+        # and ~every other one succeeds. The first EDGE_FAST_RETRIES misses stay
+        # at EDGE_BACKOFF_FAST_S (fast recovery of the display, incl. the active
+        # account), then the wait ramps up toward EDGE_BACKOFF_CAP_S so a
+        # genuinely saturated account isn't hammered every 15s forever.
+        expected = [15.0, 15.0, 15.0, 30.0, 45.0, 60.0, 75.0, 90.0, 90.0]
         for i, want in enumerate(expected):
             store.record(
                 {"1": FetchRecord(error="http-429", retry_after_s=0.0)}, IDENT
@@ -206,6 +208,13 @@ class TestBackoff:
             assert entry.consecutive_failures == i + 1
             assert entry.backoff_until == pytest.approx(clock.now + want)
             clock.advance(want + 1)
+
+    def test_edge_backoff_first_miss_is_fast(self):
+        # The property that fixes the ~10-min active-account freeze: one edge
+        # miss recovers in seconds, not a minute-plus.
+        assert usage_store._failure_backoff_s(
+            1, 0.0
+        ) == usage_store.EDGE_BACKOFF_FAST_S
 
     def test_retry_after_floor_is_capped(self):
         # A pathological Retry-After can never park an account for hours.


### PR DESCRIPTION
Fixes #103.

Edge 429s (`Retry-After: 0`) are penalty-free and ~half succeed, so the exponential-to-120s curve was the wrong shape: it froze the active account's bars for minutes exactly during heavy burn. This keeps the first `EDGE_FAST_RETRIES` (3) misses at `EDGE_BACKOFF_FAST_S` (15s) — the display recovers in seconds — then ramps toward a lowered `EDGE_BACKOFF_CAP_S` (90s), which both stops hammering a genuinely stuck limit and throttles the active account so it isn't polling into the wall every pass.

```
consecutive edge miss:   1    2    3    4    5    6    7    8
before (s):             30   60  120  120  120  120  120  120
after  (s):             15   15   15   30   45   60   75   90
```

Only the `retry-after:0` branch of `_failure_backoff_s` changes. The exponential curve for generic errors, the burst rule (`retry-after > 0`, honored as the floor), and the retry-after safety cap are all untouched.

Tests: the edge-backoff test now asserts the fast-then-ramp sequence, plus a guard that a single edge miss recovers at 15s. Full suite green.