### PR TITLE
Force UTF-8 output so glyphs don't crash on legacy cp1252 consoles

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -10,7 +10,7 @@ import sys
 from claude_swap import __version__
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
-from claude_swap.printer import dimmed, error, muted
+from claude_swap.printer import dimmed, error, force_utf8_output, muted
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -503,6 +503,7 @@ def _use_native_tls() -> None:
 
 def main() -> None:
     """Main entry point for the CLI."""
+    force_utf8_output()
     _use_native_tls()
     argv = sys.argv[1:]
 

--- a/src/claude_swap/printer.py
+++ b/src/claude_swap/printer.py
@@ -42,6 +42,21 @@ def _enable_windows_vt() -> bool:
         return False
 
 
+def force_utf8_output() -> None:
+    """Make stdout/stderr encode UTF-8 so ● → ├ ─ └ don't crash on a legacy
+    console (cp1252 on Windows, or an ASCII/C locale). errors="replace" keeps
+    output flowing on any stream that still can't render a glyph. No-op where
+    the stream can't be reconfigured (replaced/captured streams in tests)."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass
+
+
 def _detect_color_support() -> bool:
     """Detect whether the terminal supports ANSI colors."""
     # Respect NO_COLOR convention (https://no-color.org/)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1145,7 +1145,6 @@ class ClaudeAccountSwitcher:
                 data["sequence"].remove(int(migrate_from))
             del data["accounts"][migrate_from]
             self._write_json(self.sequence_file, data)
-            print(f"{dimmed(f'Moved from slot {migrate_from} → {slot}')}")
 
         # Store backups
         self._write_account_credentials(account_num, current_email, current_creds)
@@ -1172,6 +1171,8 @@ class ClaudeAccountSwitcher:
         self._write_json(self.sequence_file, data)
         tag = self._get_display_tag(current_email, organization_name, organization_uuid)
         self._logger.info(f"Added account {account_num}: {current_email} (org: {organization_uuid or 'personal'})")
+        if migrate_from:
+            print(f"{dimmed(f'Moved from slot {migrate_from} → {slot}')}")
         print(f"{accent('Added')} Account {account_num}: {current_email} {muted(f'[{tag}]')}")
 
     def add_account_from_token(
@@ -1341,7 +1342,6 @@ class ClaudeAccountSwitcher:
                 data["sequence"].remove(int(migrate_from))
             del data["accounts"][migrate_from]
             self._write_json(self.sequence_file, data)
-            print(f"{dimmed(f'Moved from slot {migrate_from} → {slot}')}")
 
         self._write_account_credentials(account_num, email, credentials)
         self._write_account_config(account_num, email, config)
@@ -1370,6 +1370,8 @@ class ClaudeAccountSwitcher:
         self._write_json(self.sequence_file, data)
         source_label = "API key" if is_api_key else "token"
         self._logger.info(f"Added account {account_num} from {source_label}: {email}")
+        if migrate_from:
+            print(f"{dimmed(f'Moved from slot {migrate_from} → {slot}')}")
         print(
             f"{accent('Added')} Account {account_num}: {email} "
             f"{muted('[personal]')} {muted(f'(from {source_label})')}"

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -151,3 +151,31 @@ def test_force_color_overrides_and_restores():
         assert printer._colors_enabled is False
     finally:
         printer._colors_enabled = saved
+
+
+class TestForceUtf8Output:
+    """Tests for force_utf8_output (issue #113: cp1252 console crash)."""
+
+    def test_reconfigures_legacy_stream_to_utf8(self, monkeypatch):
+        # A cp1252-encoded stdout raises on the tool's glyphs before the fix.
+        import io
+
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+        with pytest.raises(UnicodeEncodeError):
+            stream.write("● → ├ ─ └")
+            stream.flush()
+
+        monkeypatch.setattr(sys, "stdout", stream)
+        monkeypatch.setattr(sys, "stderr", stream)
+        printer.force_utf8_output()
+
+        assert stream.encoding == "utf-8"
+        # No longer raises now that the stream encodes UTF-8.
+        stream.write("● → ├ ─ └")
+        stream.flush()
+
+    def test_no_op_on_streams_without_reconfigure(self, monkeypatch):
+        # StringIO has no reconfigure(); the guard must skip it silently.
+        monkeypatch.setattr(sys, "stdout", StringIO())
+        monkeypatch.setattr(sys, "stderr", StringIO())
+        printer.force_utf8_output()  # must not raise


### PR DESCRIPTION
Addresses issue #113.

On a legacy console whose `sys.stdout` uses a charmap codec (cp1252 on Windows, or an ASCII/C locale), printing the tool's glyphs (`●`, `→`, `├ ─ └`) raised `UnicodeEncodeError`. This only surfaces when stdout falls back to the locale codec — redirected/piped output, Git Bash/mintty/older terminals — which is why most (interactive Windows Terminal) users never hit it.

## Changes
- Add `force_utf8_output()` in `printer.py` and call it first in `main()`: reconfigures stdout/stderr to UTF-8 with `errors="replace"`, guarded so replaced/captured streams (tests, pipes) are a silent no-op. Cross-platform; on an already-UTF-8 locale it's a no-op beyond the benign error-handler.
- Move the `Moved from slot N → M` message to after the destination is durably written, so a failure can't leave a half-migrated store or announce a move that didn't complete.
- Add regression tests covering the cp1252-stream reconfigure and the no-`reconfigure` no-op path.

Full suite: 971 passed, 3 skipped.