### PR TITLE
Add independent Codex CLI account switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,40 @@ Or let claude-swap auto-pick by remaining quota — `cswap switch --strategy bes
 
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.
 
+### Track Codex accounts too
+
+Codex support is separate from Claude account switching. Log into Codex normally, then snapshot that active auth:
+
+```bash
+codex login
+cswap codex add --label work
+```
+
+Log into another Codex account and add it the same way:
+
+```bash
+codex login
+cswap codex add --label personal
+```
+
+Switch Codex without changing your Claude account:
+
+```bash
+cswap codex switch
+cswap codex switch work
+```
+
+Check or remove Codex snapshots:
+
+```bash
+cswap codex list
+cswap codex status
+cswap codex remove work
+cswap codex list --json
+```
+
+`cswap ls` shows Claude accounts and, when present, a separate Codex accounts section. Codex switching only replaces `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`); it does not edit Codex config, plugins, sessions, hooks, or model settings. Switch while no Codex session is live - a running `codex` that refreshes its token can rewrite `auth.json` and revert a just-completed switch.
+
 ### Automatic switching
 
 Let claude-swap watch your usage and switch for you. When the active account's 5-hour or 7-day window reaches the threshold (default 90%), it switches to the account with the most quota left — before you hit the limit, and safe to run while Claude Code is working:
@@ -147,6 +181,8 @@ cswap list                      # Show all accounts with 5h/7d usage and reset t
 cswap status                    # Show current account
 cswap add --slot 3              # Add account to a specific slot (prompts before overwrite)
 cswap remove 2                  # Remove an account
+cswap codex list                # Show Codex accounts
+cswap codex switch work         # Switch Codex auth only
 cswap tui                       # Interactive dashboard (also: bare `cswap`)
 cswap watch                     # Dashboard, opened on the live watch page
 cswap upgrade                   # Upgrade claude-swap to the latest version

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -880,20 +880,26 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
                 show_token_status=args.token_status,
                 json_output=args.json,
             )
-            if not args.json:
-                # The Codex section is auxiliary: its state living in a separate
-                # tree must never fail the primary Claude listing (which has
-                # already printed). Degrade to a warning on any Codex-side error.
-                try:
-                    codex_switcher = CodexAccountSwitcher()
-                    if codex_switcher.has_accounts():
+            # The Codex section is auxiliary: its state living in a separate
+            # tree must never fail the primary Claude listing (which, in text
+            # mode, has already printed). Degrade to a stderr warning on any
+            # Codex-side error so stdout stays a clean JSON document.
+            try:
+                codex_switcher = CodexAccountSwitcher()
+                if codex_switcher.has_accounts():
+                    if args.json:
+                        if payload is not None:
+                            payload["codex"] = codex_switcher.list_accounts(
+                                json_output=True
+                            )
+                    else:
                         print()
                         codex_switcher.list_accounts(json_output=False)
-                except ClaudeSwitchError as codex_err:
-                    print(
-                        dimmed(f"Codex accounts unavailable: {codex_err}"),
-                        file=sys.stderr,
-                    )
+            except ClaudeSwitchError as codex_err:
+                print(
+                    dimmed(f"Codex accounts unavailable: {codex_err}"),
+                    file=sys.stderr,
+                )
         elif args.switch:
             payload = switcher.switch(strategy=args.strategy, json_output=args.json)
         elif args.switch_to:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -8,6 +8,7 @@ import os
 import sys
 
 from claude_swap import __version__
+from claude_swap.codex import CodexAccountSwitcher
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
 from claude_swap.printer import dimmed, error, muted
@@ -84,6 +85,63 @@ def _translate_subcommand(argv: list[str]) -> list[str]:
         return [flag, *rest]
 
     return argv
+
+
+def _codex_command(argv: list[str]) -> None:
+    """Handle `cswap codex ...` commands for independent Codex auth switching."""
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} codex",
+        description="Manage Codex CLI auth snapshots independently of Claude accounts.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="snapshot the active Codex auth")
+    add_parser.add_argument("--label", metavar="LABEL", help="Display label for the account")
+    add_parser.add_argument("--slot", type=int, metavar="NUM", help="Store in a specific slot")
+
+    list_parser = subparsers.add_parser("list", aliases=["ls"], help="list Codex accounts")
+    list_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+
+    status_parser = subparsers.add_parser("status", help="show current Codex account")
+    status_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+
+    switch_parser = subparsers.add_parser("switch", help="switch Codex auth")
+    switch_parser.add_argument("account", nargs="?", metavar="NUM|LABEL")
+    switch_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+
+    remove_parser = subparsers.add_parser("remove", aliases=["rm"], help="remove a Codex account")
+    remove_parser.add_argument("account", metavar="NUM|LABEL")
+
+    args = parser.parse_args(argv)
+    json_mode = bool(getattr(args, "json", False))
+    payload: dict | None = None
+    try:
+        switcher = CodexAccountSwitcher()
+        if args.command == "add":
+            switcher.add_account(label=args.label, slot=args.slot)
+        elif args.command in ("list", "ls"):
+            payload = switcher.list_accounts(json_output=args.json)
+        elif args.command == "status":
+            payload = switcher.status(json_output=args.json)
+        elif args.command == "switch":
+            payload = switcher.switch(args.account, json_output=args.json)
+        elif args.command in ("remove", "rm"):
+            switcher.remove_account(args.account)
+    except ClaudeSwitchError as e:
+        if json_mode:
+            print(json.dumps(error_envelope(e), indent=2))
+        else:
+            error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(
+            f"\n{dimmed('Operation cancelled')}",
+            file=sys.stderr if json_mode else sys.stdout,
+        )
+        sys.exit(130)
+
+    if json_mode and payload is not None:
+        print(json.dumps(payload, indent=2))
 
 
 def _run_command(argv: list[str]) -> None:
@@ -513,6 +571,9 @@ def main() -> None:
     if argv and argv[0] == "auto":
         _auto_command(argv[1:])
         return  # only reachable in tests where sys.exit is mocked
+    if argv and argv[0] == "codex":
+        _codex_command(argv[1:])
+        return
     if len(sys.argv) > 1 and sys.argv[1] == "config":
         _config_command(sys.argv[2:])
         return
@@ -544,6 +605,7 @@ Commands:
   %(prog)s remove <num|email>         remove an account
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s auto                       auto-switch when nearing rate limits
+  %(prog)s codex <command>            manage Codex auth snapshots
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s export <path>              export accounts
   %(prog)s import <path>              import accounts
@@ -562,6 +624,8 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s list --json
   %(prog)s add --slot 3                      # add to a specific slot
   %(prog)s add-token sk-ant-oat01-... --email me@example.com
+  %(prog)s codex add --label work
+  %(prog)s codex switch work
   %(prog)s run 2 -- --resume                 # forward args after '--' to claude
   %(prog)s auto --once                       # single auto-switch tick (cron-friendly)
   %(prog)s config set autoswitch.threshold 80
@@ -816,6 +880,20 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
                 show_token_status=args.token_status,
                 json_output=args.json,
             )
+            if not args.json:
+                # The Codex section is auxiliary: its state living in a separate
+                # tree must never fail the primary Claude listing (which has
+                # already printed). Degrade to a warning on any Codex-side error.
+                try:
+                    codex_switcher = CodexAccountSwitcher()
+                    if codex_switcher.has_accounts():
+                        print()
+                        codex_switcher.list_accounts(json_output=False)
+                except ClaudeSwitchError as codex_err:
+                    print(
+                        dimmed(f"Codex accounts unavailable: {codex_err}"),
+                        file=sys.stderr,
+                    )
         elif args.switch:
             payload = switcher.switch(strategy=args.strategy, json_output=args.json)
         elif args.switch_to:

--- a/src/claude_swap/codex.py
+++ b/src/claude_swap/codex.py
@@ -1,0 +1,805 @@
+"""Codex account tracking and auth switching."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from claude_swap import oauth
+from claude_swap.exceptions import AccountNotFoundError, ConfigError, ValidationError
+from claude_swap.json_output import SCHEMA_VERSION, usage_freshness_fields
+from claude_swap.locking import FileLock
+from claude_swap.models import get_timestamp
+from claude_swap.paths import (
+    get_backup_root,
+    get_codex_auth_path,
+    get_legacy_backup_root,
+    migrate_legacy_backup_dir,
+)
+from claude_swap.printer import accent, bolded, dimmed, format_age, muted
+from claude_swap.usage_store import FetchRecord, UsageEntry, UsageStore
+
+
+class _AuthMetadata(NamedTuple):
+    account_id: str
+    auth_mode: str
+    fingerprint: str
+    access_token: str
+
+
+class _UsageFetchError(NamedTuple):
+    """An HTTP usage-fetch failure carrying the server's ``Retry-After`` (if any)
+    so ``UsageStore`` can honor the burst-block wait rather than only the default
+    exponential backoff."""
+
+    message: str
+    retry_after_s: float | None
+
+
+CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+CODEX_USAGE_TIMEOUT_S = 10.0
+_USAGE_AGE_NOTE_S = 90.0
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    # mkstemp creates the temp at 0600 from the first byte, so the auth token
+    # never has a world-readable window (write_text would create it 0644 under
+    # the default umask). Mirrors credentials._write_active_credentials_file /
+    # settings.atomic_write_json.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        os.write(fd, text.encode("utf-8"))
+        os.close(fd)
+        fd = -1
+        os.replace(tmp_name, str(path))
+        if sys.platform != "win32":
+            os.chmod(str(path), 0o600)
+    except OSError as exc:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise ConfigError(f"Failed to write {path}: {exc}") from exc
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    _atomic_write_text(path, json.dumps(data, indent=2) + "\n")
+
+
+def _fingerprint(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _safe_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _unix_seconds_to_iso(value: Any) -> str | None:
+    if not isinstance(value, (int, float)):
+        return None
+    return (
+        datetime.fromtimestamp(value, tz=timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _clamp_percent(value: Any) -> float:
+    pct = float(value) if isinstance(value, (int, float)) else 0.0
+    return min(100.0, max(0.0, pct))
+
+
+def _codex_window_label(window: dict[str, Any]) -> str:
+    seconds = window.get("limit_window_seconds")
+    if not isinstance(seconds, (int, float)):
+        return "?"
+    hours = round(seconds / 3600)
+    if hours >= 168:
+        return "Week"
+    if hours >= 24:
+        return "Day"
+    return f"{hours}h"
+
+
+def _parse_codex_usage(data: dict[str, Any]) -> dict[str, Any]:
+    rate_limit = data.get("rate_limit") if isinstance(data.get("rate_limit"), dict) else {}
+    windows = []
+    for key in ("primary_window", "secondary_window"):
+        window = rate_limit.get(key) if isinstance(rate_limit, dict) else None
+        if not isinstance(window, dict):
+            continue
+        entry: dict[str, Any] = {
+            "label": _codex_window_label(window),
+            "pct": _clamp_percent(window.get("used_percent")),
+        }
+        resets_at = _unix_seconds_to_iso(window.get("reset_at"))
+        if resets_at is not None:
+            entry["resets_at"] = resets_at
+        windows.append(entry)
+
+    usage: dict[str, Any] = {"windows": windows}
+    plan = _safe_str(data.get("plan_type"))
+    if plan:
+        usage["plan"] = plan
+    credits = data.get("credits") if isinstance(data.get("credits"), dict) else {}
+    balance = credits.get("balance") if isinstance(credits, dict) else None
+    if isinstance(balance, (int, float)):
+        usage["credits"] = float(balance)
+    elif isinstance(balance, str):
+        try:
+            usage["credits"] = float(balance)
+        except ValueError:
+            pass
+    return usage
+
+
+def _format_codex_usage_lines(usage: dict[str, Any]) -> list[str]:
+    rows: list[tuple[str, str]] = []
+    for window in usage.get("windows") or []:
+        if not isinstance(window, dict):
+            continue
+        label = _safe_str(window.get("label"))
+        pct = window.get("pct")
+        if not label or not isinstance(pct, (int, float)):
+            continue
+        body = f"{pct:>3.0f}%"
+        cell = oauth.fresh_reset_strings(window)
+        if cell:
+            countdown, clock = cell
+            body = f"{body}   resets {clock:<12}  in {countdown}"
+        rows.append((label, body))
+    plan = _safe_str(usage.get("plan"))
+    if plan:
+        rows.append(("Plan", plan))
+    credits = usage.get("credits")
+    if isinstance(credits, (int, float)):
+        rows.append(("Credits", f"{credits:g}"))
+    width = max((len(label) for label, _ in rows), default=0) + 1
+    return [f"{label + ':':<{width}} {body}" for label, body in rows]
+
+
+def _codex_window_to_json(window: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "label": _safe_str(window.get("label")),
+        "pct": window["pct"],
+    }
+    if "resets_at" in window:
+        out["resetsAt"] = window["resets_at"]
+    cell = oauth.fresh_reset_strings(window)
+    if cell:
+        out["countdown"], out["clock"] = cell
+    return out
+
+
+def _codex_usage_to_json(usage: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    windows: list[dict[str, Any]] = []
+    for window in usage.get("windows") or []:
+        if not isinstance(window, dict):
+            continue
+        pct = window.get("pct")
+        if _safe_str(window.get("label")) and isinstance(pct, (int, float)):
+            windows.append(_codex_window_to_json(window))
+    if windows:
+        out["windows"] = windows
+    plan = _safe_str(usage.get("plan"))
+    if plan:
+        out["plan"] = plan
+    credits = usage.get("credits")
+    if isinstance(credits, (int, float)):
+        out["credits"] = credits
+    return out
+
+
+def _codex_usage_fields(entry: UsageEntry) -> tuple[str, dict[str, Any] | None]:
+    usage = entry.decision_value()
+    if isinstance(usage, dict):
+        return "ok", _codex_usage_to_json(usage)
+    return "unavailable", None
+
+
+def _retry_after_seconds(exc: urllib.error.HTTPError) -> float | None:
+    raw = exc.headers.get("Retry-After") if exc.headers else None
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(raw.strip()))
+    except ValueError:
+        return None
+
+
+def fetch_codex_usage(
+    auth_text: str, timeout_s: float
+) -> dict[str, Any] | str | _UsageFetchError:
+    metadata = _metadata_from_text(auth_text)
+    if not metadata.access_token:
+        return "no access token"
+    headers = {
+        "Authorization": f"Bearer {metadata.access_token}",
+        "Accept": "application/json",
+        "originator": "claude-swap",
+        "User-Agent": "claude-swap/codex-usage",
+    }
+    if metadata.account_id:
+        headers["ChatGPT-Account-Id"] = metadata.account_id
+    request = urllib.request.Request(CODEX_USAGE_URL, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        retry_after = _retry_after_seconds(exc)
+        if exc.code in (401, 403):
+            return _UsageFetchError("token expired", retry_after)
+        return _UsageFetchError(f"HTTP {exc.code}", retry_after)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return str(exc) or "usage unavailable"
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return "malformed usage response"
+    if not isinstance(data, dict):
+        return "malformed usage response"
+    return _parse_codex_usage(data)
+
+
+def _metadata_from_text(text: str) -> _AuthMetadata:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Codex auth file is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ConfigError("Codex auth file must contain a JSON object")
+    tokens = data.get("tokens")
+    token_data = tokens if isinstance(tokens, dict) else {}
+    token_fields = ("account_id", "access_token", "refresh_token", "id_token")
+    has_token = any(_safe_str(token_data.get(field)) for field in token_fields)
+    has_key = any(
+        _safe_str(data.get(field))
+        for field in ("openai_api_key", "personal_access_token", "bedrock_api_key")
+    )
+    if not has_token and not has_key:
+        raise ConfigError("Codex auth file does not contain a supported Codex credential")
+    return _AuthMetadata(
+        account_id=_safe_str(token_data.get("account_id")),
+        auth_mode=_safe_str(data.get("auth_mode")),
+        fingerprint=_fingerprint(text),
+        access_token=_safe_str(token_data.get("access_token")),
+    )
+
+
+class CodexAccountSwitcher:
+    """Independent account switcher for Codex CLI auth snapshots."""
+
+    def __init__(self) -> None:
+        self.backup_root = get_backup_root()
+        if migrate_legacy_backup_dir(self.backup_root):
+            legacy = get_legacy_backup_root()
+            print(
+                f"claude-swap: migrated data from {legacy} to {self.backup_root}",
+                file=sys.stderr,
+            )
+        self.codex_dir = self.backup_root / "codex"
+        self.auth_dir = self.codex_dir / "auth"
+        self.sequence_file = self.codex_dir / "sequence.json"
+        self.lock_file = self.codex_dir / ".lock"
+        self.auth_path = get_codex_auth_path()
+        self._usage_store = UsageStore(self.codex_dir / "cache")
+
+    def _setup_directories(self) -> None:
+        for directory in (self.codex_dir, self.auth_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+            if sys.platform != "win32":
+                os.chmod(directory, 0o700)
+
+    def _read_json(self, path: Path) -> dict[str, Any] | None:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None
+        except json.JSONDecodeError as exc:
+            raise ConfigError(f"Codex state file is not valid JSON ({path}): {exc}") from exc
+        except OSError as exc:
+            raise ConfigError(f"Failed to read Codex state file {path}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ConfigError(f"Codex state file must contain a JSON object: {path}")
+        return data
+
+    def _write_json(self, path: Path, data: dict[str, Any]) -> None:
+        _atomic_write_json(path, data)
+
+    def _init_sequence_file(self) -> None:
+        if self.sequence_file.exists():
+            return
+        self._write_json(
+            self.sequence_file,
+            {
+                "activeAccountNumber": None,
+                "lastUpdated": get_timestamp(),
+                "sequence": [],
+                "accounts": {},
+            },
+        )
+
+    def _sequence_data(self) -> dict[str, Any]:
+        data = self._read_json(self.sequence_file)
+        if data is None:
+            return {
+                "activeAccountNumber": None,
+                "lastUpdated": get_timestamp(),
+                "sequence": [],
+                "accounts": {},
+            }
+        sequence = data.setdefault("sequence", [])
+        accounts = data.setdefault("accounts", {})
+        if not isinstance(sequence, list) or not all(
+            isinstance(num, int) for num in sequence
+        ):
+            raise ConfigError(f"Codex state sequence must be a list of numbers: {self.sequence_file}")
+        if not isinstance(accounts, dict):
+            raise ConfigError(f"Codex state accounts must be an object: {self.sequence_file}")
+        return data
+
+    def _auth_backup_path(self, account_num: str) -> Path:
+        return self.auth_dir / f"account-{account_num}.json"
+
+    def _read_active_auth(self) -> str | None:
+        try:
+            text = self.auth_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise ConfigError(f"Failed to read Codex auth file {self.auth_path}: {exc}") from exc
+        return text if text.strip() else None
+
+    def _read_required_active_auth(self) -> str:
+        text = self._read_active_auth()
+        if text is None:
+            raise ConfigError(
+                f"No active Codex auth found at {self.auth_path}. Run 'codex login' first."
+            )
+        return text
+
+    def _write_active_auth(self, text: str) -> None:
+        _atomic_write_text(self.auth_path, text)
+
+    def _read_account_auth(self, account_num: str) -> str:
+        try:
+            return self._auth_backup_path(account_num).read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise ConfigError(
+                f"Codex Account-{account_num} has no stored auth. Re-add it with: "
+                f"cswap codex add --slot {account_num}"
+            ) from exc
+        except OSError as exc:
+            raise ConfigError(f"Failed to read Codex Account-{account_num} auth: {exc}") from exc
+
+    def _write_account_auth(self, account_num: str, text: str) -> None:
+        _atomic_write_text(self._auth_backup_path(account_num), text)
+
+    def _metadata(self, text: str) -> _AuthMetadata:
+        return _metadata_from_text(text)
+
+    def _stored_metadata(self, account_num: str, text: str) -> _AuthMetadata:
+        try:
+            return self._metadata(text)
+        except ConfigError as exc:
+            raise ConfigError(
+                f"stored auth for Codex Account-{account_num} is invalid: {exc}"
+            ) from exc
+
+    def _next_account_number(self, data: dict[str, Any]) -> int:
+        accounts = data.get("accounts", {})
+        numbers = [int(num) for num in accounts.keys()]
+        return max(numbers, default=0) + 1
+
+    def _derive_label(
+        self, label: str | None, metadata: _AuthMetadata, account_num: str
+    ) -> str:
+        if label is not None:
+            normalized = label.strip()
+            if not normalized:
+                raise ValidationError("Codex account label cannot be empty")
+            if normalized.isdigit():
+                raise ValidationError("Codex account label cannot be only digits")
+            return normalized
+        if metadata.account_id:
+            return metadata.account_id
+        return f"codex-account-{account_num}"
+
+    def _account_by_label(self, data: dict[str, Any], label: str) -> str | None:
+        for num, account in data.get("accounts", {}).items():
+            if account.get("label") == label:
+                return num
+        return None
+
+    def _current_account_number(
+        self, data: dict[str, Any], active_auth: str | None
+    ) -> str | None:
+        if active_auth is None:
+            active_auth = self._read_active_auth()
+        if active_auth is None:
+            return None
+        metadata = self._metadata(active_auth)
+        accounts = data.get("accounts", {})
+        if metadata.account_id:
+            for num, account in accounts.items():
+                if account.get("accountId") == metadata.account_id:
+                    return num
+        for num, account in accounts.items():
+            if account.get("fingerprint") == metadata.fingerprint:
+                return num
+        return None
+
+    def _resolve_account_identifier(
+        self, data: dict[str, Any], identifier: str
+    ) -> str | None:
+        accounts = data.get("accounts", {})
+        if identifier.isdigit():
+            return identifier if identifier in accounts else None
+        return self._account_by_label(data, identifier)
+
+    def _set_account_record(
+        self,
+        data: dict[str, Any],
+        account_num: str,
+        label: str,
+        metadata: _AuthMetadata,
+    ) -> None:
+        existing = data.get("accounts", {}).get(account_num, {})
+        data["accounts"][account_num] = {
+            "label": label,
+            "accountId": metadata.account_id,
+            "authMode": metadata.auth_mode,
+            "fingerprint": metadata.fingerprint,
+            "added": existing.get("added") or get_timestamp(),
+        }
+        numeric = int(account_num)
+        if numeric not in data["sequence"]:
+            data["sequence"].append(numeric)
+            data["sequence"].sort()
+
+    def _account_ref(self, data: dict[str, Any], account_num: str | None) -> dict | None:
+        if account_num is None:
+            return None
+        account = data.get("accounts", {}).get(account_num)
+        if not account:
+            return None
+        return {"number": int(account_num), "label": account.get("label", "")}
+
+    def has_accounts(self) -> bool:
+        return bool(self._sequence_data().get("accounts"))
+
+    def add_account(self, label: str | None, slot: int | None) -> None:
+        active_auth = self._read_required_active_auth()
+        metadata = self._metadata(active_auth)
+        self._setup_directories()
+        self._init_sequence_file()
+
+        with FileLock(self.lock_file):
+            data = self._sequence_data()
+            existing_num = self._current_account_number(data, active_auth)
+            if slot is None:
+                account_num = existing_num or str(self._next_account_number(data))
+            else:
+                if slot < 1:
+                    raise ConfigError("Codex slot number must be >= 1")
+                account_num = str(slot)
+                # existing_num already covers both auth modes (accountId match,
+                # else fingerprint), so the guard must not gate on account_id —
+                # api-key auth has none and would otherwise duplicate across slots.
+                if existing_num is not None and existing_num != account_num:
+                    raise ValidationError(
+                        f"This Codex auth is already stored as Codex Account-{existing_num}"
+                    )
+                if (
+                    account_num in data.get("accounts", {})
+                    and existing_num != account_num
+                ):
+                    raise ConfigError(
+                        f"Codex Account-{account_num} already exists. Remove it first "
+                        f"or choose another slot."
+                    )
+
+            existing_account = data.get("accounts", {}).get(account_num, {})
+            if label is None and existing_account:
+                resolved_label = existing_account.get("label", "")
+            else:
+                resolved_label = self._derive_label(label, metadata, account_num)
+            duplicate = self._account_by_label(data, resolved_label)
+            if duplicate is not None and duplicate != account_num:
+                raise ValidationError(
+                    f"Codex account label '{resolved_label}' already exists as Account-{duplicate}"
+                )
+
+            self._write_account_auth(account_num, active_auth)
+            self._set_account_record(data, account_num, resolved_label, metadata)
+            data["activeAccountNumber"] = int(account_num)
+            data["lastUpdated"] = get_timestamp()
+            self._write_json(self.sequence_file, data)
+
+        action = "Updated" if existing_num == account_num else "Added"
+        print(f"{accent(action)} Codex Account-{account_num}: {resolved_label}")
+
+    def _usage_identities(self, data: dict[str, Any]) -> dict[str, tuple[str, str]]:
+        identities: dict[str, tuple[str, str]] = {}
+        for num, account in data.get("accounts", {}).items():
+            account_id = _safe_str(account.get("accountId"))
+            fingerprint = _safe_str(account.get("fingerprint"))
+            label = _safe_str(account.get("label"))
+            if account_id and fingerprint:
+                identities[num] = (f"{account_id}:{fingerprint}", "")
+            else:
+                identities[num] = (account_id or fingerprint or label or num, "")
+        return identities
+
+    def _fetch_usage_record(self, account_num: str) -> FetchRecord:
+        try:
+            auth_text = self._read_account_auth(account_num)
+            usage = fetch_codex_usage(auth_text, CODEX_USAGE_TIMEOUT_S)
+        except ConfigError as exc:
+            return FetchRecord(error=str(exc))
+        if isinstance(usage, dict):
+            return FetchRecord(usage=usage)
+        if isinstance(usage, _UsageFetchError):
+            return FetchRecord(error=usage.message, retry_after_s=usage.retry_after_s)
+        return FetchRecord(error=usage or "usage unavailable")
+
+    def _collect_usage_entries(self, data: dict[str, Any]) -> dict[str, UsageEntry]:
+        identities = self._usage_identities(data)
+        if not identities:
+            return {}
+        store = self._usage_store
+        now = store.clock()
+        entries = store.entries(identities)
+        to_fetch = [
+            num
+            for num in sorted(identities.keys(), key=int)
+            if not entries[num].fresh(now)
+            and not entries[num].in_backoff(now)
+            and not entries[num].claimed(now)
+        ]
+        if to_fetch:
+            store.claim(to_fetch, identities)
+            store.record(
+                {num: self._fetch_usage_record(num) for num in to_fetch},
+                identities,
+            )
+            entries = store.entries(identities)
+        return entries
+
+    def _build_list_payload(
+        self, data: dict[str, Any], entries: dict[str, UsageEntry]
+    ) -> dict:
+        active_num = self._current_account_number(data, None)
+        accounts = []
+        for num in sorted(data.get("accounts", {}).keys(), key=int):
+            account = data["accounts"][num]
+            entry = entries.get(num, UsageEntry())
+            usage_status, usage = _codex_usage_fields(entry)
+            row = {
+                "number": int(num),
+                "label": account.get("label", ""),
+                "active": num == active_num,
+                "usageStatus": usage_status,
+                "usage": usage,
+            }
+            if usage is not None:
+                row.update(usage_freshness_fields(entry.fetched_at, entry.age_s))
+            elif entry.last_error:
+                # "unavailable" alone can't tell a permanently-expired stored
+                # token from a transient network blip; surface the detail.
+                row["usageError"] = entry.last_error
+            accounts.append(row)
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "provider": "codex",
+            "activeAccountNumber": int(active_num) if active_num is not None else None,
+            "accounts": accounts,
+        }
+
+    def _codex_usage_lines(self, entry: UsageEntry) -> list[str]:
+        if entry.last_good is not None:
+            lines = _format_codex_usage_lines(entry.last_good)
+            if (
+                lines
+                and entry.age_s is not None
+                and entry.age_s > _USAGE_AGE_NOTE_S
+                and entry.fetched_at is not None
+            ):
+                lines[-1] += f" · {format_age(int(entry.fetched_at * 1000))}"
+            if lines:
+                return [
+                    f"{dimmed('└' if j == len(lines) - 1 else '├')} {muted(line)}"
+                    for j, line in enumerate(lines)
+                ]
+        detail = "usage unavailable"
+        if entry.last_error:
+            detail += f" ({entry.last_error})"
+        return [dimmed(detail)]
+
+    def list_accounts(self, json_output: bool) -> dict | None:
+        data = self._sequence_data()
+        entries = self._collect_usage_entries(data)
+        if json_output:
+            return self._build_list_payload(data, entries)
+
+        accounts = data.get("accounts", {})
+        if not accounts:
+            print(dimmed("No Codex accounts are managed yet."))
+            return None
+
+        payload = self._build_list_payload(data, entries)
+        print(bolded("Codex accounts:"))
+        for account in payload["accounts"]:
+            marker = f" {accent('(active)')}" if account["active"] else ""
+            print(f"  {account['number']}: {account['label']}{marker}")
+            entry = entries.get(str(account["number"]), UsageEntry())
+            for line in self._codex_usage_lines(entry):
+                print(f"     {line}")
+        return None
+
+    def status(self, json_output: bool) -> dict | None:
+        data = self._sequence_data()
+        active_auth = self._read_active_auth()
+        if active_auth is None:
+            payload = {"schemaVersion": SCHEMA_VERSION, "provider": "codex", "active": None}
+        else:
+            current_num = self._current_account_number(data, active_auth)
+            if current_num is None:
+                payload = {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "provider": "codex",
+                    "active": {"managed": False},
+                }
+            else:
+                account = data["accounts"][current_num]
+                payload = {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "provider": "codex",
+                    "active": {
+                        "number": int(current_num),
+                        "label": account.get("label", ""),
+                        "managed": True,
+                    },
+                    "totalManagedAccounts": len(data.get("accounts", {})),
+                }
+        if json_output:
+            return payload
+
+        active = payload["active"]
+        if active is None:
+            print(f"{bolded('Codex status:')} {dimmed('No active Codex auth')}")
+        elif active.get("managed"):
+            active_label = accent(f"Account-{active['number']}")
+            print(
+                f"{bolded('Codex status:')} "
+                f"{active_label} ({active['label']})"
+            )
+        else:
+            print(f"{bolded('Codex status:')} {muted('(not managed)')}")
+        return None
+
+    def _rotation_target(self, data: dict[str, Any]) -> str | None:
+        sequence = data.get("sequence", [])
+        if not sequence:
+            return None
+        if len(sequence) == 1:
+            return str(sequence[0])
+        current_num = self._current_account_number(data, None)
+        if current_num is None:
+            active = data.get("activeAccountNumber")
+            current_num = str(active) if active is not None else str(sequence[0])
+        try:
+            current_index = sequence.index(int(current_num))
+        except ValueError:
+            current_index = 0
+        return str(sequence[(current_index + 1) % len(sequence)])
+
+    def switch(self, identifier: str | None, json_output: bool) -> dict | None:
+        self._setup_directories()
+        with FileLock(self.lock_file):
+            data = self._sequence_data()
+            if not data.get("accounts"):
+                raise ConfigError("No Codex accounts are managed yet")
+
+            target_account = (
+                self._rotation_target(data)
+                if identifier is None
+                else self._resolve_account_identifier(data, identifier)
+            )
+            if target_account is None:
+                raise AccountNotFoundError(f"No Codex account found with identifier: {identifier}")
+            if target_account not in data.get("accounts", {}):
+                raise AccountNotFoundError(f"Codex Account-{target_account} does not exist")
+
+            active_auth = self._read_active_auth()
+            current_num = self._current_account_number(data, active_auth) if active_auth else None
+            from_ref = self._account_ref(data, current_num)
+            to_ref = self._account_ref(data, target_account)
+            if current_num == target_account:
+                result = {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "provider": "codex",
+                    "switched": False,
+                    "from": from_ref,
+                    "to": to_ref,
+                    "reason": "already-active",
+                    "message": f"Already on Codex Account-{target_account}",
+                }
+                if json_output:
+                    return result
+                print(f"{accent('Already on')} Codex Account-{target_account}")
+                return None
+
+            if active_auth is not None and current_num is not None:
+                metadata = self._metadata(active_auth)
+                current_label = data["accounts"][current_num].get("label", "")
+                self._write_account_auth(current_num, active_auth)
+                self._set_account_record(data, current_num, current_label, metadata)
+
+            target_auth = self._read_account_auth(target_account)
+            self._stored_metadata(target_account, target_auth)
+            had_active_auth = active_auth is not None
+            self._write_active_auth(target_auth)
+            try:
+                data["activeAccountNumber"] = int(target_account)
+                data["lastUpdated"] = get_timestamp()
+                self._write_json(self.sequence_file, data)
+            except ConfigError:
+                if had_active_auth and active_auth is not None:
+                    self._write_active_auth(active_auth)
+                else:
+                    self.auth_path.unlink(missing_ok=True)
+                raise
+
+        label = data["accounts"][target_account].get("label", "")
+        result = {
+            "schemaVersion": SCHEMA_VERSION,
+            "provider": "codex",
+            "switched": True,
+            "from": from_ref,
+            "to": to_ref,
+            "reason": "switched",
+            "message": f"Switched Codex to Account-{target_account} ({label})",
+        }
+        if json_output:
+            return result
+        print(f"{accent('Switched Codex to')} Account-{target_account} ({label})")
+        return None
+
+    def remove_account(self, identifier: str) -> None:
+        self._setup_directories()
+        with FileLock(self.lock_file):
+            data = self._sequence_data()
+            account_num = self._resolve_account_identifier(data, identifier)
+            if account_num is None:
+                raise AccountNotFoundError(
+                    f"No Codex account found with identifier: {identifier}"
+                )
+            account = data.get("accounts", {}).get(account_num)
+            if account is None:
+                raise AccountNotFoundError(f"Codex Account-{account_num} does not exist")
+
+            self._auth_backup_path(account_num).unlink(missing_ok=True)
+            data["accounts"].pop(account_num, None)
+            numeric = int(account_num)
+            if numeric in data.get("sequence", []):
+                data["sequence"].remove(numeric)
+            if data.get("activeAccountNumber") == numeric:
+                data["activeAccountNumber"] = None
+            data["lastUpdated"] = get_timestamp()
+            self._write_json(self.sequence_file, data)
+
+        print(f"{accent('Removed')} Codex Account-{account_num}: {account.get('label', '')}")

--- a/src/claude_swap/codex.py
+++ b/src/claude_swap/codex.py
@@ -105,10 +105,8 @@ def _codex_window_label(window: dict[str, Any]) -> str:
     if not isinstance(seconds, (int, float)):
         return "?"
     hours = round(seconds / 3600)
-    if hours >= 168:
-        return "Week"
     if hours >= 24:
-        return "Day"
+        return f"{round(hours / 24)}d"
     return f"{hours}h"
 
 

--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -1,4 +1,4 @@
-"""Path resolution for Claude Code config and credential files.
+"""Path resolution for Claude Code, Codex, and cswap data files.
 
 Mirrors claude-code's own resolution so cswap reads and writes the same files
 claude-code does. Key rules (from claude-code source):
@@ -12,6 +12,9 @@ claude-code does. Key rules (from claude-code source):
 Also resolves the cswap backup root, which on Linux/WSL follows the XDG Base
 Directory Specification (``$XDG_DATA_HOME/claude-swap``) and falls back to the
 legacy ``~/.claude-swap-backup`` on macOS/Windows.
+
+Codex auth resolution follows Codex CLI: ``CODEX_HOME`` if set, else
+``~/.codex``, with active auth at ``auth.json`` inside that directory.
 
 References:
 - claude-code utils/env.ts getGlobalClaudeFile
@@ -56,6 +59,19 @@ def get_global_config_path() -> Path:
 def get_credentials_path() -> Path:
     """Return the path to the Claude credentials file."""
     return get_claude_config_home() / ".credentials.json"
+
+
+def get_codex_home() -> Path:
+    """Return the Codex config home directory (CODEX_HOME or ~/.codex)."""
+    env = os.environ.get("CODEX_HOME")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".codex"
+
+
+def get_codex_auth_path() -> Path:
+    """Return the active Codex auth file path."""
+    return get_codex_home() / "auth.json"
 
 
 def get_legacy_backup_root() -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,14 +89,15 @@ def _isolate_real_home(request, tmp_path_factory, monkeypatch):
     ``~/Library/Keychains``. An isolated ``$HOME`` makes those commands fail. The
     fixture itself swaps the default keychain to a throwaway one and restores it.
 
-    Always neutralize ``CLAUDE_CONFIG_DIR`` and ``XDG_DATA_HOME`` (even for
-    ``temp_home`` tests): both bypass ``$HOME`` in path resolution
-    (``paths.get_global_config_path``/``get_backup_root``), so a developer with
-    either exported could otherwise have tests read/write real Claude config or
-    backup paths — and on macOS that leads back to the real Keychain. Tests that
-    exercise those vars set them explicitly, overriding this.
+    Always neutralize ``CLAUDE_CONFIG_DIR``, ``CODEX_HOME``, and ``XDG_DATA_HOME``
+    (even for ``temp_home`` tests): these vars bypass ``$HOME`` in path resolution
+    (``paths.get_global_config_path``/``get_codex_auth_path``/``get_backup_root``),
+    so a developer with any exported could otherwise have tests read/write real
+    Claude config, Codex auth, or backup paths. On macOS that can lead back to the
+    real Keychain. Tests that exercise those vars set them explicitly, overriding this.
     """
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     if "temp_home" in request.fixturenames:
         return  # temp_home provides its own isolated home

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -729,19 +729,39 @@ class TestSubcommandAliases:
         claude_cls.return_value.list_accounts.assert_called_once()
         assert "Codex accounts unavailable" in capsys.readouterr().err
 
-    def test_list_json_does_not_append_codex_accounts(self):
-        """`cswap list --json` remains Claude-compatible."""
-        payload = {"schemaVersion": 1, "accounts": []}
+    def test_list_json_embeds_codex_accounts(self, capsys):
+        """`cswap list --json` nests Codex under `codex`, keeping Claude keys intact."""
+        claude_payload = {"schemaVersion": 1, "activeAccountNumber": None, "accounts": []}
+        codex_payload = {"schemaVersion": 1, "provider": "codex", "accounts": []}
         with patch("claude_swap.cli.ClaudeAccountSwitcher") as claude_cls, \
              patch("claude_swap.cli.CodexAccountSwitcher") as codex_cls, \
              patch.object(sys, "argv", ["claude-swap", "list", "--json"]), \
              patch("os.geteuid", return_value=1000, create=True), \
              patch("claude_swap.update_check.check_for_update", return_value=None):
-            claude_cls.return_value.list_accounts.return_value = payload
+            claude_cls.return_value.list_accounts.return_value = claude_payload
             codex_cls.return_value.has_accounts.return_value = True
+            codex_cls.return_value.list_accounts.return_value = codex_payload
+            cli.main()
+
+        codex_cls.return_value.list_accounts.assert_called_once_with(json_output=True)
+        out = json.loads(capsys.readouterr().out)
+        assert out["accounts"] == []
+        assert out["codex"] == codex_payload
+
+    def test_list_json_omits_codex_when_no_codex_accounts(self, capsys):
+        """No Codex accounts means no `codex` key at all."""
+        claude_payload = {"schemaVersion": 1, "activeAccountNumber": None, "accounts": []}
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as claude_cls, \
+             patch("claude_swap.cli.CodexAccountSwitcher") as codex_cls, \
+             patch.object(sys, "argv", ["claude-swap", "list", "--json"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            claude_cls.return_value.list_accounts.return_value = claude_payload
+            codex_cls.return_value.has_accounts.return_value = False
             cli.main()
 
         codex_cls.return_value.list_accounts.assert_not_called()
+        assert "codex" not in json.loads(capsys.readouterr().out)
 
     def test_codex_add_dispatches(self):
         """`cswap codex add` dispatches with label and slot."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,11 +42,11 @@ def _subprocess_env(**extra: str) -> dict[str, str]:
         env["USERPROFILE"] = _ISOLATED_HOME
     elif "USERPROFILE" not in extra:
         env["USERPROFILE"] = extra["HOME"]
-    # CLAUDE_CONFIG_DIR / XDG_DATA_HOME bypass HOME in path resolution, so a
-    # developer with either exported would otherwise point the spawned CLI back
-    # at real config/backup paths (and on macOS, the real Keychain). Drop them
+    # CLAUDE_CONFIG_DIR / CODEX_HOME / XDG_DATA_HOME bypass HOME in path resolution, so a
+    # developer with any exported would otherwise point the spawned CLI back
+    # at real config/auth/backup paths (and on macOS, the real Keychain). Drop them
     # unless a caller set them deliberately.
-    for var in ("CLAUDE_CONFIG_DIR", "XDG_DATA_HOME"):
+    for var in ("CLAUDE_CONFIG_DIR", "CODEX_HOME", "XDG_DATA_HOME"):
         if var not in extra:
             env.pop(var, None)
     return env
@@ -126,6 +126,12 @@ class TestCLI:
         )
         # Should run (may fail due to no config, but flag should be accepted)
         assert "--debug" not in result.stderr or "unrecognized" not in result.stderr
+
+    def test_subprocess_env_clears_codex_home(self):
+        with patch.dict(os.environ, {"CODEX_HOME": "/real/codex"}):
+            env = _subprocess_env()
+
+        assert "CODEX_HOME" not in env
 
     def test_token_status_flag_requires_list(self, capsys):
         """--token-status should only be accepted alongside --list."""
@@ -689,6 +695,85 @@ class TestSubcommandAliases:
         switcher_cls.return_value.list_accounts.assert_called_once_with(
             show_token_status=False, json_output=True,
         )
+
+    def test_list_subcommand_appends_codex_accounts(self):
+        """`cswap ls` shows Codex accounts after Claude accounts when present."""
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as claude_cls, \
+             patch("claude_swap.cli.CodexAccountSwitcher") as codex_cls, \
+             patch.object(sys, "argv", ["claude-swap", "ls"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            codex_cls.return_value.has_accounts.return_value = True
+            cli.main()
+
+        claude_cls.return_value.list_accounts.assert_called_once_with(
+            show_token_status=False,
+            json_output=False,
+        )
+        codex_cls.return_value.list_accounts.assert_called_once_with(json_output=False)
+
+    def test_list_subcommand_survives_corrupt_codex_state(self, capsys):
+        """A corrupt Codex state must not fail the primary `cswap list`."""
+        from claude_swap.exceptions import ConfigError
+
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as claude_cls, \
+             patch("claude_swap.cli.CodexAccountSwitcher") as codex_cls, \
+             patch.object(sys, "argv", ["claude-swap", "ls"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            codex_cls.return_value.has_accounts.side_effect = ConfigError(
+                "Codex state file is not valid JSON"
+            )
+            cli.main()
+
+        claude_cls.return_value.list_accounts.assert_called_once()
+        assert "Codex accounts unavailable" in capsys.readouterr().err
+
+    def test_list_json_does_not_append_codex_accounts(self):
+        """`cswap list --json` remains Claude-compatible."""
+        payload = {"schemaVersion": 1, "accounts": []}
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as claude_cls, \
+             patch("claude_swap.cli.CodexAccountSwitcher") as codex_cls, \
+             patch.object(sys, "argv", ["claude-swap", "list", "--json"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            claude_cls.return_value.list_accounts.return_value = payload
+            codex_cls.return_value.has_accounts.return_value = True
+            cli.main()
+
+        codex_cls.return_value.list_accounts.assert_not_called()
+
+    def test_codex_add_dispatches(self):
+        """`cswap codex add` dispatches with label and slot."""
+        with patch("claude_swap.cli.CodexAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "codex", "add", "--label", "work"]):
+            cli.main()
+
+        switcher_cls.return_value.add_account.assert_called_once_with(
+            label="work",
+            slot=None,
+        )
+
+    def test_codex_switch_dispatches(self):
+        """`cswap codex switch 2` dispatches to the Codex switcher."""
+        with patch("claude_swap.cli.CodexAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "codex", "switch", "2"]):
+            cli.main()
+
+        switcher_cls.return_value.switch.assert_called_once_with(
+            "2",
+            json_output=False,
+        )
+
+    def test_codex_list_json_serialized_to_stdout(self, capsys):
+        payload = {"schemaVersion": 1, "provider": "codex", "accounts": []}
+        with patch("claude_swap.cli.CodexAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "codex", "list", "--json"]):
+            switcher_cls.return_value.list_accounts.return_value = payload
+            cli.main()
+
+        switcher_cls.return_value.list_accounts.assert_called_once_with(json_output=True)
+        assert json.loads(capsys.readouterr().out) == payload
 
     def test_run_subcommand_still_dispatches(self):
         """`cswap run 2` keeps reaching the session pre-dispatch (not translated)."""

--- a/tests/test_codex_switcher.py
+++ b/tests/test_codex_switcher.py
@@ -129,7 +129,7 @@ def test_fetch_codex_usage_calls_wham_backend(monkeypatch: pytest.MonkeyPatch):
     assert usage == {
         "windows": [
             {"label": "3h", "pct": 25.0, "resets_at": "2026-07-07T21:00:00Z"},
-            {"label": "Week", "pct": 50.0, "resets_at": "2026-07-14T21:00:00Z"},
+            {"label": "7d", "pct": 50.0, "resets_at": "2026-07-14T21:00:00Z"},
         ],
         "plan": "plus",
         "credits": 2.0,
@@ -177,7 +177,7 @@ def test_list_accounts_prints_codex_usage(
         lambda auth_text, timeout_s: {
             "windows": [
                 {"label": "3h", "pct": 25.0},
-                {"label": "Week", "pct": 50.0},
+                {"label": "7d", "pct": 50.0},
             ],
             "plan": "plus",
             "credits": 2.0,
@@ -191,7 +191,7 @@ def test_list_accounts_prints_codex_usage(
     assert "  1: work (active)" in out
     assert "├ 3h:" in out
     assert "25%" in out
-    assert "├ Week:" in out
+    assert "├ 7d:" in out
     assert "50%" in out
     assert "├ Plan:" in out
     assert "plus" in out
@@ -212,7 +212,7 @@ def test_list_accounts_json_includes_codex_usage(
         lambda auth_text, timeout_s: {
             "windows": [
                 {"label": "3h", "pct": 25.0, "resets_at": "2026-01-01T00:00:00Z"},
-                {"label": "Week", "pct": 50.0},
+                {"label": "7d", "pct": 50.0},
             ],
             "plan": "plus",
             "credits": 2.0,
@@ -232,7 +232,7 @@ def test_list_accounts_json_includes_codex_usage(
     assert account["usage"]["windows"][0]["label"] == "3h"
     assert account["usage"]["windows"][0]["pct"] == 25.0
     assert account["usage"]["windows"][0]["resetsAt"] == "2026-01-01T00:00:00Z"
-    assert account["usage"]["windows"][1] == {"label": "Week", "pct": 50.0}
+    assert account["usage"]["windows"][1] == {"label": "7d", "pct": 50.0}
     assert account["usage"]["plan"] == "plus"
     assert account["usage"]["credits"] == 2.0
     assert account["usageFetchedAt"] == "1970-01-01T00:00:00Z"

--- a/tests/test_codex_switcher.py
+++ b/tests/test_codex_switcher.py
@@ -1,0 +1,739 @@
+"""Tests for Codex account switching."""
+
+from __future__ import annotations
+
+import email.message
+import json
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from claude_swap.codex import (
+    CodexAccountSwitcher,
+    _UsageFetchError,
+    fetch_codex_usage,
+)
+from claude_swap.usage_store import SERVE_TTL_S
+from claude_swap.exceptions import AccountNotFoundError, ConfigError, ValidationError
+from claude_swap.models import Platform
+
+
+def _http_error(code: int, retry_after: str | None) -> urllib.error.HTTPError:
+    headers = email.message.Message()
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    return urllib.error.HTTPError("https://chatgpt.com/x", code, "err", headers, None)
+
+
+def _raise_urlopen(exc: Exception):
+    def fake(request, timeout):
+        raise exc
+
+    return fake
+
+
+def _body_urlopen(body: bytes):
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return body
+
+    def fake(request, timeout):
+        return FakeResponse()
+
+    return fake
+
+
+def _write_auth(home: Path, payload: dict) -> Path:
+    auth_path = home / ".codex" / "auth.json"
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.write_text(json.dumps(payload), encoding="utf-8")
+    return auth_path
+
+
+def _auth(account_id: str) -> dict:
+    return {
+        "auth_mode": "chatgpt",
+        "tokens": {"account_id": account_id, "access_token": f"token-{account_id}"},
+    }
+
+
+def _auth_with_token(account_id: str, access_token: str) -> dict:
+    return {
+        "auth_mode": "chatgpt",
+        "tokens": {"account_id": account_id, "access_token": access_token},
+    }
+
+
+def _api_key_auth(api_key: str) -> dict:
+    return {"auth_mode": "apikey", "openai_api_key": api_key}
+
+
+def test_fetch_codex_usage_calls_wham_backend(monkeypatch: pytest.MonkeyPatch):
+    captured = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "rate_limit": {
+                        "primary_window": {
+                            "limit_window_seconds": 10800,
+                            "used_percent": 25,
+                            "reset_at": 1783458000,
+                        },
+                        "secondary_window": {
+                            "limit_window_seconds": 604800,
+                            "used_percent": 50,
+                            "reset_at": 1784062800,
+                        },
+                    },
+                    "plan_type": "plus",
+                    "credits": {"balance": "2"},
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["authorization"] = request.get_header("Authorization")
+        captured["account"] = request.get_header("Chatgpt-account-id")
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("claude_swap.codex.urllib.request.urlopen", fake_urlopen)
+
+    usage = fetch_codex_usage(json.dumps(_auth("acct-1")), timeout_s=3.0)
+
+    assert captured == {
+        "url": "https://chatgpt.com/backend-api/wham/usage",
+        "authorization": "Bearer token-acct-1",
+        "account": "acct-1",
+        "timeout": 3.0,
+    }
+    assert usage == {
+        "windows": [
+            {"label": "3h", "pct": 25.0, "resets_at": "2026-07-07T21:00:00Z"},
+            {"label": "Week", "pct": 50.0, "resets_at": "2026-07-14T21:00:00Z"},
+        ],
+        "plan": "plus",
+        "credits": 2.0,
+    }
+
+
+def test_add_snapshots_active_auth(temp_home: Path, monkeypatch: pytest.MonkeyPatch):
+    _write_auth(temp_home, _auth("acct-1"))
+    monkeypatch.setattr(
+        "claude_swap.codex.fetch_codex_usage",
+        lambda auth_text, timeout_s: "usage unavailable",
+    )
+
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="work", slot=None)
+
+    payload = switcher.list_accounts(json_output=True)
+    assert payload == {
+        "schemaVersion": 1,
+        "provider": "codex",
+        "activeAccountNumber": 1,
+        "accounts": [
+            {
+                "number": 1,
+                "label": "work",
+                "active": True,
+                "usageStatus": "unavailable",
+                "usage": None,
+                "usageError": "usage unavailable",
+            }
+        ],
+    }
+
+
+def test_list_accounts_prints_codex_usage(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="work", slot=None)
+    capsys.readouterr()
+
+    monkeypatch.setattr(
+        "claude_swap.codex.fetch_codex_usage",
+        lambda auth_text, timeout_s: {
+            "windows": [
+                {"label": "3h", "pct": 25.0},
+                {"label": "Week", "pct": 50.0},
+            ],
+            "plan": "plus",
+            "credits": 2.0,
+        },
+    )
+
+    switcher.list_accounts(json_output=False)
+
+    out = capsys.readouterr().out
+    assert "Codex accounts:" in out
+    assert "  1: work (active)" in out
+    assert "├ 3h:" in out
+    assert "25%" in out
+    assert "├ Week:" in out
+    assert "50%" in out
+    assert "├ Plan:" in out
+    assert "plus" in out
+    assert "└ Credits:" in out
+    assert "2" in out
+
+
+def test_list_accounts_json_includes_codex_usage(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="work", slot=None)
+    switcher._usage_store.clock = lambda: 0.0
+
+    monkeypatch.setattr(
+        "claude_swap.codex.fetch_codex_usage",
+        lambda auth_text, timeout_s: {
+            "windows": [
+                {"label": "3h", "pct": 25.0, "resets_at": "2026-01-01T00:00:00Z"},
+                {"label": "Week", "pct": 50.0},
+            ],
+            "plan": "plus",
+            "credits": 2.0,
+        },
+    )
+
+    payload = switcher.list_accounts(json_output=True)
+
+    assert payload["schemaVersion"] == 1
+    assert payload["provider"] == "codex"
+    assert payload["activeAccountNumber"] == 1
+    account = payload["accounts"][0]
+    assert account["number"] == 1
+    assert account["label"] == "work"
+    assert account["active"] is True
+    assert account["usageStatus"] == "ok"
+    assert account["usage"]["windows"][0]["label"] == "3h"
+    assert account["usage"]["windows"][0]["pct"] == 25.0
+    assert account["usage"]["windows"][0]["resetsAt"] == "2026-01-01T00:00:00Z"
+    assert account["usage"]["windows"][1] == {"label": "Week", "pct": 50.0}
+    assert account["usage"]["plan"] == "plus"
+    assert account["usage"]["credits"] == 2.0
+    assert account["usageFetchedAt"] == "1970-01-01T00:00:00Z"
+    assert account["usageAgeSeconds"] == 0.0
+
+
+def test_codex_usage_fetch_is_cached_between_list_calls(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="work", slot=None)
+    calls = []
+    now = [0.0]
+    switcher._usage_store.clock = lambda: now[0]
+
+    def fake_fetch(auth_text: str, timeout_s: float) -> dict:
+        calls.append((auth_text, timeout_s))
+        return {"windows": [{"label": "3h", "pct": 25.0}]}
+
+    monkeypatch.setattr("claude_swap.codex.fetch_codex_usage", fake_fetch)
+
+    switcher.list_accounts(json_output=False)
+    payload = switcher.list_accounts(json_output=True)
+
+    assert len(calls) == 1
+    assert payload["accounts"][0]["usageStatus"] == "ok"
+    assert payload["accounts"][0]["usage"] == {
+        "windows": [{"label": "3h", "pct": 25.0}]
+    }
+    assert "3h:" in capsys.readouterr().out
+
+
+def test_codex_usage_fetch_failure_serves_last_good(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="work", slot=None)
+    now = [0.0]
+    switcher._usage_store.clock = lambda: now[0]
+    outcomes: list[dict | str] = [
+        {"windows": [{"label": "3h", "pct": 25.0}]},
+        "HTTP 503",
+    ]
+
+    def fake_fetch(auth_text: str, timeout_s: float) -> dict | str:
+        return outcomes.pop(0)
+
+    monkeypatch.setattr("claude_swap.codex.fetch_codex_usage", fake_fetch)
+
+    first = switcher.list_accounts(json_output=True)
+    now[0] = SERVE_TTL_S + 1.0
+    second = switcher.list_accounts(json_output=True)
+
+    assert first["accounts"][0]["usageStatus"] == "ok"
+    assert second["accounts"][0]["usageStatus"] == "ok"
+    assert second["accounts"][0]["usage"] == {
+        "windows": [{"label": "3h", "pct": 25.0}]
+    }
+    assert second["accounts"][0]["usageAgeSeconds"] == SERVE_TTL_S + 1.0
+
+
+def test_codex_usage_cache_identity_changes_when_auth_fingerprint_changes(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    auth_path = _write_auth(temp_home, _auth_with_token("acct-1", "token-old"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="work", slot=1)
+    now = [0.0]
+    switcher._usage_store.clock = lambda: now[0]
+    calls = []
+    outcomes: list[dict | str] = [
+        "HTTP 503",
+        {"windows": [{"label": "3h", "pct": 25.0}]},
+    ]
+
+    def fake_fetch(auth_text: str, timeout_s: float) -> dict | str:
+        calls.append(auth_text)
+        return outcomes.pop(0)
+
+    monkeypatch.setattr("claude_swap.codex.fetch_codex_usage", fake_fetch)
+
+    first = switcher.list_accounts(json_output=True)
+    auth_path.write_text(
+        json.dumps(_auth_with_token("acct-1", "token-new")),
+        encoding="utf-8",
+    )
+    switcher.add_account(label="work", slot=1)
+    second = switcher.list_accounts(json_output=True)
+
+    assert first["accounts"][0]["usageStatus"] == "unavailable"
+    assert second["accounts"][0]["usageStatus"] == "ok"
+    assert second["accounts"][0]["usage"] == {
+        "windows": [{"label": "3h", "pct": 25.0}]
+    }
+    assert len(calls) == 2
+
+
+def test_add_without_label_uses_account_id(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _write_auth(temp_home, _auth("acct-derived"))
+    monkeypatch.setattr(
+        "claude_swap.codex.fetch_codex_usage",
+        lambda auth_text, timeout_s: "usage unavailable",
+    )
+
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label=None, slot=None)
+
+    payload = switcher.list_accounts(json_output=True)
+    assert payload["accounts"][0]["label"] == "acct-derived"
+
+
+def test_empty_auth_object_rejected(temp_home: Path):
+    _write_auth(temp_home, {})
+    switcher = CodexAccountSwitcher()
+
+    with pytest.raises(ConfigError, match="does not contain a supported Codex credential"):
+        switcher.add_account(label=None, slot=None)
+
+
+def test_add_without_auth_fails(temp_home: Path):
+    switcher = CodexAccountSwitcher()
+
+    with pytest.raises(ConfigError, match="No active Codex auth found"):
+        switcher.add_account(label=None, slot=None)
+
+
+def test_switch_replaces_only_auth_json(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+
+    switcher.switch("1", json_output=False)
+
+    assert json.loads(auth_path.read_text(encoding="utf-8"))["tokens"]["account_id"] == "acct-1"
+    assert switcher.status(json_output=True)["active"] == {
+        "number": 1,
+        "label": "one",
+        "managed": True,
+    }
+
+
+def test_switch_rotation_is_independent_from_claude_sequence(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+
+    claude_sequence = switcher.backup_root / "sequence.json"
+    claude_sequence.write_text(
+        json.dumps({"activeAccountNumber": 99, "sequence": [99], "accounts": {}}),
+        encoding="utf-8",
+    )
+
+    switcher.switch(None, json_output=False)
+
+    assert json.loads(auth_path.read_text(encoding="utf-8"))["tokens"]["account_id"] == "acct-1"
+
+
+def test_switch_backs_up_current_managed_auth_before_replacing(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+
+    refreshed_two = {"auth_mode": "chatgpt", "tokens": {"account_id": "acct-2", "refresh": "new"}}
+    auth_path.write_text(json.dumps(refreshed_two), encoding="utf-8")
+    switcher.switch("one", json_output=False)
+    switcher.switch("two", json_output=False)
+
+    assert json.loads(auth_path.read_text(encoding="utf-8")) == refreshed_two
+
+
+def test_switch_json_uses_codex_label_refs(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+
+    result = switcher.switch("one", json_output=True)
+
+    assert result["to"] == {"number": 1, "label": "one"}
+    assert "email" not in result["to"]
+
+
+def test_switch_rejects_corrupt_stored_auth(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+    (switcher.auth_dir / "account-1.json").write_text("{", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="stored auth for Codex Account-1"):
+        switcher.switch("one", json_output=False)
+
+    assert json.loads(auth_path.read_text(encoding="utf-8"))["tokens"]["account_id"] == "acct-2"
+
+
+def test_remove_account_keeps_live_auth_file(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+
+    switcher.remove_account("one")
+
+    assert auth_path.exists()
+    assert switcher.list_accounts(json_output=True)["accounts"] == []
+    assert switcher.status(json_output=True)["active"] == {"managed": False}
+
+
+def test_duplicate_label_rejected(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="same", slot=1)
+
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    with pytest.raises(ValidationError, match="already exists"):
+        switcher.add_account(label="same", slot=2)
+
+
+def test_numeric_label_rejected(temp_home: Path):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+
+    with pytest.raises(ValidationError, match="cannot be only digits"):
+        switcher.add_account(label="123", slot=None)
+
+
+def test_duplicate_account_id_in_different_slot_rejected(temp_home: Path):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+
+    with pytest.raises(ValidationError, match="already stored as Codex Account-1"):
+        switcher.add_account(label="same-account", slot=2)
+
+
+def test_corrupt_sequence_fails_before_overwrite(temp_home: Path):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.codex_dir.mkdir(parents=True)
+    switcher.sequence_file.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="Codex state file is not valid JSON"):
+        switcher.add_account(label="one", slot=None)
+
+    assert switcher.sequence_file.read_text(encoding="utf-8") == "{"
+
+
+def test_legacy_backup_migrated_before_codex_write(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(Platform, "detect", staticmethod(lambda: Platform.LINUX))
+    legacy = temp_home / ".claude-swap-backup"
+    legacy.mkdir()
+    (legacy / "sequence.json").write_text(
+        json.dumps({"activeAccountNumber": None, "sequence": [], "accounts": {}}),
+        encoding="utf-8",
+    )
+    _write_auth(temp_home, _auth("acct-1"))
+
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=None)
+
+    target = temp_home / ".local" / "share" / "claude-swap"
+    assert not legacy.exists()
+    assert (target / "codex" / "sequence.json").exists()
+
+
+def test_unknown_switch_target_fails(temp_home: Path):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+
+    with pytest.raises(AccountNotFoundError, match="No Codex account found"):
+        switcher.switch("missing", json_output=False)
+
+
+def test_api_key_auth_duplicate_across_slots_rejected(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """API-key auth (no account_id) must still be dedup-checked by fingerprint."""
+    monkeypatch.setattr(
+        "claude_swap.codex.fetch_codex_usage",
+        lambda auth_text, timeout_s: "no access token",
+    )
+    _write_auth(temp_home, _api_key_auth("sk-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="work", slot=1)
+
+    with pytest.raises(ValidationError, match="already stored as Codex Account-1"):
+        switcher.add_account(label="personal", slot=2)
+
+    payload = switcher.list_accounts(json_output=True)
+    assert [a["number"] for a in payload["accounts"]] == [1]
+
+
+def test_fetch_codex_usage_429_carries_retry_after(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "claude_swap.codex.urllib.request.urlopen",
+        _raise_urlopen(_http_error(429, "300")),
+    )
+    result = fetch_codex_usage(json.dumps(_auth("acct-1")), timeout_s=3.0)
+    assert result == _UsageFetchError("HTTP 429", 300.0)
+
+
+def test_fetch_codex_usage_401_is_token_expired(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "claude_swap.codex.urllib.request.urlopen",
+        _raise_urlopen(_http_error(401, None)),
+    )
+    result = fetch_codex_usage(json.dumps(_auth("acct-1")), timeout_s=3.0)
+    assert result == _UsageFetchError("token expired", None)
+
+
+def test_fetch_codex_usage_500_has_no_retry_after(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "claude_swap.codex.urllib.request.urlopen",
+        _raise_urlopen(_http_error(500, None)),
+    )
+    result = fetch_codex_usage(json.dumps(_auth("acct-1")), timeout_s=3.0)
+    assert result == _UsageFetchError("HTTP 500", None)
+
+
+def test_fetch_codex_usage_network_error_returns_string(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "claude_swap.codex.urllib.request.urlopen",
+        _raise_urlopen(urllib.error.URLError("boom")),
+    )
+    result = fetch_codex_usage(json.dumps(_auth("acct-1")), timeout_s=3.0)
+    assert isinstance(result, str)
+    assert "boom" in result
+
+
+def test_fetch_codex_usage_non_json_body_is_malformed(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "claude_swap.codex.urllib.request.urlopen", _body_urlopen(b"not json")
+    )
+    result = fetch_codex_usage(json.dumps(_auth("acct-1")), timeout_s=3.0)
+    assert result == "malformed usage response"
+
+
+def test_fetch_codex_usage_json_list_is_malformed(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "claude_swap.codex.urllib.request.urlopen", _body_urlopen(b"[]")
+    )
+    result = fetch_codex_usage(json.dumps(_auth("acct-1")), timeout_s=3.0)
+    assert result == "malformed usage response"
+
+
+def test_fetch_codex_usage_api_key_has_no_access_token():
+    result = fetch_codex_usage(json.dumps(_api_key_auth("sk-1")), timeout_s=3.0)
+    assert result == "no access token"
+
+
+def test_fetch_usage_record_threads_retry_after(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+    monkeypatch.setattr(
+        "claude_swap.codex.fetch_codex_usage",
+        lambda auth_text, timeout_s: _UsageFetchError("HTTP 429", 300.0),
+    )
+
+    record = switcher._fetch_usage_record("1")
+
+    assert record.error == "HTTP 429"
+    assert record.retry_after_s == 300.0
+
+
+def test_switch_restores_auth_when_sequence_write_fails(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+
+    def boom(path, data):
+        raise ConfigError("sequence write failed")
+
+    monkeypatch.setattr(switcher, "_write_json", boom)
+
+    with pytest.raises(ConfigError, match="sequence write failed"):
+        switcher.switch("1", json_output=False)
+
+    assert json.loads(auth_path.read_text())["tokens"]["account_id"] == "acct-2"
+
+
+def test_switch_unlinks_auth_when_no_prior_auth_and_sequence_write_fails(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+    auth_path.unlink()
+
+    def boom(path, data):
+        raise ConfigError("sequence write failed")
+
+    monkeypatch.setattr(switcher, "_write_json", boom)
+
+    with pytest.raises(ConfigError, match="sequence write failed"):
+        switcher.switch("1", json_output=False)
+
+    assert not auth_path.exists()
+
+
+def test_switch_with_no_active_auth_activates_target(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+    auth_path.unlink()
+
+    switcher.switch("1", json_output=False)
+
+    assert json.loads(auth_path.read_text())["tokens"]["account_id"] == "acct-1"
+    assert switcher.status(json_output=True)["active"]["number"] == 1
+
+
+def test_rotation_falls_back_when_active_auth_unmanaged(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+    # Live auth is an unmanaged account; activeAccountNumber (2) drives rotation.
+    auth_path.write_text(json.dumps(_auth("acct-foreign")), encoding="utf-8")
+
+    switcher.switch(None, json_output=False)
+
+    assert json.loads(auth_path.read_text())["tokens"]["account_id"] == "acct-1"
+
+
+def test_add_slot_collision_with_different_account_rejected(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="already exists. Remove it first"):
+        switcher.add_account(label="two", slot=1)
+
+    stored = json.loads((switcher.auth_dir / "account-1.json").read_text())
+    assert stored["tokens"]["account_id"] == "acct-1"
+
+
+def test_api_key_auth_identified_by_fingerprint(
+    temp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        "claude_swap.codex.fetch_codex_usage",
+        lambda auth_text, timeout_s: "no access token",
+    )
+    _write_auth(temp_home, _api_key_auth("sk-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label=None, slot=None)
+
+    payload = switcher.list_accounts(json_output=True)
+    assert payload["accounts"][0]["label"] == "codex-account-1"
+    assert switcher.status(json_output=True)["active"] == {
+        "number": 1,
+        "label": "codex-account-1",
+        "managed": True,
+    }
+
+
+def test_remove_active_account_resets_active_number(temp_home: Path):
+    auth_path = _write_auth(temp_home, _auth("acct-1"))
+    switcher = CodexAccountSwitcher()
+    switcher.add_account(label="one", slot=1)
+    auth_path.write_text(json.dumps(_auth("acct-2")), encoding="utf-8")
+    switcher.add_account(label="two", slot=2)
+
+    switcher.remove_account("one")
+    assert json.loads(switcher.sequence_file.read_text())["activeAccountNumber"] == 2
+
+    switcher.remove_account("two")
+    assert json.loads(switcher.sequence_file.read_text())["activeAccountNumber"] is None

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -19,6 +19,8 @@ from claude_swap.paths import (
     LEGACY_BACKUP_DIRNAME,
     get_backup_root,
     get_claude_config_home,
+    get_codex_auth_path,
+    get_codex_home,
     get_credentials_path,
     get_global_config_path,
     get_legacy_backup_root,
@@ -32,6 +34,7 @@ def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))
     with patch("pathlib.Path.home", return_value=home):
@@ -90,6 +93,29 @@ class TestGetCredentialsPath:
         custom = tmp_path / "ccd"
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
         assert get_credentials_path() == custom / ".credentials.json"
+
+
+class TestGetCodexHome:
+    def test_default_is_dot_codex_in_home(self, isolated_home: Path):
+        assert get_codex_home() == isolated_home / ".codex"
+
+    def test_respects_codex_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        custom = tmp_path / "custom-codex"
+        monkeypatch.setenv("CODEX_HOME", str(custom))
+        assert get_codex_home() == custom
+
+    def test_empty_codex_home_uses_default(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("CODEX_HOME", "")
+        assert get_codex_home() == isolated_home / ".codex"
+
+
+class TestGetCodexAuthPath:
+    def test_auth_json_inside_codex_home(self, isolated_home: Path):
+        assert get_codex_auth_path() == isolated_home / ".codex" / "auth.json"
 
 
 class TestGetBackupRoot:


### PR DESCRIPTION
Adds `cswap codex <add|list|status|switch|remove>` to snapshot and swap `$CODEX_HOME/auth.json` independently of Claude accounts, with per-account usage from the ChatGPT wham endpoint, and appends a Codex section to `cswap list`. Reuses the shared UsageStore/FileLock/json_output infra.

Most of the diff is tests, and I have run this locally with my codex and it seems to work well.

Fixes #15 