### PR TITLE
feat: usage.display setting for percent used vs. remaining (#125 part 1)

### DIFF
--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -24,7 +24,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from claude_swap.exceptions import ClaudeSwitchError, CredentialReadError
+from claude_swap.settings import USAGE_DISPLAY_CHOICES, USAGE_DISPLAY_USED, reframe_pct
 from claude_swap.switcher import SENTINEL_NOTES
+
+USAGE_DISPLAY_LABELS = {USAGE_DISPLAY_USED: "Used", "remaining": "Remaining"}
 
 ICON = "⇄"
 REFRESH_CHOICES: tuple[int, ...] = (30, 60, 300)
@@ -169,8 +172,16 @@ def _rolled_weekly_window(window: dict | None, now: float) -> dict | None:
     return rolled
 
 
-def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
-    """One-line usage summary for an account row (reset countdown computed live)."""
+def usage_summary(
+    usage: dict | str | None, now: float | None = None, display: str = USAGE_DISPLAY_USED
+) -> str:
+    """One-line usage summary for an account row (reset countdown computed live).
+
+    ``display`` (the usage.display setting) reframes each window's pct via
+    ``reframe_pct``; the over-limit (!) marker still keys off the raw
+    utilization, since a window is exhausted at pct >= 100 regardless of how
+    the number is framed.
+    """
     if isinstance(usage, str):
         return usage
     if usage is None:
@@ -183,7 +194,8 @@ def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
         if key == "seven_day":
             window = _rolled_weekly_window(window, now)  # reflect a passed weekly reset
         if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)):
-            seg = f"{label} {window['pct']:.0f}%"
+            val, suffix = reframe_pct(window["pct"], display)
+            seg = f"{label} {val:.0f}%{suffix}"
             countdown = _live_countdown(window, now)
             if countdown:
                 seg += f" ({countdown})"  # time until this window resets
@@ -192,7 +204,8 @@ def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
     for window in usage.get("scoped") or []:
         window = _rolled_weekly_window(window, now)  # weekly cadence, same roll-forward
         if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)) and window.get("name"):
-            seg = f"{window['name']} {window['pct']:.0f}%"
+            val, suffix = reframe_pct(window["pct"], display)
+            seg = f"{window['name']} {val:.0f}%{suffix}"
             if window["pct"] >= 100:
                 seg += " (!)"  # maxed model — the usual reason to switch
             countdown = _live_countdown(window, now)
@@ -201,15 +214,17 @@ def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
             parts.append(seg)
     spend = usage.get("spend")
     if isinstance(spend, dict) and isinstance(spend.get("pct"), (int, float)):
-        parts.append(f"$ {spend['pct']:.0f}%")
+        val, suffix = reframe_pct(spend["pct"], display)
+        parts.append(f"$ {val:.0f}%{suffix}")
     return " · ".join(parts) if parts else "usage unavailable"
 
 
 def format_account_label(
-    num, email: str, usage: dict | str | None, now: float | None = None
+    num, email: str, usage: dict | str | None, now: float | None = None,
+    display: str = USAGE_DISPLAY_USED,
 ) -> str:
     """Build one account row's menu label."""
-    return f"{num}  {email}  {usage_summary(usage, now)}"
+    return f"{num}  {email}  {usage_summary(usage, now, display)}"
 
 
 def _local_part(email: str, limit: int = 12) -> str:
@@ -225,8 +240,13 @@ def format_title(
     active_usage: dict | str | None,
     settings: MenuBarSettings,
     now: float | None = None,
+    display: str = USAGE_DISPLAY_USED,
 ) -> str:
-    """Build the menu-bar title from the active account and settings."""
+    """Build the menu-bar title from the active account and settings.
+
+    ``display`` (the usage.display setting) reframes the title's percentage
+    segment(s) the same way ``usage_summary`` does.
+    """
     if active_email is None:
         return ICON
     if now is None:
@@ -237,26 +257,31 @@ def format_title(
     if settings.title_pct in ("5h", "both"):
         p = _window_pct(active_usage, "five_hour")
         if p is not None:
-            segments.append(f"{p:.0f}%")
+            val, suffix = reframe_pct(p, display)
+            segments.append(f"{val:.0f}%{suffix}")
     if settings.title_pct in ("7d", "both"):
         seven = active_usage.get("seven_day") if isinstance(active_usage, dict) else None
         seven = _rolled_weekly_window(seven, now)  # reflect a passed weekly reset
         p = seven["pct"] if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)) else None
         if p is not None:
-            segments.append(f"{p:.0f}%")
+            val, suffix = reframe_pct(p, display)
+            segments.append(f"{val:.0f}%{suffix}")
     if settings.title_scoped and isinstance(active_usage, dict):
         # Per-model weekly limits (e.g. Fable), same shape/roll-forward as the
         # dropdown rows; named so multiple scoped models stay distinguishable.
         for window in active_usage.get("scoped") or []:
             window = _rolled_weekly_window(window, now)
             if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)) and window.get("name"):
-                segments.append(f"{window['name']} {window['pct']:.0f}%")
+                val, suffix = reframe_pct(window["pct"], display)
+                segments.append(f"{window['name']} {val:.0f}%{suffix}")
     if not segments:
         return ICON
     return f"{ICON} " + " · ".join(segments)
 
 
-def format_usage_log(email: str, usage: dict | str | None) -> str | None:
+def format_usage_log(
+    email: str, usage: dict | str | None, display: str = USAGE_DISPLAY_USED
+) -> str | None:
     """A log line of an account's session (5h) and weekly (7d) limits.
 
     Uses each window's absolute reset ``clock`` rather than a live countdown,
@@ -271,7 +296,8 @@ def format_usage_log(email: str, usage: dict | str | None) -> str | None:
             continue
         window = usage.get(key)  # a dict — _window_pct found a numeric pct in it
         clock = window.get("clock") if isinstance(window, dict) else None
-        seg = f"{label} {pct:.0f}%"
+        val, suffix = reframe_pct(pct, display)
+        seg = f"{label} {val:.0f}%{suffix}"
         if clock:
             seg += f" (resets {clock})"
         parts.append(seg)
@@ -352,7 +378,7 @@ def run(switcher) -> int:
     import rumps  # lazy: optional dependency, imported only when launching
 
     from claude_swap.autoswitch import AutoSwitchEngine
-    from claude_swap.settings import load_settings, set_setting
+    from claude_swap.settings import load_settings, load_usage_settings, set_setting
     from claude_swap.snapshot_source import SnapshotSource
 
     settings_path = switcher.backup_dir / "menubar_settings.json"
@@ -363,6 +389,12 @@ def run(switcher) -> int:
             super().__init__(ICON, quit_button=None)
             self.switcher = switcher
             self.settings = MenuBarSettings.load(settings_path)
+            # usage.display lives in the main settings.json (not
+            # menubar_settings.json), alongside autoswitch.*, so `cswap
+            # config set usage.display remaining` and the menu bar toggle
+            # below both act on the same source of truth `cswap list`/
+            # `status` read.
+            self.usage_display = load_usage_settings(switcher.backup_dir).display
             # The supported paced read path: per refresh it fetches only the
             # active account plus (at most once per freshness window) one stale
             # alternate, so an open menu costs O(1) requests per window instead
@@ -432,7 +464,7 @@ def run(switcher) -> int:
                 key = _usage_log_key(last_good)
                 if key == (None, None) or self._last_usage_log.get(num) == key:
                     continue
-                line = format_usage_log(email, last_good)
+                line = format_usage_log(email, last_good, self.usage_display)
                 if line:
                     self.switcher._logger.info(line)
                     self._last_usage_log[num] = key
@@ -538,13 +570,14 @@ def run(switcher) -> int:
         # ---- menu construction -----------------------------------------------
         def rebuild_menu(self):
             self.title = format_title(
-                self.snapshot["active_email"], self.snapshot["active_usage"], self.settings
+                self.snapshot["active_email"], self.snapshot["active_usage"], self.settings,
+                display=self.usage_display,
             )
             self.menu.clear()
             account_items = []
             for num, email, is_active, display, _last_good in self.snapshot["accounts"]:
                 item = rumps.MenuItem(
-                    format_account_label(num, email, display),
+                    format_account_label(num, email, display, display=self.usage_display),
                     callback=self._make_switch_to(num),
                 )
                 item.state = 1 if is_active else 0
@@ -621,6 +654,19 @@ def run(switcher) -> int:
             )
             scoped_item.state = 1 if self.settings.title_scoped else 0
             menu.add(scoped_item)
+
+            # Mirrors the Title percentage picker but flips the usage.display
+            # setting in the main settings.json (not menubar_settings.json),
+            # so the menu bar, `cswap list`, and `cswap status` all reframe
+            # percentages together.
+            usage_display_menu = rumps.MenuItem("Usage display")
+            for mode in USAGE_DISPLAY_CHOICES:
+                ch = rumps.MenuItem(
+                    USAGE_DISPLAY_LABELS[mode], callback=self._make_usage_display(mode)
+                )
+                ch.state = 1 if self.usage_display == mode else 0
+                usage_display_menu.add(ch)
+            menu.add(usage_display_menu)
 
             interval = rumps.MenuItem("Refresh interval")
             labels = {30: "30 seconds", 60: "60 seconds", 300: "5 minutes"}
@@ -770,6 +816,13 @@ def run(switcher) -> int:
             def cb(_sender):
                 self.settings.title_pct = mode
                 self._save_and_rebuild()
+            return cb
+
+        def _make_usage_display(self, mode):
+            def cb(_sender):
+                set_setting(self.switcher.backup_dir, "usage.display", mode)
+                self.usage_display = mode
+                self.rebuild_menu()
             return cb
 
         def _make_interval(self, secs):

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -25,6 +25,14 @@ from claude_swap.exceptions import ConfigError
 SETTINGS_SCHEMA_VERSION = 1
 SETTINGS_FILENAME = "settings.json"
 
+# Usage display modes for the ``usage.display`` key: how a window's
+# utilization percentage is framed across the human surfaces (``cswap
+# list``/``status`` and the macOS menu bar). ``used`` (the default) shows the
+# raw utilization; ``remaining`` shows ``100 - pct`` with a ``left`` suffix.
+USAGE_DISPLAY_USED = "used"
+USAGE_DISPLAY_REMAINING = "remaining"
+USAGE_DISPLAY_CHOICES = (USAGE_DISPLAY_USED, USAGE_DISPLAY_REMAINING)
+
 _logger = logging.getLogger("claude-swap")
 
 
@@ -59,6 +67,27 @@ class AutoSwitchSettings:
 
 
 @dataclass(frozen=True)
+class UsageSettings:
+    """Display preferences for usage surfaces (the ``usage`` section).
+
+    Parallel to :class:`AutoSwitchSettings` but for presentation, not engine
+    policy. ``display`` reframes utilization percentages: ``used`` (default,
+    the raw pct) or ``remaining`` (``100 - pct`` with a ``left`` suffix).
+    """
+
+    display: str = USAGE_DISPLAY_USED
+
+
+# Section → zero-arg factory for that section's settings dataclass, so
+# :pyattr:`SettingSpec.default` can resolve a spec's default no matter which
+# section it lives in (``autoswitch`` today, ``usage`` added additively).
+_SECTION_DEFAULTS: dict[str, type] = {
+    "autoswitch": AutoSwitchSettings,
+    "usage": UsageSettings,
+}
+
+
+@dataclass(frozen=True)
 class SettingSpec:
     """Metadata for one user-tunable settings.json key.
 
@@ -82,7 +111,7 @@ class SettingSpec:
 
     @property
     def default(self):
-        return getattr(AutoSwitchSettings(), self.field)
+        return getattr(_SECTION_DEFAULTS[self.section](), self.field)
 
 
 # settings.json uses camelCase (matching the repo's other JSON artifacts);
@@ -128,6 +157,64 @@ SETTING_SPECS: dict[str, SettingSpec] = {
 _AUTOSWITCH_KEYS: dict[str, str] = {
     spec.field: spec.json_key for spec in SETTING_SPECS.values()
 }
+
+# The ``usage`` section, kept in its own registry so the autoswitch-only
+# machinery above (``_clamped``/``load_settings``/``save_settings``, all keyed
+# off ``SETTING_SPECS`` and :class:`AutoSwitchSettings`) never has to consider
+# a non-autoswitch field. ``setting_spec``/``set_setting``/``unset_setting``
+# are section-agnostic already, so ``cswap config set usage.display remaining``
+# routes here and writes ``raw["usage"]["display"]``.
+USAGE_SPECS: dict[str, SettingSpec] = {
+    spec.dotted: spec
+    for spec in (
+        SettingSpec(
+            "usage", "display", "display", "choice", choices=USAGE_DISPLAY_CHOICES,
+            help="Show account usage as percent used or percent remaining",
+        ),
+    )
+}
+
+_USAGE_KEYS: dict[str, str] = {
+    spec.field: spec.json_key for spec in USAGE_SPECS.values()
+}
+
+
+def load_usage_settings(backup_root: Path) -> UsageSettings:
+    """Load the ``usage`` section; missing/corrupt/unknown → defaults.
+
+    Mirrors :func:`load_settings`' forgiving posture: a garbled value degrades
+    to the default rather than raising, so a bad hand edit never blocks the
+    tool. Unknown choices are logged (matching ``_clamped``'s choice warning).
+    """
+    raw = _read_raw(settings_path(backup_root))
+    section = raw.get("usage")
+    if not isinstance(section, dict):
+        return UsageSettings()
+    display = section.get("display", UsageSettings.display)
+    if display not in USAGE_DISPLAY_CHOICES:
+        _logger.warning(
+            "settings.json: unsupported usage.display %r; using %r",
+            display, UsageSettings.display,
+        )
+        display = UsageSettings.display
+    return UsageSettings(display=display)
+
+
+def reframe_pct(pct: float, display: str) -> tuple[float, str]:
+    """Split a utilization pct into ``(value, suffix)`` for a display mode.
+
+    ``used`` → ``(pct, "")``; ``remaining`` → ``(100 - pct, " left")``, clamped
+    at 0 so an over-limit window reads ``0% left`` rather than a negative
+    number. Each surface formats the width itself; this only picks the number
+    and the trailing label, so every surface renders ``62%`` or ``38% left``
+    consistently. An unknown mode falls through to ``used``.
+    """
+    if display == USAGE_DISPLAY_REMAINING:
+        remaining = 100.0 - pct
+        if remaining < 0:
+            remaining = 0.0
+        return remaining, " left"
+    return pct, ""
 
 
 def settings_path(backup_root: Path) -> Path:
@@ -225,12 +312,18 @@ def save_settings(backup_root: Path, settings: AutoSwitchSettings) -> None:
 
 
 def setting_spec(dotted_key: str) -> SettingSpec:
-    """Look up a spec by dotted key; unknown keys raise with the valid list."""
+    """Look up a spec by dotted key; unknown keys raise with the valid list.
+
+    Consults every section's registry (``autoswitch``, then ``usage``) so the
+    one config dispatch path serves all sections.
+    """
     spec = SETTING_SPECS.get(dotted_key)
+    if spec is None:
+        spec = USAGE_SPECS.get(dotted_key)
     if spec is None:
         raise ConfigError(
             f"unknown setting '{dotted_key}'\n"
-            f"Valid keys: {', '.join(SETTING_SPECS)}"
+            f"Valid keys: {', '.join([*SETTING_SPECS, *USAGE_SPECS])}"
         )
     return spec
 
@@ -377,6 +470,14 @@ def effective_settings(backup_root: Path) -> list[tuple[SettingSpec, object, boo
         section = raw.get(spec.section)
         is_set = isinstance(section, dict) and spec.json_key in section
         rows.append((spec, getattr(effective, spec.field), is_set))
+    # Additive sections resolved through their own loaders, each spec's
+    # ``is_set`` read from its own section so a non-autoswitch key is detected
+    # in raw["usage"], not the autoswitch section.
+    usage = load_usage_settings(backup_root)
+    for spec in USAGE_SPECS.values():
+        section = raw.get(spec.section)
+        is_set = isinstance(section, dict) and spec.json_key in section
+        rows.append((spec, getattr(usage, spec.field), is_set))
     return rows
 
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -74,7 +74,14 @@ from claude_swap.paths import (
 )
 from claude_swap.process_detection import get_running_instances
 from claude_swap import poll_policy
-from claude_swap.settings import load_settings, parse_model_names, settings_path
+from claude_swap.settings import (
+    USAGE_DISPLAY_USED,
+    load_settings,
+    load_usage_settings,
+    parse_model_names,
+    reframe_pct,
+    settings_path,
+)
 from claude_swap.usage_store import (
     FetchRecord,
     UsageEntry,
@@ -105,38 +112,44 @@ _FETCH_STAGGER_S = 0.25
 _USAGE_AGE_NOTE_S = poll_policy.SERVE_TTL_S
 
 
-def _format_usage_lines(usage: dict) -> list[str]:
+def _format_usage_lines(usage: dict, display: str = USAGE_DISPLAY_USED) -> list[str]:
     # Collect (label, body) rows first, then pad every label to the widest one so
     # per-model names (e.g. "Fable") don't shift the columns of the other lines.
+    # ``display`` (the usage.display setting) reframes each pct as used or
+    # remaining via reframe_pct; the over-limit (!) marker still keys off the
+    # raw utilization, since a window is exhausted at pct >= 100 regardless of
+    # how the number is framed.
     rows: list[tuple[str, str]] = []
     spend = usage.get("spend")
     if spend:
         used = spend["used"]
         limit = spend["limit"]
-        pct = spend["pct"]
+        val, suffix = reframe_pct(spend["pct"], display)
         cell = oauth.fresh_reset_strings(spend)
         if cell:
-            rows.append(("$$", f"{pct:>3.0f}%   resets {cell[1]:<12}  ${used:,.2f} / ${limit:,.2f}"))
+            rows.append(("$$", f"{val:>3.0f}%{suffix}   resets {cell[1]:<12}  ${used:,.2f} / ${limit:,.2f}"))
         else:
-            rows.append(("$$", f"{pct:>3.0f}%   ${used:,.2f} / ${limit:,.2f}"))
+            rows.append(("$$", f"{val:>3.0f}%{suffix}   ${used:,.2f} / ${limit:,.2f}"))
     for label, w in (("5h", usage.get("five_hour")), ("7d", usage.get("seven_day"))):
         if w:
+            val, suffix = reframe_pct(w["pct"], display)
             cell = oauth.fresh_reset_strings(w)
             if cell:
                 countdown, clock = cell
-                rows.append((label, f"{w['pct']:>3.0f}%   resets {clock:<12}  in {countdown}"))
+                rows.append((label, f"{val:>3.0f}%{suffix}   resets {clock:<12}  in {countdown}"))
             else:
-                rows.append((label, f"{w['pct']:>3.0f}%"))
+                rows.append((label, f"{val:>3.0f}%{suffix}"))
     for w in usage.get("scoped") or []:
         # Per-model weekly limits (e.g. Fable). Flag ones at/over the limit so a
         # maxed model — the usual reason to switch — stands out.
         marker = "  (!)" if w["pct"] >= 100 else ""
+        val, suffix = reframe_pct(w["pct"], display)
         cell = oauth.fresh_reset_strings(w)
         if cell:
             countdown, clock = cell
-            rows.append((w["name"], f"{w['pct']:>3.0f}%   resets {clock:<12}  in {countdown}{marker}"))
+            rows.append((w["name"], f"{val:>3.0f}%{suffix}   resets {clock:<12}  in {countdown}{marker}"))
         else:
-            rows.append((w["name"], f"{w['pct']:>3.0f}%{marker}"))
+            rows.append((w["name"], f"{val:>3.0f}%{suffix}{marker}"))
     width = max((len(label) for label, _ in rows), default=0) + 1  # label + ':'
     return [f"{label + ':':<{width}} {body}" for label, body in rows]
 
@@ -153,24 +166,27 @@ SENTINEL_NOTES = {
 }
 
 
-def last_seen_note(entry: UsageEntry) -> str | None:
+def last_seen_note(entry: UsageEntry, display: str = USAGE_DISPLAY_USED) -> str | None:
     """"last seen 53% used · 12m ago" from an entry's last-good measurement.
 
     Public: the TUI renders the same note under sentinel states (see
     ``SENTINEL_NOTES``), so both surfaces stay word-for-word identical.
+    ``display`` (the usage.display setting) reframes the percentage: ``used``
+    shows ``100 - headroom`` (the utilized pct), ``remaining`` shows the
+    headroom itself with a ``left`` suffix.
     """
     if entry.last_good is None or entry.fetched_at is None:
         return None
     headroom = oauth.account_headroom(entry.last_good)
     if headroom is None:
         return None
-    return (
-        f"last seen {100 - headroom:.0f}% used · "
-        f"{format_age(int(entry.fetched_at * 1000))}"
-    )
+    age = format_age(int(entry.fetched_at * 1000))
+    if display == "remaining":
+        return f"last seen {headroom:.0f}% left · {age}"
+    return f"last seen {100 - headroom:.0f}% used · {age}"
 
 
-def _usage_entry_lines(entry: UsageEntry) -> list[str]:
+def _usage_entry_lines(entry: UsageEntry, display: str = USAGE_DISPLAY_USED) -> list[str]:
     """Styled usage lines (sans indent) for one account's entry.
 
     Sentinel states render their note first, with a supplementary "last seen"
@@ -178,15 +194,17 @@ def _usage_entry_lines(entry: UsageEntry) -> list[str]:
     annotated once older than ``_USAGE_AGE_NOTE_S`` (stale-served); an account
     with no measurement at all shows "usage unavailable" plus the last fetch
     error, so a failing endpoint is visible instead of a silent blank.
+    ``display`` threads the usage.display setting through the measurement and
+    last-seen lines alike.
     """
     if entry.sentinel is not None:
         out = [dimmed(SENTINEL_NOTES.get(entry.sentinel, entry.sentinel))]
-        last_seen = last_seen_note(entry)
+        last_seen = last_seen_note(entry, display)
         if last_seen is not None and entry.sentinel != USAGE_API_KEY:
             out.append(f"{dimmed('└')} {muted(last_seen)}")
         return out
     if entry.last_good is not None:
-        lines = _format_usage_lines(entry.last_good)
+        lines = _format_usage_lines(entry.last_good, display)
         if (
             lines
             and entry.age_s is not None
@@ -2352,6 +2370,7 @@ class ClaudeAccountSwitcher:
             return self._build_list_payload(accounts_info, entries)
 
         print(bolded("Accounts:"))
+        display = load_usage_settings(self.backup_dir).display
         for i, (num, email, org_name, org_uuid, is_active, _) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
             # NOTE: the TUI watch view (tui._watch_account_rows) parses this
@@ -2363,7 +2382,7 @@ class ClaudeAccountSwitcher:
                 print(f"  {num}: {email} {muted(f'[{tag}]')}{marker}")
             else:
                 print(f"  {num}: {email} {muted(f'[{tag}]')}")
-            for line in _usage_entry_lines(entries[str(num)]):
+            for line in _usage_entry_lines(entries[str(num)], display):
                 print(f"     {line}")
 
             if show_token_status:
@@ -2513,7 +2532,8 @@ class ClaudeAccountSwitcher:
             entry = self._active_account_usage(
                 account_num, current_email, current_org_uuid
             )
-            for line in _usage_entry_lines(entry):
+            display = load_usage_settings(self.backup_dir).display
+            for line in _usage_entry_lines(entry, display):
                 print(f"  {line}")
         else:
             print(f"{bolded('Status:')} {current_email} {dimmed('(not managed)')}")

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -50,7 +50,7 @@ class TestConfigList:
             "autoswitch.model",
         ):
             assert key in out
-        assert out.count("(default)") == 8
+        assert out.count("(default)") == 9
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -77,7 +77,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 8
+        assert len(by_key) == 9
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -127,6 +127,24 @@ def test_format_account_label():
     assert label == "2  loc@papaya.asia  5h 42% · 7d 18% · $ 30%"
 
 
+# --- usage.display toggle (issue #125 part 1) -----------------------------------
+
+def test_usage_summary_remaining_mode_reframes_every_window():
+    got = menubar.usage_summary(_USAGE, display="remaining")
+    assert got == "5h 58% left · 7d 82% left · $ 70% left"
+
+
+def test_usage_summary_remaining_mode_clamps_over_limit_scoped_window():
+    usage = {"scoped": [{"name": "Fable", "pct": 120.0}]}
+    got = menubar.usage_summary(usage, display="remaining")
+    assert got == "Fable 0% left (!)"  # the (!) marker still keys off raw pct
+
+
+def test_format_account_label_remaining_mode():
+    label = menubar.format_account_label(2, "loc@papaya.asia", _USAGE, display="remaining")
+    assert label == "2  loc@papaya.asia  5h 58% left · 7d 82% left · $ 70% left"
+
+
 # --- usage logging -------------------------------------------------------------
 
 def test_format_usage_log_full():
@@ -147,6 +165,12 @@ def test_format_usage_log_without_clock():
 def test_format_usage_log_partial_window():
     usage = {"seven_day": {"pct": 12.0, "clock": "Jul 3"}}
     assert menubar.format_usage_log("a@x.com", usage) == "usage a@x.com: 7d 12% (resets Jul 3)"
+
+
+def test_format_usage_log_remaining_mode():
+    usage = {"five_hour": {"pct": 35.0, "clock": "06:59"}}
+    got = menubar.format_usage_log("a@x.com", usage, display="remaining")
+    assert got == "usage a@x.com: 5h 65% left (resets 06:59)"
 
 
 def test_format_usage_log_none_when_no_numeric_window():
@@ -194,6 +218,12 @@ def test_format_title_both_windows():
 def test_format_title_both_windows_with_name():
     s = menubar.MenuBarSettings(show_account_name=True, title_pct="both")
     assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄ loc · 42% · 18%"
+
+
+def test_format_title_remaining_mode_reframes_percentages():
+    s = menubar.MenuBarSettings(show_account_name=False, title_pct="both")
+    got = menubar.format_title("loc@papaya.asia", _USAGE, s, display="remaining")
+    assert got == "⇄ 58% left · 82% left"
 
 
 def test_format_title_icon_only_when_off():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -13,10 +13,14 @@ import pytest
 from claude_swap.exceptions import ConfigError
 from claude_swap.settings import (
     SETTING_SPECS,
+    USAGE_DISPLAY_REMAINING,
+    USAGE_SPECS,
     AutoSwitchSettings,
     effective_settings,
     load_settings,
+    load_usage_settings,
     merged_with_cli,
+    reframe_pct,
     save_settings,
     set_setting,
     settings_path,
@@ -195,8 +199,10 @@ class TestSetUnsetSetting:
 class TestEffectiveSettings:
     def test_missing_file_reports_all_defaults(self, tmp_path: Path):
         rows = effective_settings(tmp_path)
-        assert len(rows) == len(SETTING_SPECS)
+        assert len(rows) == len(SETTING_SPECS) + len(USAGE_SPECS)
         assert all(not is_set for _, _, is_set in rows)
+        by_key = {spec.dotted: value for spec, value, _ in rows}
+        assert by_key["usage.display"] == "used"
 
     def test_presence_not_value_equality_marks_set(self, tmp_path: Path):
         set_setting(tmp_path, "autoswitch.threshold", "90")  # equals default
@@ -230,3 +236,55 @@ class TestMergedWithCli:
     def test_model_override(self):
         merged = merged_with_cli(AutoSwitchSettings(), _args(model="Fable"))
         assert merged.model == "Fable"
+
+
+class TestUsageSettings:
+    """Issue #125 part 1: the ``usage`` section (usage.display), additive and
+    isolated from the ``autoswitch`` section's machinery."""
+
+    def test_missing_file_defaults_to_used(self, tmp_path: Path):
+        assert load_usage_settings(tmp_path).display == "used"
+
+    def test_round_trips_through_load(self, tmp_path: Path):
+        set_setting(tmp_path, "usage.display", "remaining")
+        assert load_usage_settings(tmp_path).display == USAGE_DISPLAY_REMAINING
+
+    def test_garbage_value_degrades_to_default(self, tmp_path: Path):
+        path = settings_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"usage": {"display": "half"}}')
+        assert load_usage_settings(tmp_path).display == "used"
+
+    def test_set_does_not_disturb_autoswitch_section(self, tmp_path: Path):
+        set_setting(tmp_path, "autoswitch.threshold", "75")
+        set_setting(tmp_path, "usage.display", "remaining")
+        assert load_settings(tmp_path).threshold == 75.0
+        assert load_usage_settings(tmp_path).display == USAGE_DISPLAY_REMAINING
+
+    def test_invalid_choice_raises(self, tmp_path: Path):
+        with pytest.raises(ConfigError):
+            set_setting(tmp_path, "usage.display", "half")
+
+    def test_unset_removes_key_and_empty_section(self, tmp_path: Path):
+        set_setting(tmp_path, "usage.display", "remaining")
+        assert unset_setting(tmp_path, "usage.display") is True
+        assert load_usage_settings(tmp_path).display == "used"
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert "usage" not in raw
+
+    def test_second_unset_is_a_no_op(self, tmp_path: Path):
+        assert unset_setting(tmp_path, "usage.display") is False
+
+
+class TestReframePct:
+    def test_used_mode_is_identity(self):
+        assert reframe_pct(62.0, "used") == (62.0, "")
+
+    def test_remaining_mode_inverts_with_left_suffix(self):
+        assert reframe_pct(62.0, "remaining") == (38.0, " left")
+
+    def test_remaining_mode_clamps_over_limit_at_zero(self):
+        assert reframe_pct(120.0, "remaining") == (0.0, " left")
+
+    def test_unknown_mode_falls_back_to_used(self):
+        assert reframe_pct(62.0, "half-baked") == (62.0, "")

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -33,6 +33,7 @@ from claude_swap.switcher import (
     SECURITY_SERVICE,
     SETUP_TOKEN_SCOPES,
     _format_usage_lines,
+    last_seen_note,
 )
 
 
@@ -4599,6 +4600,36 @@ class TestFormatUsageLines:
         usage = {"five_hour": {"pct": 7.0, "clock": "20:39", "countdown": "1h 30m"}}
         lines = _format_usage_lines(usage)
         assert lines == ["5h:   7%   resets 20:39         in 1h 30m"]
+
+
+class TestUsageDisplayMode:
+    """Issue #125 part 1: usage.display reframes _format_usage_lines and
+    last_seen_note as used (default) or remaining, without touching JSON."""
+
+    def test_default_display_is_used_unchanged(self):
+        usage = {"five_hour": {"pct": 62.0}}
+        assert _format_usage_lines(usage) == _format_usage_lines(usage, "used")
+
+    def test_remaining_mode_shows_left_suffix(self):
+        usage = {"five_hour": {"pct": 62.0}, "spend": {"used": 1.0, "limit": 10.0, "pct": 12.0, "currency": "USD"}}
+        lines = _format_usage_lines(usage, "remaining")
+        assert "88% left" in lines[0]  # spend line ($$) sorts first, pct=12 -> 88 left
+        assert "38% left" in lines[1]  # 5h window, pct=62 -> 38 left
+
+    def test_remaining_mode_clamps_over_limit_at_zero(self):
+        usage = {"scoped": [{"name": "Fable", "pct": 120.0}]}
+        lines = _format_usage_lines(usage, "remaining")
+        assert "0% left" in lines[0]
+        assert lines[0].rstrip().endswith("(!)")  # marker still keys off raw pct
+
+    def test_unknown_display_falls_back_to_used(self):
+        usage = {"five_hour": {"pct": 62.0}}
+        assert _format_usage_lines(usage, "half-baked") == _format_usage_lines(usage, "used")
+
+    def test_last_seen_note_used_vs_remaining(self):
+        entry = UsageEntry(last_good={"five_hour": {"pct": 30.0}}, fetched_at=1_000_000.0)
+        assert "30% used" in last_seen_note(entry, "used")
+        assert "70% left" in last_seen_note(entry, "remaining")
 
 
 def _read_safety_copy(switcher, entry_id: str) -> str:


### PR DESCRIPTION
## Problem

`pct` everywhere (`cswap list`, `cswap status`, the menu bar) is percent **used**. There's no way to see percent remaining, which is closes issue #125's first ask: a `used`/`remaining` display toggle (the second half of that issue, a pace/reserve indicator, is a separate follow-up not included here).

## What this does

Adds a `usage.display` setting (`"used"`, the default, or `"remaining"`):

```
cswap config set usage.display remaining
```

- `cswap list`/`cswap status`: every window (5h, 7d, spend, per-model scoped) reframes as `100 - pct` with a `left` suffix, e.g. `5h 62%` becomes `5h 38% left`. The `last seen` fallback note reframes the same way.
- Menu bar: title, dropdown rows, and the usage log line all reframe together. A new **Settings → Usage display** submenu mirrors the existing Title percentage picker.
- **JSON output is unchanged** — `pct` stays the raw utilization, so scripts can derive either framing themselves without a schema bump.
- The over-limit `(!)` marker still keys off the raw utilization regardless of display mode (a window is exhausted at `pct >= 100` either way).

## Implementation

- New `usage` section in `settings.json`, parallel to `autoswitch` (not a new `AutoSwitchSettings` field — it's a display preference, not engine policy). `SettingSpec.default` now resolves through a section → dataclass map so `cswap config get/set/unset/list usage.display` work through the existing generic plumbing without special-casing.
- `reframe_pct(pct, display)` in `settings.py` is the one place that does the `100 - pct` math and clamps at 0 (an over-limit window reads `0% left`, never negative).
- `_format_usage_lines`/`last_seen_note` (switcher.py) and `usage_summary`/`format_title`/`format_account_label`/`format_usage_log` (menubar.py) all take an optional `display` param defaulting to `"used"`, so every existing call site (and the TUI, untouched) keeps working byte-for-byte.

## Tests

- `test_settings.py`: `TestUsageSettings` (load/round-trip/garbage-degrades/section-isolation/invalid-choice/unset) + `TestReframePct` (identity, inversion, clamp, unknown-mode fallback).
- `test_switcher.py`: `TestUsageDisplayMode` (remaining-mode rendering, over-limit clamp, unknown-mode fallback, `last_seen_note` both ways).
- `test_menubar.py`: remaining-mode coverage for `usage_summary`, `format_account_label`, `format_title`, `format_usage_log`.
- `test_config_cli.py`/`test_settings.py`: updated the two settings-count assertions (8 → 9 keys).
- Full suite: 1226 passed, 3 skipped (up from 1205 passed on main).