### PR TITLE
Add 'cswap login': standalone browser OAuth login with optional --private (#107)

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -45,6 +45,7 @@ _SUBCOMMAND_FLAGS = {
     "status": "--status",
     "add": "--add-account",
     "add-token": "--add-token",
+    "login": "--login",
     "remove": "--remove-account",
     "rm": "--remove-account",
     "export": "--export",
@@ -720,6 +721,22 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         const="",
         help=argparse.SUPPRESS,
     )
+    group.add_argument(
+        "--login",
+        action="store_true",
+        help=(
+            "Add an account via a standalone browser OAuth login — no Claude Code "
+            "log-out/log-in dance. Full scopes, so usage still shows in list."
+        ),
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help=(
+            "With --login: open the browser in a private/incognito window so you "
+            "can log in as another account without touching your normal session."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -759,8 +776,16 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.strategy is not None and not args.switch:
         parser.error("--strategy can only be used with bare 'switch'")
 
-    if args.slot is not None and not (args.add_account or args.add_token is not None):
-        parser.error("--slot can only be used with 'add' or 'add-token'")
+    if args.slot is not None and not (
+        args.add_account or args.add_token is not None or args.login
+    ):
+        parser.error("--slot can only be used with 'add', 'add-token', or 'login'")
+
+    if args.private and not args.login:
+        parser.error("--private can only be used with --login")
+
+    if args.private and not args.login:
+        parser.error("--private can only be used with --login")
 
     if args.email is not None and args.add_token is None:
         parser.error("--email can only be used with 'add-token'")
@@ -809,6 +834,8 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
                 email=args.email,
                 slot=args.slot,
             )
+        elif args.login:
+            switcher.login_and_add(slot=args.slot, private=args.private)
         elif args.remove_account:
             switcher.remove_account(args.remove_account)
         elif args.list:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -542,6 +542,7 @@ Commands:
   %(prog)s switch <num|email>         switch to a specific account
   %(prog)s add                        add the current account
   %(prog)s add-token [TOKEN|-]        register a setup-token or API key
+  %(prog)s login                      add an account via browser OAuth login
   %(prog)s remove <num|email>         remove an account
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s auto                       auto-switch when nearing rate limits
@@ -563,6 +564,7 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s list --json
   %(prog)s add --slot 3                      # add to a specific slot
   %(prog)s add-token sk-ant-oat01-... --email me@example.com
+  %(prog)s login --private                   # log in as a second account in a private window
   %(prog)s run 2 -- --resume                 # forward args after '--' to claude
   %(prog)s auto --once                       # single auto-switch tick (cron-friendly)
   %(prog)s config set autoswitch.threshold 80
@@ -724,16 +726,13 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     group.add_argument(
         "--login",
         action="store_true",
-        help=(
-            "Add an account via a standalone browser OAuth login — no Claude Code "
-            "log-out/log-in dance. Full scopes, so usage still shows in list."
-        ),
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--private",
         action="store_true",
         help=(
-            "With --login: open the browser in a private/incognito window so you "
+            "With 'login': open the browser in a private/incognito window so you "
             "can log in as another account without touching your normal session."
         ),
     )

--- a/src/claude_swap/standalone_login.py
+++ b/src/claude_swap/standalone_login.py
@@ -1,0 +1,324 @@
+"""Standalone browser OAuth login — add an account without the Claude Code login dance.
+
+``cswap login`` runs Claude Code's own PKCE authorization-code flow directly
+against ``claude.ai``, so a fresh account (or a second org of an email you are
+already logged in as) lands in a slot without the usual log-out / log-in / add
+ping-pong through Claude Code. Unlike ``add-token`` (setup-tokens, which are
+inference-only server-side and so show no usage in ``list``), the full flow
+returns the same broad-scope credential Claude Code itself gets — refresh token,
+expiry, and the account/organization metadata needed for usage tracking and the
+(email, org) identity key.
+
+This reuses Claude Code's public OAuth client id and endpoints; it is a
+reverse-engineered flow, not a supported API, so treat breakage as expected if
+Anthropic changes the flow. Local-only helper — not part of the upstream package.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import webbrowser
+from dataclasses import dataclass
+
+from claude_swap.exceptions import ClaudeSwitchError
+from claude_swap.oauth import OAUTH_CLIENT_ID, OAUTH_TOKEN_URL
+from claude_swap.printer import accent, dimmed, muted, warning
+
+_logger = logging.getLogger("claude-swap")
+
+# Claude Code's authorization endpoint and the exact-match redirect its client id
+# is registered for. The redirect renders the authorization code on-screen for
+# the manual copy-paste (out-of-band) flow, so no local callback server is needed.
+AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+
+# The broad scopes Claude Code requests — user:profile is what unlocks the usage
+# API (setup-tokens carry only user:inference and 403 on the profile endpoints).
+LOGIN_SCOPES = ("org:create_api_key", "user:profile", "user:inference")
+
+
+class LoginError(ClaudeSwitchError):
+    """The standalone OAuth login could not complete."""
+
+
+@dataclass(frozen=True)
+class LoginResult:
+    """Everything a slot write needs from a completed login."""
+
+    credentials: str  # Claude Code credential JSON: {"claudeAiOauth": {...}}
+    email: str
+    account_uuid: str
+    organization_uuid: str
+    organization_name: str
+
+
+@dataclass(frozen=True)
+class PendingLogin:
+    """An authorization round-trip in flight: the URL is open in a browser,
+    the pasted code hasn't come back yet. Holds the PKCE verifier and state
+    that ``complete_login`` needs to finish the exchange."""
+
+    verifier: str
+    state: str
+    url: str
+
+
+# Browsers that open a fresh private/incognito window from the command line, in
+# preference order. Each entry: (label, incognito flag, macOS app binary,
+# POSIX binary names for shutil.which). A private window carries no claude.ai
+# cookies, so you can log in as a second account without disturbing the one your
+# normal browser is signed into. Safari and Arc are intentionally absent: neither
+# exposes a reliable private-window CLI flag.
+_PRIVATE_BROWSERS = (
+    ("Chrome", "--incognito", "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+     ("google-chrome", "google-chrome-stable", "chrome")),
+    ("Brave", "--incognito", "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+     ("brave-browser", "brave")),
+    ("Edge", "--inprivate", "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+     ("microsoft-edge", "microsoft-edge-stable")),
+    ("Chromium", "--incognito", "/Applications/Chromium.app/Contents/MacOS/Chromium",
+     ("chromium", "chromium-browser")),
+    ("Vivaldi", "--incognito", "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi",
+     ("vivaldi", "vivaldi-stable")),
+    ("Firefox", "--private-window", "/Applications/Firefox.app/Contents/MacOS/firefox",
+     ("firefox",)),
+)
+
+
+def _resolve_private_browser() -> tuple[str, str, str] | None:
+    """First installed private-capable browser as ``(label, binary, flag)``."""
+    for label, flag, mac_bin, posix_names in _PRIVATE_BROWSERS:
+        if sys.platform == "darwin":
+            if os.path.exists(mac_bin):
+                return label, mac_bin, flag
+        else:
+            for name in posix_names:
+                found = shutil.which(name)
+                if found:
+                    return label, found, flag
+    return None
+
+
+def _open_private_browser(url: str) -> str | None:
+    """Launch ``url`` in a private/incognito window; return the browser label or None.
+
+    Direct-binary launch (not ``webbrowser``/``open -a``) so the flag is honored
+    even when the browser is already running — it opens a new private window in
+    the existing instance rather than a normal tab.
+    """
+    resolved = _resolve_private_browser()
+    if resolved is None:
+        return None
+    label, binary, flag = resolved
+    try:
+        subprocess.Popen(
+            [binary, flag, url],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return label
+    except OSError as e:
+        _logger.debug("Private browser launch failed (%s): %r", binary, e)
+        return None
+
+
+def _b64url(raw: bytes) -> str:
+    """Base64url without padding (PKCE / RFC 7636)."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _generate_pkce() -> tuple[str, str]:
+    """Return ``(verifier, challenge)`` for the S256 PKCE method."""
+    verifier = _b64url(os.urandom(32))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+def _build_authorize_url(challenge: str, state: str) -> str:
+    from urllib.parse import urlencode
+
+    params = {
+        "code": "true",
+        "client_id": OAUTH_CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": " ".join(LOGIN_SCOPES),
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+
+def _parse_pasted_code(pasted: str, fallback_state: str) -> tuple[str, str]:
+    """Split the pasted callback value into ``(code, state)``.
+
+    The callback page renders the code as ``<code>#<state>``; some surfaces show
+    a bare code. Accept a full redirect URL too and pull ``code``/``state`` out.
+    """
+    pasted = pasted.strip()
+    if pasted.startswith("http"):
+        from urllib.parse import parse_qs, urlparse
+
+        q = parse_qs(urlparse(pasted).query)
+        code = (q.get("code") or [""])[0]
+        state = (q.get("state") or [fallback_state])[0]
+        return code, state
+    if "#" in pasted:
+        code, _, state = pasted.partition("#")
+        return code.strip(), (state.strip() or fallback_state)
+    return pasted, fallback_state
+
+
+def _exchange_code(code: str, state: str, verifier: str) -> dict:
+    """Trade the authorization code for tokens; returns the raw token response."""
+    body = json.dumps({
+        "grant_type": "authorization_code",
+        "code": code,
+        "state": state,
+        "client_id": OAUTH_CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "code_verifier": verifier,
+    }).encode()
+    req = urllib.request.Request(
+        OAUTH_TOKEN_URL,
+        data=body,
+        headers={"Content-Type": "application/json", "User-Agent": "claude-swap/1.0"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace") if hasattr(e, "read") else ""
+        _logger.debug("Token exchange failed: %r, body: %s", e, detail[:500])
+        raise LoginError(
+            f"Token exchange rejected (HTTP {e.code}). The code may have expired "
+            f"or been mistyped — rerun 'cswap login' for a fresh one."
+        ) from e
+    except (urllib.error.URLError, TimeoutError) as e:
+        raise LoginError(f"Could not reach the token endpoint: {e}") from e
+
+
+def _credentials_from_token_response(resp: dict) -> str:
+    """Build Claude Code's credential JSON from the token endpoint response."""
+    from datetime import datetime, timezone
+
+    access_token = resp.get("access_token")
+    if not access_token:
+        raise LoginError("Token response contained no access_token.")
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    oauth: dict = {"accessToken": access_token}
+    if resp.get("refresh_token"):
+        oauth["refreshToken"] = resp["refresh_token"]
+    if isinstance(resp.get("expires_in"), (int, float)):
+        oauth["expiresAt"] = now_ms + int(resp["expires_in"]) * 1000
+    scope = resp.get("scope")
+    oauth["scopes"] = scope.split() if isinstance(scope, str) else list(LOGIN_SCOPES)
+    return json.dumps({"claudeAiOauth": oauth})
+
+
+def prepare_login(
+    *, open_browser: bool = True, private: bool = False
+) -> tuple[PendingLogin, str | None]:
+    """Start an authorization round-trip: PKCE, URL, browser (best effort).
+
+    Non-interactive half of the login, shared by the CLI and the TUI. Returns
+    ``(pending, private_label)`` — ``private_label`` is the browser a private
+    window was opened in, or ``None`` (not requested, or none found: the
+    caller tells the user to open ``pending.url`` in a private window
+    themselves).
+    """
+    verifier, challenge = _generate_pkce()
+    state = _b64url(os.urandom(24))
+    url = _build_authorize_url(challenge, state)
+    pending = PendingLogin(verifier=verifier, state=state, url=url)
+
+    private_label = None
+    if open_browser and private:
+        private_label = _open_private_browser(url)
+    elif open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:  # noqa: BLE001 — headless/no-browser is fine, URL is shown
+            pass
+    return pending, private_label
+
+
+def complete_login(pending: PendingLogin, pasted: str) -> LoginResult:
+    """Finish an authorization round-trip from the pasted callback value.
+
+    Raises LoginError when no code can be read or the exchange fails.
+    """
+    pasted = pasted.strip()
+    if not pasted:
+        raise LoginError("No authorization code entered.")
+    code, returned_state = _parse_pasted_code(pasted, pending.state)
+    if not code:
+        raise LoginError("Could not read an authorization code from that input.")
+
+    resp = _exchange_code(code, returned_state, pending.verifier)
+    credentials = _credentials_from_token_response(resp)
+
+    account = resp.get("account") if isinstance(resp.get("account"), dict) else {}
+    org = resp.get("organization") if isinstance(resp.get("organization"), dict) else {}
+    email = account.get("email_address") or account.get("email") or ""
+    return LoginResult(
+        credentials=credentials,
+        email=email,
+        account_uuid=account.get("uuid", "") or "",
+        organization_uuid=org.get("uuid", "") or "",
+        organization_name=org.get("name", "") or "",
+    )
+
+
+def run_login_flow(*, open_browser: bool = True, private: bool = False) -> LoginResult:
+    """Drive the interactive PKCE login and return the resulting credential.
+
+    Prints the authorization URL, opens it in a browser (best effort), then reads
+    the pasted authorization code from stdin and exchanges it. With ``private``,
+    the URL opens in an incognito/private window so a second account can be added
+    without touching the claude.ai session your normal browser is signed into.
+    Raises LoginError on any failure; the caller persists the result into a slot.
+    """
+    print(accent("Standalone login") + " — authorize claude-swap in your browser.")
+    print()
+    print(muted("If your browser doesn't open, paste this URL manually:"))
+
+    pending, private_label = prepare_login(open_browser=open_browser, private=private)
+    print(pending.url)
+    print()
+    print(dimmed(
+        "Pick the account (and, for a merged email, the organization) you want, "
+        "then copy the code the page shows you."
+    ))
+    print()
+
+    if open_browser and private:
+        if private_label:
+            print(muted(
+                f"Opened a private {private_label} window "
+                "(your normal session stays signed in)."
+            ))
+        else:
+            warning(
+                "No incognito-capable browser found (Chrome/Firefox/Brave/Edge). "
+                "Open the URL above in a private window yourself, then paste the code."
+            )
+
+    try:
+        pasted = input("Paste the authorization code here: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        raise LoginError("Login cancelled.")
+
+    return complete_login(pending, pasted)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1347,6 +1347,141 @@ class ClaudeAccountSwitcher:
             f"{muted('[personal]')} {muted(f'(from {source_label})')}"
         )
 
+    def login_and_add(
+        self, slot: int | None = None, assume_yes: bool = False, private: bool = False
+    ) -> None:
+        """Add an account via a standalone browser OAuth login (no Claude Code dance).
+
+        Runs Claude Code's PKCE authorization-code flow directly, then persists the
+        resulting broad-scope credential (refresh token, expiry, real org metadata —
+        everything usage tracking needs) into a slot. Identity and slot handling
+        mirror ``add_account``: an existing ``(email, org)`` refreshes in place,
+        otherwise the next free slot (or ``--slot``) is used. Unlike ``add_account``
+        this never touches the live ``~/.claude`` login, so ``activeAccountNumber``
+        is left as-is. With ``private`` the browser opens an incognito window so a
+        second account can be added without disturbing your normal claude.ai session.
+        """
+        from claude_swap.standalone_login import run_login_flow
+
+        self._setup_directories()
+        self._init_sequence_file()
+        self._migrate_org_fields()
+
+        result = run_login_flow(private=private)
+        self.add_login_result(result, slot=slot, assume_yes=assume_yes)
+
+    def add_login_result(
+        self, result, slot: int | None = None, assume_yes: bool = False
+    ) -> None:
+        """Persist a completed standalone login (``LoginResult``) into a slot.
+
+        The persistence half of ``login_and_add``, callable with a result
+        obtained elsewhere: the TUI drives the browser round-trip itself (via
+        ``prepare_login``/``complete_login``) because the CLI flow reads the
+        pasted code from stdin, which a TUI doesn't have.
+        """
+        self._setup_directories()
+        self._init_sequence_file()
+        self._migrate_org_fields()
+
+        email = result.email
+        if not email:
+            raise ConfigError(
+                "Login completed but returned no email, so the account can't be "
+                "keyed. This usually means the OAuth response shape changed."
+            )
+        org_uuid = result.organization_uuid
+        org_name = result.organization_name
+        credentials = result.credentials
+        config = json.dumps({
+            "oauthAccount": {
+                "emailAddress": email,
+                "accountUuid": result.account_uuid,
+                "organizationUuid": org_uuid or None,
+                "organizationName": org_name or None,
+            }
+        })
+
+        # In-place refresh when this (email, org) already occupies a slot.
+        seq = self._get_sequence_data() or {}
+        existing_slot = self._find_account_slot(seq, email, org_uuid)
+        if slot is None and existing_slot is not None:
+            self._write_account_credentials(existing_slot, email, credentials)
+            self._write_account_config(existing_slot, email, config)
+            seq = self._get_sequence_data()
+            seq["lastUpdated"] = get_timestamp()
+            self._write_json(self.sequence_file, seq)
+            tag = self._get_display_tag(email, org_name, org_uuid)
+            self._logger.info(f"Refreshed credentials via login for account {existing_slot}: {email}")
+            print(
+                f"{accent('Updated credentials')} for Account {existing_slot} "
+                f"({email} {muted(f'[{tag}]')})."
+            )
+            return
+
+        # New slot, or an explicit --slot that may be occupied by a different account.
+        if slot is not None:
+            if slot < 1:
+                raise ConfigError("Slot number must be >= 1")
+            account_num = str(slot)
+            data = self._get_sequence_data()
+            if account_num in data.get("accounts", {}):
+                existing = data["accounts"][account_num]
+                is_same = (
+                    existing.get("email") == email
+                    and existing.get("organizationUuid", "") == org_uuid
+                )
+                if not is_same:
+                    existing_tag = self._get_display_tag(
+                        existing.get("email", "unknown"),
+                        existing.get("organizationName", ""),
+                        existing.get("organizationUuid", ""),
+                    )
+                    warning(f"Slot {slot} already occupied")
+                    print(f"{existing.get('email', 'unknown')} {muted(f'[{existing_tag}]')}")
+                    if not assume_yes:
+                        try:
+                            answer = input(f"Overwrite slot {slot}? [y/N] ").strip().lower()
+                        except (EOFError, KeyboardInterrupt):
+                            print(f"\n{dimmed('Cancelled')}")
+                            return
+                        if answer not in ("y", "yes"):
+                            print(dimmed("Cancelled"))
+                            return
+                    self._delete_account_files(account_num, existing.get("email", ""))
+                    data = self._get_sequence_data()
+                    if int(account_num) in data.get("sequence", []):
+                        data["sequence"].remove(int(account_num))
+                    data["accounts"].pop(account_num, None)
+                    self._write_json(self.sequence_file, data)
+        else:
+            account_num = str(self._get_next_account_number())
+
+        self._write_account_credentials(account_num, email, credentials)
+        self._write_account_config(account_num, email, config)
+
+        data = self._get_sequence_data()
+        data["accounts"][account_num] = {
+            "email": email,
+            "uuid": result.account_uuid,
+            "organizationUuid": org_uuid,
+            "organizationName": org_name,
+            "added": get_timestamp(),
+        }
+        if int(account_num) not in data["sequence"]:
+            data["sequence"].append(int(account_num))
+            data["sequence"].sort()
+        # Deliberately NOT setting activeAccountNumber: a standalone login adds a
+        # slot without switching the live ~/.claude login.
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+
+        tag = self._get_display_tag(email, org_name, org_uuid)
+        self._logger.info(
+            f"Added account {account_num} via login: {email} (org: {org_uuid or 'personal'})"
+        )
+        print(f"{accent('Added')} Account {account_num}: {email} {muted(f'[{tag}]')} {muted('(via login)')}")
+
     def remove_account(self, identifier: str, assume_yes: bool = False) -> None:
         """Remove account from managed accounts.
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1347,6 +1347,19 @@ class ClaudeAccountSwitcher:
             f"{muted('[personal]')} {muted(f'(from {source_label})')}"
         )
 
+    def _lift_quarantine_on_relogin(self, num: str, identity: tuple[str, str]) -> None:
+        """Lift any dead-token quarantine on a slot after a re-login refreshes it.
+
+        A quarantined account (dead refresh token) has its usage fetches disabled,
+        so the strike that quarantined it can never clear on its own — only a fresh
+        credential can. ``clear_dead_token`` ships in #106; this is guarded via
+        getattr so ``cswap login`` stays self-contained here and simply no-ops until
+        that helper is present, then activates once both land.
+        """
+        clear = getattr(self._usage_store, "clear_dead_token", None)
+        if clear is not None:
+            clear([num], {num: identity})
+
     def login_and_add(
         self, slot: int | None = None, assume_yes: bool = False, private: bool = False
     ) -> None:
@@ -1408,6 +1421,7 @@ class ClaudeAccountSwitcher:
         if slot is None and existing_slot is not None:
             self._write_account_credentials(existing_slot, email, credentials)
             self._write_account_config(existing_slot, email, config)
+            self._lift_quarantine_on_relogin(existing_slot, (email, org_uuid or ""))
             seq = self._get_sequence_data()
             seq["lastUpdated"] = get_timestamp()
             self._write_json(self.sequence_file, seq)
@@ -1459,6 +1473,7 @@ class ClaudeAccountSwitcher:
 
         self._write_account_credentials(account_num, email, credentials)
         self._write_account_config(account_num, email, config)
+        self._lift_quarantine_on_relogin(account_num, (email, org_uuid or ""))
 
         data = self._get_sequence_data()
         data["accounts"][account_num] = {

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -20,7 +20,13 @@ from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui.autoview import AutoScreen
 from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
 from claude_swap.tui.data import ActionResult, SnapshotSource, run_action
-from claude_swap.tui.modals import AddTokenModal, ConfirmModal, OutputModal, TokenForm
+from claude_swap.tui.modals import (
+    AddTokenModal,
+    BrowserLoginModal,
+    ConfirmModal,
+    OutputModal,
+    TokenForm,
+)
 from claude_swap.tui.theme import CSWAP_DARK
 
 
@@ -256,6 +262,51 @@ class CswapApp(App):
             if acc.number == str(slot):
                 return acc.email
         return None
+
+    # -- browser login (cswap login) ---------------------------------------------
+
+    def action_add_browser(self, private: bool = False) -> None:
+        """Standalone browser OAuth login — the TUI face of ``cswap login``.
+
+        The CLI flow reads the pasted authorization code from stdin, which a
+        TUI doesn't have; drive the same round-trip with a modal instead:
+        open the browser now, collect the code, finish off-thread.
+        """
+        from claude_swap.standalone_login import prepare_login
+
+        pending, private_label = prepare_login(private=private)
+        if not private:
+            notice = None
+        elif private_label:
+            notice = (
+                f"Opened a private {private_label} window (your normal "
+                "session stays signed in)."
+            )
+        else:
+            notice = (
+                "No incognito-capable browser found (Chrome/Firefox/Brave/"
+                "Edge) — open the URL below in a private window yourself."
+            )
+        self.push_screen(
+            BrowserLoginModal(url=pending.url, notice=notice),
+            partial(self._on_browser_login_code, pending),
+        )
+
+    def _on_browser_login_code(self, pending, pasted: str | None) -> None:
+        if pasted is None:
+            return
+        self._start_action(
+            "Add account via browser login",
+            partial(self._complete_browser_login, pending, pasted),
+            show_output=True,
+        )
+
+    def _complete_browser_login(self, pending, pasted: str) -> None:
+        """Worker body: exchange the code, persist the account."""
+        from claude_swap.standalone_login import complete_login
+
+        result = complete_login(pending, pasted)
+        self.switcher.add_login_result(result)
 
     # -- navigation -------------------------------------------------------------
 

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -85,6 +85,8 @@ class DashboardScreen(Screen):
     def _add_entries(self) -> MenuEntries:
         return [
             ("From current Claude Code login", "add-login"),
+            ("From a browser login…", "add-browser"),
+            ("From a browser login (private window)…", "add-browser-private"),
             ("From a setup-token / API key…", "add-token"),
             _BACK,
         ]
@@ -131,6 +133,8 @@ class DashboardScreen(Screen):
             "watch": app.action_open_watch,
             "auto": app.action_open_auto,
             "add-login": app.action_add_current,
+            "add-browser": app.action_add_browser,
+            "add-browser-private": partial(app.action_add_browser, private=True),
             "add-token": app.action_add_token,
             "quit": app.exit,
         }

--- a/src/claude_swap/tui/modals.py
+++ b/src/claude_swap/tui/modals.py
@@ -133,6 +133,71 @@ class AddTokenModal(ModalScreen["TokenForm | None"]):
         self.dismiss(None)
 
 
+class BrowserLoginModal(ModalScreen["str | None"]):
+    """Standalone browser OAuth login: the authorize URL is already open in a
+    browser; this collects the code the callback page shows. Dismisses with
+    the pasted value, or None on cancel."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("left", "app.focus_previous", show=False),
+        Binding("right", "app.focus_next", show=False),
+    ]
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        notice: str | None = None,
+        title: str = "Add account via browser login",
+    ) -> None:
+        super().__init__()
+        self._url = url
+        self._notice = notice
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="modal-box modal-box-wide"):
+            yield Label(self._title, classes="modal-title")
+            body = (
+                "Authorize claude-swap in the browser — pick the account (and, "
+                "for a merged email, the organization) you want, then paste the "
+                "code the page shows you.\n\n"
+                "If no browser window opened, open this URL yourself:"
+            )
+            if self._notice:
+                body = f"{self._notice}\n\n{body}"
+            yield Static(body, classes="modal-body")
+            yield Static(self._url, classes="modal-body")
+            yield Input(placeholder="authorization code (required)", id="code")
+            yield Static("", id="form-error", classes="form-error")
+            with Horizontal(classes="modal-buttons"):
+                yield Button("Log in", id="login")
+                yield Button("Cancel", id="cancel")
+            yield Static("enter log in  ·  esc cancel", classes="modal-hint")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+        self._submit()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self._submit()
+
+    def _submit(self) -> None:
+        code = self.query_one("#code", Input).value.strip()
+        if not code:
+            self.query_one("#form-error", Static).update(
+                "Paste the authorization code first."
+            )
+            return
+        self.dismiss(code)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
 class OutputModal(ModalScreen[None]):
     """Scrollable display of captured (ANSI-colored) action output."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -509,6 +509,19 @@ class TestCLICommands:
         assert "add-token [TOKEN|-]" in result.stdout
         assert "--email" in result.stdout  # modifier flag stays visible
 
+    def test_login_in_help(self):
+        """The login subcommand is documented; its --login mirror flag is hidden
+        (like every other subcommand flag) while --private stays visible."""
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "add an account via browser OAuth login" in result.stdout  # command line
+        assert "--private" in result.stdout  # modifier flag stays visible
+        assert "--login" not in result.stdout  # subcommand mirror flag is suppressed
+
 
 class TestRunCommand:
     """`cswap run` pre-dispatch: parsing, forwarding, and dispatch."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,13 +200,13 @@ class TestCLI:
         )
 
     def test_slot_flag_requires_add_account(self, capsys):
-        """--slot should only be accepted alongside --add-account or --add-token."""
+        """--slot should only be accepted alongside --add-account/--add-token/--login."""
         with patch.object(sys, "argv", ["claude-swap", "--list", "--slot", "3"]):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
 
         assert excinfo.value.code == 2
-        assert "--slot can only be used with 'add' or 'add-token'" in capsys.readouterr().err
+        assert "--slot can only be used with 'add', 'add-token', or 'login'" in capsys.readouterr().err
 
     def test_slot_flag_in_help(self):
         """--slot should appear in help output."""

--- a/tests/test_standalone_login.py
+++ b/tests/test_standalone_login.py
@@ -1,0 +1,169 @@
+"""Tests for the local standalone browser-OAuth login (cswap login)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import standalone_login as sl
+
+
+class TestPkceAndUrl:
+    def test_pkce_challenge_is_s256_of_verifier(self):
+        verifier, challenge = sl._generate_pkce()
+        expected = base64.urlsafe_b64encode(
+            hashlib.sha256(verifier.encode()).digest()
+        ).rstrip(b"=").decode()
+        assert challenge == expected
+
+    def test_authorize_url_carries_required_params(self):
+        url = sl._build_authorize_url("CHAL", "STATE")
+        for frag in (
+            "claude.ai/oauth/authorize",
+            "response_type=code",
+            "code_challenge=CHAL",
+            "code_challenge_method=S256",
+            "state=STATE",
+            "user%3Aprofile",  # broad scope → usage access
+        ):
+            assert frag in url
+
+
+class TestParsePastedCode:
+    def test_code_hash_state(self):
+        assert sl._parse_pasted_code("abc#xyz", "fb") == ("abc", "xyz")
+
+    def test_bare_code_uses_fallback_state(self):
+        assert sl._parse_pasted_code("  bare  ", "fb") == ("bare", "fb")
+
+    def test_full_redirect_url(self):
+        got = sl._parse_pasted_code("https://x/cb?code=C&state=S", "fb")
+        assert got == ("C", "S")
+
+
+class TestCredentialsFromResponse:
+    def test_full_response_builds_credential_json(self):
+        creds = sl._credentials_from_token_response({
+            "access_token": "AT", "refresh_token": "RT",
+            "expires_in": 28800, "scope": "user:profile user:inference",
+        })
+        oauth = json.loads(creds)["claudeAiOauth"]
+        assert oauth["accessToken"] == "AT"
+        assert oauth["refreshToken"] == "RT"
+        assert oauth["expiresAt"] > 0
+        assert "user:profile" in oauth["scopes"]
+
+    def test_missing_access_token_raises(self):
+        with pytest.raises(sl.LoginError):
+            sl._credentials_from_token_response({"refresh_token": "RT"})
+
+
+class TestPrepareCompleteLogin:
+    """The non-interactive halves the TUI drives directly."""
+
+    def test_prepare_login_returns_pending_without_browser(self):
+        with patch.object(sl.webbrowser, "open") as opened:
+            pending, label = sl.prepare_login(open_browser=False)
+        opened.assert_not_called()
+        assert label is None
+        assert pending.verifier and pending.state
+        assert pending.url.startswith(sl.AUTHORIZE_URL)
+        assert pending.state in pending.url
+
+    def test_prepare_login_private_reports_browser_label(self):
+        with patch.object(sl, "_open_private_browser", return_value="Chrome") as opener:
+            pending, label = sl.prepare_login(private=True)
+        assert label == "Chrome"
+        opener.assert_called_once_with(pending.url)
+
+    def test_complete_login_empty_paste_raises(self):
+        with pytest.raises(sl.LoginError):
+            sl.complete_login(sl.PendingLogin("v", "s", "u"), "   ")
+
+    def test_complete_login_exchanges_parsed_code(self):
+        seen: dict = {}
+
+        def fake_exchange(code, state, verifier):
+            seen.update(code=code, state=state, verifier=verifier)
+            return {
+                "access_token": "AT",
+                "account": {"email_address": "a@x.com", "uuid": "au"},
+                "organization": {"uuid": "ou", "name": "Org"},
+            }
+
+        with patch.object(sl, "_exchange_code", side_effect=fake_exchange):
+            result = sl.complete_login(
+                sl.PendingLogin("ver", "st", "url"), "code123#other"
+            )
+        assert seen == {"code": "code123", "state": "other", "verifier": "ver"}
+        assert result.email == "a@x.com"
+        assert result.organization_uuid == "ou"
+
+
+class TestPrivateBrowserResolution:
+    def test_prefers_chrome_over_firefox(self):
+        with patch("sys.platform", "darwin"), \
+             patch("os.path.exists", lambda p: "Chrome" in p or "Firefox" in p):
+            label, _bin, flag = sl._resolve_private_browser()
+        assert label == "Chrome" and flag == "--incognito"
+
+    def test_falls_back_to_firefox(self):
+        with patch("sys.platform", "darwin"), \
+             patch("os.path.exists", lambda p: "Firefox" in p):
+            label, _bin, flag = sl._resolve_private_browser()
+        assert label == "Firefox" and flag == "--private-window"
+
+    def test_none_when_no_private_browser(self):
+        with patch("sys.platform", "darwin"), patch("os.path.exists", lambda p: False):
+            assert sl._resolve_private_browser() is None
+
+    def test_launch_builds_flagged_cmdline_without_opening(self):
+        with patch.object(sl.subprocess, "Popen") as popen, \
+             patch.object(sl, "_resolve_private_browser",
+                          return_value=("Chrome", "/bin/chrome", "--incognito")):
+            label = sl._open_private_browser("https://x")
+        assert label == "Chrome"
+        assert popen.call_args[0][0] == ["/bin/chrome", "--incognito", "https://x"]
+
+    def test_launch_returns_none_when_nothing_resolves(self):
+        with patch.object(sl, "_resolve_private_browser", return_value=None):
+            assert sl._open_private_browser("https://x") is None
+
+
+class TestRunLoginFlowPrivate:
+    def _resp(self):
+        return {
+            "access_token": "AT", "refresh_token": "RT", "expires_in": 28800,
+            "scope": "user:profile",
+            "account": {"email_address": "x@y.z", "uuid": "acc"},
+            "organization": {"uuid": "org", "name": "Org"},
+        }
+
+    def test_private_uses_incognito_path(self, capsys):
+        with patch.object(sl, "_open_private_browser", return_value="Chrome") as ob, \
+             patch.object(sl, "input", create=True, return_value="CODE#STATE"), \
+             patch.object(sl, "_exchange_code", return_value=self._resp()):
+            result = sl.run_login_flow(private=True)
+        ob.assert_called_once()
+        assert result.email == "x@y.z" and result.organization_name == "Org"
+        assert "private Chrome window" in capsys.readouterr().out
+
+    def test_private_warns_when_no_incognito_browser(self, capsys):
+        with patch.object(sl, "_open_private_browser", return_value=None), \
+             patch.object(sl, "input", create=True, return_value="CODE#STATE"), \
+             patch.object(sl, "_exchange_code", return_value=self._resp()):
+            sl.run_login_flow(private=True)
+        assert "private window" in capsys.readouterr().out.lower()
+
+    def test_non_private_does_not_launch_incognito(self):
+        with patch.object(sl, "_open_private_browser") as ob, \
+             patch.object(sl, "webbrowser") as wb, \
+             patch.object(sl, "input", create=True, return_value="CODE#STATE"), \
+             patch.object(sl, "_exchange_code", return_value=self._resp()):
+            sl.run_login_flow(private=False)
+        ob.assert_not_called()
+        wb.open.assert_called_once()

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2059,6 +2059,37 @@ class TestLoginAndAdd:
         seq = json.loads((get_backup_root() / "sequence.json").read_text())
         assert len(seq["accounts"]) == 1  # refreshed, not duplicated
 
+    def test_relogin_lifts_quarantine_new_slot(self, temp_home):
+        # A fresh login into a new slot must lift any dead-token quarantine on it
+        # (via the #106 helper, guarded so cswap login is self-contained here).
+        switcher = ClaudeAccountSwitcher()
+        switcher._usage_store.clear_dead_token = MagicMock()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result()):
+            switcher.login_and_add()
+
+        switcher._usage_store.clear_dead_token.assert_called_once_with(
+            ["1"], {"1": ("new@example.com", "org-L")}
+        )
+
+    def test_relogin_lifts_quarantine_in_place(self, temp_home):
+        # Refreshing an existing account in place must lift its quarantine too;
+        # otherwise a re-login can't recover a dead-token slot (its fetches, and
+        # thus the only path that clears the strike, stay disabled).
+        switcher = ClaudeAccountSwitcher()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result()):
+            switcher.login_and_add()
+
+        switcher._usage_store.clear_dead_token = MagicMock()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result()):
+            switcher.login_and_add()  # same identity → in-place refresh
+
+        switcher._usage_store.clear_dead_token.assert_called_once_with(
+            ["1"], {"1": ("new@example.com", "org-L")}
+        )
+
     def test_empty_email_is_rejected(self, temp_home):
         switcher = ClaudeAccountSwitcher()
         with patch("claude_swap.standalone_login.run_login_flow",

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2002,6 +2002,71 @@ class TestGetCurrentAccountOrgSupport:
 
 # ── Task 5: add_account with org fields ──────────────────────────────────────
 
+class TestLoginAndAdd:
+    """Standalone-login add path: persists the flow result into a slot."""
+
+    def _result(self, email="new@example.com", org_uuid="org-L", org_name="LoginOrg"):
+        from claude_swap.standalone_login import LoginResult
+
+        creds = json.dumps({"claudeAiOauth": {
+            "accessToken": "AT", "refreshToken": "RT", "expiresAt": 9_999_999_999_000,
+            "scopes": ["user:profile", "user:inference"],
+        }})
+        return LoginResult(
+            credentials=creds, email=email, account_uuid="acc-L",
+            organization_uuid=org_uuid, organization_name=org_name,
+        )
+
+    def test_login_adds_new_slot_without_switching_active(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result()):
+            switcher.login_and_add()
+
+        seq = json.loads((get_backup_root() / "sequence.json").read_text())
+        assert seq["accounts"]["1"]["email"] == "new@example.com"
+        assert seq["accounts"]["1"]["organizationUuid"] == "org-L"
+        # Standalone login must not hijack the live-login pointer.
+        assert seq.get("activeAccountNumber") is None
+        creds = json.loads(
+            switcher.read_account_credentials("1", "new@example.com")
+        )["claudeAiOauth"]
+        assert creds["refreshToken"] == "RT" and creds["accessToken"] == "AT"
+
+    def test_same_email_different_org_gets_separate_slot(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result(org_uuid="org-A", org_name="A")):
+            switcher.login_and_add()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result(org_uuid="org-B", org_name="B")):
+            switcher.login_and_add()
+
+        seq = json.loads((get_backup_root() / "sequence.json").read_text())
+        assert len(seq["accounts"]) == 2
+        assert {seq["accounts"]["1"]["organizationUuid"],
+                seq["accounts"]["2"]["organizationUuid"]} == {"org-A", "org-B"}
+
+    def test_relogin_same_identity_refreshes_in_place(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result()):
+            switcher.login_and_add()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result()):
+            switcher.login_and_add()
+
+        seq = json.loads((get_backup_root() / "sequence.json").read_text())
+        assert len(seq["accounts"]) == 1  # refreshed, not duplicated
+
+    def test_empty_email_is_rejected(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        with patch("claude_swap.standalone_login.run_login_flow",
+                   return_value=self._result(email="")):
+            with pytest.raises(ConfigError):
+                switcher.login_and_add()
+
+
 class TestAddAccountOrgFields:
     def test_allows_same_email_different_org(self, temp_home):
         """Should allow adding same-email account if organizationUuid differs."""

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -158,6 +158,12 @@ class FakeSwitcher:
         self.calls.append(("add_token", token, email, slot, assume_yes))
         print(f"Added Account {slot or 9}")
 
+    def add_login_result(
+        self, result, slot: int | None = None, assume_yes: bool = False
+    ) -> None:
+        self.calls.append(("add_login_result", result.email, slot, assume_yes))
+        print(f"Added Account 9: {result.email}")
+
 
 def make_app(fake: FakeSwitcher):
     from claude_swap.tui.app import CswapApp
@@ -476,7 +482,13 @@ class TestDashboard:
             await pilot.press("down", "down", "down", "enter")
             await pilot.pause()
             ids = [item.action_id for item in menu.query(MenuItem)]
-            assert ids == ["add-login", "add-token", "back"]
+            assert ids == [
+                "add-login",
+                "add-browser",
+                "add-browser-private",
+                "add-token",
+                "back",
+            ]
             await pilot.press("escape")
             await pilot.pause()
             ids = [item.action_id for item in menu.query(MenuItem)]
@@ -647,6 +659,74 @@ class TestDashboard:
             await pilot.press("n")
             await settle(pilot)
             assert not any(call[0] == "add_token" for call in fake.calls)
+
+    # -- browser login (cswap login) ------------------------------------------
+
+    def _pending_and_result(self):
+        from claude_swap.standalone_login import LoginResult, PendingLogin
+
+        pending = PendingLogin(
+            verifier="ver", state="st", url="https://claude.ai/oauth?x=1"
+        )
+        result = LoginResult(
+            credentials="{}",
+            email="new@example.com",
+            account_uuid="au",
+            organization_uuid="ou",
+            organization_name="Org",
+        )
+        return pending, result
+
+    async def test_add_browser_via_menu_completes_login(self, tmp_path):
+        from unittest.mock import patch
+
+        pending, result = self._pending_and_result()
+        fake = FakeSwitcher([make_account(1, active=True)], tmp_path)
+        app = make_app(fake)
+        with patch(
+            "claude_swap.standalone_login.prepare_login",
+            return_value=(pending, None),
+        ) as prep, patch(
+            "claude_swap.standalone_login.complete_login", return_value=result
+        ) as comp:
+            async with app.run_test(size=(100, 40)) as pilot:
+                await settle(pilot)
+                await menu_select(pilot, "add-menu")
+                await menu_select(pilot, "add-browser")
+                from textual.widgets import Input
+
+                from claude_swap.tui.modals import BrowserLoginModal
+
+                assert isinstance(app.screen, BrowserLoginModal)
+                app.screen.query_one("#code", Input).value = "abc#st"
+                await pilot.click("#login")
+                await settle(pilot)
+        prep.assert_called_once_with(private=False)
+        comp.assert_called_once_with(pending, "abc#st")
+        assert ("add_login_result", "new@example.com", None, False) in fake.calls
+
+    async def test_add_browser_private_passes_flag_cancel_is_safe(self, tmp_path):
+        from unittest.mock import patch
+
+        pending, _ = self._pending_and_result()
+        fake = FakeSwitcher([make_account(1, active=True)], tmp_path)
+        app = make_app(fake)
+        with patch(
+            "claude_swap.standalone_login.prepare_login",
+            return_value=(pending, "Chrome"),
+        ) as prep:
+            async with app.run_test(size=(100, 40)) as pilot:
+                await settle(pilot)
+                await menu_select(pilot, "add-menu")
+                await menu_select(pilot, "add-browser-private")
+                from claude_swap.tui.modals import BrowserLoginModal
+
+                assert isinstance(app.screen, BrowserLoginModal)
+                assert "Chrome" in (app.screen._notice or "")
+                await pilot.press("escape")  # cancel: nothing runs
+                await settle(pilot)
+        prep.assert_called_once_with(private=True)
+        assert not any(c[0] == "add_login_result" for c in fake.calls)
 
     async def test_empty_state_hint_in_panel(self, tmp_path):
         fake = FakeSwitcher([], tmp_path)


### PR DESCRIPTION
For #107 — please read the issue first for the honest framing: I built this for my own convenience, I know it's a reverse-engineered flow that can break if Anthropic changes it, and it doesn't touch any other feature. Offering it in case it's useful; a "no thanks" is completely fine.

## What it adds

```
cswap login              # add an account via the browser, skipping log-out/log-in/add
cswap login --private    # open the OAuth page in an incognito window
```

Runs Claude Code's own PKCE authorization-code flow, so the credential has the full scopes — refresh token, expiry, account/org metadata — and the added account keeps showing usage in `list`/`watch` (unlike `add-token`'s inference-only setup-tokens). Never touches the live `~/.claude` login; it only writes a slot, mirroring `add_account`'s identity/slot handling (existing (email, org) refreshes in place, else next free slot / `--slot`).

`--private` picks the first installed incognito-capable browser (Chrome/Brave/Edge/Chromium/Vivaldi via `--incognito`/`--inprivate`, Firefox via `--private-window`) and launches the binary directly, so the flag is honored even when the browser is already running; it warns and falls back to manual paste when none is found (Safari/Arc have no reliable private-window CLI flag).

## Containment

- One new self-contained module (`standalone_login.py`) + a `login_and_add` slot-writer; nothing else in the codebase depends on it.
- Easy to gate behind an opt-in flag or drop entirely if you'd prefer not to carry the reverse-engineered surface — happy to adjust.

## Tests

PKCE challenge/URL/code-parse/credential-build; the private-browser resolver preference order + fallback (no real window opened); `run_login_flow` private vs. non-private path; and the slot-writer (new slot without hijacking active, same-email-different-org → separate slots, re-login in place, empty-email rejected). Full suite green (967 passed).