### PR TITLE
Guard the switch-time backup against foreign live credentials, failing open when ownership can't be verified (#117)

### DIFF
--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -30,7 +30,6 @@ read-modify-write under a dedicated file lock.
 from __future__ import annotations
 
 import enum
-import hashlib
 import json
 import logging
 import random
@@ -315,12 +314,12 @@ class TickOutcome(enum.Enum):
     BLOCKED = 3  # wanted to switch but no viable target / all exhausted
 
 
-def _refresh_fingerprint(credentials: str) -> str | None:
-    data = oauth.extract_oauth_data(credentials)
-    token = data.get("refreshToken") if data else None
-    if not isinstance(token, str) or not token:
-        return None
-    return "sha256:" + hashlib.sha256(token.encode()).hexdigest()
+# Quarantine state persisted fingerprints from a local refresh-token-only
+# helper; oauth.credential_fingerprint is identical for refresh-token creds.
+# Setup-token quarantines stored None where the shared helper now yields a
+# full-content hash — those release once on first recheck and re-quarantine on
+# the next dead freshen (one harmless extra cycle, migration only).
+_refresh_fingerprint = oauth.credential_fingerprint
 
 
 def binding_pct(usage: dict | None) -> float | None:
@@ -502,9 +501,11 @@ class AutoSwitchEngine:
         refresh buffer before it gets activated.
 
         Returns ``"ok"``, ``"invalid_grant"`` (dead lineage — quarantine),
-        ``"transient"`` (network trouble — try again next tick) or
-        ``"skip-live-session"``. Only ever touches the slot's *backup* store;
-        the active credential belongs to Claude Code.
+        ``"identity-conflict"`` (alive but authenticates as a different
+        account — quarantine, do not activate), ``"transient"`` (network
+        trouble — try again next tick) or ``"skip-live-session"``. Only ever
+        touches the slot's *backup* store; the active credential belongs to
+        Claude Code.
         """
         if self.switcher.account_kind_for(number) == "api_key":
             return "ok"  # API keys don't expire/refresh
@@ -532,13 +533,64 @@ class AutoSwitchEngine:
             return "ok"
         outcome = oauth.try_refresh_oauth_credentials(creds)
         if outcome.error is None and outcome.credentials:
+            # Persist first, unconditionally: the grant consumed a generation,
+            # and not writing the successor would kill the lineage regardless
+            # of whose it turns out to be.
             self.switcher.persist_backup_credentials(
                 number, email, outcome.credentials
             )
+            if self._note_token_identity(number, outcome.token_account):
+                # The slot's stored credential authenticates as a *different*
+                # account — activating it would put the user on the wrong
+                # account with every gauge reading normal. Not a viable
+                # target; the caller quarantines it (released automatically
+                # once the credential is replaced by a re-add).
+                return "identity-conflict"
             return "ok"
         if outcome.error in ("invalid_grant", "no_refresh_token"):
             return "invalid_grant"
         return "transient"
+
+    def _note_token_identity(
+        self, number: str, token_account: dict | None
+    ) -> bool:
+        """Use the token endpoint's free identity to verify/backfill a slot.
+
+        The refresh grant just ran against the slot's own stored credential,
+        so ``token_account`` (when the server includes it) names who that
+        credential really is. Returns True on a *conflict*: the credential
+        authenticates under a different organization than the slot records
+        (org compared first, whenever both sides record one), or as a
+        different account uuid. An empty slot uuid (blank-uuid records from
+        older versions, add-token placeholders) is backfilled — but only
+        when no org conflict exists: a wrong-org credential is evidence the
+        slot holds the wrong account, and backfilling *its* uuid would
+        poison the slot's identity record (backfill never rewrites a
+        non-empty uuid, so that corruption would be sticky).
+
+        ``_parse_token_account`` already enforces a strict boundary, but this
+        identity is opportunistic — re-check types here so malformed data can
+        never break the freshen that carried it (the successor credential is
+        already persisted by the time this runs).
+        """
+        if not isinstance(token_account, dict):
+            return False
+        ta_uuid = token_account.get("uuid")
+        if not isinstance(ta_uuid, str) or not ta_uuid.strip():
+            return False
+        ta_uuid = ta_uuid.strip()
+        slot_identity = self.switcher.account_identity(number)
+        ta_org = token_account.get("organizationUuid")
+        slot_org = slot_identity.get("organizationUuid") or ""
+        if isinstance(ta_org, str) and ta_org and slot_org and ta_org != slot_org:
+            return True
+        if not slot_identity.get("uuid"):
+            try:
+                self.switcher.backfill_account_uuid(number, ta_uuid)
+            except Exception as e:  # never let bookkeeping break a freshen
+                _logger.debug("uuid backfill failed for account %s: %r", number, e)
+            return False
+        return slot_identity["uuid"] != ta_uuid
 
     # -- tick -----------------------------------------------------------------
 
@@ -795,6 +847,13 @@ class AutoSwitchEngine:
                 # quarantine writes — freshening is a mutation.
                 return self._perform(num, email, trigger)
             status = self._freshen_target(num, email)
+            if status == "identity-conflict":
+                # The slot's credential is alive but belongs to a different
+                # account — switching onto it would silently run the wrong
+                # account. Quarantine (auto-released once a re-add replaces
+                # the credential).
+                self._quarantine(num, email, "identity-conflict")
+                continue
             if status == "invalid_grant":
                 self._quarantine(num, email, "invalid_grant")
                 continue

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -681,6 +681,14 @@ class CredentialStore:
             self._backup_username(account_num, email),
         )
 
+    def _kc_delete_backup_prev(self, account_num: str, email: str) -> None:
+        """Delete a slot's retained ``.prev`` Keychain item. Raises on failure."""
+        self._kc_call(
+            macos_keychain.delete_password,
+            SECURITY_SERVICE,
+            self._prev_backup_username(account_num, email),
+        )
+
     def _delete_backup_keychain_quiet(self, account_num: str, email: str) -> None:
         """Best-effort backup Keychain delete (never raises)."""
         try:
@@ -690,8 +698,12 @@ class CredentialStore:
 
     def _write_backup_enc(self, account_num: str, email: str, credentials: str) -> None:
         """Atomically write a per-account backup ``.enc`` (base64) file."""
+        self._atomic_b64_write(self._backup_enc_path(account_num, email), credentials)
+
+    def _atomic_b64_write(self, target: Path, credentials: str) -> None:
+        """Atomically write a base64-encoded credential file (0600)."""
         self._host.credentials_dir.mkdir(parents=True, exist_ok=True)
-        enc_file = self._backup_enc_path(account_num, email)
+        enc_file = target
         encoded = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
         import tempfile
         fd, tmp_path = tempfile.mkstemp(dir=str(self._host.credentials_dir), suffix=".tmp")
@@ -775,7 +787,13 @@ class CredentialStore:
 
         Raises on a file-write failure **before** returning, so the switcher wrapper
         runs ``_post_backup_write`` exactly once and only after a successful write.
+
+        Before overwriting, the current generation is retained as a ``.prev`` file
+        (one generation, best-effort): a refresh token exists in exactly one place,
+        giving a misclassified overwrite a best-effort chance of recovery without
+        a /login.
         """
+        self._retain_previous_backup(account_num, email, credentials)
         if self._use_keychain():
             try:
                 self._kc_write_backup(account_num, email, credentials)
@@ -818,5 +836,191 @@ class CredentialStore:
                     enc_file.unlink()
             except Exception as e:
                 self._host._logger.warning(f"Failed to delete credentials file: {e}")
+            prev_file = self._prev_backup_path(num, email)
+            try:
+                if prev_file.exists():
+                    prev_file.unlink()
+            except Exception as e:
+                self._host._logger.warning(f"Failed to delete .prev file: {e}")
             if self._host.platform == Platform.MACOS:
                 self._delete_backup_keychain_quiet(num, email)
+                try:
+                    self._kc_delete_backup_prev(num, email)
+                except Exception as e:
+                    self._host._logger.warning(
+                        f"Failed to delete .prev from Keychain: {e}"
+                    )
+
+    # -- previous-generation retention -------------------------------------
+    #
+    # One retained generation per slot, routed by the same rule as the backup
+    # itself: Keychain when the Keychain is in use, ``.enc.prev`` file
+    # otherwise. Retention must not *weaken* the user's storage posture — a
+    # Mac whose credentials live in the Keychain must not grow a plaintext
+    # copy just for recovery. Best-effort by design: the *primary* safety
+    # boundary is the switch-time provenance check + unclaimed stash (whose
+    # failure aborts); ``.prev`` is defense in depth for writes that were
+    # classified as safe but weren't.
+
+    def _prev_backup_path(self, account_num: str, email: str) -> Path:
+        return self._host.credentials_dir / f".creds-{account_num}-{email}.enc.prev"
+
+    def _prev_backup_username(self, account_num: str, email: str) -> str:
+        return f"{self._backup_username(account_num, email)}.prev"
+
+    def _retain_previous_backup(
+        self, account_num: str, email: str, new_credentials: str
+    ) -> None:
+        """Retain the slot's current backup as ``.prev`` before it is replaced."""
+        try:
+            current = self._read_account_credentials(account_num, email)
+        except Exception as e:  # pragma: no cover - _read swallows its own errors
+            self._host._logger.warning(f"Could not read backup for retention: {e}")
+            return
+        if not current or current == new_credentials:
+            return
+        try:
+            if self._use_keychain():
+                self._kc_call(
+                    macos_keychain.set_password,
+                    SECURITY_SERVICE,
+                    self._prev_backup_username(account_num, email),
+                    current,
+                )
+            else:
+                self._atomic_b64_write(
+                    self._prev_backup_path(account_num, email), current
+                )
+        except Exception as e:
+            self._host._logger.warning(
+                f"Failed to retain previous credential generation for "
+                f"account {account_num}: {e}"
+            )
+
+    def _read_previous_backup(self, account_num: str, email: str) -> str:
+        """Read the retained previous generation. ``""`` when absent/corrupt.
+
+        ``.enc.prev``-wins like the main backup read: a file written while the
+        Keychain was unusable beats a possibly-stale Keychain copy.
+        """
+        prev_file = self._prev_backup_path(account_num, email)
+        if prev_file.exists():
+            try:
+                encoded = prev_file.read_text(encoding="utf-8").strip()
+                decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+                if decoded:
+                    return decoded
+            except Exception as e:
+                self._host._logger.warning(f"Failed to read .prev file: {e}")
+        if self._host.platform == Platform.MACOS:
+            try:
+                return self._kc_call(
+                    macos_keychain.get_password,
+                    SECURITY_SERVICE,
+                    self._prev_backup_username(account_num, email),
+                ) or ""
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                self._host._logger.warning(f"Failed to read .prev from Keychain: {e}")
+        return ""
+
+    # -- internal safety copies (unclaimed credentials) ----------------------
+    #
+    # Write-only preservation for live credential bytes a switch positively
+    # attributed to someone other than the outgoing slot (invariant: never
+    # overwrite the live store without preserving what was in it — the bytes
+    # may be the only live copy of some account's refresh token). Entries are
+    # append-only base64 files with a JSON manifest carrying the
+    # classification evidence; nothing consumes them automatically — recovery
+    # is the documented /login + `cswap add [--slot N]`, and these files are
+    # forensic material for maintainers.
+    #
+    # Deliberately 0600 files on every platform, unlike the slot backups and
+    # ``.prev``, which route to the macOS Keychain when it is in use: a failed
+    # safety-copy write aborts the switch by design, and that abort path must
+    # not inherit the Keychain's failure modes (#101/#106 — a flaky Keychain
+    # would start blocking switches). On macOS this means these rare files
+    # sit outside the Keychain, base64-encoded with owner-only permissions.
+
+    def _stash_manifest_path(self) -> Path:
+        return self._host.credentials_dir / ".unclaimed-manifest.json"
+
+    def _stash_entry_path(self, entry_id: str) -> Path:
+        return self._host.credentials_dir / f".unclaimed-{entry_id}.enc"
+
+    def _read_stash_manifest(self) -> dict:
+        path = self._stash_manifest_path()
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            entries = data.get("entries")
+            return entries if isinstance(entries, dict) else {}
+        except Exception as e:
+            self._host._logger.warning(f"Failed to read unclaimed manifest: {e}")
+            return {}
+
+    def _write_stash_manifest(self, entries: dict) -> None:
+        from claude_swap.settings import atomic_write_json
+
+        self._host.credentials_dir.mkdir(parents=True, exist_ok=True)
+        path = self._stash_manifest_path()
+        # A corrupt manifest read as {} must not be silently clobbered — the
+        # rows are classification evidence. Set it aside (the entry *bytes*
+        # are separate files and keep being listed as orphans either way).
+        # Failing closed instead would brick switching: a stash-write failure
+        # aborts the switch by design.
+        if path.exists():
+            try:
+                json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                aside = path.with_name(
+                    f"{path.name}.corrupt-{int(time.time())}"
+                )
+                try:
+                    path.rename(aside)
+                    self._host._logger.warning(
+                        f"Unreadable unclaimed manifest preserved as {aside.name}"
+                    )
+                except OSError as e:
+                    self._host._logger.warning(
+                        f"Could not preserve corrupt unclaimed manifest: {e}"
+                    )
+        atomic_write_json(path, {"schemaVersion": 1, "entries": entries})
+
+    def _write_unclaimed_credential(self, credentials: str, context: dict) -> str:
+        """Stash a credential of unknown provenance. Returns the entry id.
+
+        Raises on any failure — callers use a successful stash as the license
+        to overwrite the live store, so a failed one must be loud. The entry
+        file is written before the manifest: an entry without manifest metadata
+        is recoverable; a manifest row without bytes is not.
+        """
+        import hashlib
+        import secrets
+        from datetime import datetime, timezone
+
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        digest = hashlib.sha256(credentials.encode("utf-8")).hexdigest()[:12]
+        # Nonce keeps ids unique even for identical bytes preserved in the
+        # same second — append-only means no write may ever land on an
+        # existing id.
+        entry_id = f"{ts}-{digest}-{secrets.token_hex(3)}"
+        self._atomic_b64_write(self._stash_entry_path(entry_id), credentials)
+        entries = self._read_stash_manifest()
+        entries[entry_id] = {
+            "createdAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            **context,
+        }
+        self._write_stash_manifest(entries)
+        return entry_id
+
+    def _list_unclaimed_credentials(self) -> dict[str, dict]:
+        """Manifest entries by id, including orphaned entry files (no metadata)."""
+        entries = dict(self._read_stash_manifest())
+        try:
+            for path in self._host.credentials_dir.glob(".unclaimed-*.enc"):
+                entry_id = path.name[len(".unclaimed-"):-len(".enc")]
+                entries.setdefault(entry_id, {"createdAt": None})
+        except OSError:
+            pass
+        return entries

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import urllib.error
@@ -39,6 +40,25 @@ def extract_oauth_data(credentials: str) -> dict | None:
     return oauth if isinstance(oauth, dict) else None
 
 
+def credential_fingerprint(credentials: str) -> str | None:
+    """Stable identity fingerprint for a stored credential.
+
+    Refresh-token hash when one exists (survives access-token rotation, so two
+    generations of the same OAuth lineage compare equal); full-content hash
+    otherwise (API keys and setup-tokens rotate never, so content identity is
+    lineage identity). None only for empty input — a caller comparing "did the
+    credential change?" must never get None for real bytes, or every
+    comparison against it would degenerate to "changed".
+    """
+    if not credentials:
+        return None
+    data = extract_oauth_data(credentials)
+    token = data.get("refreshToken") if data else None
+    if isinstance(token, str) and token:
+        return "sha256:" + hashlib.sha256(token.encode()).hexdigest()
+    return "sha256-full:" + hashlib.sha256(credentials.encode()).hexdigest()
+
+
 def is_oauth_token_expired(expires_at: object) -> bool:
     """Return whether an OAuth token is expired or about to expire."""
     if not isinstance(expires_at, (int, float)):
@@ -63,10 +83,17 @@ class RefreshOutcome:
     - ``"no_refresh_token"`` — the stored credential carries no usable refresh
       token (also permanent for retry purposes)
     - ``"transient"`` — network/server error; the token may still be valid
+
+    ``token_account`` is the account identity the token endpoint optionally
+    includes alongside a successful grant (``{"uuid", "email",
+    "organizationUuid"}``, fields possibly None) — a zero-request identity
+    source for the credential that was just refreshed. None when the server
+    omitted it or on failure; callers must treat it as opportunistic.
     """
 
     credentials: str | None
     error: str | None
+    token_account: dict | None = None
 
 
 def try_refresh_oauth_credentials(credentials: str) -> RefreshOutcome:
@@ -107,7 +134,9 @@ def try_refresh_oauth_credentials(credentials: str) -> RefreshOutcome:
             oauth["scopes"] = resp_data["scope"].split()
 
         data["claudeAiOauth"] = oauth
-        return RefreshOutcome(json.dumps(data), None)
+        return RefreshOutcome(
+            json.dumps(data), None, _parse_token_account(resp_data)
+        )
     except urllib.error.HTTPError as e:
         body = e.read().decode(errors="replace") if hasattr(e, "read") else ""
         _logger.debug("OAuth refresh failed: %r, body: %s", e, body[:500])
@@ -125,9 +154,100 @@ def try_refresh_oauth_credentials(credentials: str) -> RefreshOutcome:
         return RefreshOutcome(None, "transient")
 
 
+def _parse_token_account(resp_data: dict) -> dict | None:
+    """Extract the optional account identity from a token-endpoint response.
+
+    The refresh grant's response body may carry ``account`` / ``organization``
+    objects naming who the rotated token belongs to (Claude Code surfaces the
+    same fields as ``tokenAccount``). Absent in some responses — never rely on
+    it, but never discard it either. Same strict boundary as
+    ``fetch_oauth_profile``: usable identity requires a non-empty string
+    ``account.uuid`` (consumers backfill and compare by uuid), optional
+    fields are normalized to str-or-None, and anything malformed is None —
+    this identity is opportunistic and must never break the refresh that
+    carried it.
+    """
+    account = resp_data.get("account")
+    if not isinstance(account, dict):
+        return None
+    uuid = account.get("uuid")
+    if not isinstance(uuid, str) or not uuid.strip():
+        return None
+    email = account.get("email_address")
+    organization = resp_data.get("organization")
+    org_uuid = organization.get("uuid") if isinstance(organization, dict) else None
+    return {
+        "uuid": uuid.strip(),
+        "email": email if isinstance(email, str) else None,
+        "organizationUuid": org_uuid if isinstance(org_uuid, str) else None,
+    }
+
+
 def refresh_oauth_credentials(credentials: str) -> str | None:
     """Refresh an OAuth access token; None on any failure (see RefreshOutcome)."""
     return try_refresh_oauth_credentials(credentials).credentials
+
+
+def fetch_oauth_profile(access_token: str) -> dict | None:
+    """Resolve an OAuth access token to its account identity, or None.
+
+    ``GET /api/oauth/profile`` answers the one question the credential bytes
+    can't: *whose* token is this. Returns ``{"uuid", "email",
+    "organizationUuid"}`` or None on any failure — callers treat None as
+    "unresolvable", never as an error. The identity oracle is strictly
+    advisory (a switch proceeds pre-fix on None), so the boundary is strict
+    the other way: a response counts as resolved only when it carries a
+    non-empty string ``account.uuid`` — a response without a usable uuid,
+    including a schema change that renames it, is None, keeping that drift
+    on the fail-open path rather than silently degrading switches.
+    ``email``/``organizationUuid`` are optional (str-or-None); a uuid-only
+    response *does* resolve, and classification decides whether such partial
+    evidence is sufficient for each decision. Must not be called while any
+    credential/config lock is held (network under locks is forbidden).
+    """
+    url = "https://api.anthropic.com/api/oauth/profile"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "User-Agent": "claude-swap/1.0",
+    }
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            # Evidence, not proof: the live access token can't authenticate.
+            # A freshly rotated own-credential would carry a fresh token, but
+            # this also fires benignly (family rotated, then the access token
+            # expired on an idle machine). Log-file only — the caller falls
+            # back to pre-fix behavior and the user sees nothing.
+            _logger.warning(
+                "OAuth profile returned 401 while resolving credential "
+                "ownership; proceeding without identity (pre-fix behavior)."
+            )
+        else:
+            _logger.debug("OAuth profile fetch failed: %r", e)
+        return None
+    except Exception as e:
+        _logger.debug("OAuth profile fetch failed: %r", e)
+        return None
+    account = data.get("account") if isinstance(data, dict) else None
+    if not isinstance(account, dict):
+        _logger.debug("OAuth profile response missing account object")
+        return None
+    uuid = account.get("uuid")
+    if not isinstance(uuid, str) or not uuid.strip():
+        _logger.debug("OAuth profile response missing account.uuid")
+        return None
+    email = account.get("email")
+    organization = data.get("organization")
+    org_uuid = organization.get("uuid") if isinstance(organization, dict) else None
+    return {
+        "uuid": uuid.strip(),
+        "email": email if isinstance(email, str) else None,
+        "organizationUuid": org_uuid if isinstance(org_uuid, str) else None,
+    }
 
 
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -67,6 +67,7 @@ from claude_swap.printer import (
 )
 from claude_swap.paths import (
     get_backup_root,
+    get_credentials_path,
     get_global_config_path,
     get_legacy_backup_root,
     migrate_legacy_backup_dir,
@@ -704,6 +705,43 @@ class ClaudeAccountSwitcher:
         """
         with FileLock(self.lock_file):
             self._write_account_credentials(account_num, email, credentials)
+
+    def account_identity(self, account_num: str) -> dict:
+        """Stored identity for a slot: ``{"email", "organizationUuid", "uuid"}``."""
+        data = self._get_sequence_data() or {}
+        acct = data.get("accounts", {}).get(str(account_num), {})
+        return {
+            "email": acct.get("email", ""),
+            "organizationUuid": acct.get("organizationUuid", "") or "",
+            "uuid": (acct.get("uuid") or "").strip(),
+        }
+
+    def backfill_account_uuid(self, account_num: str, uuid: str) -> None:
+        """Record a resolved account uuid on a slot that lacks one.
+
+        Only ever fills an empty uuid (add-token placeholders) — an existing
+        uuid is identity and is never rewritten here. Caller must NOT hold
+        ``self.lock_file``.
+        """
+        if not uuid:
+            return
+        with FileLock(self.lock_file):
+            data = self._get_sequence_data() or {}
+            acct = data.get("accounts", {}).get(str(account_num))
+            if acct is not None and not (acct.get("uuid") or "").strip():
+                acct["uuid"] = uuid
+                data["lastUpdated"] = get_timestamp()
+                self._write_json(self.sequence_file, data)
+
+    def list_unclaimed_credentials(self) -> dict[str, dict]:
+        """Internal safety copies preserved at switch time (diagnostics only).
+
+        Write-only storage: entries are created when a switch displaces live
+        credential bytes it could not attribute to the outgoing slot, and are
+        never consumed automatically — recovery from any such state is the
+        documented ``/login`` + ``cswap add [--slot N]``.
+        """
+        return self._store._list_unclaimed_credentials()
 
     # -- session profile lifecycle ----------------------------------------
 
@@ -1536,7 +1574,30 @@ class ClaudeAccountSwitcher:
         owned = self._active_cc_running() or bool(
             self._live_session_pids(account_num, email)
         )
-        if owned:
+
+        # Provenance guard (issue #117): the no-owner path below rotates the
+        # live credential and writes it into this slot's backup — the same
+        # config-chose-the-slot / bytes-came-from-the-store split the switch
+        # guard closes. Only a lineage match against the slot's stored backup
+        # proves the live bytes are actually this slot's. On mismatch, don't
+        # consume a generation of a credential we can't attribute: read usage
+        # with the token as-is and leave reconciliation to the switch-time
+        # guard (which can resolve identity, or back up pre-fix style).
+        unattributed = False
+        if not owned:
+            backup = self._read_account_credentials(account_num, email)
+            unattributed = creds != backup and (
+                oauth.credential_fingerprint(creds)
+                != oauth.credential_fingerprint(backup)
+            )
+            if unattributed:
+                self._logger.warning(
+                    "Active credential does not match Account-%s's stored "
+                    "backup; skipping its refresh (provenance unknown).",
+                    account_num,
+                )
+
+        if owned or unattributed:
             if oauth.is_oauth_token_expired(oauth_data.get("expiresAt")):
                 # The request would just 401 (an owned credential may not be
                 # refreshed), so skip it — Claude Code's own /usage does the
@@ -1879,6 +1940,114 @@ class ClaudeAccountSwitcher:
             return None, "exhausted"
         return None, "stay"
 
+    def _duplicate_account_warnings(
+        self, accounts_info: list[tuple[int, str, str, str, bool, str]]
+    ) -> list[str]:
+        """Slots that provably authenticate as the same account.
+
+        Impossible by construction, so a collision means one slot's credential
+        was overwritten with another's (issue #117's end state) or the same
+        account was registered twice. Two offline signals:
+
+        - identical credential fingerprint (same refresh-token lineage or
+          identical raw token) across two slots;
+        - the same non-empty ``uuid`` + org recorded for two slots (empty
+          uuids — add-token placeholders — never match each other).
+
+        Limitation: two *different generations* of the same account (the
+        poisoned end state a pre-guard switch could produce) carry different
+        fingerprints and untouched sequence.json identities, so they are not
+        offline-detectable here — ``_lockstep_usage_warnings`` covers that
+        case heuristically. The switch-time guard prevents new occurrences
+        whenever the identity oracle answers.
+        """
+        data = self._get_sequence_data() or {}
+        by_fp: dict[str, str] = {}
+        by_identity: dict[tuple[str, str], str] = {}
+        out: list[str] = []
+        for num, email, _org_name, org_uuid, _is_active, creds in accounts_info:
+            snum = str(num)
+            fp = oauth.credential_fingerprint(creds) if creds else None
+            if fp:
+                other = by_fp.get(fp)
+                if other:
+                    out.append(
+                        f"Account-{other} and Account-{snum} hold the same "
+                        f"credential ({email}) — one slot's backup was "
+                        "overwritten. Log in with the missing account and "
+                        "re-add it: cswap add --slot N"
+                    )
+                else:
+                    by_fp[fp] = snum
+            uuid = (data.get("accounts", {}).get(snum, {}).get("uuid") or "").strip()
+            if uuid:
+                key = (uuid, org_uuid or "")
+                other = by_identity.get(key)
+                if other and other != snum:
+                    out.append(
+                        f"Account-{other} and Account-{snum} both authenticate "
+                        f"as {email} — remove or re-login one of them."
+                    )
+                elif not other:
+                    by_identity[key] = snum
+        return out
+
+    def _lockstep_usage_warnings(
+        self,
+        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        entries: dict[str, UsageEntry],
+    ) -> list[str]:
+        """Heuristic: slots whose usage moves in perfect lockstep.
+
+        Two different *generations* of the same account (the poisoned end
+        state a pre-guard switch could produce — issue #117) carry different
+        fingerprints and untouched sequence.json identities, so
+        ``_duplicate_account_warnings`` cannot see them. But both tokens
+        report the same account's usage: identical 5h *and* 7d percentages
+        with identical reset timestamps — the exact signal the issue's
+        reporter had to reverse-engineer by hand, automated here from data
+        ``list``/watch already fetched.
+
+        Heuristic, not proof: it goes quiet once the older generation dies
+        and stops producing comparable usage, and only rows where both
+        windows carry a non-null ``resets_at`` are compared (two idle
+        accounts at 0% with nothing scheduled are indistinguishable, never
+        flagged; API-key slots have sentinel usage and never reach the
+        comparison). Known benign false-positive source until PR #119 lands:
+        a session profile that drifted to another account makes its slot
+        report that account's usage — same lockstep signature, different
+        cause.
+        """
+        seen: dict[tuple, str] = {}
+        out: list[str] = []
+        for num, _email, _org_name, _org_uuid, _is_active, _creds in accounts_info:
+            snum = str(num)
+            entry = entries.get(snum)
+            usage = entry.decision_value() if entry else None
+            if not isinstance(usage, dict):
+                continue
+            h5 = usage.get("five_hour")
+            d7 = usage.get("seven_day")
+            if not isinstance(h5, dict) or not isinstance(d7, dict):
+                continue
+            key = (
+                h5.get("pct"), h5.get("resets_at"),
+                d7.get("pct"), d7.get("resets_at"),
+            )
+            if key[1] is None or key[3] is None or key[0] is None or key[2] is None:
+                continue
+            other = seen.get(key)
+            if other:
+                out.append(
+                    f"Account-{other} and Account-{snum} report identical "
+                    "usage and reset times — they may be the same account "
+                    "(issue #117). If it persists, log in with the missing "
+                    "account and re-add it: cswap add --slot N"
+                )
+            else:
+                seen[key] = snum
+        return out
+
     def _build_list_payload(
         self,
         accounts_info: list[tuple[int, str, str, str, bool, str]],
@@ -1903,11 +2072,23 @@ class ClaudeAccountSwitcher:
                     usage_age_s=entry.age_s,
                 )
             )
-        return {
+        payload = {
             "schemaVersion": SCHEMA_VERSION,
             "activeAccountNumber": active_num,
             "accounts": accounts,
         }
+        # Additive fields (absent when clean) — never printed warnings; the
+        # JSON contract keeps stdout a single machine-readable object.
+        dup_warnings = self._duplicate_account_warnings(accounts_info)
+        if dup_warnings:
+            payload["duplicateAccountWarnings"] = dup_warnings
+        lockstep_warnings = self._lockstep_usage_warnings(accounts_info, entries)
+        if lockstep_warnings:
+            payload["lockstepUsageWarnings"] = lockstep_warnings
+        unclaimed = self._store._list_unclaimed_credentials()
+        if unclaimed:
+            payload["unclaimedCredentials"] = sorted(unclaimed)
+        return payload
 
     def list_accounts(
         self,
@@ -1964,6 +2145,19 @@ class ClaudeAccountSwitcher:
                     print(f"     {dimmed('•')} {muted(token_status)}")
             if i < len(accounts_info) - 1:
                 print()
+
+        # Safety copies (unclaimed credentials) are deliberately NOT surfaced
+        # here: users can't act on them (recovery is always /login + cswap
+        # add), and with no GC a one-time event would nag forever. They stay
+        # in the JSON payload and logs for diagnostics.
+        dup_warnings = self._duplicate_account_warnings(accounts_info)
+        lockstep_warnings = self._lockstep_usage_warnings(accounts_info, entries)
+        if dup_warnings or lockstep_warnings:
+            print()
+            for msg in dup_warnings:
+                warning(msg)
+            for msg in lockstep_warnings:
+                warning(msg)
 
         # Running instances
         try:
@@ -2471,7 +2665,36 @@ class ClaudeAccountSwitcher:
             ))
             return None
 
-        op = self._perform_switch(next_account, emit_output=not json_output)
+        # Rotation anchored on a drifted activeAccountNumber can land on the
+        # slot the user is already on — a self-switch would pointlessly rewrite
+        # the live credentials (issue #79's hazard, on the strategy path).
+        # Provenance-aware: only a no-op when the live credential matches the
+        # slot's backup (or the divergence can't be classified — pre-fix
+        # behavior, silent); a resolved divergence falls through so
+        # _perform_switch can reconcile it.
+        provenance: dict | None = None
+        if next_account == current_num:
+            action, provenance = self._self_switch_action(
+                next_account, current_email
+            )
+            if action != "reconcile":
+                if json_output:
+                    return self._switch_noop(
+                        strategy=strategy_label,
+                        reason="already-active",
+                        from_ref=current_ref,
+                        to_ref=current_ref,
+                        warnings=warnings,
+                        message=f"Already on Account-{next_account} ({current_email})",
+                    )
+                print(
+                    f"{accent('Already on')} Account-{next_account} ({current_email})"
+                )
+                return None
+
+        op = self._perform_switch(
+            next_account, emit_output=not json_output, provenance=provenance
+        )
         return (
             self._switch_result_from_op(op, strategy_label, warnings)
             if json_output else None
@@ -2539,12 +2762,21 @@ class ClaudeAccountSwitcher:
         # then read them straight back. It also re-writes credentials, takes
         # the lock, and (on macOS) touches the Keychain for nothing. --force
         # skips this guard on purpose: its job is to rewrite the live login
-        # from the stored backup.
+        # from the stored backup. Provenance-aware (issue #117): the no-op is
+        # only taken when the live credential matches the slot's backup or
+        # the divergence can't be classified — pre-fix behavior, silent — and
+        # a *resolved* divergence falls through so _perform_switch can
+        # reconcile it.
+        provenance: dict | None = None
         if not force and data:
             identity = self._get_current_account()
             if identity is not None:
                 cur_slot = self._find_account_slot(data, identity[0], identity[1])
                 if cur_slot == target_account:
+                    action, provenance = self._self_switch_action(
+                        target_account, identity[0]
+                    )
+                if cur_slot == target_account and action != "reconcile":
                     email = (
                         data.get("accounts", {}).get(target_account, {}).get("email", "")
                     )
@@ -2568,7 +2800,10 @@ class ClaudeAccountSwitcher:
                     )
 
         op = self._perform_switch(
-            target_account, emit_output=not json_output, force_activate=force
+            target_account,
+            emit_output=not json_output,
+            force_activate=force,
+            provenance=provenance,
         )
         result = self._switch_result_from_op(op, "direct") if json_output else None
         # A forced self-activation really rewrote the live credentials from the
@@ -2583,11 +2818,289 @@ class ClaudeAccountSwitcher:
             )
         return result
 
+    def _live_matches_slot_backup(self, slot: str, email: str) -> bool:
+        """Whether the live credential is provably the slot's stored lineage.
+
+        Byte or refresh-token-fingerprint equality against the slot's backup.
+        Used to make self-switch short-circuits provenance-aware: a no-op is
+        only safe when live state matches what the slot holds — when they
+        have diverged, the switch should run so ``_perform_switch`` can
+        classify the live bytes (re-sync or preserve) instead of silently
+        leaving the divergence in place. Unreadable/empty live credentials
+        return True (keep the no-op: forcing a switch on missing evidence
+        would fail later anyway).
+        """
+        try:
+            live = self._read_credentials()
+        except Exception:
+            return True
+        if not live:
+            return True
+        backup = self._read_account_credentials(slot, email)
+        if not backup:
+            return False
+        return live == backup or (
+            oauth.credential_fingerprint(live)
+            == oauth.credential_fingerprint(backup)
+        )
+
+    def _self_switch_action(self, slot: str, email: str) -> tuple[str, dict | None]:
+        """How to treat a switch that targets the already-active slot.
+
+        Returns ``(action, provenance)``:
+
+        - ``("noop", None)`` — live matches the slot's backup; nothing to do
+          (issue #79's short-circuit).
+        - ``("reconcile", provenance)`` — live diverged and its owner was
+          resolved: run the full switch so ``_perform_switch`` can classify
+          (re-sync a legitimate rotation, or preserve foreign bytes and
+          restore the slot's stored credential).
+        - ``("noop-diverged", None)`` — live diverged but cannot be
+          classified (offline / endpoint failure / no profile access). Exact
+          pre-fix behavior: an ordinary already-active no-op, silent to the
+          user — endpoint trouble must never surface on the self-switch path
+          either. Leaving everything untouched is also the safe write:
+          activating the stored backup over an unverified live credential
+          could replace a freshly rotated token with its consumed ancestor.
+        """
+        if self._live_matches_slot_backup(slot, email):
+            return "noop", None
+        provenance = self._prefetch_live_identity()
+        if provenance.get("resolved") is None:
+            self._logger.info(
+                "Live credential diverges from Account-%s's stored backup "
+                "and ownership could not be verified; self-switch left "
+                "everything untouched (pre-fix no-op).",
+                slot,
+            )
+            return "noop-diverged", None
+        return "reconcile", provenance
+
+    def _prefetch_live_identity(self) -> dict:
+        """Resolve the live credential's owner BEFORE the locks are taken.
+
+        The switch-time backup copies live credential bytes into the slot named
+        by ``~/.claude.json`` — two files with independent writers. When they
+        agree (bytes or refresh-token lineage match the slot's stored backup)
+        no network is needed. When they diverge, only the API can say whose
+        token the live bytes are (the credential blob carries no identity), and
+        "no network while locks are held" forces that call to happen here.
+
+        Returns ``{"live": str|None, "resolved": dict|None}``. ``resolved`` is
+        only trustworthy while the live bytes haven't moved — the under-lock
+        classifier re-checks byte equality before using it.
+        """
+        result: dict = {"live": None, "resolved": None}
+        try:
+            live = self._read_credentials()
+        except Exception as e:
+            self._logger.debug(f"Pre-lock live credential read failed: {e!r}")
+            return result
+        result["live"] = live
+        if not live:
+            return result
+        identity = self._get_current_account()
+        if identity is None:
+            return result
+        data = self._get_sequence_data() or {}
+        slot = self._find_account_slot(data, identity[0], identity[1])
+        if slot is None:
+            return result
+        backup = self._read_account_credentials(slot, identity[0])
+        if backup == live or (
+            oauth.credential_fingerprint(backup)
+            == oauth.credential_fingerprint(live)
+        ):
+            return result  # provenance already established locally
+        access_token = oauth.extract_access_token(live)
+        if not access_token:
+            return result  # raw API key / garbled JSON — nothing to resolve
+        try:
+            result["resolved"] = oauth.fetch_oauth_profile(access_token)
+        except Exception as e:
+            # fetch_oauth_profile swallows its own failures; this belt keeps
+            # the invariant structural — the oracle is advisory and must
+            # never fail a switch.
+            self._logger.debug(f"Profile resolution raised: {e!r}")
+        return result
+
+    def _classify_outgoing_credential(
+        self,
+        current_account: str,
+        current_email: str,
+        original_creds: str,
+        provenance: dict,
+        data: dict,
+    ) -> tuple[str, str | None]:
+        """Decide what the switch-time backup may do with the live credential.
+
+        Returns ``(kind, foreign_slot)``:
+
+        - ``"own-bytes"``      — byte-identical to the slot's stored backup;
+          nothing changed, nothing to capture.
+        - ``"own-family"``     — same refresh-token lineage (access token
+          rotated); back up normally.
+        - ``"own-rotated"``    — full rotation, but the profile endpoint
+          resolved the live token to this slot's identity; back up normally
+          (the live→backup re-sync that keeps slots alive across Claude
+          Code's routine refresh-token rotations).
+        - ``"foreign"``        — uuid-positively resolved to *another* managed
+          slot (``foreign_slot``) holding a different lineage; backing it up
+          here would destroy this slot's only refresh token (issue #117's
+          poisoning). Preserved in a safety copy, never written into any
+          slot: identity proves ownership, not generation freshness.
+        - ``"foreign-synced"`` — resolved to another managed slot whose
+          stored backup already holds this exact lineage; nothing needs
+          preserving, nothing may be written.
+        - ``"alien"``          — a *structurally complete* identity (uuid +
+          email + organization) that matches no managed slot (unmanaged
+          login, recycled email wearing a managed address, or an email+org
+          match without uuid confirmation). Preserved in a safety copy.
+        - ``"unresolved"``     — mismatch and identity could not be
+          established (offline, endpoint failure, malformed response, no
+          access token in the blob, bytes moved since the pre-lock read) —
+          or was only *partially* established: a response missing email or
+          organization matching nothing is indistinguishable from schema
+          drift, and preserve-and-skip on drift would silently recreate the
+          fail-closed behavior this design forbids. The caller falls back to
+          the exact pre-fix backup: the identity oracle is advisory, and
+          endpoint state must never change switch behavior beyond skipping
+          the extra safety.
+        """
+        backup = self._read_account_credentials(current_account, current_email)
+        if backup and backup == original_creds:
+            return ("own-bytes", None)
+        if backup and (
+            oauth.credential_fingerprint(backup)
+            == oauth.credential_fingerprint(original_creds)
+        ):
+            return ("own-family", None)
+        resolved = provenance.get("resolved")
+        if resolved is None or provenance.get("live") != original_creds:
+            return ("unresolved", None)
+        r_email = resolved.get("email") or ""
+        r_org = resolved.get("organizationUuid") or ""
+        r_uuid = (resolved.get("uuid") or "").strip()
+        # Outgoing-slot uuid match first: robust to partial responses (a
+        # drifted schema may drop email/organization) and to an account
+        # whose email changed. Organization must agree only when both sides
+        # record one — the codebase's usual leniency for org matching.
+        own = data.get("accounts", {}).get(current_account, {})
+        own_uuid = (own.get("uuid") or "").strip()
+        own_org = own.get("organizationUuid", "") or ""
+        if r_uuid and own_uuid and r_uuid == own_uuid and (
+            not r_org or not own_org or r_org == own_org
+        ):
+            return ("own-rotated", None)
+        slot = self._find_account_slot(data, r_email, r_org) if r_email else None
+        if slot is not None and r_uuid:
+            # When both sides carry a uuid it must agree: an email+org match
+            # with a conflicting uuid is a *different* account wearing a
+            # recycled email (e.g. deleted/recreated claude.ai account), and
+            # treating it as the slot would poison the slot's backup.
+            stored_uuid = (
+                data.get("accounts", {}).get(slot, {}).get("uuid") or ""
+            ).strip()
+            if stored_uuid and stored_uuid != r_uuid:
+                slot = None
+        if slot is None and r_uuid:
+            # Fall back to the account uuid (org-scoped) in case the slot's
+            # stored email is stale or synthesized (add-token placeholder).
+            for num, acct in data.get("accounts", {}).items():
+                if (
+                    acct.get("uuid")
+                    and acct.get("uuid") == r_uuid
+                    and (acct.get("organizationUuid", "") or "") == r_org
+                ):
+                    slot = num
+                    break
+        if slot == current_account:
+            return ("own-rotated", None)
+        if slot is None:
+            # A positive "alien" needs a structurally complete identity —
+            # email plus organization — matching nothing. A partial one is
+            # indistinguishable from schema drift and must fail open like
+            # any other oracle degradation, not preserve-and-skip.
+            if r_email and resolved.get("organizationUuid") is not None:
+                return ("alien", None)
+            return ("unresolved", None)
+        # A cross-slot attribution must be uuid-positive: an email+org match
+        # against a slot with no recorded uuid (add-token placeholder) is not
+        # evidence enough to name that slot in user output — treat as alien.
+        stored_uuid = (
+            data.get("accounts", {}).get(slot, {}).get("uuid") or ""
+        ).strip()
+        if not r_uuid or stored_uuid != r_uuid:
+            return ("alien", None)
+        foreign_email = data.get("accounts", {}).get(slot, {}).get("email", "")
+        foreign_backup = self._read_account_credentials(slot, foreign_email)
+        if foreign_backup and (
+            foreign_backup == original_creds
+            or oauth.credential_fingerprint(foreign_backup)
+            == oauth.credential_fingerprint(original_creds)
+        ):
+            return ("foreign-synced", slot)
+        return ("foreign", slot)
+
+    def _stash_live_credential(
+        self,
+        original_creds: str,
+        reason: str,
+        current_account: str,
+        resolved: dict | None,
+    ) -> str:
+        """Preserve an unowned live credential before it is overwritten.
+
+        Raises on failure — a successful stash is the license to overwrite the
+        live store (the bytes may be the only live copy of some account's
+        refresh token). The logged evidence doubles as the instrumentation for
+        identifying what wrote the credential (#117's writer is unidentified).
+        """
+        creds_mtime: str | None = None
+        try:
+            mtime = get_credentials_path().stat().st_mtime
+            from datetime import datetime, timezone
+
+            creds_mtime = datetime.fromtimestamp(
+                mtime, tz=timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except OSError:
+            pass  # Keychain backend or file absent
+        live_oauth_account: dict | None = None
+        try:
+            config = self._read_json(self._get_claude_config_path())
+            if isinstance(config, dict):
+                live_oauth_account = config.get("oauthAccount")
+        except Exception:
+            pass
+        entry_id = self._store._write_unclaimed_credential(
+            original_creds,
+            {
+                "reason": reason,
+                "configSlot": current_account,
+                "fingerprint": oauth.credential_fingerprint(original_creds),
+                "liveOauthAccount": live_oauth_account,
+                "resolvedIdentity": resolved,
+                "credentialsMtime": creds_mtime,
+            },
+        )
+        self._logger.warning(
+            "Live credential does not belong to Account-%s (%s): stashed as %s "
+            "(credentials mtime %s). Something outside cswap rewrote the live "
+            "login after the last switch.",
+            current_account,
+            reason,
+            entry_id,
+            creds_mtime or "unknown",
+        )
+        return entry_id
+
     def _perform_switch(
         self,
         target_account: str,
         emit_output: bool = True,
         force_activate: bool = False,
+        provenance: dict | None = None,
     ) -> dict:
         """Perform the actual account switch with transaction support.
 
@@ -2630,6 +3143,17 @@ class ClaudeAccountSwitcher:
                     warning(msg)
                 else:
                     warnings_out.append(msg)
+
+        # Pre-lock identity resolution (may hit the network — must happen
+        # before the locks). Callers that already resolved (self-switch
+        # reconciliation) pass it in; force activation never backs up the
+        # live credential so it skips the lookup.
+        if provenance is None:
+            provenance = (
+                {"live": None, "resolved": None}
+                if force_activate
+                else self._prefetch_live_identity()
+            )
 
         # Beyond cswap's own lock, hold Claude Code's advisory locks for the
         # whole mutation (including rollback paths): its token refresh runs
@@ -2715,6 +3239,42 @@ class ClaudeAccountSwitcher:
                             raise ConfigError(
                                 f"Cannot snapshot live config before activation: {e}"
                             )
+
+                # Invariant II (issue #117): this path skips the backup step,
+                # so the live credential it replaces would otherwise have no
+                # surviving copy — stash it first. For an unmanaged login the
+                # stash is the only copy anywhere; for --force it guards
+                # against the "stale" live login actually being the fresher
+                # generation. A failed stash aborts, except under --force
+                # where the user explicitly asked for the overwrite.
+                if (
+                    rollback_creds
+                    and rollback_creds != target_creds
+                    and current_identity is not None
+                ):
+                    try:
+                        self._stash_live_credential(
+                            rollback_creds,
+                            "displaced-live-login",
+                            current_account or "unmanaged",
+                            None,
+                        )
+                    except Exception as e:
+                        if not force_activate:
+                            raise SwitchError(
+                                "Could not preserve the live credential before "
+                                f"activation (safety-copy write failed: {e}); "
+                                "aborting rather than destroying it"
+                            )
+                        msg = (
+                            "Could not preserve the replaced live credential "
+                            f"(safety-copy write failed: {e}) — proceeding "
+                            "because --force explicitly rewrites the live login."
+                        )
+                        if emit_output:
+                            warning(msg)
+                        else:
+                            warnings_out.append(msg)
 
                 creds_written = False
                 config_written = False
@@ -2811,14 +3371,107 @@ class ClaudeAccountSwitcher:
             )
 
             try:
-                # Step 1: Backup current account
-                self._write_account_credentials(
-                    current_account, current_email, original_creds
+                # Step 1: Backup current account. Position in ~/.claude.json
+                # says which slot is active; only the classification says who
+                # owns the live bytes (issue #117: an external write here
+                # used to destroy the outgoing slot's refresh token). The
+                # identity oracle is strictly advisory — "unresolved" falls
+                # back to the exact pre-fix backup, so endpoint state never
+                # decides whether a switch completes.
+                kind, foreign_slot = self._classify_outgoing_credential(
+                    current_account, current_email, original_creds,
+                    provenance, data,
                 )
-                self._write_account_config(
-                    current_account, current_email, original_config
-                )
-                self._logger.info(f"Backed up account {current_account}")
+                if kind in ("foreign", "alien"):
+                    # Positively not this slot's bytes: never into a slot;
+                    # never silently destroyed. The safety copy (which raises
+                    # on failure, aborting before the live store is
+                    # overwritten) is the license to proceed.
+                    self._stash_live_credential(
+                        original_creds, kind, current_account,
+                        provenance.get("resolved"),
+                    )
+                    if kind == "foreign":
+                        msg = (
+                            "Credential ownership mismatch detected. The live "
+                            "credential was preserved and was not written "
+                            f"into Account-{current_account}. If Account-"
+                            f"{foreign_slot} later cannot authenticate, log "
+                            "in as it and run: cswap add --slot "
+                            f"{foreign_slot}"
+                        )
+                    else:
+                        msg = (
+                            "The live login does not match a managed "
+                            "account. It was preserved and not written into "
+                            f"Account-{current_account}. If you need that "
+                            "account, log in as it and run: cswap add"
+                        )
+                    if emit_output:
+                        warning(msg)
+                    else:
+                        warnings_out.append(msg)
+                elif kind == "foreign-synced":
+                    # Another managed account's bytes, and that slot already
+                    # holds this lineage — nothing needs preserving, nothing
+                    # may be written.
+                    msg = (
+                        "Credential ownership mismatch detected. The live "
+                        f"credential already matches Account-{foreign_slot}'s "
+                        "stored backup, so nothing was written into "
+                        f"Account-{current_account}."
+                    )
+                    if emit_output:
+                        warning(msg)
+                    else:
+                        warnings_out.append(msg)
+                elif kind == "unresolved":
+                    # Ownership could not be established (offline, endpoint
+                    # failure, malformed response, non-OAuth blob). Fail
+                    # open: exact pre-fix backup. Most such divergences are
+                    # the account's own rotation — skipping the backup would
+                    # leave the slot holding a consumed token — and the
+                    # .prev retention inside the write gives even a wrong
+                    # call a best-effort recovery cushion. Log only:
+                    # indistinguishable from a legitimate rotation, so a
+                    # warning would cry wolf.
+                    self._write_account_credentials(
+                        current_account, current_email, original_creds
+                    )
+                    self._write_account_config(
+                        current_account, current_email, original_config
+                    )
+                    self._logger.info(
+                        f"Backed up account {current_account} (lineage "
+                        "differs from the stored backup and ownership could "
+                        "not be verified — pre-fix backup)"
+                    )
+                elif kind == "own-bytes":
+                    # Untouched since cswap wrote it — the slot already holds
+                    # these bytes. Refresh only the config backup.
+                    self._write_account_config(
+                        current_account, current_email, original_config
+                    )
+                    self._logger.info(
+                        f"Backed up account {current_account} (config only; "
+                        "credentials unchanged)"
+                    )
+                else:  # own-family / own-rotated
+                    self._write_account_credentials(
+                        current_account, current_email, original_creds
+                    )
+                    self._write_account_config(
+                        current_account, current_email, original_config
+                    )
+                    if kind == "own-rotated":
+                        # The profile call proved the identity; backfill a
+                        # missing slot uuid (add-token placeholder) while the
+                        # sequence file is being rewritten anyway.
+                        resolved = provenance.get("resolved") or {}
+                        acct = data.get("accounts", {}).get(current_account, {})
+                        if not acct.get("uuid") and resolved.get("uuid"):
+                            acct["uuid"] = resolved["uuid"]
+                    self._logger.info(f"Backed up account {current_account}")
 
                 # Step 2: Retrieve target account
                 target_creds = self._read_account_credentials(

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -1114,3 +1114,244 @@ class TestRunLoop:
     def test_sleep_cap(self, harness):
         harness.engine._sleep_until_ts = harness.clock() + 50 * 3600
         assert harness.engine._next_delay(TickOutcome.BLOCKED) == 6 * 3600
+
+
+class TestTokenIdentity:
+    """The token endpoint's free identity data: uuid backfill and the
+    identity-conflict detector (the zero-request check that catches a
+    poisoned slot the moment auto freshens it)."""
+
+    def test_uuid_backfill_from_token_account_on_freshen(self, harness):
+        data = harness.switcher._get_sequence_data()
+        data["accounts"]["2"]["uuid"] = ""
+        harness.switcher._write_json(harness.switcher.sequence_file, data)
+        # Slot 2 near expiry → freshen path runs.
+        harness.switcher._write_account_credentials(
+            "2", "b@example.com",
+            json.dumps({"claudeAiOauth": {
+                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
+            }}),
+        )
+        fresh = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-2f", "refreshToken": "rt-2f",
+            "expiresAt": 99_999_999_999_000,
+        }})
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(
+                fresh, None,
+                {"uuid": "uuid-2-real", "email": "b@example.com",
+                 "organizationUuid": ""},
+            ),
+        ):
+            status = harness.engine._freshen_target("2", "b@example.com")
+        assert status == "ok"
+        assert harness.switcher._get_sequence_data()["accounts"]["2"]["uuid"] == (
+            "uuid-2-real"
+        )
+
+    def test_conflicting_token_identity_returns_identity_conflict(self, harness):
+        """A slot whose credential authenticates as a different account is not
+        a viable target — but the rotated generation is still persisted (the
+        grant consumed its predecessor)."""
+        harness.switcher._write_account_credentials(
+            "2", "b@example.com",
+            json.dumps({"claudeAiOauth": {
+                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
+            }}),
+        )
+        fresh = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-2f", "refreshToken": "rt-2f",
+            "expiresAt": 99_999_999_999_000,
+        }})
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(
+                fresh, None,
+                {"uuid": "uuid-somebody-else", "email": "z@example.com",
+                 "organizationUuid": ""},
+            ),
+        ):
+            status = harness.engine._freshen_target("2", "b@example.com")
+        assert status == "identity-conflict"
+        # The consumed generation's successor was persisted regardless.
+        assert harness.switcher.read_account_credentials(
+            "2", "b@example.com"
+        ) == fresh
+
+    def test_identity_conflict_quarantines_instead_of_activating(self, harness):
+        """Tick path: the conflicted slot is quarantined (wrong-account switch
+        prevented); rotation falls through to the next candidate."""
+        harness.switcher._write_account_credentials(
+            "2", "b@example.com",
+            json.dumps({"claudeAiOauth": {
+                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
+            }}),
+        )
+        fresh = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-2f", "refreshToken": "rt-2f",
+            "expiresAt": 99_999_999_999_000,
+        }})
+
+        def refresh(creds):
+            data = json.loads(creds)["claudeAiOauth"]
+            if data["refreshToken"] == "rt-2":
+                return oauth.RefreshOutcome(
+                    fresh, None,
+                    {"uuid": "uuid-somebody-else", "email": "z@example.com",
+                     "organizationUuid": ""},
+                )
+            return oauth.RefreshOutcome(creds, None)
+
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            side_effect=refresh,
+        ):
+            outcome = harness.tick_with_usage({
+                "1": _usage(95), "2": _usage(10), "3": _usage(80),
+            })
+        # Account 2 had the most headroom but is conflicted → quarantined,
+        # and the switch landed elsewhere.
+        assert "account-quarantined" in harness.kinds()
+        q = harness.state().get("quarantine", {})
+        assert q.get("2", {}).get("reason") == "identity-conflict"
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3
+
+    def test_dead_slot_quarantined_even_with_safety_copy_present(self, harness):
+        """No automatic promotion (fail-open rework of the issue #117 guard):
+        a dead slot is quarantined outright; safety copies are forensic
+        material, and recovery is the documented /login + cswap add."""
+        harness.switcher._store._write_unclaimed_credential(
+            json.dumps({"claudeAiOauth": {
+                "accessToken": "sk-2-successor",
+                "refreshToken": "rt-2-successor",
+                "expiresAt": 99_999_999_999_000,
+            }}),
+            {"resolvedIdentity": {
+                "uuid": "uuid-2", "email": "b@example.com",
+                "organizationUuid": "",
+            }},
+        )
+        harness.switcher._write_account_credentials(
+            "2", "b@example.com",
+            json.dumps({"claudeAiOauth": {
+                "accessToken": "sk-2-dead", "refreshToken": "rt-2-dead",
+                "expiresAt": 0,
+            }}),
+        )
+
+        def refresh(creds):
+            data = json.loads(creds)["claudeAiOauth"]
+            if data["refreshToken"] == "rt-2-dead":
+                return oauth.RefreshOutcome(None, "invalid_grant")
+            return oauth.RefreshOutcome(creds, None)
+
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            side_effect=refresh,
+        ):
+            outcome = harness.tick_with_usage({
+                "1": _usage(95), "2": _usage(10), "3": _usage(80),
+            })
+        q = harness.state().get("quarantine", {})
+        assert q.get("2", {}).get("reason") == "invalid_grant"
+        # The safety copy was not consumed, and the switch landed elsewhere.
+        assert len(harness.switcher.list_unclaimed_credentials()) == 1
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3
+
+    def test_same_uuid_different_org_is_identity_conflict(self, harness):
+        """Organization is part of account identity everywhere else in the
+        codebase: the same account uuid under a different org is a conflict
+        (org compared only when both sides record one)."""
+        data = harness.switcher._get_sequence_data()
+        data["accounts"]["2"]["organizationUuid"] = "org-2"
+        harness.switcher._write_json(harness.switcher.sequence_file, data)
+        harness.switcher._write_account_credentials(
+            "2", "b@example.com",
+            json.dumps({"claudeAiOauth": {
+                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
+            }}),
+        )
+        fresh = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-2f", "refreshToken": "rt-2f",
+            "expiresAt": 99_999_999_999_000,
+        }})
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(
+                fresh, None,
+                {"uuid": "uuid-2", "email": "b@example.com",
+                 "organizationUuid": "org-other"},
+            ),
+        ):
+            status = harness.engine._freshen_target("2", "b@example.com")
+        assert status == "identity-conflict"
+
+    def test_malformed_token_identity_never_breaks_freshen(self, harness):
+        """A schema change feeding a non-string uuid must be ignored, not
+        raise — by this point the refreshed credential is already persisted,
+        and a crash here would skip the persist bookkeeping and error the
+        tick."""
+        harness.switcher._write_account_credentials(
+            "2", "b@example.com",
+            json.dumps({"claudeAiOauth": {
+                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
+            }}),
+        )
+        fresh = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-2f", "refreshToken": "rt-2f",
+            "expiresAt": 99_999_999_999_000,
+        }})
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(
+                fresh, None, {"uuid": 12345, "email": ["weird"]},
+            ),
+        ):
+            status = harness.engine._freshen_target("2", "b@example.com")
+        assert status == "ok"
+        assert harness.switcher.read_account_credentials(
+            "2", "b@example.com"
+        ) == fresh
+
+    def test_blank_uuid_slot_with_org_conflict_quarantines_not_backfills(
+        self, harness,
+    ):
+        """Org conflict must be checked before the blank-uuid backfill: a
+        wrong-org credential is evidence the slot holds the wrong account,
+        and backfilling its uuid would stick a foreign identity onto the
+        slot (backfill never rewrites a non-empty uuid). Blank-uuid slots
+        with a recorded org are what accounts added by older versions look
+        like."""
+        data = harness.switcher._get_sequence_data()
+        data["accounts"]["2"]["uuid"] = ""
+        data["accounts"]["2"]["organizationUuid"] = "org-A"
+        harness.switcher._write_json(harness.switcher.sequence_file, data)
+        harness.switcher._write_account_credentials(
+            "2", "b@example.com",
+            json.dumps({"claudeAiOauth": {
+                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
+            }}),
+        )
+        fresh = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-2f", "refreshToken": "rt-2f",
+            "expiresAt": 99_999_999_999_000,
+        }})
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(
+                fresh, None,
+                {"uuid": "uuid-real", "email": "z@example.com",
+                 "organizationUuid": "org-B"},
+            ),
+        ):
+            status = harness.engine._freshen_target("2", "b@example.com")
+        assert status == "identity-conflict"
+        # The foreign uuid was NOT backfilled onto the slot.
+        assert harness.switcher._get_sequence_data()["accounts"]["2"]["uuid"] == ""
+        # The successor generation was still persisted (grant consumed it).
+        assert harness.switcher.read_account_credentials(
+            "2", "b@example.com"
+        ) == fresh

--- a/tests/test_macos_keychain_contract.py
+++ b/tests/test_macos_keychain_contract.py
@@ -71,6 +71,9 @@ class TestBackupCredentialsSecurity:
         self, macos_switcher: ClaudeAccountSwitcher
     ):
         with patch("claude_swap.credentials.macos_keychain") as mock_kc:
+            # No existing backup → the .prev retention step has nothing to
+            # keep and the write stays a single Keychain call.
+            mock_kc.get_password.return_value = None
             macos_switcher._write_account_credentials(
                 "2", "alice@example.com", "secret-token"
             )
@@ -78,6 +81,28 @@ class TestBackupCredentialsSecurity:
             mock_kc.set_password.assert_called_once_with(
                 "claude-swap", "account-2-alice@example.com", "secret-token"
             )
+
+    def test_write_retains_prev_generation_in_keychain_not_a_file(
+        self, macos_switcher: ClaudeAccountSwitcher
+    ):
+        """Retention must not weaken storage posture: on a Keychain-backed
+        Mac the previous generation goes to the Keychain, never a file."""
+        with patch("claude_swap.credentials.macos_keychain") as mock_kc:
+            mock_kc.get_password.return_value = "old-generation"
+            macos_switcher._write_account_credentials(
+                "2", "alice@example.com", "secret-token"
+            )
+
+            mock_kc.set_password.assert_has_calls([
+                call("claude-swap", "account-2-alice@example.com.prev",
+                     "old-generation"),
+                call("claude-swap", "account-2-alice@example.com",
+                     "secret-token"),
+            ])
+        prev_file = macos_switcher._store._prev_backup_path(
+            "2", "alice@example.com"
+        )
+        assert not prev_file.exists()
 
     def test_delete_account_credentials_uses_security_service(
         self, macos_switcher: ClaudeAccountSwitcher
@@ -87,7 +112,9 @@ class TestBackupCredentialsSecurity:
 
             mock_kc.delete_password.assert_has_calls([
                 call("claude-swap", "account-3-bob@example.com"),
+                call("claude-swap", "account-3-bob@example.com.prev"),
                 call("claude-swap", "account-None-bob@example.com"),
+                call("claude-swap", "account-None-bob@example.com.prev"),
             ])
 
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1017,3 +1017,275 @@ class TestInvalidGrantPropagation:
                 "1", "a@b.c", self._valid_credentials(), is_active=False,
             )
         assert outcome.error == "refresh-failed"
+
+
+class TestCredentialFingerprint:
+    """Identity fingerprints for stored credentials (issue #117 guard)."""
+
+    def test_stable_across_access_token_rotation(self):
+        a = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-old", "refreshToken": "rt-1"}})
+        b = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-new", "refreshToken": "rt-1", "expiresAt": 5}})
+        assert oauth.credential_fingerprint(a) == oauth.credential_fingerprint(b)
+
+    def test_differs_across_refresh_token_rotation(self):
+        a = json.dumps({"claudeAiOauth": {"refreshToken": "rt-1"}})
+        b = json.dumps({"claudeAiOauth": {"refreshToken": "rt-2"}})
+        assert oauth.credential_fingerprint(a) != oauth.credential_fingerprint(b)
+
+    def test_full_content_fallback_for_api_keys_and_setup_tokens(self):
+        api_key = "sk-ant-api03-xyz"
+        setup = json.dumps({"claudeAiOauth": {"accessToken": "sk-ant-oat01-abc"}})
+        assert oauth.credential_fingerprint(api_key) is not None
+        assert oauth.credential_fingerprint(setup) is not None
+        # Never None for real bytes: a None would make every "did it change?"
+        # comparison degenerate to "changed".
+        assert oauth.credential_fingerprint(api_key) != oauth.credential_fingerprint(setup)
+
+    def test_full_hash_never_collides_with_refresh_hash(self):
+        with_rt = json.dumps({"claudeAiOauth": {"refreshToken": "rt-1"}})
+        assert oauth.credential_fingerprint(with_rt).startswith("sha256:")
+        assert oauth.credential_fingerprint("raw-token").startswith("sha256-full:")
+
+    def test_empty_input_is_none(self):
+        assert oauth.credential_fingerprint("") is None
+
+
+class TestTokenAccountParsing:
+    """The token endpoint's optional account identity must not be discarded."""
+
+    _make_credentials = staticmethod(TestRefreshOAuthCredentials._make_credentials)
+
+    def _refresh_with_response(self, payload: dict) -> oauth.RefreshOutcome:
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(payload).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen", return_value=mock_response
+        ):
+            return oauth.try_refresh_oauth_credentials(self._make_credentials())
+
+    def test_token_account_surfaced_when_present(self):
+        outcome = self._refresh_with_response({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+            "account": {"uuid": "acc-uuid", "email_address": "a@b.c"},
+            "organization": {"uuid": "org-uuid"},
+        })
+        assert outcome.error is None
+        assert outcome.token_account == {
+            "uuid": "acc-uuid", "email": "a@b.c", "organizationUuid": "org-uuid",
+        }
+
+    def test_token_account_absent_is_none(self):
+        outcome = self._refresh_with_response({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        })
+        assert outcome.error is None
+        assert outcome.token_account is None
+
+    # Same strict boundary as fetch_oauth_profile: identity is opportunistic
+    # and must never break the refresh that carried it — malformed or
+    # uuid-less data is None, optional fields normalize to str-or-None.
+
+    def test_token_account_without_uuid_is_none(self):
+        outcome = self._refresh_with_response({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+            "account": {"email_address": "a@b.c"},
+        })
+        assert outcome.error is None
+        assert outcome.token_account is None
+
+    def test_token_account_non_string_uuid_is_none(self):
+        outcome = self._refresh_with_response({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+            "account": {"uuid": 12345, "email_address": "a@b.c"},
+        })
+        assert outcome.error is None
+        assert outcome.token_account is None
+
+    def test_token_account_uuid_whitespace_normalized(self):
+        """Normalization happens at the boundary so padded uuids never reach
+        comparisons or sequence.json backfills."""
+        outcome = self._refresh_with_response({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+            "account": {"uuid": "  acc-uuid  ", "email_address": "a@b.c"},
+        })
+        assert outcome.token_account["uuid"] == "acc-uuid"
+
+    def test_token_account_non_string_optionals_normalized(self):
+        outcome = self._refresh_with_response({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+            "account": {"uuid": "acc-uuid", "email_address": {"weird": 1}},
+            "organization": {"uuid": 99},
+        })
+        assert outcome.error is None
+        assert outcome.token_account == {
+            "uuid": "acc-uuid", "email": None, "organizationUuid": None,
+        }
+
+
+class TestFetchOauthProfile:
+    """Access-token → account-identity resolution (/api/oauth/profile)."""
+
+    def _profile_response(self, payload: dict):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(payload).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        return mock_response
+
+    def test_resolves_identity(self):
+        seen = {}
+
+        def mock_urlopen(req, timeout=0):
+            seen["url"] = req.full_url
+            seen["auth"] = req.headers.get("Authorization")
+            return self._profile_response({
+                "account": {"uuid": "acc-uuid", "email": "a@b.c"},
+                "organization": {"uuid": "org-uuid"},
+            })
+
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=mock_urlopen):
+            result = oauth.fetch_oauth_profile("sk-live")
+        assert result == {
+            "uuid": "acc-uuid", "email": "a@b.c", "organizationUuid": "org-uuid",
+        }
+        assert seen["url"].endswith("/api/oauth/profile")
+        assert seen["auth"] == "Bearer sk-live"
+
+    def test_uses_bounded_timeout(self):
+        """One bounded call: the profile lookup may only ever add latency,
+        never hang a switch."""
+        seen = {}
+
+        def mock_urlopen(req, timeout=0):
+            seen["timeout"] = timeout
+            return self._profile_response({
+                "account": {"uuid": "acc-uuid", "email": "a@b.c"},
+            })
+
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=mock_urlopen):
+            oauth.fetch_oauth_profile("sk-live")
+        assert seen["timeout"] == 5
+
+    def test_network_failure_is_unresolvable_not_error(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("down"),
+        ):
+            assert oauth.fetch_oauth_profile("sk-live") is None
+
+    def test_missing_account_object_is_unresolvable(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            return_value=self._profile_response({"unexpected": True}),
+        ):
+            assert oauth.fetch_oauth_profile("sk-live") is None
+
+    # Strict resolution boundary: the oracle is advisory (None keeps the
+    # switch on the fail-open path), so a response only counts as resolved
+    # with a non-empty string account.uuid — a schema change must degrade to
+    # pre-fix behavior, not to preserve-and-skip.
+
+    def test_missing_uuid_is_unresolvable(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            return_value=self._profile_response({
+                "account": {"email": "a@b.c"},
+                "organization": {"uuid": "org-uuid"},
+            }),
+        ):
+            assert oauth.fetch_oauth_profile("sk-live") is None
+
+    def test_non_string_uuid_is_unresolvable(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            return_value=self._profile_response({
+                "account": {"uuid": 12345, "email": "a@b.c"},
+            }),
+        ):
+            assert oauth.fetch_oauth_profile("sk-live") is None
+
+    def test_blank_uuid_is_unresolvable(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            return_value=self._profile_response({
+                "account": {"uuid": "   ", "email": "a@b.c"},
+            }),
+        ):
+            assert oauth.fetch_oauth_profile("sk-live") is None
+
+    def test_malformed_json_is_unresolvable(self):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"<!doctype html><html>gateway error"
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen", return_value=mock_response,
+        ):
+            assert oauth.fetch_oauth_profile("sk-live") is None
+
+    def test_uuid_whitespace_normalized_at_boundary(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            return_value=self._profile_response({
+                "account": {"uuid": "  acc-uuid  ", "email": "a@b.c"},
+            }),
+        ):
+            result = oauth.fetch_oauth_profile("sk-live")
+        assert result["uuid"] == "acc-uuid"
+
+    def test_valid_uuid_with_missing_email_still_resolves(self):
+        """email/organization are optional; uuid is the identity."""
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            return_value=self._profile_response({
+                "account": {"uuid": "acc-uuid"},
+            }),
+        ):
+            result = oauth.fetch_oauth_profile("sk-live")
+        assert result == {"uuid": "acc-uuid", "email": None, "organizationUuid": None}
+
+    def test_non_string_optional_fields_are_dropped_not_fatal(self):
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen",
+            return_value=self._profile_response({
+                "account": {"uuid": "acc-uuid", "email": {"weird": True}},
+                "organization": {"uuid": 99},
+            }),
+        ):
+            result = oauth.fetch_oauth_profile("sk-live")
+        assert result == {"uuid": "acc-uuid", "email": None, "organizationUuid": None}
+
+    def test_401_is_unresolvable_with_log_file_warning(self, caplog):
+        """401 is evidence (the live token can't authenticate) but not proof —
+        fail open, and record it at warning level in the log only (the
+        console handler exists only under --debug)."""
+        import logging
+
+        err = urllib.error.HTTPError(
+            "https://api.anthropic.com/api/oauth/profile", 401,
+            "Unauthorized", {}, None,
+        )
+        with patch(
+            "claude_swap.oauth.urllib.request.urlopen", side_effect=err,
+        ), caplog.at_level(logging.WARNING, logger="claude-swap"):
+            assert oauth.fetch_oauth_profile("sk-live") is None
+        assert any(
+            "401" in r.message and "pre-fix" in r.message
+            for r in caplog.records
+        )

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -19,9 +19,10 @@ from claude_swap.exceptions import (
     AccountNotFoundError,
     ConfigError,
     CredentialReadError,
+    SwitchError,
     ValidationError,
 )
-from claude_swap.usage_store import FetchRecord, UsageStore
+from claude_swap.usage_store import FetchRecord, UsageEntry, UsageStore
 from claude_swap.macos_keychain import KeychainError
 from claude_swap.models import Platform
 from claude_swap.paths import get_backup_root, get_credentials_path
@@ -951,6 +952,9 @@ class TestActiveAccountRefresh:
             return oauth.UsageOutcome(usage_result)
 
         with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch.object(
+                 switcher, "_read_account_credentials", return_value=self._EXPIRED
+             ), \
              patch.object(switcher, "_active_cc_running", return_value=False), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials") as write_live, \
@@ -1100,6 +1104,9 @@ class TestActiveAccountRefresh:
             return oauth.UsageOutcome({"five_hour": {"pct": 10}})
 
         with patch.object(switcher, "_read_credentials", return_value=self._EXPIRED), \
+             patch.object(
+                 switcher, "_read_account_credentials", return_value=self._EXPIRED
+             ), \
              patch.object(switcher, "_active_cc_running", return_value=False), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch.object(switcher, "_write_credentials"), \
@@ -1329,6 +1336,17 @@ class TestPerformSwitchPostDisplay:
                 return_value={
                     "five_hour": {"utilization": 12.0, "resets_at": None},
                     "seven_day": {"utilization": 34.0, "resets_at": None},
+                },
+            ), patch(
+                # Account 1 has no stored backup, so the provenance guard
+                # (issue #117) resolves the live credential's owner before
+                # backing it into slot 1 — answer with slot 1's identity so
+                # the capture proceeds as a legitimate own-credential backup.
+                "claude_swap.oauth.fetch_oauth_profile",
+                return_value={
+                    "uuid": "uuid-1",
+                    "email": "test@example.com",
+                    "organizationUuid": "",
                 },
             ):
                 switcher._perform_switch("2")
@@ -1592,7 +1610,18 @@ class TestPerformSwitchPostDisplay:
         )
 
         try:
-            with patch.object(switcher, "list_accounts"):
+            with patch.object(switcher, "list_accounts"), patch(
+                # Slot 4's stored backup doesn't match the live bytes, so the
+                # provenance guard resolves the live credential's owner —
+                # answer with slot 4's identity so the backup is written as a
+                # legitimate rotation of the live-identity slot.
+                "claude_swap.oauth.fetch_oauth_profile",
+                return_value={
+                    "uuid": "",
+                    "email": "realiti44@gmail.com",
+                    "organizationUuid": "",
+                },
+            ):
                 switcher._perform_switch("3")
         finally:
             for p in patches:
@@ -4203,3 +4232,1109 @@ class TestFormatUsageLines:
         usage = {"five_hour": {"pct": 7.0, "clock": "20:39", "countdown": "1h 30m"}}
         lines = _format_usage_lines(usage)
         assert lines == ["5h:   7%   resets 20:39         in 1h 30m"]
+
+
+def _read_safety_copy(switcher, entry_id: str) -> str:
+    """Decode a preserved credential entry straight from its file (the store
+    is write-only by design — no read helper exists in production code)."""
+    path = switcher._store._stash_entry_path(entry_id)
+    return base64.b64decode(path.read_text().strip(), validate=True).decode()
+
+
+class TestProvenanceGuard:
+    """Issue #117, fail-open hybrid: the identity oracle is advisory.
+
+    Positively-foreign bytes are preserved and never written into a slot;
+    an *unverifiable* divergence falls back to the exact pre-fix backup, so
+    endpoint state never changes whether or how a switch completes.
+
+    Two timelines, kept explicitly separate:
+
+    - *normal operation* — Claude Code legitimately rotated the active
+      account's token (same lineage, or resolved to the outgoing slot);
+    - *fault injection* — the live store holds a foreign or unattributable
+      credential (the poisoning precondition).
+    """
+
+    _setup_two_accounts = TestPerformSwitchPostDisplay._setup_two_accounts
+    _install_store_patches = staticmethod(
+        TestPerformSwitchPostDisplay._install_store_patches
+    )
+
+    _A1_BACKUP = json.dumps({"claudeAiOauth": {
+        "accessToken": "sk-stored-1", "refreshToken": "rt-1",
+    }})
+
+    def _run_switch(self, switcher, resolver=None, quiet=True):
+        with patch.object(switcher, "list_accounts"), patch(
+            "claude_swap.oauth.fetch_oauth_profile",
+            side_effect=(lambda token: resolver) if resolver is not None
+            else (lambda token: None),
+        ):
+            return switcher._perform_switch("2", emit_output=not quiet)
+
+    # -- normal-operation timeline ---------------------------------------
+
+    def test_byte_identical_live_skips_credential_backup(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Nothing rotated since cswap's own write → nothing to capture."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        live_state = {"creds": self._A1_BACKUP}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        writes: list = []
+        try:
+            switcher._write_account_credentials = (
+                lambda n, e, c: writes.append((n, e))
+            )
+            op = self._run_switch(switcher)
+        finally:
+            for p in patches:
+                p.stop()
+        assert writes == []  # credential backup skipped entirely
+        assert op["warnings"] == []
+        # Config backup still refreshed.
+        assert configs_store.get(("1", "test@example.com"))
+
+    def test_access_token_rotation_same_lineage_backs_up(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Same refresh token, new access token → provenance is local, no
+        network needed, backup captures the rotation."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        rotated = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-fresh-1", "refreshToken": "rt-1", "expiresAt": 9,
+        }})
+        live_state = {"creds": rotated}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with patch(
+                "claude_swap.oauth.fetch_oauth_profile",
+            ) as profile:
+                with patch.object(switcher, "list_accounts"):
+                    op = switcher._perform_switch("2")
+        finally:
+            for p in patches:
+                p.stop()
+        profile.assert_not_called()
+        assert creds_store[("1", "test@example.com")] == rotated
+        assert op["warnings"] == []
+
+    def test_full_rotation_resolved_to_outgoing_slot_backs_up(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Refresh-token rotation of the *same* account (the routine case a
+        long-lived Claude Code session produces) re-syncs into the slot."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        rotated = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-fresh-1", "refreshToken": "rt-1-rotated",
+        }})
+        live_state = {"creds": rotated}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver={
+                "uuid": "uuid-1", "email": "test@example.com",
+                "organizationUuid": "",
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        assert creds_store[("1", "test@example.com")] == rotated
+        assert op["warnings"] == []
+        assert switcher.list_unclaimed_credentials() == {}
+
+    def test_resolution_backfills_empty_slot_uuid(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        sample_sequence_data["accounts"]["1"]["uuid"] = ""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        live_state = {"creds": json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-f", "refreshToken": "rt-1-rotated",
+        }})}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            self._run_switch(switcher, resolver={
+                "uuid": "uuid-resolved", "email": "test@example.com",
+                "organizationUuid": "",
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["uuid"] == "uuid-resolved"
+
+    # -- fault-injection timeline -----------------------------------------
+
+    def test_foreign_credential_preserved_never_backed_into_any_slot(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """The poisoning precondition: live bytes belong to another managed
+        slot (uuid-positive). They must be preserved as a safety copy — not
+        written into the outgoing slot, and not routed into the resolved slot
+        either (identity proves ownership, not generation freshness). Here the
+        foreign slot is also the switch target: the switch still activates the
+        target's *stored* backup, never the displaced live bytes."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        a2_backup = creds_store[("2", "account2@example.com")]
+        foreign = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-2-rotated", "refreshToken": "rt-2-rotated",
+        }})
+        live_state = {"creds": foreign}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver={
+                "uuid": "uuid-2", "email": "account2@example.com",
+                "organizationUuid": "",
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        # Outgoing slot untouched; resolved slot untouched.
+        assert creds_store[("1", "test@example.com")] == self._A1_BACKUP
+        assert creds_store[("2", "account2@example.com")] == a2_backup
+        # Foreign bytes preserved byte-exactly.
+        entries = switcher.list_unclaimed_credentials()
+        assert len(entries) == 1
+        (entry_id,) = entries
+        assert _read_safety_copy(switcher, entry_id) == foreign
+        assert entries[entry_id]["resolvedIdentity"]["uuid"] == "uuid-2"
+        assert any(
+            "ownership mismatch" in w and "Account-2" in w
+            for w in op["warnings"]
+        )
+        # The switch itself proceeded, onto the stored backup.
+        assert json.loads(live_state["creds"])["claudeAiOauth"]["accessToken"] == "sk-stale-2"
+
+    def test_foreign_synced_lineage_warns_without_any_write(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Foreign bytes whose lineage already sits in that slot's backup:
+        nothing needs preserving, nothing may be written — warn only."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        a2_backup = creds_store[("2", "account2@example.com")]
+        live_state = {"creds": a2_backup}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver={
+                "uuid": "uuid-2", "email": "account2@example.com",
+                "organizationUuid": "",
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        assert creds_store[("1", "test@example.com")] == self._A1_BACKUP
+        assert creds_store[("2", "account2@example.com")] == a2_backup
+        assert switcher.list_unclaimed_credentials() == {}
+        assert any("already matches Account-2" in w for w in op["warnings"])
+
+    def test_alien_credential_preserved_and_skipped(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Resolved to no managed slot: preserve, warn, proceed — the message
+        can't name a slot, so it recommends a plain `cswap add`."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        alien = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-x", "refreshToken": "rt-x",
+        }})
+        live_state = {"creds": alien}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver={
+                "uuid": "uuid-unmanaged", "email": "elsewhere@example.com",
+                "organizationUuid": "",
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        assert creds_store[("1", "test@example.com")] == self._A1_BACKUP
+        entries = switcher.list_unclaimed_credentials()
+        assert len(entries) == 1
+        (entry_id,) = entries
+        assert _read_safety_copy(switcher, entry_id) == alien
+        assert any(
+            "does not match a managed account" in w for w in op["warnings"]
+        )
+
+    def test_blank_stored_uuid_email_match_is_alien_not_foreign(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """A cross-slot attribution must be uuid-positive: an email+org match
+        against a slot with no recorded uuid is preserved as alien, and that
+        slot is never named or touched."""
+        sample_sequence_data["accounts"]["2"]["uuid"] = ""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        a2_backup = creds_store[("2", "account2@example.com")]
+        drifted = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-d", "refreshToken": "rt-d",
+        }})
+        live_state = {"creds": drifted}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver={
+                "uuid": "uuid-2-real", "email": "account2@example.com",
+                "organizationUuid": "",
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        assert creds_store[("1", "test@example.com")] == self._A1_BACKUP
+        assert creds_store[("2", "account2@example.com")] == a2_backup
+        assert len(switcher.list_unclaimed_credentials()) == 1
+        assert any(
+            "does not match a managed account" in w for w in op["warnings"]
+        )
+
+    def test_partial_identity_uuid_only_matching_outgoing_slot_backs_up(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """A response that dropped email/organization but whose uuid equals
+        the outgoing slot's must classify own-rotated: partial data must
+        never turn a legitimate rotation into preserve-and-skip (that would
+        recreate the fail-closed stale-slot behavior on schema drift)."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        rotated = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-f", "refreshToken": "rt-1-rotated",
+        }})
+        live_state = {"creds": rotated}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver={
+                "uuid": "uuid-1", "email": None, "organizationUuid": None,
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        assert creds_store[("1", "test@example.com")] == rotated
+        assert switcher.list_unclaimed_credentials() == {}
+        assert op["warnings"] == []
+
+    def test_partial_identity_uuid_match_with_slot_org_recorded(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Same, with the outgoing slot recording an organization: org must
+        agree only when *both* sides carry one, so a uuid-only response
+        still resolves to the outgoing slot."""
+        sample_sequence_data["accounts"]["1"]["organizationUuid"] = "org-1"
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        data = switcher._get_sequence_data()
+        rotated = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-f", "refreshToken": "rt-1-rotated",
+        }})
+        with patch.object(
+            switcher, "_read_account_credentials",
+            return_value=self._A1_BACKUP,
+        ):
+            kind, foreign_slot = switcher._classify_outgoing_credential(
+                "1", "test@example.com", rotated,
+                {"live": rotated,
+                 "resolved": {"uuid": "uuid-1", "email": None,
+                              "organizationUuid": None}},
+                data,
+            )
+        assert (kind, foreign_slot) == ("own-rotated", None)
+
+    def test_partial_identity_matching_nothing_falls_open(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """A response missing email/organization that matches no slot is
+        indistinguishable from schema drift → unresolved (pre-fix backup),
+        never alien (preserve-and-skip)."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        mystery = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-x", "refreshToken": "rt-x",
+        }})
+        live_state = {"creds": mystery}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver={
+                "uuid": "uuid-nobody", "email": None,
+                "organizationUuid": None,
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        assert creds_store[("1", "test@example.com")] == mystery
+        assert switcher.list_unclaimed_credentials() == {}
+        assert op["warnings"] == []
+
+    def test_foreign_attribution_survives_missing_email(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """uuid+org is a positive cross-slot match even without an email —
+        preserve-and-skip stays available where the evidence is complete
+        enough to be positive."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        a2_backup = creds_store[("2", "account2@example.com")]
+        foreign = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-2-rotated", "refreshToken": "rt-2-rotated",
+        }})
+        live_state = {"creds": foreign}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver={
+                "uuid": "uuid-2", "email": None, "organizationUuid": "",
+            })
+        finally:
+            for p in patches:
+                p.stop()
+        assert creds_store[("1", "test@example.com")] == self._A1_BACKUP
+        assert creds_store[("2", "account2@example.com")] == a2_backup
+        assert len(switcher.list_unclaimed_credentials()) == 1
+        assert any("Account-2" in w for w in op["warnings"])
+
+    def test_unresolvable_mismatch_backs_up_pre_fix(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """The fail-open core: offline / endpoint failure means the identity
+        oracle is silent, and the switch behaves exactly pre-fix — the
+        divergent bytes are backed into the outgoing slot (most such
+        divergences are the account's own rotation; skipping would leave the
+        slot holding a consumed token), with no safety copy and no
+        user-facing warning."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        mystery = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-x", "refreshToken": "rt-x",
+        }})
+        live_state = {"creds": mystery}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            op = self._run_switch(switcher, resolver=None)
+        finally:
+            for p in patches:
+                p.stop()
+        # Pre-fix backup happened; the switch completed quietly.
+        assert creds_store[("1", "test@example.com")] == mystery
+        assert switcher.list_unclaimed_credentials() == {}
+        assert op["warnings"] == []
+        assert json.loads(live_state["creds"])["claudeAiOauth"]["accessToken"] == "sk-stale-2"
+
+    def test_profile_exception_falls_back_to_pre_fix_backup(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """A raising profile call must be indistinguishable from None: the
+        switch completes with the pre-fix backup."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        mystery = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-x", "refreshToken": "rt-x",
+        }})
+        live_state = {"creds": mystery}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with patch.object(switcher, "list_accounts"), patch(
+                "claude_swap.oauth.fetch_oauth_profile",
+                side_effect=OSError("network down"),
+            ):
+                op = switcher._perform_switch("2", emit_output=False)
+        finally:
+            for p in patches:
+                p.stop()
+        assert creds_store[("1", "test@example.com")] == mystery
+        assert switcher.list_unclaimed_credentials() == {}
+        assert op["warnings"] == []
+
+    def test_safety_copy_failure_aborts_before_live_overwrite(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Preservation is the safety boundary for positively-foreign bytes:
+        no safety copy, no switch. (Never reachable from endpoint failure —
+        the unresolved path writes no safety copy.)"""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        mystery = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-x", "refreshToken": "rt-x",
+        }})
+        live_state = {"creds": mystery}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with patch.object(
+                switcher._store, "_write_unclaimed_credential",
+                side_effect=OSError("disk full"),
+            ):
+                with pytest.raises(Exception):
+                    self._run_switch(switcher, resolver={
+                        "uuid": "uuid-unmanaged",
+                        "email": "elsewhere@example.com",
+                        "organizationUuid": "",
+                    })
+        finally:
+            for p in patches:
+                p.stop()
+        # Nothing moved: live store, outgoing backup both untouched.
+        assert live_state["creds"] == mystery
+        assert creds_store[("1", "test@example.com")] == self._A1_BACKUP
+
+    def test_moved_bytes_between_prefetch_and_lock_fall_to_unresolved(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """A pre-lock resolution only binds to the bytes it resolved: when
+        the live store moved in between, the stale answer is discarded and
+        the switch falls back to the pre-fix backup of the current bytes."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = self._A1_BACKUP
+        provenance = {
+            "live": "something-else-entirely",
+            "resolved": {"uuid": "uuid-2", "email": "account2@example.com",
+                         "organizationUuid": ""},
+        }
+        moved = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-m", "refreshToken": "rt-m",
+        }})
+        live_state = {"creds": moved}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with patch.object(switcher, "list_accounts"):
+                op = switcher._perform_switch(
+                    "2", emit_output=False, provenance=provenance
+                )
+        finally:
+            for p in patches:
+                p.stop()
+        # Stale resolution rejected → unresolved → pre-fix backup, no copy.
+        assert creds_store[("1", "test@example.com")] == moved
+        assert switcher.list_unclaimed_credentials() == {}
+        assert op["warnings"] == []
+
+
+class TestSelfSwitchProvenance:
+    """The already-active short-circuits must not hide a diverged live login."""
+
+    _setup_two_accounts = TestPerformSwitchPostDisplay._setup_two_accounts
+    _install_store_patches = staticmethod(
+        TestPerformSwitchPostDisplay._install_store_patches
+    )
+
+    def test_matching_self_switch_is_noop(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        backup = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-1", "refreshToken": "rt-1",
+        }})
+        creds_store[("1", "test@example.com")] = backup
+        live_state = {"creds": backup}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            result = switcher.switch_to("1", json_output=True)
+        finally:
+            for p in patches:
+                p.stop()
+        assert result["switched"] is False
+        assert result["reason"] == "already-active"
+
+    def test_diverged_unresolvable_self_switch_noops_silently(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Endpoint trouble must be invisible on the self-switch path too:
+        an unclassifiable divergence is an ordinary already-active no-op
+        (exact pre-fix behavior — no mutation, no user-facing warning; the
+        diagnostic goes to the log). Leaving everything untouched is also the
+        safe write: activating the stored backup over an unverified live
+        credential could replace a fresh rotated token with its consumed
+        ancestor."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        backup = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-1", "refreshToken": "rt-1",
+        }})
+        diverged = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-1-new", "refreshToken": "rt-1-rotated",
+        }})
+        creds_store[("1", "test@example.com")] = backup
+        live_state = {"creds": diverged}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with patch("claude_swap.oauth.fetch_oauth_profile", return_value=None):
+                result = switcher.switch_to("1", json_output=True)
+        finally:
+            for p in patches:
+                p.stop()
+        assert result["switched"] is False
+        assert result["reason"] == "already-active"
+        assert result.get("warnings", []) == []
+        assert live_state["creds"] == diverged  # left untouched
+        assert creds_store[("1", "test@example.com")] == backup
+
+    def test_diverged_resolved_self_switch_reconciles(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """A rotation proven to be the slot's own gets re-synced to backup."""
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        backup = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-1", "refreshToken": "rt-1",
+        }})
+        rotated = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-1-new", "refreshToken": "rt-1-rotated",
+        }})
+        creds_store[("1", "test@example.com")] = backup
+        configs_store[("1", "test@example.com")] = json.dumps({
+            "oauthAccount": {"emailAddress": "test@example.com", "accountUuid": "uuid-1"},
+        })
+        live_state = {"creds": rotated}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with patch(
+                "claude_swap.oauth.fetch_oauth_profile",
+                return_value={"uuid": "uuid-1", "email": "test@example.com",
+                              "organizationUuid": ""},
+            ), patch.object(switcher, "list_accounts"):
+                result = switcher.switch_to("1", json_output=True)
+        finally:
+            for p in patches:
+                p.stop()
+        # The rotation was captured into the slot's backup.
+        assert creds_store[("1", "test@example.com")] == rotated
+        assert result["switched"] is False or result["to"]["number"] == 1
+
+
+class TestDuplicateAccountDetection:
+    def _switcher(self, temp_home, sample_sequence_data):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+        return switcher
+
+    def test_same_fingerprint_across_slots_flagged(
+        self, temp_home, sample_sequence_data,
+    ):
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        same = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk", "refreshToken": "rt-shared",
+        }})
+        info = [
+            (1, "account1@example.com", "", "", True, same),
+            (2, "account2@example.com", "", "", False, same),
+        ]
+        warnings = switcher._duplicate_account_warnings(info)
+        assert len(warnings) == 1
+        assert "Account-1 and Account-2" in warnings[0]
+
+    def test_same_uuid_across_slots_flagged(
+        self, temp_home, sample_sequence_data,
+    ):
+        sample_sequence_data["accounts"]["2"]["uuid"] = "uuid-1"
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        info = [
+            (1, "account1@example.com", "", "", True, "creds-a"),
+            (2, "account2@example.com", "", "", False, "creds-b"),
+        ]
+        warnings = switcher._duplicate_account_warnings(info)
+        assert len(warnings) == 1
+        assert "both authenticate" in warnings[0]
+
+    def test_empty_uuids_never_match_each_other(
+        self, temp_home, sample_sequence_data,
+    ):
+        """add-token placeholders (uuid "") must not false-positive."""
+        sample_sequence_data["accounts"]["1"]["uuid"] = ""
+        sample_sequence_data["accounts"]["2"]["uuid"] = ""
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        info = [
+            (1, "setup-token-1@token.local", "", "", True, "creds-a"),
+            (2, "setup-token-2@token.local", "", "", False, "creds-b"),
+        ]
+        assert switcher._duplicate_account_warnings(info) == []
+
+    def test_clean_accounts_produce_no_warnings(
+        self, temp_home, sample_sequence_data,
+    ):
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        info = [
+            (1, "account1@example.com", "", "", True,
+             json.dumps({"claudeAiOauth": {"refreshToken": "rt-1"}})),
+            (2, "account2@example.com", "", "", False,
+             json.dumps({"claudeAiOauth": {"refreshToken": "rt-2"}})),
+        ]
+        assert switcher._duplicate_account_warnings(info) == []
+
+
+class TestLockstepUsageDetection:
+    """Heuristic detector for the different-generation collapse (issue #117):
+    fingerprints and sequence identities look distinct, but both slots report
+    the same account's usage — identical percentages and reset instants."""
+
+    def _switcher(self, temp_home, sample_sequence_data):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+        return switcher
+
+    @staticmethod
+    def _info(n=2):
+        return [
+            (i, f"account{i}@example.com", "", "", i == 1, f"creds-{i}")
+            for i in range(1, n + 1)
+        ]
+
+    @staticmethod
+    def _entry(h5_pct, h5_reset, d7_pct, d7_reset):
+        usage = {}
+        if h5_pct is not None:
+            usage["five_hour"] = {"pct": h5_pct}
+            if h5_reset is not None:
+                usage["five_hour"]["resets_at"] = h5_reset
+        if d7_pct is not None:
+            usage["seven_day"] = {"pct": d7_pct}
+            if d7_reset is not None:
+                usage["seven_day"]["resets_at"] = d7_reset
+        return UsageEntry(last_good=usage, fetched_at=time.time(), age_s=0.0)
+
+    def test_identical_usage_and_resets_flagged(
+        self, temp_home, sample_sequence_data,
+    ):
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        entries = {
+            "1": self._entry(25.0, "2026-07-10T12:00:00Z", 60.0, "2026-07-14T00:00:00Z"),
+            "2": self._entry(25.0, "2026-07-10T12:00:00Z", 60.0, "2026-07-14T00:00:00Z"),
+        }
+        warnings = switcher._lockstep_usage_warnings(self._info(), entries)
+        assert len(warnings) == 1
+        assert "Account-1 and Account-2" in warnings[0]
+        assert "may be the same account" in warnings[0]
+
+    def test_differing_resets_not_flagged(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        entries = {
+            "1": self._entry(25.0, "2026-07-10T12:00:00Z", 60.0, "2026-07-14T00:00:00Z"),
+            "2": self._entry(25.0, "2026-07-10T13:00:00Z", 60.0, "2026-07-14T00:00:00Z"),
+        }
+        assert switcher._lockstep_usage_warnings(self._info(), entries) == []
+
+    def test_idle_accounts_without_resets_not_flagged(
+        self, temp_home, sample_sequence_data,
+    ):
+        """Two fresh accounts at 0% with no reset scheduled are
+        indistinguishable — never flag them."""
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        entries = {
+            "1": self._entry(0.0, None, 0.0, None),
+            "2": self._entry(0.0, None, 0.0, None),
+        }
+        assert switcher._lockstep_usage_warnings(self._info(), entries) == []
+
+    def test_sentinel_usage_never_compared(self, temp_home, sample_sequence_data):
+        """API-key slots (and other sentinel states) carry no comparable
+        usage."""
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        entries = {
+            "1": UsageEntry(sentinel="api-key"),
+            "2": UsageEntry(sentinel="api-key"),
+        }
+        assert switcher._lockstep_usage_warnings(self._info(), entries) == []
+
+    def test_payload_carries_lockstep_warnings_additively(
+        self, temp_home, sample_sequence_data,
+    ):
+        switcher = self._switcher(temp_home, sample_sequence_data)
+        lockstep = {
+            "1": self._entry(25.0, "2026-07-10T12:00:00Z", 60.0, "2026-07-14T00:00:00Z"),
+            "2": self._entry(25.0, "2026-07-10T12:00:00Z", 60.0, "2026-07-14T00:00:00Z"),
+        }
+        payload = switcher._build_list_payload(self._info(), lockstep)
+        assert len(payload["lockstepUsageWarnings"]) == 1
+        clean = {
+            "1": self._entry(25.0, "2026-07-10T12:00:00Z", 60.0, "2026-07-14T00:00:00Z"),
+            "2": self._entry(30.0, "2026-07-10T13:00:00Z", 10.0, "2026-07-15T00:00:00Z"),
+        }
+        payload = switcher._build_list_payload(self._info(), clean)
+        assert "lockstepUsageWarnings" not in payload
+
+
+class TestStashAndRetentionStore:
+    """CredentialStore: unclaimed stash + previous-generation retention."""
+
+    def _switcher(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        return switcher
+
+    def test_safety_copy_write_and_list(self, temp_home):
+        """The store is write-only in production; bytes land 0600 base64."""
+        switcher = self._switcher(temp_home)
+        store = switcher._store
+        entry_id = store._write_unclaimed_credential(
+            "secret-bytes", {"reason": "alien"},
+        )
+        assert _read_safety_copy(switcher, entry_id) == "secret-bytes"
+        entries = store._list_unclaimed_credentials()
+        assert entries[entry_id]["reason"] == "alien"
+        assert entries[entry_id]["createdAt"]
+        mode = store._stash_entry_path(entry_id).stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_two_snapshots_same_refresh_token_never_collide(self, temp_home):
+        switcher = self._switcher(temp_home)
+        store = switcher._store
+        a = json.dumps({"claudeAiOauth": {"accessToken": "sk-a", "refreshToken": "rt"}})
+        b = json.dumps({"claudeAiOauth": {"accessToken": "sk-b", "refreshToken": "rt"}})
+        id_a = store._write_unclaimed_credential(a, {})
+        id_b = store._write_unclaimed_credential(b, {})
+        assert id_a != id_b
+        assert _read_safety_copy(switcher, id_a) == a
+        assert _read_safety_copy(switcher, id_b) == b
+
+    def test_orphaned_entry_file_still_listed(self, temp_home):
+        """Bytes without manifest metadata must stay visible, not vanish."""
+        switcher = self._switcher(temp_home)
+        store = switcher._store
+        entry_id = store._write_unclaimed_credential("bytes", {})
+        store._stash_manifest_path().unlink()
+        entries = store._list_unclaimed_credentials()
+        assert entry_id in entries
+
+    def test_prev_generation_retained_on_overwrite(self, temp_home):
+        switcher = self._switcher(temp_home)
+        store = switcher._store
+        store._write_account_credentials("1", "a@b.c", "gen-1")
+        store._write_account_credentials("1", "a@b.c", "gen-2")
+        assert store._read_account_credentials("1", "a@b.c") == "gen-2"
+        assert store._read_previous_backup("1", "a@b.c") == "gen-1"
+        # Same-value rewrite doesn't clobber the retained generation.
+        store._write_account_credentials("1", "a@b.c", "gen-2")
+        assert store._read_previous_backup("1", "a@b.c") == "gen-1"
+
+    def test_prev_removed_with_account(self, temp_home):
+        switcher = self._switcher(temp_home)
+        store = switcher._store
+        store._write_account_credentials("1", "a@b.c", "gen-1")
+        store._write_account_credentials("1", "a@b.c", "gen-2")
+        store._delete_account_credentials("1", "a@b.c")
+        assert store._read_previous_backup("1", "a@b.c") == ""
+
+
+class TestActiveRefreshProvenance:
+    """_fetch_active_usage must not rotate-and-persist an unattributed
+    credential — same hazard class as the switch-time blind backup."""
+
+    _LIVE = json.dumps({"claudeAiOauth": {
+        "accessToken": "sk-live", "refreshToken": "rt-live", "expiresAt": 1000,
+    }})
+
+    def _switcher(self, sample_sequence_data):
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+        return switcher
+
+    def test_unattributed_live_credential_is_never_refreshed(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        switcher = self._switcher(sample_sequence_data)
+        backup = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-stored", "refreshToken": "rt-stored",
+        }})
+        seen = {}
+
+        def mock_fetch(account_num, email, credentials, is_active,
+                       persist_credentials=None):
+            seen["is_active"] = is_active
+            seen["persist"] = persist_credentials
+            return oauth.UsageOutcome(None)
+
+        with patch.object(switcher, "_read_credentials", return_value=self._LIVE), \
+             patch.object(switcher, "_read_account_credentials", return_value=backup), \
+             patch.object(switcher, "_active_cc_running", return_value=False), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch.object(switcher, "_write_credentials") as write_live, \
+             patch.object(switcher, "_write_account_credentials") as write_backup, \
+             patch("claude_swap.oauth.try_fetch_usage_for_account", side_effect=mock_fetch):
+            result = switcher._fetch_active_usage("1", "test@example.com", self._LIVE)
+
+        # Expired + unattributed → sentinel before any request; nothing written.
+        assert result.sentinel is not None
+        assert seen == {}  # not even a read-only fetch for an expired token
+        write_live.assert_not_called()
+        write_backup.assert_not_called()
+
+    def test_same_lineage_live_credential_still_refreshes(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Access-token-only drift from the backup is same-lineage → the
+        normal no-owner refresh path stays available."""
+        switcher = self._switcher(sample_sequence_data)
+        backup = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-older", "refreshToken": "rt-live",
+        }})
+        refreshed = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-new", "refreshToken": "rt-new",
+            "expiresAt": 9_999_999_999_000,
+        }})
+
+        def mock_fetch(account_num, email, credentials, is_active,
+                       persist_credentials=None):
+            assert is_active is False
+            persist_credentials(account_num, email, refreshed)
+            return oauth.UsageOutcome({"five_hour": {"pct": 10}})
+
+        with patch.object(switcher, "_read_credentials", return_value=self._LIVE), \
+             patch.object(switcher, "_read_account_credentials", return_value=backup), \
+             patch.object(switcher, "_active_cc_running", return_value=False), \
+             patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch.object(switcher, "_write_credentials") as write_live, \
+             patch.object(switcher, "_write_account_credentials") as write_backup, \
+             patch("claude_swap.oauth.try_fetch_usage_for_account", side_effect=mock_fetch):
+            result = switcher._fetch_active_usage("1", "test@example.com", self._LIVE)
+
+        assert result.usage == {"five_hour": {"pct": 10}}
+        write_live.assert_called_once_with(refreshed)
+        write_backup.assert_called_once_with("1", "test@example.com", refreshed)
+
+
+class TestDirectActivationPreservation:
+    """Direct activation replaces the live credential without a backup step —
+    invariant II requires the displaced credential to be stashed first."""
+
+    def _setup(self, temp_home, live_identity_email="untracked@example.com"):
+        config_path = temp_home / ".claude.json"
+        config_path.write_text(json.dumps({
+            "oauthAccount": {
+                "emailAddress": live_identity_email,
+                "accountUuid": "",
+                "organizationUuid": None,
+                "organizationName": None,
+            }
+        }))
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, {
+            "activeAccountNumber": None,
+            "lastUpdated": "2024-01-01T00:00:00Z",
+            "sequence": [1],
+            "accounts": {
+                "1": {
+                    "email": "one@example.com",
+                    "uuid": "uuid-one",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                },
+            },
+        })
+        target_creds = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-one", "refreshToken": "rt-one",
+        }})
+        switcher._write_account_credentials("1", "one@example.com", target_creds)
+        switcher._write_account_config("1", "one@example.com", json.dumps({
+            "oauthAccount": {"emailAddress": "one@example.com", "accountUuid": "uuid-one"},
+        }))
+        # Unmanaged live credential in the (temp-home) live store.
+        unmanaged = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-unmanaged", "refreshToken": "rt-unmanaged",
+        }})
+        (temp_home / ".claude" / ".credentials.json").write_text(unmanaged)
+        return switcher, unmanaged
+
+    def test_unmanaged_live_login_stashed_before_activation(self, temp_home):
+        switcher, unmanaged = self._setup(temp_home)
+        with patch.object(switcher, "list_accounts"):
+            switcher._perform_switch("1", emit_output=False)
+        entries = switcher.list_unclaimed_credentials()
+        assert len(entries) == 1
+        (entry_id,) = entries
+        assert _read_safety_copy(switcher, entry_id) == unmanaged
+        assert entries[entry_id]["reason"] == "displaced-live-login"
+
+    def test_stash_failure_aborts_direct_activation(self, temp_home):
+        switcher, unmanaged = self._setup(temp_home)
+        with patch.object(
+            switcher._store, "_write_unclaimed_credential",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(SwitchError, match="preserve the live credential"):
+                switcher._perform_switch("1", emit_output=False)
+        # Live store untouched.
+        live = (temp_home / ".claude" / ".credentials.json").read_text()
+        assert live == unmanaged
+
+    def test_force_proceeds_with_warning_when_stash_fails(self, temp_home):
+        switcher, unmanaged = self._setup(temp_home)
+        with patch.object(
+            switcher._store, "_write_unclaimed_credential",
+            side_effect=OSError("disk full"),
+        ), patch.object(switcher, "list_accounts"):
+            op = switcher._perform_switch(
+                "1", emit_output=False, force_activate=True
+            )
+        assert any("--force" in w for w in op["warnings"])
+        live = (temp_home / ".claude" / ".credentials.json").read_text()
+        assert json.loads(live)["claudeAiOauth"]["accessToken"] == "sk-one"
+
+
+class TestUuidConflictClassification:
+    """An email+org match with a conflicting uuid is a different account
+    wearing a recycled email — never the slot."""
+
+    _setup_two_accounts = TestPerformSwitchPostDisplay._setup_two_accounts
+    _install_store_patches = staticmethod(
+        TestPerformSwitchPostDisplay._install_store_patches
+    )
+
+    def test_email_match_with_conflicting_uuid_is_not_the_slot(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        a1_backup = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-1", "refreshToken": "rt-1",
+        }})
+        creds_store[("1", "test@example.com")] = a1_backup
+        rotated = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-x", "refreshToken": "rt-x",
+        }})
+        live_state = {"creds": rotated}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with patch.object(switcher, "list_accounts"), patch(
+                # Same email/org as slot 1 — but a different, non-empty uuid
+                # (slot 1 stores uuid-1). Must NOT classify as own-rotated.
+                "claude_swap.oauth.fetch_oauth_profile",
+                return_value={
+                    "uuid": "uuid-recycled-email",
+                    "email": "test@example.com",
+                    "organizationUuid": "",
+                },
+            ):
+                op = switcher._perform_switch("2", emit_output=False)
+        finally:
+            for p in patches:
+                p.stop()
+        # Slot 1 untouched; the conflicted credential was preserved as alien
+        # (a positively-different account, so this is NOT the fail-open
+        # path — a recycled email must never be backed into the slot).
+        assert creds_store[("1", "test@example.com")] == a1_backup
+        assert len(switcher.list_unclaimed_credentials()) == 1
+        assert any(
+            "does not match a managed account" in w for w in op["warnings"]
+        )
+
+
+class TestStashStorageHardening:
+    """Round-2 review: append-only ids and manifest corruption handling."""
+
+    def _store(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        return switcher._store
+
+    def test_identical_bytes_same_second_get_distinct_ids(self, temp_home):
+        store = self._store(temp_home)
+        id_a = store._write_unclaimed_credential("same-bytes", {})
+        id_b = store._write_unclaimed_credential("same-bytes", {})
+        assert id_a != id_b
+        for entry_id in (id_a, id_b):
+            raw = store._stash_entry_path(entry_id).read_text().strip()
+            assert base64.b64decode(raw, validate=True).decode() == "same-bytes"
+
+    def test_corrupt_manifest_is_preserved_not_clobbered(self, temp_home):
+        store = self._store(temp_home)
+        entry_id = store._write_unclaimed_credential("bytes-1", {"reason": "x"})
+        # Corrupt the manifest out-of-band.
+        store._stash_manifest_path().write_text("{ not json !!!")
+        new_id = store._write_unclaimed_credential("bytes-2", {"reason": "y"})
+        # The corrupt file was set aside, not destroyed…
+        corrupt = list(store._host.credentials_dir.glob(
+            ".unclaimed-manifest.json.corrupt-*"
+        ))
+        assert len(corrupt) == 1
+        assert "not json" in corrupt[0].read_text()
+        # …the new manifest is valid, and the older entry's *bytes* are still
+        # listed (as an orphan) even though its metadata row was lost.
+        entries = store._list_unclaimed_credentials()
+        assert new_id in entries and entries[new_id]["reason"] == "y"
+        assert entry_id in entries
+        raw = store._stash_entry_path(entry_id).read_text().strip()
+        assert base64.b64decode(raw, validate=True).decode() == "bytes-1"

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -5036,7 +5036,7 @@ class TestStashAndRetentionStore:
         return switcher
 
     def test_safety_copy_write_and_list(self, temp_home):
-        """The store is write-only in production; bytes land 0600 base64."""
+        """The store is write-only in production; bytes land as base64."""
         switcher = self._switcher(temp_home)
         store = switcher._store
         entry_id = store._write_unclaimed_credential(
@@ -5046,6 +5046,12 @@ class TestStashAndRetentionStore:
         entries = store._list_unclaimed_credentials()
         assert entries[entry_id]["reason"] == "alien"
         assert entries[entry_id]["createdAt"]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="File permissions work differently on Windows")
+    def test_safety_copy_file_is_owner_only(self, temp_home):
+        switcher = self._switcher(temp_home)
+        store = switcher._store
+        entry_id = store._write_unclaimed_credential("secret-bytes", {})
         mode = store._stash_entry_path(entry_id).stat().st_mode & 0o777
         assert mode == 0o600
 


### PR DESCRIPTION
Addresses #117 

## The bug

`_perform_switch` backed up whatever bytes were in the live credential store into the slot `~/.claude.json` named, with only an emptiness check between them. Any external live-store write that skips `oauthAccount` therefore poisoned the outgoing slot: its single-use refresh token was overwritten, both slots collapsed into one account (the reporter's lockstep usage bars, identical token expiries, doubled 429s), and recovery needed `/login` + `cswap add --slot N` for each account.

## The fix — a fail-open ownership guard

Before Step 1's backup, the live credential is classified:

| Live bytes vs outgoing slot | Behavior |
| --- | --- |
| byte-identical to the slot's stored backup | config-only backup (clean switches no longer rewrite the credential backup at all) |
| same refresh-token fingerprint | normal backup |
| profile resolves to the outgoing slot | normal backup + uuid backfill |
| resolves to another managed slot whose backup already holds this lineage | warn only, no writes |
| resolves to another managed slot, different lineage | preserved as a write-only safety copy; **both slots untouched**; switch proceeds; warn |
| resolves to no managed account | safety copy + skip backup + warn |
| **oracle error / offline / partial or malformed response** | **exact pre-fix backup + log note** |

Design rules:

- The identity oracle (`GET /api/oauth/profile`, 5 s timeout, only ever outside the locks, never retried) is strictly **advisory**: any failure degrades to today's behavior, so endpoint trouble can never fail, block, or alarm a switch — on the strategy path, `switch N`, and the already-active no-op alike. The endpoint is not load-bearing.
- **Preserve-and-skip requires positive, complete evidence; anything partial fails open.** Cross-slot attribution is uuid-strict (a recycled email with a conflicting uuid, or an email match against a slot with no recorded uuid, never names that slot), and live bytes are never routed into a different slot — identity proves ownership, not generation freshness.
- Every slot-backup overwrite retains the prior generation as `.prev` (best-effort, one generation), so even a wrong call has a recovery cushion.
- Detection nets for the residual case: duplicate-credential/uuid warnings and a lockstep-usage heuristic in `list` (additive `duplicateAccountWarnings` / `lockstepUsageWarnings` JSON fields), plus a zero-request identity check on the token refresh response in the auto engine — a slot whose credential authenticates as a different account or organization is quarantined instead of activated, and blank slot uuids (older records, `add-token` placeholders) are backfilled when the identity agrees.
- Recovery for every residual or uncertain state is the existing documented workflow: `/login` + `cswap add [--slot N]`.

Safety copies are 0600 base64 files under the credentials dir on every platform — deliberately not Keychain, since a failed safety-copy write aborts the switch and that abort path must not inherit the Keychain's failure modes. They are written only for positively-foreign bytes and for unmanaged logins displaced by a direct activation; nothing consumes them automatically.

## Tests

New coverage for every classification and both timelines (normal rotation vs fault injection), the fail-open degraded paths (profile returning None, raising, partial, malformed, 401), uuid-strictness (recycled email, blank stored uuid, missing email/org fields), org-conflict ordering ahead of uuid backfill, `.prev` retention including the macOS Keychain contract, safety-copy storage hardening (append-only ids, corrupt-manifest preservation), self-switch guards, and the lockstep heuristic. Full suite: 1043 passed, 3 skipped.
