### PR TITLE
Ignore a session profile that drifted to another account when fetching usage

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -212,6 +212,51 @@ def read_session_credentials(session_dir: Path) -> str | None:
         return None
 
 
+def read_session_identity(session_dir: Path) -> tuple[str, str] | None:
+    """Best-effort read of the account identity a session profile is logged in as.
+
+    Claude records the logged-in account in the profile's ``.claude.json``
+    ``oauthAccount`` and rewrites it on every (re-)login, so this reflects the
+    profile's *current* identity — which an in-session ``/login`` can re-point
+    at a different account than the slot the profile was created for. Returns
+    ``(email, organization_uuid)`` with ``""`` for a missing org, or ``None``
+    when no identity is readable (missing dir/file/field).
+    """
+    try:
+        config = json.loads((session_dir / ".claude.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(config, dict):
+        return None
+    oauth_account = config.get("oauthAccount") or {}
+    if not isinstance(oauth_account, dict):
+        return None
+    email = oauth_account.get("emailAddress") or ""
+    if not email:
+        return None
+    return email, oauth_account.get("organizationUuid") or ""
+
+
+def session_identity_drifted(session_dir: Path, email: str, org_uuid: str) -> bool:
+    """Whether the profile is logged in as a *different* account than its slot.
+
+    An in-session ``/login`` (e.g. after the slot's account hit its rate limit
+    mid-session) re-points the profile's credential at another account while
+    the profile directory keeps claiming the original slot. Comparison mirrors
+    ``_is_session_valid``: the email must match, the org only when both sides
+    have a value. An unreadable identity is NOT drift — missing metadata
+    degrades to trusting the profile (its token family is normally the slot's
+    freshest) rather than abandoning it over a broken ``.claude.json``.
+    """
+    identity = read_session_identity(session_dir)
+    if identity is None:
+        return False
+    profile_email, profile_org = identity
+    if profile_email != email:
+        return True
+    return bool(profile_org and org_uuid and profile_org != org_uuid)
+
+
 def live_sessions_for(session_dir: Path) -> list[ClaudeSession]:
     """Live Claude instances running against a session profile."""
     if not session_dir.exists():

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1668,7 +1668,7 @@ class ClaudeAccountSwitcher:
         self, account_info: tuple[int, str, str, str, bool, str]
     ) -> FetchRecord:
         """One network fetch for one account. Never raises."""
-        num, email, _, _, is_active, creds = account_info
+        num, email, _, org_uuid, is_active, creds = account_info
 
         # The active/default account owns the live credential — route it through
         # the owner-aware path that refreshes only when no Claude Code/session is
@@ -1680,7 +1680,10 @@ class ClaudeAccountSwitcher:
             with FileLock(self.lock_file):
                 self._write_account_credentials(acct_num, acct_email, new_creds)
 
-        from claude_swap.session import read_session_credentials
+        from claude_swap.session import (
+            read_session_credentials,
+            session_identity_drifted,
+        )
 
         has_live_session = bool(self._live_session_pids(str(num), email))
 
@@ -1692,7 +1695,21 @@ class ClaudeAccountSwitcher:
         # Fetch with the profile's newest credential, strictly read-only
         # (is_active=True: no refresh, no persist): rotating the profile's
         # family here would log the next `cswap run` out the same way.
-        session_creds = read_session_credentials(self._session_dir(str(num), email))
+        session_dir = self._session_dir(str(num), email)
+        session_creds = read_session_credentials(session_dir)
+        if session_creds and session_identity_drifted(session_dir, email, org_uuid):
+            # An in-session /login re-pointed the profile at a different
+            # account; fetching with its credential would record THAT
+            # account's usage under this slot's label. The profile no longer
+            # holds this slot's token family, so the backup below is both the
+            # right identity and safe to refresh — treat the slot as not
+            # session-owned for this fetch.
+            self._logger.debug(
+                f"Session profile for account {num} is logged in as a "
+                f"different account; fetching usage from the backup credential"
+            )
+            session_creds = None
+            has_live_session = False
         if session_creds:
             session_oauth = oauth.extract_oauth_data(session_creds)
             if session_oauth and session_oauth.get("accessToken"):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -22,7 +22,9 @@ from claude_swap.session import (
     _probe_env,
     keychain_service_name,
     live_sessions_for,
+    read_session_identity,
     session_dir_for,
+    session_identity_drifted,
     slugify_email,
 )
 from claude_swap.switcher import ClaudeAccountSwitcher
@@ -214,6 +216,54 @@ class TestHelpers:
     def test_live_sessions_for_own_pid(self, tmp_path):
         make_live(tmp_path)
         assert [s.pid for s in live_sessions_for(tmp_path)] == [os.getpid()]
+
+
+class TestSessionIdentity:
+    """read_session_identity / session_identity_drifted: an in-session /login
+    can re-point a profile at a different account than its slot."""
+
+    def _write_identity(self, session_dir, email, org_uuid=None):
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / ".claude.json").write_text(json.dumps({
+            "oauthAccount": {"emailAddress": email, "organizationUuid": org_uuid}
+        }))
+
+    def test_reads_email_and_org(self, tmp_path):
+        self._write_identity(tmp_path, "a@x.com", "org-A")
+        assert read_session_identity(tmp_path) == ("a@x.com", "org-A")
+
+    def test_missing_org_reads_as_empty(self, tmp_path):
+        self._write_identity(tmp_path, "a@x.com", None)
+        assert read_session_identity(tmp_path) == ("a@x.com", "")
+
+    def test_unreadable_variants_return_none(self, tmp_path):
+        assert read_session_identity(tmp_path / "nope") is None  # no dir
+        (tmp_path / ".claude.json").write_text("{not json")
+        assert read_session_identity(tmp_path) is None  # invalid json
+        (tmp_path / ".claude.json").write_text(json.dumps({"oauthAccount": {}}))
+        assert read_session_identity(tmp_path) is None  # no email
+
+    def test_different_email_is_drift(self, tmp_path):
+        self._write_identity(tmp_path, "other@x.com", "org-A")
+        assert session_identity_drifted(tmp_path, "a@x.com", "org-A")
+
+    def test_same_email_different_org_is_drift(self, tmp_path):
+        # The j@ck.gg case: one email, two orgs — two distinct subscriptions.
+        self._write_identity(tmp_path, "a@x.com", "org-B")
+        assert session_identity_drifted(tmp_path, "a@x.com", "org-A")
+
+    def test_matching_identity_is_not_drift(self, tmp_path):
+        self._write_identity(tmp_path, "a@x.com", "org-A")
+        assert not session_identity_drifted(tmp_path, "a@x.com", "org-A")
+
+    def test_org_check_is_lenient_when_either_side_empty(self, tmp_path):
+        self._write_identity(tmp_path, "a@x.com", None)
+        assert not session_identity_drifted(tmp_path, "a@x.com", "org-A")
+        self._write_identity(tmp_path, "a@x.com", "org-B")
+        assert not session_identity_drifted(tmp_path, "a@x.com", "")
+
+    def test_unreadable_identity_is_not_drift(self, tmp_path):
+        assert not session_identity_drifted(tmp_path / "nope", "a@x.com", "org-A")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -624,6 +624,96 @@ class TestFetchAccountUsageSessionProfile:
         assert kwargs.get("is_active") is False
         assert kwargs.get("persist_credentials") is not None
 
+    def _write_profile_identity(self, switcher, email: str, org_uuid) -> None:
+        session_dir = switcher._session_dir("2", "test@example.com")
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / ".claude.json").write_text(json.dumps({
+            "oauthAccount": {"emailAddress": email, "organizationUuid": org_uuid}
+        }))
+
+    def test_drifted_profile_email_falls_back_to_backup(self, temp_home: Path):
+        """An in-session /login as another account must not feed that account's
+        usage into this slot: the fetch ignores the drifted profile credential
+        and uses the backup — refreshable, since the live session no longer
+        holds this slot's token family."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+        session = _oauth_creds("sk-session", 7200)
+        self._write_profile_identity(switcher, "other@example.com", "org-other")
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 9}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.usage == {"five_hour": {"pct": 9}}
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == backup
+        assert kwargs.get("is_active") is False
+        assert kwargs.get("persist_credentials") is not None
+
+    def test_drifted_profile_org_same_email_falls_back(self, temp_home: Path):
+        """Same email, different org (the j@ck.gg merge-artifact shape) is a
+        different subscription — still drift."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+        session = _oauth_creds("sk-session", 7200)
+        self._write_profile_identity(switcher, "test@example.com", "org-uuid-other")
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 9}})) as mock_fetch:
+            switcher._fetch_account_usage(self._info(backup))
+
+        args, _kwargs = mock_fetch.call_args
+        assert args[2] == backup
+
+    def test_matching_profile_identity_uses_session_credentials(self, temp_home: Path):
+        """The guard must not regress the normal case: matching identity keeps
+        the profile-credential fast path (read-only)."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", 7200)
+        self._write_profile_identity(switcher, "test@example.com", "org-uuid")
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 5}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.usage == {"five_hour": {"pct": 5}}
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == session
+        assert kwargs.get("is_active") is True
+
+    def test_unreadable_profile_identity_trusts_session_credentials(
+        self, temp_home: Path
+    ):
+        """A profile dir without a readable .claude.json is not treated as
+        drift — the profile's token family stays the credential truth."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", 7200)
+        switcher._session_dir("2", "test@example.com").mkdir(parents=True)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 5}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.usage == {"five_hour": {"pct": 5}}
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == session
+        assert kwargs.get("is_active") is True
+
 
 class TestListAccountsUsage:
     """Test list_accounts shows usage info."""


### PR DESCRIPTION
Follow-up to #97. The session-aware fetch prefers a session profile's credential as the slot's freshest token family — correctly so. But an in-session `/login` re-points the profile at a *different* account (a real workflow: the slot's account hits its 5h limit mid-session, and re-logging inside the session is the only way to keep the conversation). The profile directory keeps claiming the original slot, so the fetch records the other account's usage under this slot's label: two rows render byte-identical bars (down to the same reset second), and the slot's real account silently stops being tracked.

The profile's `.claude.json` `oauthAccount` records who claude is actually logged in as, right next to the credential. Before using session credentials, the fetch now compares it against the slot's identity — email must match, org only when both sides have a value (same leniency as `_is_session_valid`). On a confirmed mismatch it falls back to the backup credential, with refresh allowed: the live session no longer holds this slot's family, so rotating the backup can't log anything out. An unreadable identity is not treated as drift, so a profile with a broken `.claude.json` keeps today's behavior.

Deliberately *not* gated on the `.cswap-stale-credentials` marker: that is also set on benign same-account rotations, where the profile is still the right source.

Tests cover the identity/drift semantics (incl. same-email-different-org and lenient org matching), the drifted-profile fallback (refreshable backup fetch), and the matching/unreadable cases keeping the read-only profile fast path. Full suite green (983 passed).