### PR TITLE
feat(menubar): optional per-model weekly limits (e.g. Fable) in the title

### DIFF
--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -45,6 +45,7 @@ class MenuBarSettings:
 
     show_account_name: bool = True
     title_pct: str = "both"  # one of TITLE_PCT_CHOICES
+    title_scoped: bool = False  # append per-model weekly limits (e.g. Fable) to the title
     refresh_interval: int = 60
     auto_switch_enabled: bool = False
 
@@ -243,6 +244,13 @@ def format_title(
         p = seven["pct"] if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)) else None
         if p is not None:
             segments.append(f"{p:.0f}%")
+    if settings.title_scoped and isinstance(active_usage, dict):
+        # Per-model weekly limits (e.g. Fable), same shape/roll-forward as the
+        # dropdown rows; named so multiple scoped models stay distinguishable.
+        for window in active_usage.get("scoped") or []:
+            window = _rolled_weekly_window(window, now)
+            if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)) and window.get("name"):
+                segments.append(f"{window['name']} {window['pct']:.0f}%")
     if not segments:
         return ICON
     return f"{ICON} " + " · ".join(segments)
@@ -608,6 +616,12 @@ def run(switcher) -> int:
                 title_pct.add(ch)
             menu.add(title_pct)
 
+            scoped_item = rumps.MenuItem(
+                "Show model limits in title", callback=self.on_toggle_scoped
+            )
+            scoped_item.state = 1 if self.settings.title_scoped else 0
+            menu.add(scoped_item)
+
             interval = rumps.MenuItem("Refresh interval")
             labels = {30: "30 seconds", 60: "60 seconds", 300: "5 minutes"}
             for secs in REFRESH_CHOICES:
@@ -746,6 +760,10 @@ def run(switcher) -> int:
 
         def on_toggle_name(self, _sender):
             self.settings.show_account_name = not self.settings.show_account_name
+            self._save_and_rebuild()
+
+        def on_toggle_scoped(self, _sender):
+            self.settings.title_scoped = not self.settings.title_scoped
             self._save_and_rebuild()
 
         def _make_title_pct(self, mode):

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -201,6 +201,30 @@ def test_format_title_icon_only_when_off():
     assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄"
 
 
+def test_format_title_scoped_appends_model_limits():
+    # title_pct="off" + title_scoped gives a title tracking only the scoped model
+    s = menubar.MenuBarSettings(show_account_name=True, title_pct="off", title_scoped=True)
+    usage = {**_USAGE, "scoped": [{"name": "Fable", "pct": 55.0}]}
+    assert menubar.format_title("loc@papaya.asia", usage, s) == "⇄ loc · Fable 55%"
+
+
+def test_format_title_scoped_after_windows_multiple_models():
+    s = menubar.MenuBarSettings(show_account_name=False, title_pct="both", title_scoped=True)
+    usage = {
+        **_USAGE,
+        "scoped": [{"name": "Fable", "pct": 55.0}, {"name": "Opus", "pct": 7.0}],
+    }
+    assert menubar.format_title("loc@papaya.asia", usage, s) == "⇄ 42% · 18% · Fable 55% · Opus 7%"
+
+
+def test_format_title_scoped_off_by_default():
+    # default settings ignore scoped windows entirely
+    s = menubar.MenuBarSettings(show_account_name=False, title_pct="off")
+    usage = {**_USAGE, "scoped": [{"name": "Fable", "pct": 55.0}]}
+    assert not s.title_scoped
+    assert menubar.format_title("loc@papaya.asia", usage, s) == "⇄"
+
+
 def test_format_title_icon_only_when_no_active_account():
     s = menubar.MenuBarSettings(show_account_name=True, title_pct="both")
     assert menubar.format_title(None, None, s) == "⇄"


### PR DESCRIPTION
The dropdown account rows gained scoped per-model windows (e.g. Fable) recently, which is great — but the menu-bar **title** still only renders `five_hour`/`seven_day`. Right now the number many of us are actually rationing is the Fable weekly bucket, and it's a click away.

This adds an opt-in `title_scoped` setting (default **off**, so existing titles are unchanged) with a toggle under **Settings → Show model limits in title**. When enabled, each scoped window is appended to the title as `<name> <pct>%`, after the 5h/7d segments, reusing `_rolled_weekly_window` so a passed weekly reset renders as 0% just like the dropdown rows.

Combined with `title_pct: off` you can make the title track only the model bucket:

```
⇄ asgeirtj6 · Fable 24%
```

or with `title_pct: both`:

```
⇄ asgeirtj6 · 24% · 15% · Fable 24%
```

- Settings round-trip via the existing `MenuBarSettings` load/save (unknown-key-tolerant, so older configs are unaffected)
- 3 new tests in `tests/test_menubar.py`; full suite passes
- Running it live on my own menubar since this afternoon

Happy to adjust naming (`title_scoped` vs `show_scoped_in_title`) or fold it into `TITLE_PCT_CHOICES` if you'd rather model it that way.