### PR TITLE
feat(tui): themeable dashboard — cswap-dark + 4 Catppuccin flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usag
 
 <img src="assets/tui-watch.png" width="760" alt="cswap watch — live 5h/7d usage bars for every account, with reset times and the active account marked">
 
+Open the command palette (`ctrl+p`) and run "Change theme" to pick between `cswap-dark` (default) and the four Catppuccin flavors (Latte, Frappé, Macchiato, Mocha) — the choice persists via `cswap config set tui.theme <name>`, or override it for one session with `cswap tui --theme <name>` / `cswap watch --theme <name>`. The CLI's own accent color follows whichever theme is set.
+
 
 ### Refresh expired tokens
 
@@ -213,6 +215,7 @@ cswap config                              # list effective settings ("(default)"
 cswap config get autoswitch.threshold
 cswap config set autoswitch.threshold 80  # validated: rejects out-of-range values loudly
 cswap config set autoswitch.model Fable   # per-model switching (see "auto"); Fable,Opus for several
+cswap config set tui.theme catppuccin-mocha  # persisted TUI theme; also sets the CLI's accent
 cswap config unset autoswitch.threshold   # back to the default
 cswap config path                         # where settings.json lives
 ```

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -11,6 +11,7 @@ from claude_swap import __version__
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
 from claude_swap.printer import dimmed, error, force_utf8_output, muted
+from claude_swap.settings import TUI_THEME_CHOICES
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -626,6 +627,14 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         ),
     )
     parser.add_argument(
+        "--theme",
+        choices=TUI_THEME_CHOICES,
+        help=(
+            "With 'tui'/'watch': theme for this session only, overriding the "
+            "persisted tui.theme setting"
+        ),
+    )
+    parser.add_argument(
         "--slot",
         type=int,
         metavar="NUM",
@@ -788,6 +797,9 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             "'switch --strategy next-available'"
         )
 
+    if args.theme is not None and not (args.tui or args.watch):
+        parser.error("--theme can only be used with 'tui' or 'watch'")
+
     if args.slot is not None and not (args.add_account or args.add_token is not None):
         parser.error("--slot can only be used with 'add' or 'add-token'")
 
@@ -886,11 +898,11 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         elif args.tui:
             from claude_swap.tui import run as tui_run
 
-            sys.exit(tui_run(switcher))
+            sys.exit(tui_run(switcher, theme=args.theme))
         elif args.watch:
             from claude_swap.tui import run as tui_run
 
-            sys.exit(tui_run(switcher, start="watch"))
+            sys.exit(tui_run(switcher, start="watch", theme=args.theme))
         elif args.menubar:
             if sys.platform != "darwin":
                 error("The menu bar is only available on macOS.")

--- a/src/claude_swap/palette.py
+++ b/src/claude_swap/palette.py
@@ -1,0 +1,157 @@
+"""Theme color data, with zero third-party dependencies.
+
+Single source of truth for every theme's hex palette. Kept dependency-free
+(no textual, no rich) so it can be imported from printer.py and settings.py —
+both on the hot path for plain CLI commands like ``cswap list`` — without
+paying for textual's import cost. ``claude_swap.tui.theme`` builds the actual
+Textual ``Theme`` objects (for the TUI's own CSS design tokens) from this
+same data, so the TUI and the plain CLI can never disagree on what a theme's
+colors are.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# cswap-dark's own palette. A subtle modern dark theme: neutral charcoal
+# backgrounds in the VS Code register, one warm terracotta accent (the same
+# xterm-173 tone printer.py has always used for the CLI — a deliberate nod to
+# Claude Code's orange, used sparingly), and desaturated severity colors so
+# usage bars read calmly on a dark background. Deliberately *not* a wholesale
+# copy of any other tool's palette.
+ACCENT = "#d7875f"  # warm terracotta, xterm 173
+FOREGROUND = "#e8e4de"  # soft, slightly warm off-white
+MUTED = "#8a8a8a"  # secondary text
+BACKGROUND = "#141414"
+SURFACE = "#1e1e1e"
+PANEL = "#262626"
+
+# Usage severity ramp (desaturated for dark backgrounds).
+SEV_OK = "#87af87"  # calm green: plenty of headroom
+SEV_WARN = "#d7af5f"  # amber: climbing (>= 70%)
+SEV_CRIT = "#d75f5f"  # soft red: near the limit (>= 90%)
+TRACK = "#3a3a3a"  # unfilled bar track
+
+# Severity band edges. WARN mirrors where a user starts caring; CRIT mirrors
+# the auto-switch default threshold so bar color and switch behavior agree.
+WARN_PCT = 70.0
+CRIT_PCT = 90.0
+
+
+@dataclass(frozen=True)
+class ThemeColors:
+    """One theme's resolved colors, for both Rich-style rendering (TUI) and
+    24-bit truecolor ANSI escapes (plain CLI, see printer.py)."""
+
+    accent: str
+    foreground: str
+    muted: str
+    background: str
+    surface: str
+    panel: str
+    track: str
+    sev_ok: str
+    sev_warn: str
+    sev_crit: str
+    dark: bool = True
+
+
+CSWAP_DARK_COLORS = ThemeColors(
+    accent=ACCENT,
+    foreground=FOREGROUND,
+    muted=MUTED,
+    background=BACKGROUND,
+    surface=SURFACE,
+    panel=PANEL,
+    track=TRACK,
+    sev_ok=SEV_OK,
+    sev_warn=SEV_WARN,
+    sev_crit=SEV_CRIT,
+)
+
+
+def _catppuccin(
+    *,
+    base: str,
+    text: str,
+    surface0: str,
+    surface1: str,
+    overlay1: str,
+    green: str,
+    yellow: str,
+    red: str,
+    peach: str,
+    dark: bool = True,
+) -> ThemeColors:
+    """One Catppuccin flavor's ``ThemeColors``.
+
+    Token mapping shared by all four flavors: surface0 -> surface/track,
+    surface1 -> panel, overlay1 -> muted, peach -> accent, green/yellow/red
+    -> the OK/WARN/CRIT severity ramp.
+    """
+    return ThemeColors(
+        accent=peach,
+        foreground=text,
+        muted=overlay1,
+        background=base,
+        surface=surface0,
+        panel=surface1,
+        track=surface0,
+        sev_ok=green,
+        sev_warn=yellow,
+        sev_crit=red,
+        dark=dark,
+    )
+
+
+# Hex values cross-checked against the official Catppuccin palette
+# (catppuccin/palette, palette.json) and, for Mocha, against this rice's own
+# plymouth-themes/tools/catppuccin-recolor.sh.
+LATTE_COLORS = _catppuccin(
+    base="#eff1f5", text="#4c4f69", surface0="#ccd0da", surface1="#bcc0cc",
+    overlay1="#8c8fa1", green="#40a02b", yellow="#df8e1d", red="#d20f39",
+    peach="#fe640b", dark=False,
+)
+FRAPPE_COLORS = _catppuccin(
+    base="#303446", text="#c6d0f5", surface0="#414559", surface1="#51576d",
+    overlay1="#838ba7", green="#a6d189", yellow="#e5c890", red="#e78284",
+    peach="#ef9f76",
+)
+MACCHIATO_COLORS = _catppuccin(
+    base="#24273a", text="#cad3f5", surface0="#363a4f", surface1="#494d64",
+    overlay1="#8087a2", green="#a6da95", yellow="#eed49f", red="#ed8796",
+    peach="#f5a97f",
+)
+MOCHA_COLORS = _catppuccin(
+    base="#1e1e2e", text="#cdd6f4", surface0="#313244", surface1="#45475a",
+    overlay1="#7f849c", green="#a6e3a1", yellow="#f9e2af", red="#f38ba8",
+    peach="#fab387",
+)
+
+DEFAULT_THEME = "cswap-dark"
+
+THEME_COLORS: dict[str, ThemeColors] = {
+    "cswap-dark": CSWAP_DARK_COLORS,
+    "catppuccin-latte": LATTE_COLORS,
+    "catppuccin-frappe": FRAPPE_COLORS,
+    "catppuccin-macchiato": MACCHIATO_COLORS,
+    "catppuccin-mocha": MOCHA_COLORS,
+}
+THEME_NAMES: tuple[str, ...] = tuple(THEME_COLORS)
+
+
+def theme_colors(name: str) -> ThemeColors:
+    """``ThemeColors`` for a theme name; unregistered names fall back to
+    cswap-dark's."""
+    return THEME_COLORS.get(name, CSWAP_DARK_COLORS)
+
+
+def severity_for(pct: float | None, colors: ThemeColors) -> str:
+    """Bar/percentage color for a utilization percentage, in ``colors``."""
+    if pct is None:
+        return colors.muted
+    if pct >= CRIT_PCT:
+        return colors.sev_crit
+    if pct >= WARN_PCT:
+        return colors.sev_warn
+    return colors.sev_ok

--- a/src/claude_swap/printer.py
+++ b/src/claude_swap/printer.py
@@ -13,16 +13,52 @@ import sys
 import time
 from pathlib import Path
 
+from claude_swap.palette import DEFAULT_THEME, theme_colors
+
 # ANSI escape codes
 _RESET = "\033[0m"
 _BOLD = "\033[1m"
 _DIM = "\033[2m"
 _RED = "\033[31m"
 _YELLOW = "\033[33m"
-_ACCENT = "\033[38;5;173m"  # Warm salmon/terracotta
 _MUTED = "\033[38;5;250m"  # Soft gray -- readable, but quieter than normal
 
 _colors_enabled: bool | None = None  # lazy-initialized
+_accent_escape: str | None = None  # lazy-initialized
+
+
+def _truecolor(hex_color: str) -> str:
+    """24-bit truecolor foreground escape for a ``#rrggbb`` string.
+
+    Unlike the old fixed 256-color index, the resolved theme's accent can be
+    any hex value (the Catppuccin flavors aren't xterm-palette colors), so
+    this needs the full RGB escape. Safe for the target terminal (kitty).
+    """
+    r, g, b = (int(hex_color[i : i + 2], 16) for i in (1, 3, 5))
+    return f"\033[38;2;{r};{g};{b}m"
+
+
+def _resolve_accent() -> str:
+    """The CLI accent color, following the persisted ``tui.theme`` setting.
+
+    Resolved independent of any ``--theme`` CLI override — that flag only
+    exists on `tui`/`watch`, and printer.py is used by plain commands
+    (`list`, `status`, `auto`, ...) that never see it. Best-effort: any
+    failure to read settings.json (including no backup root yet) falls back
+    to cswap-dark's own terracotta, matching the tool's long-standing
+    default CLI color.
+    """
+    global _accent_escape
+    if _accent_escape is None:
+        try:
+            from claude_swap.paths import get_backup_root
+            from claude_swap.settings import load_tui_settings
+
+            theme_name = load_tui_settings(get_backup_root()).theme
+        except Exception:
+            theme_name = DEFAULT_THEME
+        _accent_escape = _truecolor(theme_colors(theme_name).accent)
+    return _accent_escape
 
 
 def _enable_windows_vt() -> bool:
@@ -115,7 +151,7 @@ def _style(text: str, *codes: str) -> str:
 
 def accent(text: str) -> str:
     """Warm accent color for important elements."""
-    return _style(text, _ACCENT)
+    return _style(text, _resolve_accent())
 
 
 def muted(text: str) -> str:
@@ -135,7 +171,7 @@ def bolded(text: str) -> str:
 
 def bold_accent(text: str) -> str:
     """Bold + accent for key markers like (active)."""
-    return _style(text, _BOLD, _ACCENT)
+    return _style(text, _BOLD, _resolve_accent())
 
 
 def yellowed(text: str) -> str:

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -1,9 +1,9 @@
 """Tool settings persisted at ``<backup_root>/settings.json``.
 
 One versioned JSON file for user-tunable claude-swap preferences, written
-atomically with the backup dir's 0600/0700 modes. v1 carries only the
-``autoswitch`` section; other sections can be added additively. Unknown keys
-(future fields, other tools' experiments) survive a round trip.
+atomically with the backup dir's 0600/0700 modes. v1 carried only the
+``autoswitch`` section; ``tui`` was added additively alongside it. Unknown
+keys (future fields, other tools' experiments) survive a round trip.
 
 Reading is forgiving — a missing or corrupt file yields defaults with a logged
 warning, never a crash — so a bad hand edit degrades to default behavior.
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from claude_swap.exceptions import ConfigError
+from claude_swap.palette import DEFAULT_THEME, THEME_NAMES as TUI_THEME_CHOICES
 
 SETTINGS_SCHEMA_VERSION = 1
 SETTINGS_FILENAME = "settings.json"
@@ -59,6 +60,30 @@ class AutoSwitchSettings:
 
 
 @dataclass(frozen=True)
+class TuiSettings:
+    """Persisted TUI display preference.
+
+    ``theme`` names one of the themes in ``claude_swap.palette.THEME_NAMES``
+    (also the ``TUI_THEME_CHOICES`` re-export below). Themes live in the
+    dependency-free ``palette`` module rather than ``tui.theme`` (which pulls
+    in textual) so loading this section stays as cheap as ``autoswitch``'s
+    for CLI paths that never touch the TUI — ``tui/__init__.py`` defers all
+    textual/rich imports to :func:`tui.run` for exactly this reason.
+    """
+
+    theme: str = DEFAULT_THEME
+
+
+# Which dataclass (and its field defaults) a SETTING_SPECS section belongs
+# to. Populated once both dataclasses exist; extend this when adding a
+# section for a new dataclass.
+_SECTION_DEFAULTS: dict[str, type] = {
+    "autoswitch": AutoSwitchSettings,
+    "tui": TuiSettings,
+}
+
+
+@dataclass(frozen=True)
 class SettingSpec:
     """Metadata for one user-tunable settings.json key.
 
@@ -67,9 +92,9 @@ class SettingSpec:
     (`parse_setting_value`) read from here, so the two can't drift.
     """
 
-    section: str  # top-level JSON section ("autoswitch")
+    section: str  # top-level JSON section ("autoswitch", "tui")
     json_key: str  # camelCase key inside the section
-    field: str  # snake_case AutoSwitchSettings field
+    field: str  # snake_case field on the section's settings dataclass
     kind: str  # "float" | "int" | "bool" | "choice"
     lo: float | None = None
     hi: float | None = None
@@ -82,7 +107,7 @@ class SettingSpec:
 
     @property
     def default(self):
-        return getattr(AutoSwitchSettings(), self.field)
+        return getattr(_SECTION_DEFAULTS[self.section](), self.field)
 
 
 # settings.json uses camelCase (matching the repo's other JSON artifacts);
@@ -122,12 +147,25 @@ SETTING_SPECS: dict[str, SettingSpec] = {
             "autoswitch", "model", "model", "string",
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
         ),
+        SettingSpec(
+            "tui", "theme", "theme", "choice", choices=TUI_THEME_CHOICES,
+            help="Textual theme for the TUI dashboard/watch view",
+        ),
     )
 }
 
-_AUTOSWITCH_KEYS: dict[str, str] = {
-    spec.field: spec.json_key for spec in SETTING_SPECS.values()
-}
+
+def _section_keys(section: str) -> dict[str, str]:
+    """field -> json_key for the specs belonging to one section."""
+    return {
+        spec.field: spec.json_key
+        for spec in SETTING_SPECS.values()
+        if spec.section == section
+    }
+
+
+_AUTOSWITCH_KEYS: dict[str, str] = _section_keys("autoswitch")
+_TUI_KEYS: dict[str, str] = _section_keys("tui")
 
 
 def settings_path(backup_root: Path) -> Path:
@@ -148,16 +186,25 @@ def parse_model_names(value: str | None) -> tuple[str, ...]:
     return tuple(seen.values())
 
 
-def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:
-    """Clamp values into the SETTING_SPECS ranges; bad types → the default."""
+def _clamped(settings):
+    """Clamp values into the SETTING_SPECS ranges; bad types → the default.
+
+    Only consults specs for ``settings``'s own section, so this works for any
+    of the section dataclasses (``AutoSwitchSettings``, ``TuiSettings``, ...).
+    """
 
     def num(value, default: float, lo: float, hi: float) -> float:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             return default
         return float(min(max(value, lo), hi))
 
+    section = next(
+        name for name, cls in _SECTION_DEFAULTS.items() if cls is type(settings)
+    )
     kwargs = {}
     for spec in SETTING_SPECS.values():
+        if spec.section != section:
+            continue
         value = getattr(settings, spec.field)
         if spec.kind in ("float", "int"):
             clamped = num(value, spec.default, spec.lo, spec.hi)
@@ -176,7 +223,7 @@ def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:
                 )
                 value = spec.default
             kwargs[spec.field] = value
-    return AutoSwitchSettings(**kwargs)
+    return type(settings)(**kwargs)
 
 
 def _read_raw(path: Path) -> dict:
@@ -193,21 +240,31 @@ def _read_raw(path: Path) -> dict:
     return raw
 
 
-def load_settings(backup_root: Path) -> AutoSwitchSettings:
-    """Load the autoswitch section; missing/corrupt file or fields → defaults."""
+def _load_section(backup_root: Path, section_name: str, cls: type, keys: dict[str, str]):
+    """Load one settings.json section into ``cls``; missing/corrupt → defaults."""
     raw = _read_raw(settings_path(backup_root))
-    section = raw.get("autoswitch")
+    section = raw.get(section_name)
     if not isinstance(section, dict):
-        return AutoSwitchSettings()
+        return cls()
     kwargs = {}
-    for field, json_key in _AUTOSWITCH_KEYS.items():
+    for field, json_key in keys.items():
         if json_key in section:
             kwargs[field] = section[json_key]
     try:
-        settings = AutoSwitchSettings(**kwargs)
+        settings = cls(**kwargs)
     except TypeError:
-        settings = AutoSwitchSettings()
+        settings = cls()
     return _clamped(settings)
+
+
+def load_settings(backup_root: Path) -> AutoSwitchSettings:
+    """Load the autoswitch section; missing/corrupt file or fields → defaults."""
+    return _load_section(backup_root, "autoswitch", AutoSwitchSettings, _AUTOSWITCH_KEYS)
+
+
+def load_tui_settings(backup_root: Path) -> TuiSettings:
+    """Load the tui section; missing/corrupt file or fields → defaults."""
+    return _load_section(backup_root, "tui", TuiSettings, _TUI_KEYS)
 
 
 def save_settings(backup_root: Path, settings: AutoSwitchSettings) -> None:
@@ -363,6 +420,14 @@ def unset_setting(backup_root: Path, dotted_key: str) -> bool:
     return True
 
 
+# Section name -> loader, so effective_settings() can show every section's
+# keys (not just autoswitch's) in one `cswap config list`.
+_SECTION_LOADERS = {
+    "autoswitch": load_settings,
+    "tui": load_tui_settings,
+}
+
+
 def effective_settings(backup_root: Path) -> list[tuple[SettingSpec, object, bool]]:
     """(spec, effective value, explicitly set?) per key, in registry order.
 
@@ -371,11 +436,14 @@ def effective_settings(backup_root: Path) -> list[tuple[SettingSpec, object, boo
     reflects the file, not value equality.
     """
     raw = _read_raw(settings_path(backup_root))
-    effective = load_settings(backup_root)
+    effective_by_section = {
+        name: loader(backup_root) for name, loader in _SECTION_LOADERS.items()
+    }
     rows = []
     for spec in SETTING_SPECS.values():
         section = raw.get(spec.section)
         is_set = isinstance(section, dict) and spec.json_key in section
+        effective = effective_by_section[spec.section]
         rows.append((spec, getattr(effective, spec.field), is_set))
     return rows
 

--- a/src/claude_swap/tui/__init__.py
+++ b/src/claude_swap/tui/__init__.py
@@ -14,14 +14,20 @@ if TYPE_CHECKING:
     from claude_swap.switcher import ClaudeAccountSwitcher
 
 
-def run(switcher: "ClaudeAccountSwitcher", start: str = "dashboard") -> int:
+def run(
+    switcher: "ClaudeAccountSwitcher",
+    start: str = "dashboard",
+    *,
+    theme: str | None = None,
+) -> int:
     """Run the TUI over an existing switcher. Returns the process exit code.
 
     ``start="watch"`` (the ``cswap watch`` command) opens directly on the
-    live watch page, stacked over the dashboard.
+    live watch page, stacked over the dashboard. ``theme``, from ``--theme``,
+    overrides the persisted ``tui.theme`` setting for this session only.
     """
     from claude_swap.tui.app import CswapApp
 
-    app = CswapApp(switcher, start=start)
+    app = CswapApp(switcher, start=start, theme=theme)
     app.run()
     return app.return_code or 0

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -15,13 +15,13 @@ from textual.reactive import reactive
 from textual.worker import WorkerState
 
 from claude_swap.models import AccountsSnapshot
-from claude_swap.settings import load_settings
+from claude_swap.settings import load_settings, load_tui_settings
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui.autoview import AutoScreen
 from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
 from claude_swap.tui.data import ActionResult, SnapshotSource, run_action
 from claude_swap.tui.modals import AddTokenModal, ConfirmModal, OutputModal, TokenForm
-from claude_swap.tui.theme import CSWAP_DARK
+from claude_swap.tui.theme import DEFAULT_THEME, THEMES
 
 
 class CswapApp(App):
@@ -29,10 +29,10 @@ class CswapApp(App):
 
     TITLE = "claude-swap"
     CSS_PATH = "cswap.tcss"
-    # No command palette: actions live in the dashboard's nested menu, in
-    # their own context — not in a global searchable list. This also drops
-    # Textual's system commands (theme picker included; there is one theme).
-    ENABLE_COMMAND_PALETTE = False
+    # Textual's command palette auto-gains a "Change theme" command once more
+    # than one theme is registered — the free interactive picker for
+    # cycling between cswap-dark and the bundled Catppuccin flavors.
+    ENABLE_COMMAND_PALETTE = True
 
     POLL_INTERVAL_S = 3.0  # matches the old watch view's recapture cadence
 
@@ -40,11 +40,16 @@ class CswapApp(App):
     busy: reactive[bool] = reactive(False)
 
     def __init__(
-        self, switcher: ClaudeAccountSwitcher, *, start: str = "dashboard"
+        self,
+        switcher: ClaudeAccountSwitcher,
+        *,
+        start: str = "dashboard",
+        theme: str | None = None,
     ) -> None:
         super().__init__()
         self.switcher = switcher
         self._start = start  # "dashboard" | "watch" (`cswap watch`)
+        self._theme_override = theme  # `--theme`, wins over the persisted setting
         self.source = SnapshotSource(switcher)
         self._store_only = False
         self._full_next = False
@@ -60,8 +65,13 @@ class CswapApp(App):
             self.threshold_pct = None
 
     def on_mount(self) -> None:
-        self.register_theme(CSWAP_DARK)
-        self.theme = "cswap-dark"
+        for registered in THEMES.values():
+            self.register_theme(registered)
+        try:
+            persisted = load_tui_settings(self.switcher.backup_dir).theme
+        except Exception:
+            persisted = DEFAULT_THEME
+        self.theme = self._theme_override or persisted
         self.push_screen(DashboardScreen())
         if self._start == "watch":
             # Stacked over the dashboard so Esc lands there, not on exit.

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -15,7 +15,7 @@ from textual.reactive import reactive
 from textual.worker import WorkerState
 
 from claude_swap.models import AccountsSnapshot
-from claude_swap.settings import load_settings, load_tui_settings
+from claude_swap.settings import load_settings, load_tui_settings, set_setting
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui.autoview import AutoScreen
 from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
@@ -55,6 +55,10 @@ class CswapApp(App):
         self._full_next = False
         self._refreshing = False
         self._last_refresh_error = ""
+        # Set once startup assigns the initial theme (override or persisted);
+        # guards watch_theme against persisting that assignment itself, and
+        # against ever persisting a --theme override (session-only).
+        self._theme_persistable = False
         # The auto-switch threshold, drawn as a tick on the status strip's
         # bars everywhere. Missing/invalid settings fall back to the default.
         try:
@@ -72,12 +76,29 @@ class CswapApp(App):
         except Exception:
             persisted = DEFAULT_THEME
         self.theme = self._theme_override or persisted
+        # Only a theme picked *after* startup (command palette / future UI)
+        # should be saved — not this initial assignment, and never a
+        # --theme override, which is documented as session-only.
+        self._theme_persistable = self._theme_override is None
         self.push_screen(DashboardScreen())
         if self._start == "watch":
             # Stacked over the dashboard so Esc lands there, not on exit.
             self.push_screen(WatchScreen())
         self.set_interval(self.POLL_INTERVAL_S, self._tick)
         self._tick()
+
+    def watch_theme(self, old_theme: str, new_theme: str) -> None:
+        """Persist a theme picked via the command palette (or future UI).
+
+        Best-effort like the other settings writes here: a failure to save
+        shouldn't crash the session over a cosmetic preference.
+        """
+        if not self._theme_persistable or new_theme == old_theme:
+            return
+        try:
+            set_setting(self.switcher.backup_dir, "tui.theme", new_theme)
+        except Exception:
+            pass
 
     # -- snapshot poll loop ---------------------------------------------------
 

--- a/src/claude_swap/tui/autoview.py
+++ b/src/claude_swap/tui/autoview.py
@@ -28,35 +28,29 @@ from claude_swap.models import AccountsSnapshot
 from claude_swap.settings import load_settings, parse_model_names
 from claude_swap.tui import data
 from claude_swap.tui.modals import ConfirmModal
-from claude_swap.tui.theme import (
-    ACCENT,
-    FOREGROUND,
-    MUTED,
-    SEV_CRIT,
-    SEV_WARN,
-    severity_color,
-)
+from claude_swap.tui.theme import current_theme_colors, severity_color
 from claude_swap.tui.widgets import AccountsPanel
 
 if TYPE_CHECKING:
     from claude_swap.tui.app import CswapApp
 
-_EVENT_STYLES = {
-    "switch": ACCENT,
-    "error": SEV_WARN,
-    "account-quarantined": SEV_WARN,
-    "all-exhausted": SEV_CRIT,
-}
 _QUIET_KINDS = {"poll", "no-switch", "sleep", "account-unquarantined"}
 
 
 def event_text(event: AutoSwitchEvent) -> Text:
     """Log line for one engine event, styled like the CLI's human renderer."""
-    style = _EVENT_STYLES.get(event.kind)
+    colors = current_theme_colors()
+    event_styles = {
+        "switch": colors.accent,
+        "error": colors.sev_warn,
+        "account-quarantined": colors.sev_warn,
+        "all-exhausted": colors.sev_crit,
+    }
+    style = event_styles.get(event.kind)
     if style is None:
-        style = MUTED if event.kind in _QUIET_KINDS else FOREGROUND
+        style = colors.muted if event.kind in _QUIET_KINDS else colors.foreground
     text = Text()
-    text.append(f"{data.clock_stamp()}  ", style=MUTED)
+    text.append(f"{data.clock_stamp()}  ", style=colors.muted)
     text.append(event.human(), style=style)
     return text
 
@@ -125,7 +119,7 @@ class AutoScreen(Screen):
         self._update_badge()
         log = self.query_one("#event-log", RichLog)
         mode = "DRY-RUN (watching only)" if dry_run else "LIVE (will switch accounts)"
-        log.write(Text(f"— engine started: {mode} —", style=MUTED))
+        log.write(Text(f"— engine started: {mode} —", style=current_theme_colors().muted))
 
     def _emit_from_thread(self, event: AutoSwitchEvent) -> None:
         """Engine ``on_event`` callback — runs on the worker thread."""
@@ -192,6 +186,7 @@ class AutoScreen(Screen):
         """Switch targets ranked by remaining headroom (best first)."""
         # Same window set as the engine (autoswitch.model included), so the
         # displayed ranking can never disagree with the account it picks.
+        colors = current_theme_colors()
         models = parse_model_names(self._settings.model) if self._settings else ()
         ranked: list[tuple[float, str]] = []  # (sort key: pct used, number)
         lines: dict[str, Text] = {}
@@ -200,15 +195,15 @@ class AutoScreen(Screen):
                 continue
             pct = binding_pct(acc.usage.last_good, models)
             entry = Text()
-            entry.append(f"\n  {acc.number:>2}  ", style=FOREGROUND)
-            entry.append(acc.email, style=FOREGROUND)
+            entry.append(f"\n  {acc.number:>2}  ", style=colors.foreground)
+            entry.append(acc.email, style=colors.foreground)
             if acc.usage.sentinel is not None:
                 entry.append(
-                    f"  {data.sentinel_label(acc.usage.sentinel)}", style=MUTED
+                    f"  {data.sentinel_label(acc.usage.sentinel)}", style=colors.muted
                 )
                 ranked.append((998.0, acc.number))
             elif pct is None:
-                entry.append("  usage unknown", style=MUTED)
+                entry.append("  usage unknown", style=colors.muted)
                 ranked.append((999.0, acc.number))
             else:
                 entry.append(f"  {pct:3.0f}% used", style=severity_color(pct))
@@ -216,9 +211,9 @@ class AutoScreen(Screen):
             lines[acc.number] = entry
 
         text = Text()
-        text.append("Next best", style=MUTED)
+        text.append("Next best", style=colors.muted)
         if not ranked:
-            text.append("\n  no other switchable accounts", style=MUTED)
+            text.append("\n  no other switchable accounts", style=colors.muted)
             return text
         for _pct, number in sorted(ranked):
             text.append(lines[number])

--- a/src/claude_swap/tui/theme.py
+++ b/src/claude_swap/tui/theme.py
@@ -1,67 +1,86 @@
-"""The "cswap-dark" Textual theme and shared color constants.
+"""Textual themes for claude-swap, built from ``claude_swap.palette``.
 
-A subtle modern dark theme: neutral charcoal backgrounds in the VS Code
-register, one warm terracotta accent (the same xterm-173 tone printer.py has
-always used for the CLI — a deliberate nod to Claude Code's orange, used
-sparingly), and desaturated severity colors so usage bars read calmly on a
-dark background. Deliberately *not* a wholesale copy of any other tool's
-palette.
+Textual's ``Theme``/``register_theme`` mechanism only covers its own design
+tokens ($accent, $foreground, ...) consumed by CSS. widgets.py and
+autoview.py render usage bars, account rows, and severity markers with Rich
+``Text.append(style=...)`` calls that bypass CSS entirely, so they need their
+own resolution: ``current_theme_colors()`` reads whichever theme is active on
+the running app and returns the matching ``palette.ThemeColors``, falling
+back to cswap-dark's colors outside a running app (e.g. unit tests calling
+these render functions directly) or for an unregistered theme name.
 """
 
 from __future__ import annotations
 
+from textual.app import active_app
 from textual.theme import Theme
 
-# Core palette (single source of truth — widgets import these for rich
-# renderables, the Theme below maps them onto Textual's design tokens).
-ACCENT = "#d7875f"  # warm terracotta, xterm 173 — matches printer._ACCENT
-FOREGROUND = "#e8e4de"  # soft, slightly warm off-white
-MUTED = "#8a8a8a"  # secondary text
-BACKGROUND = "#141414"
-SURFACE = "#1e1e1e"
-PANEL = "#262626"
+from claude_swap.palette import (
+    CRIT_PCT,
+    DEFAULT_THEME,
+    THEME_COLORS,
+    WARN_PCT,
+    ThemeColors,
+    theme_colors,
+)
 
-# Usage severity ramp (desaturated for dark backgrounds).
-SEV_OK = "#87af87"  # calm green: plenty of headroom
-SEV_WARN = "#d7af5f"  # amber: climbing (>= 70%)
-SEV_CRIT = "#d75f5f"  # soft red: near the limit (>= 90%)
-TRACK = "#3a3a3a"  # unfilled bar track
 
-# Severity band edges. WARN mirrors where a user starts caring; CRIT mirrors
-# the auto-switch default threshold so bar color and switch behavior agree.
-WARN_PCT = 70.0
-CRIT_PCT = 90.0
+def _textual_theme(name: str, colors: ThemeColors) -> Theme:
+    return Theme(
+        name=name,
+        primary=colors.accent,
+        secondary=colors.muted,
+        accent=colors.accent,
+        foreground=colors.foreground,
+        background=colors.background,
+        surface=colors.surface,
+        panel=colors.panel,
+        success=colors.sev_ok,
+        warning=colors.sev_warn,
+        error=colors.sev_crit,
+        dark=colors.dark,
+        variables={
+            # Footer keys pick up the accent instead of the default blue.
+            "footer-key-foreground": colors.accent,
+            "block-cursor-background": colors.panel,
+            "block-cursor-foreground": colors.foreground,
+            "block-cursor-text-style": "none",
+        },
+    )
+
+
+# Registry consulted by app.py (register_theme + the command palette's theme
+# picker). THEME_NAMES/DEFAULT_THEME/theme_colors are re-exported from
+# palette.py so callers only need one import.
+THEMES: dict[str, Theme] = {
+    name: _textual_theme(name, colors) for name, colors in THEME_COLORS.items()
+}
+THEME_NAMES: tuple[str, ...] = tuple(THEMES)
+
+CSWAP_DARK = THEMES["cswap-dark"]
+
+
+def current_theme_colors() -> ThemeColors:
+    """``ThemeColors`` for the currently running app's active theme.
+
+    Outside a running app (e.g. a unit test calling a widgets.py/autoview.py
+    render function directly) there is no active theme, so this falls back
+    to cswap-dark's colors — the same as today's fixed behavior.
+    """
+    app = active_app.get(None)
+    if app is None:
+        return theme_colors(DEFAULT_THEME)
+    return theme_colors(app.theme)
 
 
 def severity_color(pct: float | None) -> str:
-    """Bar/percentage color for a utilization percentage."""
+    """Bar/percentage color for a utilization percentage, in the currently
+    active theme."""
+    colors = current_theme_colors()
     if pct is None:
-        return MUTED
+        return colors.muted
     if pct >= CRIT_PCT:
-        return SEV_CRIT
+        return colors.sev_crit
     if pct >= WARN_PCT:
-        return SEV_WARN
-    return SEV_OK
-
-
-CSWAP_DARK = Theme(
-    name="cswap-dark",
-    primary=ACCENT,
-    secondary=MUTED,
-    accent=ACCENT,
-    foreground=FOREGROUND,
-    background=BACKGROUND,
-    surface=SURFACE,
-    panel=PANEL,
-    success=SEV_OK,
-    warning=SEV_WARN,
-    error=SEV_CRIT,
-    dark=True,
-    variables={
-        # Footer keys pick up the accent instead of the default blue.
-        "footer-key-foreground": ACCENT,
-        "block-cursor-background": PANEL,
-        "block-cursor-foreground": FOREGROUND,
-        "block-cursor-text-style": "none",
-    },
-)
+        return colors.sev_warn
+    return colors.sev_ok

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -18,15 +18,7 @@ from claude_swap.json_output import USAGE_API_KEY
 from claude_swap.models import AccountSnapshot
 from claude_swap.usage_store import STALE_OK_S
 from claude_swap.tui import data
-from claude_swap.tui.theme import (
-    ACCENT,
-    FOREGROUND,
-    MUTED,
-    SEV_CRIT,
-    SEV_WARN,
-    TRACK,
-    severity_color,
-)
+from claude_swap.tui.theme import current_theme_colors, severity_color
 
 if TYPE_CHECKING:
     from claude_swap.tui.app import CswapApp
@@ -45,9 +37,10 @@ def bar_cells(
     threshold: float | None = None,
 ) -> Text:
     """Just the bar glyphs: severity-colored fill, track, optional tick."""
+    colors = current_theme_colors()
     text = Text()
     if pct is None:
-        text.append(_BAR_EMPTY * width, style=TRACK)
+        text.append(_BAR_EMPTY * width, style=colors.track)
         return text
     frac = min(max(pct, 0.0), 100.0) / 100.0
     cells = frac * width
@@ -60,13 +53,13 @@ def bar_cells(
     fill_style = f"{color} dim" if stale else color
     for i in range(width):
         if tick_at is not None and i == tick_at:
-            text.append(_BAR_TICK, style=SEV_WARN)
+            text.append(_BAR_TICK, style=colors.sev_warn)
         elif i < full:
             text.append(_BAR_FILLED, style=fill_style)
         elif i == full and half:
             text.append(_BAR_HALF, style=fill_style)
         else:
-            text.append(_BAR_EMPTY, style=TRACK)
+            text.append(_BAR_EMPTY, style=colors.track)
     return text
 
 
@@ -80,16 +73,17 @@ def usage_bar(
     threshold: float | None = None,
 ) -> Text:
     """One full bar line: ``5h ━━━━╸────┃──  47%  resets 2h 13m``."""
+    colors = current_theme_colors()
     text = Text()
-    text.append(f"{label} ", style=MUTED)
+    text.append(f"{label} ", style=colors.muted)
     text.append(bar_cells(pct, width, stale=stale, threshold=threshold))
     if pct is None:
-        text.append("  usage unknown", style=MUTED)
+        text.append("  usage unknown", style=colors.muted)
     else:
         color = severity_color(pct)
         text.append(f" {pct:3.0f}%", style=f"{color} dim" if stale else color)
     if suffix:
-        text.append(f"  {suffix}", style=MUTED)
+        text.append(f"  {suffix}", style=colors.muted)
     return text
 
 
@@ -133,21 +127,22 @@ def account_card_text(
 ) -> Text:
     """The full account card: header line + per-window bar rows."""
     now = now if now is not None else time.time()
+    colors = current_theme_colors()
 
     text = Text()
-    text.append(f"{acc.number:>2}  ", style=f"bold {FOREGROUND}")
-    text.append(acc.email, style=FOREGROUND)
-    text.append(f"  [{acc.display_tag}]", style=MUTED)
+    text.append(f"{acc.number:>2}  ", style=f"bold {colors.foreground}")
+    text.append(acc.email, style=colors.foreground)
+    text.append(f"  [{acc.display_tag}]", style=colors.muted)
     if acc.is_active:
-        text.append("   ● active", style=f"bold {ACCENT}")
+        text.append("   ● active", style=f"bold {colors.accent}")
     age = data.format_age(acc.usage.age_s)
     if age:
-        text.append(f"   {age}", style=MUTED)
+        text.append(f"   {age}", style=colors.muted)
 
     sentinel = acc.usage.sentinel
     if sentinel is not None:
         text.append("\n    ")
-        style = MUTED if sentinel == USAGE_API_KEY else SEV_WARN
+        style = colors.muted if sentinel == USAGE_API_KEY else colors.sev_warn
         marker = "·" if sentinel == USAGE_API_KEY else "⚠"
         text.append(f"{marker} {data.sentinel_label(sentinel)}", style=style)
         # Same supplementary line `cswap list` prints: the last good
@@ -157,15 +152,15 @@ def account_card_text(
             last_seen = data.last_seen_note(acc.usage)
             if last_seen is not None:
                 text.append("\n    ")
-                text.append(f"└ {last_seen}", style=MUTED)
+                text.append(f"└ {last_seen}", style=colors.muted)
         return text
 
     rows = usage_rows(acc.usage.last_good, now)
     if not rows:
         text.append("\n    ")
-        text.append("usage unavailable", style=MUTED)
+        text.append("usage unavailable", style=colors.muted)
         if acc.usage.last_error:
-            text.append(f" · {acc.usage.last_error}", style=MUTED)
+            text.append(f" · {acc.usage.last_error}", style=colors.muted)
         return text
 
     stale = acc.usage.age_s is not None and acc.usage.age_s > STALE_OK_S
@@ -194,15 +189,16 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
     maxed per-model window shows as ``Fable (!)``. Sentinel states show
     their label instead.
     """
+    colors = current_theme_colors()
     text = Text(no_wrap=True, overflow="ellipsis")
-    text.append(f"{acc.number:>2}  ", style=f"bold {MUTED}")
-    text.append(acc.email, style=FOREGROUND)
-    text.append(f"  [{acc.display_tag}]", style=MUTED)
+    text.append(f"{acc.number:>2}  ", style=f"bold {colors.muted}")
+    text.append(acc.email, style=colors.foreground)
+    text.append(f"  [{acc.display_tag}]", style=colors.muted)
     text.append("   ")
 
     sentinel = acc.usage.sentinel
     if sentinel is not None:
-        style = MUTED if sentinel == USAGE_API_KEY else SEV_WARN
+        style = colors.muted if sentinel == USAGE_API_KEY else colors.sev_warn
         text.append(data.sentinel_label(sentinel), style=style)
         return text
 
@@ -215,14 +211,14 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
             continue
         pct = float(window["pct"])
         if parts:
-            text.append(" · ", style=TRACK)
+            text.append(" · ", style=colors.track)
         color = severity_color(pct)
-        text.append(f"{label} ", style=MUTED)
+        text.append(f"{label} ", style=colors.muted)
         text.append(f"{pct:.0f}%", style=f"{color} dim" if stale else color)
         if pct >= 100:
             reset = data.reset_text(window, now)
             if reset:
-                text.append(f" ({reset})", style=MUTED)
+                text.append(f" ({reset})", style=colors.muted)
         parts += 1
     maxed = [
         w["name"]
@@ -231,11 +227,11 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
     ]
     for name in maxed:
         if parts:
-            text.append(" · ", style=TRACK)
-        text.append(f"{name} (!)", style=SEV_CRIT)
+            text.append(" · ", style=colors.track)
+        text.append(f"{name} (!)", style=colors.sev_crit)
         parts += 1
     if not parts:
-        text.append("usage unknown", style=MUTED)
+        text.append("usage unknown", style=colors.muted)
     return text
 
 
@@ -253,15 +249,16 @@ class AccountsPanel(Static):
 
     def render(self) -> Text:
         app: "CswapApp" = self.app  # type: ignore[assignment]
+        colors = current_theme_colors()
         snap = app.snapshot
         if snap is None:
-            return Text("loading…", style=MUTED)
+            return Text("loading…", style=colors.muted)
         if not snap.accounts:
             return Text(
                 "No managed accounts yet.\n"
                 "Use the menu below: Add account — from your current "
                 "Claude Code login, or from a setup-token / API key.",
-                style=MUTED,
+                style=colors.muted,
             )
         now = time.time()
         width = (self.size.width or 80) - 2
@@ -276,7 +273,7 @@ class AccountsPanel(Static):
             elif self._show_minis:
                 blocks.append(mini_account_text(acc, now))
         if not blocks:
-            return Text("no active managed login", style=MUTED)
+            return Text("no active managed login", style=colors.muted)
         text = Text()
         previous_multiline = False
         for i, block in enumerate(blocks):
@@ -325,6 +322,7 @@ class MenuItem(ListItem):
     """One menu row: a label plus an action id the screen dispatches on."""
 
     def __init__(self, label: str, action_id: str, *, muted: bool = False) -> None:
-        style = MUTED if muted else FOREGROUND
+        colors = current_theme_colors()
+        style = colors.muted if muted else colors.foreground
         super().__init__(Static(Text(label, style=style)))
         self.action_id = action_id

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,9 +48,10 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "tui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 8
+        assert out.count("(default)") == 9
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -77,7 +78,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 8
+        assert len(by_key) == 9
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -12,10 +12,12 @@ from claude_swap import printer
 
 @pytest.fixture(autouse=True)
 def _reset_color_cache():
-    """Reset the color detection cache before each test."""
+    """Reset the color detection/accent caches before each test."""
     printer._colors_enabled = None
+    printer._accent_escape = None
     yield
     printer._colors_enabled = None
+    printer._accent_escape = None
 
 
 class TestColorDetection:
@@ -76,7 +78,7 @@ class TestStyling:
         monkeypatch.setenv("FORCE_COLOR", "1")
         result = printer.accent("hello")
         assert "hello" in result
-        assert "\033[38;5;173m" in result
+        assert "\033[38;2;215;135;95m" in result
         assert "\033[0m" in result
 
     def test_muted_with_colors_enabled(self, monkeypatch):
@@ -105,7 +107,7 @@ class TestStyling:
         monkeypatch.setenv("FORCE_COLOR", "1")
         result = printer.bold_accent("(active)")
         assert "\033[1m" in result
-        assert "\033[38;5;173m" in result
+        assert "\033[38;2;215;135;95m" in result
         assert "(active)" in result
 
 
@@ -147,7 +149,7 @@ def test_force_color_overrides_and_restores():
         printer._colors_enabled = False
         with printer.force_color():
             assert printer.colors_enabled() is True
-            assert printer.accent("X") == "\x1b[38;5;173mX\x1b[0m"
+            assert printer.accent("X") == "\x1b[38;2;215;135;95mX\x1b[0m"
         assert printer._colors_enabled is False
     finally:
         printer._colors_enabled = saved

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,6 +14,7 @@ from claude_swap.exceptions import ConfigError
 from claude_swap.settings import (
     SETTING_SPECS,
     AutoSwitchSettings,
+    TuiSettings,
     effective_settings,
     load_settings,
     merged_with_cli,
@@ -22,6 +23,8 @@ from claude_swap.settings import (
     settings_path,
     unset_setting,
 )
+
+_SECTION_DATACLASSES = {"autoswitch": AutoSwitchSettings, "tui": TuiSettings}
 
 
 def _args(**kwargs) -> argparse.Namespace:
@@ -112,16 +115,20 @@ class TestSaveSettings:
 
 class TestSettingSpecs:
     def test_registry_covers_every_dataclass_field(self):
-        spec_fields = {spec.field for spec in SETTING_SPECS.values()}
-        dataclass_fields = {
-            f.name for f in AutoSwitchSettings.__dataclass_fields__.values()
-        }
-        assert spec_fields == dataclass_fields
+        for section, cls in _SECTION_DATACLASSES.items():
+            spec_fields = {
+                spec.field for spec in SETTING_SPECS.values() if spec.section == section
+            }
+            dataclass_fields = {f.name for f in cls.__dataclass_fields__.values()}
+            assert spec_fields == dataclass_fields
 
     def test_defaults_match_dataclass(self):
-        defaults = AutoSwitchSettings()
-        for spec in SETTING_SPECS.values():
-            assert spec.default == getattr(defaults, spec.field)
+        for section, cls in _SECTION_DATACLASSES.items():
+            defaults = cls()
+            for spec in SETTING_SPECS.values():
+                if spec.section != section:
+                    continue
+                assert spec.default == getattr(defaults, spec.field)
 
 
 class TestSetUnsetSetting:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -663,6 +663,30 @@ class TestDashboard:
 
         assert CswapApp.ENABLE_COMMAND_PALETTE is True
 
+    async def test_theme_pick_is_persisted(self, tmp_path):
+        from claude_swap.settings import load_tui_settings
+
+        fake = FakeSwitcher([make_account(1, active=True)], tmp_path)
+        app = make_app(fake)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert load_tui_settings(tmp_path).theme == "cswap-dark"
+            app.theme = "catppuccin-mocha"
+            await pilot.pause()
+            assert load_tui_settings(tmp_path).theme == "catppuccin-mocha"
+
+    async def test_theme_override_is_not_persisted(self, tmp_path):
+        from claude_swap.settings import load_tui_settings, set_setting
+        from claude_swap.tui.app import CswapApp
+
+        set_setting(tmp_path, "tui.theme", "catppuccin-frappe")
+        fake = FakeSwitcher([make_account(1, active=True)], tmp_path)
+        app = CswapApp(fake, theme="catppuccin-latte")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.theme == "catppuccin-latte"
+            assert load_tui_settings(tmp_path).theme == "catppuccin-frappe"
+
 
 @pytest.mark.asyncio
 class TestWatchScreen:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -658,10 +658,10 @@ class TestDashboard:
             panel = app.screen.query_one(AccountsPanel).render().plain
             assert "No managed accounts yet" in panel
 
-    async def test_palette_is_disabled(self, tmp_path):
+    async def test_palette_is_enabled(self, tmp_path):
         from claude_swap.tui.app import CswapApp
 
-        assert CswapApp.ENABLE_COMMAND_PALETTE is False
+        assert CswapApp.ENABLE_COMMAND_PALETTE is True
 
 
 @pytest.mark.asyncio
@@ -967,7 +967,7 @@ class TestBareInvocation:
 
         launched = {}
 
-        def fake_run(switcher):
+        def fake_run(switcher, start="dashboard", *, theme=None):
             launched["switcher"] = switcher
             return 0
 
@@ -996,7 +996,7 @@ class TestBareInvocation:
 
         launched = {}
 
-        def fake_run(switcher, start="dashboard"):
+        def fake_run(switcher, start="dashboard", *, theme=None):
             launched["start"] = start
             return 0
 


### PR DESCRIPTION
Closes #122.

## Summary

- Registers `cswap-dark` (unchanged default) plus Catppuccin Latte/Frappé/Macchiato/Mocha as selectable Textual themes.
- Re-enables the command palette (`ctrl+p`) so Textual's built-in "Change theme" command becomes available — the old comment justifying disabling it ("there is one theme") no longer holds.
- Persists the choice as a new `tui.theme` section in `settings.json`, readable/writable through the existing generic `cswap config` machinery.
- Adds a `--theme NAME` flag to `cswap tui`/`cswap watch` that overrides the persisted setting for one session.
- The CLI's own accent color (`printer.py`, previously a fixed 256-color escape) now follows the same setting, using a 24-bit truecolor escape since the Catppuccin accents aren't xterm-palette colors.

### A note on scope

`widgets.py`/`autoview.py` previously imported `theme.py`'s colors (`ACCENT`, `MUTED`, `SEV_WARN`, ...) as fixed module constants and used them directly as Rich `Text` styles — bypassing Textual's `$variable` CSS system entirely. Just registering new `Theme` objects would only have recolored Textual's own chrome (borders, footer keys, block cursor) and left the usage bars, account list, and severity colors — most of what's actually on screen — stuck on `cswap-dark`'s palette regardless of the selected theme. Both modules now resolve colors from the active theme at render time (`current_theme_colors()`), falling back to `cswap-dark`'s colors outside a running app (e.g. the existing unit tests that call these render functions directly), so switching themes actually recolors everything.

Theme hex data lives in a new dependency-free `claude_swap/palette.py`, imported by both `tui/theme.py` (which builds the Textual `Theme` objects) and `settings.py`/`printer.py`. Those two are on the hot path for every plain CLI invocation (`cswap list`, `cswap auto --once`, ...), and `tui/__init__.py` already documents a deliberate policy of keeping textual/rich imports out of that path — `palette.py` keeps that intact.

Catppuccin hex values cross-checked against the official palette (`catppuccin/palette`, `palette.json`).

## Test plan

- [x] `uv run pytest` — 1109 passed, 3 skipped
- [x] Pilot-driven manual check: all 5 themes register, command palette opens/closes without crashing, `current_theme_colors()` reflects the active theme and updates on switch, `cswap-dark` unchanged after reverting
- [x] `cswap config set tui.theme <name>` + `cswap config unset` round-tripped through `load_tui_settings`/`effective_settings`
- [x] `printer.accent()` verified to follow `tui.theme` across `catppuccin-mocha`, `catppuccin-latte`, and unset (falls back to `cswap-dark`'s original terracotta) — exact truecolor escapes checked against each flavor's official peach hex
- [x] Persisted-setting vs `--theme` CLI override precedence verified directly against `CswapApp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)