### PR TITLE
Quarantine dead-refresh-token accounts and surface 're-login needed' (#105)

### DIFF
--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -27,6 +27,11 @@ USAGE_API_KEY = "api key"
 # with no plaintext fallback — distinct from a genuinely empty slot, so the user
 # isn't misled into an unnecessary re-login.
 USAGE_KEYCHAIN_UNAVAILABLE = "keychain unavailable"
+# The stored refresh-token lineage is dead (repeated ``invalid_grant``). The
+# account is quarantined from fetching until a re-login (``cswap login`` / ``add``)
+# replaces the credential; distinct from "token expired" (which Claude Code can
+# refresh on its own) because only the user can fix it.
+USAGE_RELOGIN_REQUIRED = "re-login needed"
 
 
 def _window_to_json(entry: dict) -> dict:
@@ -99,6 +104,8 @@ def usage_fields(entry: dict | str | None) -> tuple[str, dict | None]:
         return "api_key", None
     if entry == USAGE_KEYCHAIN_UNAVAILABLE:
         return "keychain_unavailable", None
+    if entry == USAGE_RELOGIN_REQUIRED:
+        return "relogin_required", None
     if isinstance(entry, str):
         return "no_credentials", None
     return "unavailable", None

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -408,12 +408,20 @@ def try_fetch_usage_for_account(
         and oauth.get("refreshToken")
         and is_oauth_token_expired(oauth.get("expiresAt"))
     ):
-        refreshed = refresh_oauth_credentials(working_credentials)
-        if refreshed:
-            working_credentials = refreshed
+        refresh = try_refresh_oauth_credentials(working_credentials)
+        if refresh.credentials:
+            working_credentials = refresh.credentials
             _persist(persist_credentials, account_num, email, working_credentials)
             oauth = extract_oauth_data(working_credentials) or oauth
             access_token = oauth.get("accessToken") or access_token
+        elif refresh.error == "invalid_grant":
+            # The refresh-token lineage is server-rejected — permanently dead.
+            # Don't hit the usage endpoint with a token we know is expired
+            # (that just adds a 401/429 to a lost cause): report the permanent
+            # failure distinctly so the store can quarantine the account.
+            return UsageOutcome(None, error="invalid_grant")
+        # A transient refresh failure falls through to try the (expired) token;
+        # the 401 path below retries the refresh.
 
     try:
         data = request_usage_data(access_token)
@@ -429,13 +437,18 @@ def try_fetch_usage_for_account(
             _log_usage_failure(context, e, kind, retry_after)
             return UsageOutcome(None, error=kind, retry_after_s=retry_after)
 
-        # Retry once after refreshing on 401 (inactive accounts only).
-        refreshed = refresh_oauth_credentials(working_credentials)
-        if not refreshed:
+        # Retry once after refreshing on 401 (inactive accounts only). A
+        # server-rejected grant (invalid_grant) means this refresh-token lineage
+        # is permanently dead — surface it distinctly (not the generic
+        # "refresh-failed") so the store can quarantine instead of retrying a
+        # dead token forever.
+        refresh = try_refresh_oauth_credentials(working_credentials)
+        if not refresh.credentials:
             _log_usage_failure(context, e, kind)
-            return UsageOutcome(None, error="refresh-failed")
+            dead = refresh.error == "invalid_grant"
+            return UsageOutcome(None, error="invalid_grant" if dead else "refresh-failed")
 
-        working_credentials = refreshed
+        working_credentials = refresh.credentials
         _persist(persist_credentials, account_num, email, working_credentials)
         refreshed_oauth = extract_oauth_data(working_credentials)
         new_token = refreshed_oauth.get("accessToken") if refreshed_oauth else None

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -29,6 +29,7 @@ from claude_swap.json_output import (
     USAGE_API_KEY,
     USAGE_KEYCHAIN_UNAVAILABLE,
     USAGE_NO_CREDENTIALS,
+    USAGE_RELOGIN_REQUIRED,
     USAGE_TOKEN_EXPIRED,
     account_ref,
     account_row,
@@ -144,6 +145,7 @@ SENTINEL_NOTES = {
     USAGE_TOKEN_EXPIRED: "token expired — Claude Code refreshes the active account",
     USAGE_API_KEY: "API key (no quota)",
     USAGE_KEYCHAIN_UNAVAILABLE: "keychain unavailable — locked or in use; try again",
+    USAGE_RELOGIN_REQUIRED: "re-login needed — refresh token dead; run: cswap login",
 }
 
 
@@ -1030,6 +1032,9 @@ class ClaudeAccountSwitcher:
 
             self._write_account_credentials(account_num, current_email, current_creds)
             self._write_account_config(account_num, current_email, current_config)
+            self._usage_store.clear_dead_token(
+                [account_num], {account_num: (current_email, current_org_uuid)}
+            )
 
             seq["activeAccountNumber"] = int(account_num)
             seq["lastUpdated"] = get_timestamp()
@@ -1137,6 +1142,9 @@ class ClaudeAccountSwitcher:
         # Store backups
         self._write_account_credentials(account_num, current_email, current_creds)
         self._write_account_config(account_num, current_email, current_config)
+        self._usage_store.clear_dead_token(
+            [account_num], {account_num: (current_email, organization_uuid)}
+        )
 
         # Update sequence.json
         data = self._get_sequence_data()
@@ -1743,6 +1751,12 @@ class ClaudeAccountSwitcher:
                 sentinels[num] = static
 
         entries = store.entries(identities)
+        # Dead refresh-token lineage: quarantine. Surfacing the sentinel here both
+        # drives the "re-login needed" display and (via ``num not in sentinels``
+        # below) stops the endless fetch loop that would otherwise 401/429 forever.
+        for num in info_by_num:
+            if num not in sentinels and entries[num].token_dead():
+                sentinels[num] = USAGE_RELOGIN_REQUIRED
         to_fetch = [
             num
             for num in info_by_num

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -145,7 +145,7 @@ SENTINEL_NOTES = {
     USAGE_TOKEN_EXPIRED: "token expired — Claude Code refreshes the active account",
     USAGE_API_KEY: "API key (no quota)",
     USAGE_KEYCHAIN_UNAVAILABLE: "keychain unavailable — locked or in use; try again",
-    USAGE_RELOGIN_REQUIRED: "re-login needed — refresh token dead; run: cswap login",
+    USAGE_RELOGIN_REQUIRED: "re-login needed — refresh token dead; log in with Claude Code, then run: cswap add",
 }
 
 
@@ -1257,6 +1257,13 @@ class ClaudeAccountSwitcher:
                 )
             self._write_account_credentials(account_num, email, credentials)
             self._write_account_config(account_num, email, config)
+            # A refreshed credential invalidates any dead-token quarantine on this
+            # slot (mirrors ``add_account``); otherwise the stale strike row keeps
+            # the account stuck at "re-login needed" and it never fetches the new
+            # token. Token accounts are always personal, so org is "".
+            self._usage_store.clear_dead_token(
+                [account_num], {account_num: (email, "")}
+            )
             seq["lastUpdated"] = get_timestamp()
             self._write_json(self.sequence_file, seq)
             kind_label = "API key" if is_api_key else "token"
@@ -1330,6 +1337,11 @@ class ClaudeAccountSwitcher:
 
         self._write_account_credentials(account_num, email, credentials)
         self._write_account_config(account_num, email, config)
+        # Reusing/overwriting a slot with a fresh credential lifts any dead-token
+        # quarantine carried by that slot's prior lineage (mirrors ``add_account``).
+        self._usage_store.clear_dead_token(
+            [account_num], {account_num: (email, "")}
+        )
 
         data = self._get_sequence_data()
         record = {
@@ -1777,6 +1789,13 @@ class ClaudeAccountSwitcher:
                 if record.sentinel is not None:
                     sentinels[num] = record.sentinel
             entries = store.entries(identities)
+            # A fetch that just returned invalid_grant advances the strike to the
+            # dead threshold. The pre-fetch quarantine scan above couldn't see it,
+            # so surface "re-login needed" in *this* pass instead of leaving the
+            # slot looking merely refresh-failed until the next refresh notices.
+            for num in to_fetch:
+                if entries[num].token_dead():
+                    sentinels[num] = USAGE_RELOGIN_REQUIRED
 
         return {
             num: with_sentinel(entries[num], sentinels.get(num))

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -68,6 +68,25 @@ BACKOFF_CAP_S = 600.0
 EDGE_BACKOFF_CAP_S = 120.0
 RETRY_AFTER_FLOOR_CAP_S = 900.0
 
+# A dead refresh-token lineage (the token endpoint answered ``invalid_grant``,
+# e.g. "Refresh token not found or invalid") can never recover on its own —
+# only a re-login helps. One such answer is already definitive: the server
+# explicitly rejected the grant, which no transient 429/timeout/network blip
+# does, so there is nothing to gain by retrying (and each retry with a dead
+# token just draws a fresh 401/429). At this many strikes the account is
+# quarantined: no more fetches, and the collector surfaces "re-login needed".
+# A single success — or a credential refresh via login/add — resets the count
+# and lifts the quarantine. Raise to 2 if a buffer against a one-off
+# misclassification is ever wanted; the trade-off is a ~10-min-slower verdict
+# (the failure backoff between the two strikes).
+AUTH_DEAD_STRIKES = 1
+
+# Fetch errors that prove the stored credential is permanently unusable (vs.
+# transient 429/timeout/network). Only these advance the dead-token strike
+# count; everything else leaves it untouched (a transient error is no evidence
+# the token is alive *or* dead).
+PERMANENT_AUTH_ERRORS = frozenset({"invalid_grant"})
+
 # (email, organizationUuid) — the identity a slot number currently maps to.
 Identity = tuple[str, str]
 
@@ -110,6 +129,9 @@ class UsageEntry:
     backoff_until: float | None = None
     next_poll_at: float | None = None
     poll_interval_s: float | None = None
+    # Consecutive permanent-auth failures (``invalid_grant``). At or above
+    # AUTH_DEAD_STRIKES the token is treated as dead: see ``token_dead``.
+    auth_dead_strikes: int = 0
     # Staleness past STALE_OK_S is still decision-trusted when it is
     # *deliberate*: the server is refusing fresher data (failure state), or the
     # scheduler itself chose the cadence (within nextPollAt). Capped at
@@ -128,6 +150,15 @@ class UsageEntry:
             self.last_attempt_at is not None
             and (now - self.last_attempt_at) < CLAIM_TTL_S
         )
+
+    def token_dead(self, threshold: int = AUTH_DEAD_STRIKES) -> bool:
+        """Whether the stored credential's refresh-token lineage is provably dead.
+
+        True once ``invalid_grant`` has recurred ``threshold`` times without an
+        intervening success. Such an account is quarantined: not fetched (see
+        ``due_candidate`` and the collector) and surfaced as "re-login needed".
+        """
+        return self.auth_dead_strikes >= threshold
 
     def decision_value(self) -> dict | str | None:
         """The ``dict | sentinel | None`` value switch decisions run on.
@@ -170,6 +201,8 @@ def due_candidate(
             continue
         if entry.sentinel is not None:
             continue
+        if entry.token_dead():
+            continue  # dead refresh-token: quarantined, needs a re-login
         if entry.in_backoff(now):
             continue
         if entry.next_poll_at is not None and now < entry.next_poll_at:
@@ -286,6 +319,7 @@ class UsageStore:
                 backoff_until=_num_or_none(row.get("backoffUntil")),
                 next_poll_at=next_poll_at,
                 poll_interval_s=_num_or_none(row.get("pollIntervalS")),
+                auth_dead_strikes=int(row.get("authDeadStrikes") or 0),
                 trust_extended=trust_extended,
             )
         return out
@@ -338,6 +372,7 @@ class UsageStore:
                 row["consecutiveFailures"] = 0
                 row["lastError"] = None
                 row["backoffUntil"] = None
+                row["authDeadStrikes"] = 0  # a success proves the token is alive
             else:
                 failures = int(row.get("consecutiveFailures") or 0) + 1
                 row["consecutiveFailures"] = failures
@@ -345,6 +380,11 @@ class UsageStore:
                 row["backoffUntil"] = now + _failure_backoff_s(
                     failures, rec.retry_after_s
                 )
+                # Only a permanent-auth failure advances the dead-token count; a
+                # transient error (429/timeout) leaves it as-is — it is no
+                # evidence either way and must not reset a real dead-token tally.
+                if rec.error in PERMANENT_AUTH_ERRORS:
+                    row["authDeadStrikes"] = int(row.get("authDeadStrikes") or 0) + 1
 
         self._mutate(identities, effective.keys(), apply)
 
@@ -363,6 +403,28 @@ class UsageStore:
             row["pollIntervalS"] = interval
 
         self._mutate(identities, plans.keys(), apply)
+
+    def clear_dead_token(
+        self, nums: Iterable[str], identities: dict[str, Identity]
+    ) -> None:
+        """Lift the dead-token quarantine for slots whose credential was refreshed.
+
+        Called after a re-login/add rewrites a slot's stored credential: the
+        strike count (and the failure/backoff state riding with it) no longer
+        reflects reality, and the account must become fetch-eligible again so the
+        next pass can prove the new token good. A no-op for rows with no strikes.
+        """
+        nums = list(nums)
+        if not nums:
+            return
+
+        def apply(_num: str, row: dict) -> None:
+            row["authDeadStrikes"] = 0
+            row["consecutiveFailures"] = 0
+            row["lastError"] = None
+            row["backoffUntil"] = None
+
+        self._mutate(identities, nums, apply)
 
 
 def _num_or_none(value: object) -> float | None:

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -101,6 +101,7 @@ class TestJsonHelpers:
         from claude_swap.json_output import (
             USAGE_KEYCHAIN_UNAVAILABLE,
             USAGE_NO_CREDENTIALS,
+            USAGE_RELOGIN_REQUIRED,
             USAGE_TOKEN_EXPIRED,
         )
 
@@ -110,6 +111,7 @@ class TestJsonHelpers:
         assert usage_fields("no credentials") == ("no_credentials", None)
         assert usage_fields(USAGE_TOKEN_EXPIRED) == ("token_expired", None)
         assert usage_fields(USAGE_KEYCHAIN_UNAVAILABLE) == ("keychain_unavailable", None)
+        assert usage_fields(USAGE_RELOGIN_REQUIRED) == ("relogin_required", None)
         assert usage_fields(None) == ("unavailable", None)
 
     def test_error_envelope_shape(self):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -951,3 +951,69 @@ class TestTryFetchUsageOutcome:
             "1", "a@b.c", json.dumps({"claudeAiOauth": {}}), is_active=False,
         )
         assert outcome.error == "no-access-token"
+
+
+class TestInvalidGrantPropagation:
+    """A dead refresh-token lineage surfaces as error='invalid_grant', distinct
+    from a transient 'refresh-failed', so the store can quarantine the account."""
+
+    @staticmethod
+    def _expired_credentials() -> str:
+        from datetime import timedelta
+        past_ms = int(
+            (datetime.now(timezone.utc) - timedelta(hours=1)).timestamp() * 1000
+        )
+        return json.dumps({"claudeAiOauth": {
+            "accessToken": "old-access", "refreshToken": "dead-refresh",
+            "expiresAt": past_ms,
+        }})
+
+    @staticmethod
+    def _valid_credentials() -> str:
+        from datetime import timedelta
+        future_ms = int(
+            (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp() * 1000
+        )
+        return json.dumps({"claudeAiOauth": {
+            "accessToken": "good-access", "refreshToken": "dead-refresh",
+            "expiresAt": future_ms,
+        }})
+
+    def test_proactive_refresh_invalid_grant_short_circuits(self):
+        """Expired token + dead refresh: report invalid_grant without hitting usage."""
+        with patch("claude_swap.oauth.try_refresh_oauth_credentials",
+                   return_value=oauth.RefreshOutcome(None, "invalid_grant")), \
+             patch("claude_swap.oauth.request_usage_data") as usage:
+            outcome = oauth.try_fetch_usage_for_account(
+                "1", "a@b.c", self._expired_credentials(), is_active=False,
+            )
+        assert outcome.error == "invalid_grant"
+        usage.assert_not_called()  # no pointless 401/429 on a lost cause
+
+    def test_401_retry_invalid_grant_is_permanent(self):
+        """Valid-looking token, server 401, dead refresh → invalid_grant."""
+        err = urllib.error.HTTPError(
+            "https://api.anthropic.com/api/oauth/usage", 401, "Unauthorized",
+            hdrs=None, fp=None,
+        )
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err), \
+             patch("claude_swap.oauth.try_refresh_oauth_credentials",
+                   return_value=oauth.RefreshOutcome(None, "invalid_grant")):
+            outcome = oauth.try_fetch_usage_for_account(
+                "1", "a@b.c", self._valid_credentials(), is_active=False,
+            )
+        assert outcome.error == "invalid_grant"
+
+    def test_transient_refresh_failure_is_not_permanent(self):
+        """A transient refresh failure stays 'refresh-failed', not invalid_grant."""
+        err = urllib.error.HTTPError(
+            "https://api.anthropic.com/api/oauth/usage", 401, "Unauthorized",
+            hdrs=None, fp=None,
+        )
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err), \
+             patch("claude_swap.oauth.try_refresh_oauth_credentials",
+                   return_value=oauth.RefreshOutcome(None, "transient")):
+            outcome = oauth.try_fetch_usage_for_account(
+                "1", "a@b.c", self._valid_credentials(), is_active=False,
+            )
+        assert outcome.error == "refresh-failed"

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -1319,8 +1319,11 @@ class TestPerformSwitchPostDisplay:
 
         try:
             with patch(
-                "claude_swap.oauth.refresh_oauth_credentials",
-                return_value=rotated_creds,
+                # Patch the classifying base (refresh_oauth_credentials delegates
+                # to it), so both the proactive and 401-retry paths see the
+                # rotation regardless of which wrapper they call.
+                "claude_swap.oauth.try_refresh_oauth_credentials",
+                return_value=oauth.RefreshOutcome(rotated_creds, None),
             ), patch(
                 "claude_swap.oauth.request_usage_data",
                 return_value={
@@ -2001,6 +2004,54 @@ class TestGetCurrentAccountOrgSupport:
 
 
 # ── Task 5: add_account with org fields ──────────────────────────────────────
+
+class TestDeadTokenQuarantine:
+    """A dead refresh-token account is surfaced as re-login-needed and not fetched."""
+
+    def _dead_creds(self):
+        return json.dumps({"claudeAiOauth": {
+            "accessToken": "at", "refreshToken": "rt", "expiresAt": 1,
+        }})
+
+    def _make_dead(self, switcher, num="2", identity=("test@example.com", "")):
+        store = switcher._usage_store
+        from claude_swap.usage_store import FetchRecord
+        store.record({num: FetchRecord(error="invalid_grant")}, {num: identity})
+
+    def test_collector_surfaces_relogin_sentinel_and_skips_fetch(self, temp_home):
+        from claude_swap.json_output import USAGE_RELOGIN_REQUIRED
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        self._make_dead(switcher)
+        info = [(2, "test@example.com", "Org", "", False, self._dead_creds())]
+
+        with patch("claude_swap.oauth.try_fetch_usage_for_account") as fetch:
+            entries = switcher._collect_usage_entries(info)
+
+        assert entries["2"].sentinel == USAGE_RELOGIN_REQUIRED
+        fetch.assert_not_called()  # quarantined: no endless 401/429 loop
+
+    def test_readd_clears_quarantine(self, temp_home):
+        # Re-adding an account (fresh credential) must lift the quarantine, so
+        # the disabled fetches don't leave it stuck at "re-login needed" forever.
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        identity = ("user@example.com", "org-A")
+        self._make_dead(switcher, num="1", identity=identity)
+        assert switcher._usage_store.entries({"1": identity})["1"].token_dead()
+
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+        config_path = temp_home / ".claude.json"
+        config_path.write_text(json.dumps({"oauthAccount": {
+            "emailAddress": "user@example.com", "accountUuid": "u",
+            "organizationUuid": "org-A", "organizationName": "Acme",
+        }}))
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"):
+            switcher.add_account()
+
+        assert not switcher._usage_store.entries({"1": identity})["1"].token_dead()
+
 
 class TestAddAccountOrgFields:
     def test_allows_same_email_different_org(self, temp_home):

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2031,6 +2031,25 @@ class TestDeadTokenQuarantine:
         assert entries["2"].sentinel == USAGE_RELOGIN_REQUIRED
         fetch.assert_not_called()  # quarantined: no endless 401/429 loop
 
+    def test_relogin_surfaces_same_pass_on_invalid_grant(self, temp_home):
+        # A fetch that returns invalid_grant crosses the dead threshold this pass;
+        # the pre-fetch quarantine scan couldn't see it, so the collector must
+        # still render "re-login needed" now, not only on the next refresh.
+        from claude_swap.json_output import USAGE_RELOGIN_REQUIRED
+        from claude_swap.usage_store import FetchRecord
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        info = [(2, "test@example.com", "Org", "", False, self._dead_creds())]
+
+        with patch.object(
+            switcher, "_run_usage_fetches",
+            return_value={"2": FetchRecord(error="invalid_grant")},
+        ) as run:
+            entries = switcher._collect_usage_entries(info)
+
+        run.assert_called_once()  # it was fetch-eligible, not pre-quarantined
+        assert entries["2"].sentinel == USAGE_RELOGIN_REQUIRED
+
     def test_readd_clears_quarantine(self, temp_home):
         # Re-adding an account (fresh credential) must lift the quarantine, so
         # the disabled fetches don't leave it stuck at "re-login needed" forever.
@@ -2831,6 +2850,45 @@ class TestAddAccountFromToken:
         oauth_blob = json.loads(stored_creds)["claudeAiOauth"]
         assert oauth_blob["accessToken"] == "token-v2"
         assert oauth_blob["scopes"] == list(SETUP_TOKEN_SCOPES)
+
+    def test_update_in_place_clears_quarantine(self, temp_home):
+        """Refreshing a token in place must lift the dead-token quarantine, so a
+        stale strike doesn't leave the account stuck at 're-login needed' and
+        never fetching the new token (mirrors add_account)."""
+        from claude_swap.usage_store import FetchRecord
+        switcher = self._make_switcher(temp_home)
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("token-v1", "user@example.com")
+
+        identity = ("user@example.com", "")
+        switcher._usage_store.record(
+            {"1": FetchRecord(error="invalid_grant")}, {"1": identity}
+        )
+        assert switcher._usage_store.entries({"1": identity})["1"].token_dead()
+
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("token-v2", "user@example.com")
+
+        assert not switcher._usage_store.entries({"1": identity})["1"].token_dead()
+
+    def test_new_write_clears_stale_quarantine(self, temp_home):
+        """Writing a fresh credential into a slot whose lingering usage row still
+        carries a dead-token strike (same identity) must start it clean."""
+        from claude_swap.usage_store import FetchRecord
+        switcher = self._make_switcher(temp_home)
+        identity = ("user@example.com", "")
+        switcher._usage_store.record(
+            {"5": FetchRecord(error="invalid_grant")}, {"5": identity}
+        )
+        assert switcher._usage_store.entries({"5": identity})["5"].token_dead()
+
+        with patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_write_account_config"):
+            switcher.add_account_from_token("tok", "user@example.com", slot=5)
+
+        assert not switcher._usage_store.entries({"5": identity})["5"].token_dead()
 
     def test_update_in_place_rejects_inconsistent_metadata(self, temp_home):
         """Never write account-None-* credentials if sequence lookup is corrupt."""

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -350,3 +350,56 @@ class TestDueCandidate:
 
     def test_none_when_no_candidates(self):
         assert due_candidate([], {}, self.NOW) is None
+
+
+class TestDeadTokenQuarantine:
+    """invalid_grant strikes → token_dead → quarantined from fetching."""
+
+    def test_invalid_grant_advances_strikes(self, store):
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        assert store.entries(IDENT)["1"].auth_dead_strikes == 1
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        assert store.entries(IDENT)["1"].auth_dead_strikes == 2
+
+    def test_transient_error_does_not_advance_or_reset(self, store):
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        store.record({"1": FetchRecord(error="http-429")}, IDENT)  # transient
+        # 429 must neither bump nor clear the dead-token tally.
+        assert store.entries(IDENT)["1"].auth_dead_strikes == 1
+
+    def test_success_resets_strikes(self, store):
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        assert store.entries(IDENT)["1"].auth_dead_strikes == 0
+
+    def test_token_dead_at_threshold(self, store):
+        assert not store.entries(IDENT)["1"].token_dead()  # no strikes yet
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        # A single server-confirmed invalid_grant is definitive.
+        assert store.entries(IDENT)["1"].token_dead()
+
+    def test_transient_error_alone_never_marks_dead(self, store):
+        for _ in range(5):
+            store.record({"1": FetchRecord(error="http-429")}, IDENT)
+        assert not store.entries(IDENT)["1"].token_dead()
+
+    def test_due_candidate_skips_dead_token(self, store, clock):
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        clock.advance(10_000)  # past any backoff
+        entries = store.entries(IDENT)
+        assert entries["1"].token_dead()
+        # A dead token is never nominated as the alternate to poll.
+        assert due_candidate(["1"], entries, clock.now) is None
+
+    def test_clear_dead_token_lifts_quarantine(self, store):
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        assert store.entries(IDENT)["1"].token_dead()
+        store.clear_dead_token(["1"], IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.auth_dead_strikes == 0
+        assert not entry.token_dead()
+        assert entry.last_error is None
+        assert entry.backoff_until is None


### PR DESCRIPTION
Fixes #105.

A refresh-token lineage the server rejects with `invalid_grant` can't recover on its own, but the fetch loop retried it forever — silently aging the bars and drawing fresh 401/429s each cycle. This detects it and quarantines the account.

## Change

- **oauth**: `try_fetch_usage_for_account` now surfaces `invalid_grant` distinctly from a transient `refresh-failed` (via `try_refresh_oauth_credentials`). The proactive-refresh path short-circuits on `invalid_grant` **without hitting the usage endpoint**, so a dead token stops drawing 429s immediately.
- **usage_store**: a consecutive-`invalid_grant` strike count. One server-confirmed `invalid_grant` ("Refresh token not found or invalid") is definitive, so `AUTH_DEAD_STRIKES = 1`; transient errors (429/timeout) neither advance nor reset it. `token_dead()` gates `due_candidate`; `clear_dead_token()` lifts the quarantine; a success resets the count.
- **switcher**: the collector surfaces `USAGE_RELOGIN_REQUIRED` for dead tokens — which both drives the display and (via `num not in sentinels`) stops the fetch loop. `add_account`/`add_account_from_token` clear the quarantine on a fresh credential, so recovery is just a re-add — no cache surgery.
- **TUI/list**: the sentinel renders like the other warn states (⚠ + note + last-seen line); no per-surface special-casing.

## Notes

- Purely additive: healthy accounts and every existing sentinel path are untouched.
- `AUTH_DEAD_STRIKES` is a one-line knob — raise to 2 if you'd prefer a buffer against a one-off misclassification (the trade-off is a ~10-min-slower verdict, one failure-backoff between strikes).

Tests cover: invalid_grant propagation (proactive short-circuit + 401-retry) vs. transient staying `refresh-failed`; strike counting/reset/transient-immunity; `due_candidate` skipping a dead token; the collector surfacing the sentinel and skipping the fetch; and re-add clearing the quarantine. Full suite green (960 passed).