### PR TITLE
feat: per-account aliases (#110)

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -12,6 +12,7 @@ from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
 from claude_swap.printer import (
     accent,
+    bolded,
     dimmed,
     error,
     force_utf8_output,
@@ -322,6 +323,89 @@ def _unmap_command(argv: list[str]) -> None:
             print(f"{accent('Unmapped')} {shown}")
         else:
             print(dimmed(f"No mapping for {shown}"))
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
+def _alias_command(argv: list[str]) -> None:
+    """Handle `cswap alias [NUM|EMAIL|ALIAS [NAME | --unset]]`.
+
+    With no arguments, lists every set alias. With one identifier and no
+    NAME/--unset, that's a usage error (nothing to do). Pre-dispatched before
+    the main parser for the same reason as `map`/`run` (a positional
+    subcommand can't coexist with the main parser's required mutually-
+    exclusive flag group).
+    """
+    parser = argparse.ArgumentParser(
+        prog="cswap alias",
+        description=(
+            "Give a managed account a short, memorable name — usable "
+            "anywhere a slot number or email is (switch, remove, run). "
+            "With no arguments, lists every set alias."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap alias                    # list current aliases
+  cswap alias 2 dev              # set (also: cswap alias user@example.com dev)
+  cswap alias dev prod           # rename an existing alias
+  cswap alias 2 --unset          # remove
+  cswap switch dev               # aliases work anywhere an identifier does
+        """,
+    )
+    parser.add_argument(
+        "identifier",
+        nargs="?",
+        metavar="NUM|EMAIL|ALIAS",
+        help="Account to name (number, email, or its current alias). Omit to list.",
+    )
+    parser.add_argument(
+        "name",
+        nargs="?",
+        metavar="NAME",
+        help="The new alias (letters, digits, '-', '_', '.'; not purely numeric)",
+    )
+    parser.add_argument(
+        "--unset",
+        action="store_true",
+        help="Remove the identifier's alias instead of setting one",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    if args.unset and args.name is not None:
+        parser.error("--unset takes no NAME")
+    if args.identifier is not None and args.name is None and not args.unset:
+        parser.error("expected NAME (or --unset)")
+    if args.identifier is None and (args.name is not None or args.unset):
+        parser.error("NAME/--unset require an identifier")
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+
+        if args.identifier is None:
+            aliases = switcher.list_aliases()
+            if not aliases:
+                print(dimmed("No aliases set yet."))
+                print(muted("Set one with: cswap alias <NUM|EMAIL> <NAME>"))
+                return
+            print(bolded("Aliases:"))
+            for num, alias, email in aliases:
+                print(f"  {num}: {accent(alias)} ({email})")
+            return
+
+        if args.unset:
+            account_num = switcher.unset_alias(args.identifier)
+            print(f"{accent('Cleared alias')} for Account-{account_num}")
+            return
+
+        account_num, normalized = switcher.set_alias(args.identifier, args.name)
+        print(f"{accent('Aliased')} Account-{account_num} {muted('as')} {normalized}")
     except ClaudeSwitchError as e:
         error(f"Error: {e}")
         sys.exit(1)
@@ -684,6 +768,9 @@ def main() -> None:
     if argv and argv[0] == "unmap":
         _unmap_command(argv[1:])
         return
+    if argv and argv[0] == "alias":
+        _alias_command(argv[1:])
+        return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like
     # lazygit/k9s). TTY-gated on both ends so scripts and pipes keep getting
@@ -715,6 +802,8 @@ Commands:
   %(prog)s map <num|email> [path]     map a directory to an account
   %(prog)s map                        list directory mappings
   %(prog)s unmap [path]               remove a directory mapping
+  %(prog)s alias <num|email> <name>   give an account a short name
+  %(prog)s alias                      list aliases
   %(prog)s auto                       auto-switch when nearing rate limits
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s export <path>              export accounts
@@ -790,6 +879,14 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         type=int,
         metavar="NUM",
         help="Specify slot number when adding account (use with 'add' or 'add-token')",
+    )
+    parser.add_argument(
+        "--alias",
+        metavar="NAME",
+        help=(
+            "Set an alias at add time (use with 'add'), equivalent to a "
+            "follow-up 'cswap alias <num> <alias>'"
+        ),
     )
     parser.add_argument(
         "--email",
@@ -951,6 +1048,9 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.slot is not None and not (args.add_account or args.add_token is not None):
         parser.error("--slot can only be used with 'add' or 'add-token'")
 
+    if args.alias is not None and not args.add_account:
+        parser.error("--alias can only be used with 'add'")
+
     if args.email is not None and args.add_token is None:
         parser.error("--email can only be used with 'add-token'")
 
@@ -991,7 +1091,7 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
                 sys.exit(1)
 
         if args.add_account:
-            switcher.add_account(slot=args.slot)
+            switcher.add_account(slot=args.slot, alias=args.alias)
         elif args.add_token is not None:
             switcher.add_account_from_token(
                 token=args.add_token,

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -146,6 +146,7 @@ def account_row(
     *,
     usage_fetched_at: float | None = None,
     usage_age_s: float | None = None,
+    alias: str | None = None,
 ) -> dict:
     """A full account row for ``--list``."""
     status, usage = usage_fields(usage_entry)
@@ -159,6 +160,8 @@ def account_row(
         "usageStatus": status,
         "usage": usage,
     }
+    if alias:
+        row["alias"] = alias
     if usage is not None:
         row.update(usage_freshness_fields(usage_fetched_at, usage_age_s))
     return row

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -206,10 +206,12 @@ def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
 
 
 def format_account_label(
-    num, email: str, usage: dict | str | None, now: float | None = None
+    num, email: str, usage: dict | str | None, now: float | None = None,
+    alias: str | None = None,
 ) -> str:
-    """Build one account row's menu label."""
-    return f"{num}  {email}  {usage_summary(usage, now)}"
+    """Build one account row's menu label. Prepends the alias when set."""
+    label = f"{alias} ({email})" if alias else email
+    return f"{num}  {label}  {usage_summary(usage, now)}"
 
 
 def _local_part(email: str, limit: int = 12) -> str:
@@ -225,15 +227,20 @@ def format_title(
     active_usage: dict | str | None,
     settings: MenuBarSettings,
     now: float | None = None,
+    active_alias: str | None = None,
 ) -> str:
-    """Build the menu-bar title from the active account and settings."""
+    """Build the menu-bar title from the active account and settings.
+
+    ``active_alias``, when set, is shown instead of the email's local-part
+    (still truncated to the same 12-char limit for a long alias).
+    """
     if active_email is None:
         return ICON
     if now is None:
         now = time.time()
     segments: list[str] = []
     if settings.show_account_name:
-        segments.append(_local_part(active_email))
+        segments.append(_local_part(active_alias or active_email))
     if settings.title_pct in ("5h", "both"):
         p = _window_pct(active_usage, "five_hour")
         if p is not None:
@@ -321,28 +328,33 @@ def _account_display_usage(entry) -> dict | str | None:
     return entry.last_good
 
 
-EMPTY_SNAPSHOT: dict = {"accounts": [], "active_email": None, "active_usage": None}
+EMPTY_SNAPSHOT: dict = {
+    "accounts": [], "active_email": None, "active_usage": None, "active_alias": None,
+}
 
 
 def _adapt_snapshot(snap) -> dict:
     """Adapt an ``AccountsSnapshot`` to the menu bar's render dict.
 
-    Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good), ...],
-    "active_email": str | None, "active_usage": dict | str | None}``. The snapshot
-    itself is produced by ``SnapshotSource`` (the paced read path), so this is a
-    pure transform — no fetching, no I/O.
+    Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good, alias), ...],
+    "active_email": str | None, "active_usage": dict | str | None,
+    "active_alias": str | None}``. The snapshot itself is produced by
+    ``SnapshotSource`` (the paced read path), so this is a pure transform —
+    no fetching, no I/O.
     """
     accounts = []
     active_email = None
     active_usage = None
+    active_alias = None
     for acc in snap.accounts:
         display = _account_display_usage(acc.usage)
-        accounts.append((acc.number, acc.email, acc.is_active, display, acc.usage.last_good))
+        accounts.append((acc.number, acc.email, acc.is_active, display, acc.usage.last_good, acc.alias))
         if acc.is_active:
-            active_email, active_usage = acc.email, display
+            active_email, active_usage, active_alias = acc.email, display, acc.alias
     return {
         "accounts": accounts,
         "active_email": active_email,
+        "active_alias": active_alias,
         "active_usage": active_usage,
     }
 
@@ -428,7 +440,7 @@ def run(switcher) -> int:
             but de-dupes per account on the (5h, 7d) percentages so an idle
             machine doesn't churn the rotating log with identical lines.
             """
-            for num, email, _is_active, _display, last_good in snap["accounts"]:
+            for num, email, _is_active, _display, last_good, _alias in snap["accounts"]:
                 key = _usage_log_key(last_good)
                 if key == (None, None) or self._last_usage_log.get(num) == key:
                     continue
@@ -538,13 +550,14 @@ def run(switcher) -> int:
         # ---- menu construction -----------------------------------------------
         def rebuild_menu(self):
             self.title = format_title(
-                self.snapshot["active_email"], self.snapshot["active_usage"], self.settings
+                self.snapshot["active_email"], self.snapshot["active_usage"], self.settings,
+                active_alias=self.snapshot.get("active_alias"),
             )
             self.menu.clear()
             account_items = []
-            for num, email, is_active, display, _last_good in self.snapshot["accounts"]:
+            for num, email, is_active, display, _last_good, alias in self.snapshot["accounts"]:
                 item = rumps.MenuItem(
-                    format_account_label(num, email, display),
+                    format_account_label(num, email, display, alias=alias),
                     callback=self._make_switch_to(num),
                 )
                 item.state = 1 if is_active else 0
@@ -581,8 +594,9 @@ def run(switcher) -> int:
             accounts = self.snapshot["accounts"]
             if not accounts:
                 menu.add(rumps.MenuItem("No managed accounts", callback=None))
-            for num, email, _is_active, _display, _last_good in accounts:
-                menu.add(rumps.MenuItem(f"{num}  {email}", callback=self._make_remove(num)))
+            for num, email, _is_active, _display, _last_good, alias in accounts:
+                label = f"{alias} ({email})" if alias else email
+                menu.add(rumps.MenuItem(f"{num}  {label}", callback=self._make_remove(num)))
             return menu
 
         def _history_menu(self, rumps):

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -45,6 +46,32 @@ class Platform(Enum):
         return cls.UNKNOWN
 
 
+#: Alias validation: letters/digits/-/_/., non-empty, not purely digits (so
+#: an alias can never collide with a slot number in _resolve_account_identifier).
+_ALIAS_RE = re.compile(r"^[a-z0-9_.-]+$")
+
+
+def normalize_alias(name: str) -> str:
+    """Lowercase and validate a proposed alias; raise ValueError if invalid.
+
+    Shared by the CLI (`cswap alias`) and `cswap add --alias` so both paths
+    enforce identical rules: letters/digits/``-``/``_``/``.`` only, and not
+    purely digits (a numeric alias would be indistinguishable from a slot
+    number in ``_resolve_account_identifier``, which checks ``isdigit()``
+    first).
+    """
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("alias cannot be empty")
+    if normalized.isdigit():
+        raise ValueError(f"alias '{name}' cannot be purely numeric (reserved for slot numbers)")
+    if not _ALIAS_RE.match(normalized):
+        raise ValueError(
+            f"alias '{name}' may only contain letters, digits, '-', '_', and '.'"
+        )
+    return normalized
+
+
 @dataclass
 class AccountInfo:
     """Information about a managed account."""
@@ -55,6 +82,7 @@ class AccountInfo:
     organization_name: str
     added: str
     number: int
+    alias: str | None = None
 
     @property
     def is_organization(self) -> bool:
@@ -63,8 +91,10 @@ class AccountInfo:
 
     @property
     def display_label(self) -> str:
-        """Display label: 'email [OrgName]' or 'email [personal]'."""
+        """Display label: 'alias (email) [OrgName]' or 'email [personal]'."""
         tag = self.organization_name if self.organization_name else "personal"
+        if self.alias:
+            return f"{self.alias} ({self.email}) [{tag}]"
         return f"{self.email} [{tag}]"
 
     @classmethod
@@ -77,17 +107,21 @@ class AccountInfo:
             organization_name=data.get("organizationName", "") or "",
             added=data.get("added", ""),
             number=number,
+            alias=data.get("alias") or None,
         )
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
-        return {
+        d = {
             "email": self.email,
             "uuid": self.uuid,
             "organizationUuid": self.organization_uuid,
             "organizationName": self.organization_name,
             "added": self.added,
         }
+        if self.alias:
+            d["alias"] = self.alias
+        return d
 
 
 @dataclass(frozen=True)
@@ -108,6 +142,7 @@ class AccountSnapshot:
     kind: str  # "oauth" | "api_key"
     switchable: bool
     usage: UsageEntry
+    alias: str | None = None
 
     @property
     def display_tag(self) -> str:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -51,6 +51,7 @@ from claude_swap.models import (
     Platform,
     SwitchTransaction,
     get_timestamp,
+    normalize_alias,
 )
 from claude_swap.printer import (
     abbreviate_path,
@@ -664,7 +665,7 @@ class ClaudeAccountSwitcher:
         entries = self._collect_usage_entries(accounts_info, fetch=fetch)
         active_number: str | None = None
         accounts: list[AccountSnapshot] = []
-        for num, email, org_name, org_uuid, is_active, _creds in accounts_info:
+        for num, email, org_name, org_uuid, is_active, _creds, alias in accounts_info:
             n = str(num)
             if is_active:
                 active_number = n
@@ -678,6 +679,7 @@ class ClaudeAccountSwitcher:
                     kind=self._account_kind(n),
                     switchable=self._account_is_switchable(n),
                     usage=entries[n],
+                    alias=alias,
                 )
             )
         return AccountsSnapshot(
@@ -1012,7 +1014,11 @@ class ClaudeAccountSwitcher:
         return org_name if org_name else "personal"
 
     def _resolve_account_identifier(self, identifier: str) -> str | None:
-        """Resolve account identifier (number or email) to account number.
+        """Resolve account identifier (number, alias, or email) to account number.
+
+        Precedence: slot number, then alias, then email — aliases are
+        case-normalized and enforced unique at set time (see ``set_alias``),
+        so an alias match is never ambiguous the way an email can be.
 
         Raises:
             ConfigError: if the email matches multiple accounts (ambiguous).
@@ -1023,6 +1029,11 @@ class ClaudeAccountSwitcher:
         data = self._get_sequence_data()
         if not data:
             return None
+
+        alias_key = identifier.strip().lower()
+        for num, account in data.get("accounts", {}).items():
+            if account.get("alias") == alias_key:
+                return num
 
         matches = [
             num for num, account in data.get("accounts", {}).items()
@@ -1042,6 +1053,95 @@ class ClaudeAccountSwitcher:
             f"Email '{identifier}' is ambiguous — matches accounts: {details}. "
             f"Use account number instead (e.g., cswap --switch-to 1)."
         )
+
+    def _is_known_alias(self, identifier: str) -> bool:
+        """Whether identifier (case-insensitive) is a currently set alias.
+
+        Used ahead of the email-format validation gate in switch_to/
+        remove_account so a bare alias like ``dev`` doesn't get rejected as
+        an invalid email before ``_resolve_account_identifier`` ever sees it.
+        """
+        data = self._get_sequence_data()
+        if not data:
+            return False
+        alias_key = identifier.strip().lower()
+        return any(
+            account.get("alias") == alias_key
+            for account in data.get("accounts", {}).values()
+        )
+
+    def set_alias(self, identifier: str, alias: str) -> tuple[str, str]:
+        """Set (or rename) the alias for the account matching identifier.
+
+        ``identifier`` is a slot number, email, or existing alias (so a
+        typo'd alias can be corrected with ``cswap alias <old> <new>`` as
+        well as by number/email). Returns ``(account_num, normalized_alias)``.
+
+        Raises:
+            ValidationError: if the normalized alias fails validate_alias's
+                rules (empty, non-slug characters, or purely numeric).
+            ConfigError: if the account isn't found, or the normalized alias
+                is already used by a different account.
+        """
+        try:
+            normalized = normalize_alias(alias)
+        except ValueError as e:
+            raise ValidationError(str(e)) from e
+
+        account_num = self._resolve_account_identifier(identifier)
+        if not account_num:
+            raise AccountNotFoundError(f"No account found with identifier: {identifier}")
+
+        data = self._get_sequence_data()
+        if not data or account_num not in data.get("accounts", {}):
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+
+        for num, account in data["accounts"].items():
+            if num != account_num and account.get("alias") == normalized:
+                existing_email = account.get("email", "unknown")
+                raise ConfigError(
+                    f"Alias '{normalized}' is already used by Account-{num} ({existing_email})"
+                )
+
+        data["accounts"][account_num]["alias"] = normalized
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        return account_num, normalized
+
+    def unset_alias(self, identifier: str) -> str:
+        """Clear the alias for the account matching identifier.
+
+        Returns the account number. Idempotent: clearing an already-unset
+        alias succeeds silently (no error), matching ``cswap config unset``'s
+        posture of "the end state is what you asked for".
+        """
+        account_num = self._resolve_account_identifier(identifier)
+        if not account_num:
+            raise AccountNotFoundError(f"No account found with identifier: {identifier}")
+
+        data = self._get_sequence_data()
+        if not data or account_num not in data.get("accounts", {}):
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+
+        if "alias" in data["accounts"][account_num]:
+            del data["accounts"][account_num]["alias"]
+            data["lastUpdated"] = get_timestamp()
+            self._write_json(self.sequence_file, data)
+        return account_num
+
+    def list_aliases(self) -> list[tuple[str, str, str]]:
+        """Every set alias as ``(account_num, alias, email)``, sequence order."""
+        data = self._get_sequence_data()
+        if not data:
+            return []
+        accounts = data.get("accounts", {})
+        out = []
+        for num in data.get("sequence", []):
+            account = accounts.get(str(num), {})
+            alias = account.get("alias")
+            if alias:
+                out.append((str(num), alias, account.get("email", "")))
+        return out
 
     def _get_sequence_data_migrated(self) -> dict | None:
         """Get sequence data, ensuring org-field migration has run."""
@@ -1118,7 +1218,9 @@ class ClaudeAccountSwitcher:
             data["lastUpdated"] = get_timestamp()
             self._write_json(self.sequence_file, data)
 
-    def add_account(self, slot: int | None = None, assume_yes: bool = False) -> None:
+    def add_account(
+        self, slot: int | None = None, assume_yes: bool = False, alias: str | None = None
+    ) -> None:
         """Add current account to managed accounts.
 
         Args:
@@ -1128,6 +1230,15 @@ class ClaudeAccountSwitcher:
                   is already occupied by a different account.
             assume_yes: Skip that overwrite prompt (callers with their own
                   confirmation UI, e.g. the TUI, confirm before calling).
+            alias: Convenience for setting an alias at add time (equivalent
+                  to a follow-up ``cswap alias <num> <alias>``). Only applies
+                  on the new-account path below — the refresh-in-place branch
+                  above never touches ``alias`` (a token refresh must not
+                  require re-specifying the account's existing name).
+
+        Raises:
+            ValidationError: if ``alias`` fails validate_alias's rules.
+            ConfigError: if ``alias`` is already used by a different account.
         """
         self._setup_directories()
         self._init_sequence_file()
@@ -1252,6 +1363,42 @@ class ClaudeAccountSwitcher:
         organization_uuid = oauth_data.get("organizationUuid", "") or ""
         organization_name = oauth_data.get("organizationName", "") or ""
 
+        # Carry an existing alias into the rewritten record below, from
+        # whichever slot currently holds it: migrate_from (the account moving
+        # to a new explicit slot) takes precedence, else the target slot
+        # itself (a re-run of `cswap add --slot N` on the same account/slot).
+        # Otherwise re-adding/moving an aliased account would silently wipe
+        # its name.
+        preserved_alias = None
+        data = self._get_sequence_data()
+        if migrate_from:
+            preserved_alias = data["accounts"].get(migrate_from, {}).get("alias")
+        elif account_num in data.get("accounts", {}):
+            preserved_alias = data["accounts"][account_num].get("alias")
+
+        # Validate (and collision-check) any effective alias BEFORE the
+        # destructive cleanup below, so an invalid/taken --alias fails
+        # cleanly with the old slot(s) still intact, not half-migrated.
+        effective_alias = alias or preserved_alias
+        normalized_alias = None
+        if effective_alias:
+            try:
+                normalized_alias = normalize_alias(effective_alias)
+            except ValueError as e:
+                raise ValidationError(str(e)) from e
+            for num, acc in data["accounts"].items():
+                # Skip account_num (the target slot itself) and migrate_from
+                # (the account's own old slot, about to be deleted below): a
+                # preserved alias legitimately already lives on one of these
+                # two, which isn't a real collision with a different account.
+                if num in (account_num, migrate_from):
+                    continue
+                if acc.get("alias") == normalized_alias:
+                    raise ConfigError(
+                        f"Alias '{normalized_alias}' is already used by "
+                        f"Account-{num} ({acc.get('email', 'unknown')})"
+                    )
+
         # Now safe to perform destructive cleanup (new account data is in memory)
         if displace_slot:
             d_num, d_email, d_org = displace_slot
@@ -1288,6 +1435,8 @@ class ClaudeAccountSwitcher:
             "organizationName": organization_name,
             "added": get_timestamp(),
         }
+        if normalized_alias:
+            data["accounts"][account_num]["alias"] = normalized_alias
         if int(account_num) not in data["sequence"]:
             data["sequence"].append(int(account_num))
             data["sequence"].sort()
@@ -1520,8 +1669,10 @@ class ClaudeAccountSwitcher:
         # Ensure org fields are migrated before resolving accounts
         self._get_sequence_data_migrated()
 
-        # Resolve identifier
-        if not identifier.isdigit():
+        # Resolve identifier. A known alias skips the email-format gate below
+        # entirely — it never needs the ambiguous-match prompt either, since
+        # aliases are enforced unique at set time (see set_alias).
+        if not identifier.isdigit() and not self._is_known_alias(identifier):
             if not self._validate_email(identifier):
                 raise ValidationError(f"Invalid email format: {identifier}")
 
@@ -1592,13 +1743,15 @@ class ClaudeAccountSwitcher:
 
         self._prune_mappings(email, account_info.get("organizationUuid", ""))
 
-    def _build_accounts_info(self) -> list[tuple[int, str, str, str, bool, str]]:
-        """Build per-account (num, email, org_name, org_uuid, is_active, creds).
+    def _build_accounts_info(self) -> list[tuple[int, str, str, str, bool, str, str | None]]:
+        """Build per-account (num, email, org_name, org_uuid, is_active, creds, alias).
 
         Shared by list_accounts and the usage-aware switch helpers so the active
         slot is detected and credentials are read in exactly one place. The
         active account's credentials come from Claude Code's live store; every
-        other slot reads its backup copy.
+        other slot reads its backup copy. ``alias`` is appended as the 7th
+        element (not inserted earlier) so existing positional index reads
+        (e.g. ``accounts_info[i][5]`` for creds) stay correct.
         """
         data = self._get_sequence_data_migrated() or {}
         current_identity = self._get_current_account()
@@ -1609,7 +1762,7 @@ class ClaudeAccountSwitcher:
             current_email, current_org_uuid = current_identity
             active_num = self._find_account_slot(data, current_email, current_org_uuid)
 
-        accounts_info: list[tuple[int, str, str, str, bool, str]] = []
+        accounts_info: list[tuple[int, str, str, str, bool, str, str | None]] = []
         # Reset each build; set below only when the active slot's OAuth Keychain
         # read failed with no fallback. Read by _static_usage_sentinel (main
         # thread writes it here before the fetch pool starts → no data race).
@@ -1620,6 +1773,7 @@ class ClaudeAccountSwitcher:
             org_name = account.get("organizationName", "") or ""
             org_uuid = account.get("organizationUuid", "") or ""
             is_active = str(num) == active_num
+            alias = account.get("alias") or None
 
             if is_active:
                 active = self._read_active_credentials()
@@ -1628,7 +1782,7 @@ class ClaudeAccountSwitcher:
             else:
                 creds = self._read_account_credentials(str(num), email)
 
-            accounts_info.append((num, email, org_name, org_uuid, is_active, creds))
+            accounts_info.append((num, email, org_name, org_uuid, is_active, creds, alias))
         return accounts_info
 
     def _active_cc_running(self) -> bool:
@@ -1786,14 +1940,14 @@ class ClaudeAccountSwitcher:
         )
 
     def _static_usage_sentinel(
-        self, account_info: tuple[int, str, str, str, bool, str]
+        self, account_info: tuple[int, str, str, str, bool, str, str | None]
     ) -> str | None:
         """Sentinel state derivable without any network call, or ``None``.
 
         Re-derived on every collect pass (never persisted), so it can't
         outlive the condition that produced it.
         """
-        num, email, _, _, is_active, creds = account_info
+        num, email, _, _, is_active, creds, _alias = account_info
         if looks_like_api_key(creds):
             # Managed API-key account: no subscription quota to fetch.
             return USAGE_API_KEY
@@ -1821,10 +1975,10 @@ class ClaudeAccountSwitcher:
         return None
 
     def _fetch_account_usage(
-        self, account_info: tuple[int, str, str, str, bool, str]
+        self, account_info: tuple[int, str, str, str, bool, str, str | None]
     ) -> FetchRecord:
         """One network fetch for one account. Never raises."""
-        num, email, _, org_uuid, is_active, creds = account_info
+        num, email, _, org_uuid, is_active, creds, _alias = account_info
 
         # The active/default account owns the live credential — route it through
         # the owner-aware path that refreshes only when no Claude Code/session is
@@ -1918,7 +2072,7 @@ class ClaudeAccountSwitcher:
 
     def _collect_usage_entries(
         self,
-        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        accounts_info: list[tuple[int, str, str, str, bool, str, str | None]],
         fetch: set[str] | None = None,
     ) -> dict[str, UsageEntry]:
         """Store-backed usage collection: one :class:`UsageEntry` per account.
@@ -1939,7 +2093,7 @@ class ClaudeAccountSwitcher:
         store = self._usage_store
         identities = {
             str(num): (email, org_uuid or "")
-            for num, email, _org_name, org_uuid, _active, _creds in accounts_info
+            for num, email, _org_name, org_uuid, _active, _creds, _alias in accounts_info
         }
         info_by_num = {str(info[0]): info for info in accounts_info}
         sentinels: dict[str, str] = {}
@@ -2168,7 +2322,7 @@ class ClaudeAccountSwitcher:
         return None, "stay"
 
     def _duplicate_account_warnings(
-        self, accounts_info: list[tuple[int, str, str, str, bool, str]]
+        self, accounts_info: list[tuple[int, str, str, str, bool, str, str | None]]
     ) -> list[str]:
         """Slots that provably authenticate as the same account.
 
@@ -2192,7 +2346,7 @@ class ClaudeAccountSwitcher:
         by_fp: dict[str, str] = {}
         by_identity: dict[tuple[str, str], str] = {}
         out: list[str] = []
-        for num, email, _org_name, org_uuid, _is_active, creds in accounts_info:
+        for num, email, _org_name, org_uuid, _is_active, creds, _alias in accounts_info:
             snum = str(num)
             fp = oauth.credential_fingerprint(creds) if creds else None
             if fp:
@@ -2221,7 +2375,7 @@ class ClaudeAccountSwitcher:
 
     def _lockstep_usage_warnings(
         self,
-        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        accounts_info: list[tuple[int, str, str, str, bool, str, str | None]],
         entries: dict[str, UsageEntry],
     ) -> list[str]:
         """Heuristic: slots whose usage moves in perfect lockstep.
@@ -2247,7 +2401,7 @@ class ClaudeAccountSwitcher:
         """
         seen: dict[tuple, str] = {}
         out: list[str] = []
-        for num, _email, _org_name, _org_uuid, _is_active, _creds in accounts_info:
+        for num, _email, _org_name, _org_uuid, _is_active, _creds, _alias in accounts_info:
             snum = str(num)
             entry = entries.get(snum)
             usage = entry.decision_value() if entry else None
@@ -2277,13 +2431,13 @@ class ClaudeAccountSwitcher:
 
     def _build_list_payload(
         self,
-        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        accounts_info: list[tuple[int, str, str, str, bool, str, str | None]],
         entries: dict[str, UsageEntry],
     ) -> dict:
         """Build the ``--list --json`` payload from gathered account + usage data."""
         active_num: int | None = None
         accounts = []
-        for num, email, org_name, org_uuid, is_active, _ in accounts_info:
+        for num, email, org_name, org_uuid, is_active, _, alias in accounts_info:
             if is_active:
                 active_num = num
             entry = entries[str(num)]
@@ -2297,6 +2451,7 @@ class ClaudeAccountSwitcher:
                     entry.decision_value(),
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
+                    alias=alias,
                 )
             )
         payload = {
@@ -2352,17 +2507,20 @@ class ClaudeAccountSwitcher:
             return self._build_list_payload(accounts_info, entries)
 
         print(bolded("Accounts:"))
-        for i, (num, email, org_name, org_uuid, is_active, _) in enumerate(accounts_info):
+        for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
             # NOTE: the TUI watch view (tui._watch_account_rows) parses this
             # output to map rows to accounts for quick-switch: it relies on the
             # uncolored ``  {num}: `` prefix and the ``(active)`` marker below.
             # Keep them intact when tweaking this line, or update that parser.
+            # An alias renders right after that prefix (accent-colored, like
+            # the "(active)" marker), never in place of the email.
+            label = f"{accent(alias)} ({email})" if alias else email
             if is_active:
                 marker = f" {bold_accent('(active)')}"
-                print(f"  {num}: {email} {muted(f'[{tag}]')}{marker}")
+                print(f"  {num}: {label} {muted(f'[{tag}]')}{marker}")
             else:
-                print(f"  {num}: {email} {muted(f'[{tag}]')}")
+                print(f"  {num}: {label} {muted(f'[{tag}]')}")
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
 
@@ -2432,7 +2590,7 @@ class ClaudeAccountSwitcher:
         active = self._read_active_credentials()
         creds = active.value or ""
         self._active_keychain_unavailable = active.keychain_unavailable
-        info = (int(account_num), current_email, "", org_uuid or "", True, creds)
+        info = (int(account_num), current_email, "", org_uuid or "", True, creds, None)
         return self._collect_usage_entries([info])[str(account_num)]
 
     def _build_status_payload(self) -> dict:
@@ -2985,8 +3143,10 @@ class ClaudeAccountSwitcher:
         # Ensure org fields are migrated before resolving accounts
         self._get_sequence_data_migrated()
 
-        # Resolve identifier
-        if not identifier.isdigit():
+        # Resolve identifier. A known alias skips the email-format gate below
+        # entirely — it never needs the ambiguous-match prompt either, since
+        # aliases are enforced unique at set time (see set_alias).
+        if not identifier.isdigit() and not self._is_known_alias(identifier):
             if not self._validate_email(identifier):
                 raise ValidationError(f"Invalid email format: {identifier}")
 

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -21,7 +21,7 @@ from claude_swap.exceptions import (
     CredentialReadError,
     TransferError,
 )
-from claude_swap.models import Platform, get_timestamp
+from claude_swap.models import Platform, get_timestamp, normalize_alias
 
 if TYPE_CHECKING:
     from claude_swap.switcher import ClaudeAccountSwitcher
@@ -74,15 +74,21 @@ def _validate_imported_account(switcher: ClaudeAccountSwitcher, account: dict) -
             f"invalid slot number in imported account ({email}): {raw_number!r}"
         )
 
-    # Org/uuid/added must be strings (or absent). A list/dict here would
+    # Org/uuid/added/alias must be strings (or absent). A list/dict here would
     # otherwise blow up downstream (unhashable in seen_keys, broken composite
     # key matching, garbage in sequence.json).
-    for field in ("organizationUuid", "organizationName", "uuid", "added"):
+    for field in ("organizationUuid", "organizationName", "uuid", "added", "alias"):
         if field in account and account[field] is not None:
             if not isinstance(account[field], str):
                 raise TransferError(
                     f"{field} for {email} must be a string, got {type(account[field]).__name__}"
                 )
+
+    if account.get("alias"):
+        try:
+            normalize_alias(account["alias"])
+        except ValueError as e:
+            raise TransferError(f"invalid alias for {email}: {e}") from e
 
     return email, str(raw_number)
 
@@ -220,6 +226,8 @@ def export_accounts(
         }
         if is_api_key:
             entry["kind"] = "api_key"
+        if record.get("alias"):
+            entry["alias"] = record["alias"]
         accounts_payload.append(entry)
 
     if not accounts_payload:
@@ -311,6 +319,7 @@ def import_accounts(
     # later in the list must not leave earlier accounts half-imported.
     normalized: list[dict[str, Any]] = []
     seen_keys: set[tuple[str, str]] = set()
+    seen_aliases: set[str] = set()
     for raw in accounts:
         email, exported_num = _validate_imported_account(switcher, raw)
         org_uuid = raw.get("organizationUuid", "") or ""
@@ -339,6 +348,12 @@ def import_accounts(
                 f"duplicate account in export: {email} (org={org_uuid or 'personal'})"
             )
         seen_keys.add(key)
+        alias = raw.get("alias") or None
+        if alias:
+            alias = alias.strip().lower()
+            if alias in seen_aliases:
+                raise TransferError(f"duplicate alias in export: {alias}")
+            seen_aliases.add(alias)
         normalized.append(
             {
                 "email": email,
@@ -347,6 +362,7 @@ def import_accounts(
                 "org_name": raw.get("organizationName", "") or "",
                 "uuid": raw.get("uuid", "") or "",
                 "added": raw.get("added") or get_timestamp(),
+                "alias": alias,
                 "kind": "api_key" if is_api_key else "oauth",
                 "creds_text": creds_text,
                 "config_text": json.dumps(config_obj, indent=2),
@@ -440,6 +456,26 @@ def import_accounts(
         }
         if entry["kind"] == "api_key":
             new_record["kind"] = "api_key"
+        if entry["alias"]:
+            # Alias is display sugar, not critical account data: a collision
+            # with an already-present *different* local account (not this
+            # import's own target/prior slot) drops the alias with a warning
+            # rather than aborting the whole import — writes already
+            # committed for earlier accounts in this pass can't be undone.
+            colliding = next(
+                (
+                    n for n, acc in data["accounts"].items()
+                    if n != target_num and acc.get("alias") == entry["alias"]
+                ),
+                None,
+            )
+            if colliding:
+                _eprint(
+                    f"Alias '{entry['alias']}' for {entry['email']} collides with "
+                    f"Account-{colliding}'s existing alias — imported without it"
+                )
+            else:
+                new_record["alias"] = entry["alias"]
         data["accounts"][target_num] = new_record
         if int(target_num) not in data["sequence"]:
             data["sequence"].append(int(target_num))

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -92,7 +92,11 @@ class DashboardScreen(Screen):
     def _remove_entries(self) -> MenuEntries:
         snap = self.app.snapshot
         entries: MenuEntries = [
-            (f"{acc.number}  {acc.email}  [{acc.display_tag}]", f"remove:{acc.number}")
+            (
+                f"{acc.number}  {acc.alias + ' (' + acc.email + ')' if acc.alias else acc.email}"
+                f"  [{acc.display_tag}]",
+                f"remove:{acc.number}",
+            )
             for acc in (snap.accounts if snap else ())
         ]
         entries.append(_BACK)

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -157,7 +157,11 @@ def account_card_text(
 
     text = Text()
     text.append(f"{acc.number:>2}  ", style=f"bold {FOREGROUND}")
-    text.append(acc.email, style=FOREGROUND)
+    if acc.alias:
+        text.append(acc.alias, style=f"bold {ACCENT}")
+        text.append(f" ({acc.email})", style=FOREGROUND)
+    else:
+        text.append(acc.email, style=FOREGROUND)
     text.append(f"  [{acc.display_tag}]", style=MUTED)
     if acc.is_active:
         text.append("   ● active", style=f"bold {ACCENT}")
@@ -223,7 +227,11 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
     """
     text = Text(no_wrap=True, overflow="ellipsis")
     text.append(f"{acc.number:>2}  ", style=f"bold {MUTED}")
-    text.append(acc.email, style=FOREGROUND)
+    if acc.alias:
+        text.append(acc.alias, style=f"bold {ACCENT}")
+        text.append(f" ({acc.email})", style=FOREGROUND)
+    else:
+        text.append(acc.email, style=FOREGROUND)
     text.append(f"  [{acc.display_tag}]", style=MUTED)
     text.append("   ")
 

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -229,7 +229,7 @@ class TestUsageDisplay:
 
     def test_collect_usage_short_circuits(self, temp_home: Path):
         s = _linux_switcher()
-        info = [(2, "api-key-2@token.local", "", "", False, API_KEY)]
+        info = [(2, "api-key-2@token.local", "", "", False, API_KEY, None)]
         entries = s._collect_usage_entries(info)
         assert entries["2"].sentinel == USAGE_API_KEY
         assert entries["2"].decision_value() == USAGE_API_KEY

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1143,6 +1143,161 @@ class TestMapCommand:
         assert "root" in capsys.readouterr().err
 
 
+class TestAliasCommand:
+    """`cswap alias` — issue #110's per-account short names."""
+
+    def _seeded_switcher_env(self, temp_home):
+        """Build a real switcher with two managed accounts."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["1"] = {
+            "email": "dev@co.com", "uuid": "u1",
+            "organizationUuid": "", "organizationName": "", "added": "2024-01-01T00:00:00Z",
+        }
+        data["accounts"]["2"] = {
+            "email": "content@co.com", "uuid": "u2",
+            "organizationUuid": "", "organizationName": "", "added": "2024-01-02T00:00:00Z",
+        }
+        data["sequence"] = [1, 2]
+        switcher._write_json(switcher.sequence_file, data)
+        return switcher
+
+    def test_set_alias_by_number(self, temp_home, capsys):
+        switcher = self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command(["1", "dev"])
+        assert "Aliased" in capsys.readouterr().out
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["alias"] == "dev"
+
+    def test_list_empty(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command([])
+        assert "No aliases set yet" in capsys.readouterr().out
+
+    def test_list_shows_entries(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command(["1", "dev"])
+            cli._alias_command([])
+        out = capsys.readouterr().out
+        assert "dev" in out
+        assert "dev@co.com" in out
+
+    def test_unset_alias(self, temp_home, capsys):
+        switcher = self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command(["1", "dev"])
+            cli._alias_command(["1", "--unset"])
+        assert "Cleared alias" in capsys.readouterr().out
+        data = switcher._get_sequence_data()
+        assert "alias" not in data["accounts"]["1"]
+
+    def test_duplicate_alias_errors(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command(["1", "dev"])
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["2", "dev"])
+        assert exc.value.code == 1
+        assert "already used" in capsys.readouterr().err
+
+    def test_purely_numeric_alias_errors(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["1", "123"])
+        assert exc.value.code == 1
+        assert "Error" in capsys.readouterr().err
+
+    def test_unknown_identifier_errors(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["999", "dev"])
+        assert exc.value.code == 1
+        assert "Error" in capsys.readouterr().err
+
+    def test_identifier_without_name_or_unset_is_usage_error(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["1"])
+        assert exc.value.code == 2
+
+    def test_unset_with_name_is_usage_error(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["1", "dev", "--unset"])
+        assert exc.value.code == 2
+
+    def test_name_or_unset_without_identifier_is_usage_error(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        # argparse can't actually produce name-without-identifier via nargs="?"
+        # positional consumption order, but --unset alone (no identifier) can.
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["--unset"])
+        assert exc.value.code == 2
+
+    def test_alias_dispatched_from_main(self, temp_home):
+        """`cswap alias` routes through main() to _alias_command."""
+        with patch("claude_swap.cli._alias_command") as alias_fn, \
+             patch.object(sys, "argv", ["claude-swap", "alias", "1", "dev"]):
+            cli.main()
+        alias_fn.assert_called_once_with(["1", "dev"])
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="root guard is POSIX-only")
+    def test_alias_refuses_root(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=0, create=True), \
+             patch.object(ClaudeAccountSwitcher, "_is_running_in_container", return_value=False):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["1", "dev"])
+        assert exc.value.code == 1
+        assert "root" in capsys.readouterr().err
+
+    def test_switch_by_alias_end_to_end(self, temp_home, capsys):
+        """The real regression this feature fixes: switch_to used to reject
+        any non-digit identifier as an invalid email before the alias table
+        was ever consulted."""
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command(["2", "dev"])
+        # Drive main()'s translated `switch dev` -> --switch-to dev, same
+        # entry point a real invocation uses, and confirm it gets PAST
+        # identifier resolution (no "Invalid email format") to the next,
+        # expected failure (no stored credentials for this fixture account).
+        with patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "switch", "dev"]):
+            with pytest.raises(SystemExit):
+                cli.main()
+        err = capsys.readouterr().err
+        assert "Invalid email format" not in err
+
+
+class TestAddAliasFlag:
+    """`cswap add --alias NAME` convenience."""
+
+    def test_add_alias_wired_to_switcher(self, temp_home):
+        with patch.object(ClaudeAccountSwitcher, "add_account") as add_fn, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "add", "--alias", "dev"]):
+            cli.main()
+        add_fn.assert_called_once_with(slot=None, alias="dev")
+
+    def test_alias_flag_without_add_is_usage_error(self, temp_home, capsys):
+        with patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "status", "--alias", "dev"]):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code == 2
+
+
 class TestRunAutoResolve:
     """`cswap run` with no account resolves the cwd's directory mapping."""
 

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -171,6 +171,30 @@ class TestListJson:
         assert acct1["usageStatus"] == "ok"
         assert acct1["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
 
+    def test_list_payload_includes_alias_when_set(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        """Issue #110: the JSON payload carries alias per account for
+        scripting, absent when unset (never a null/empty-string filler)."""
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        sample_sequence_data["accounts"]["1"]["alias"] = "dev"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
+             patch.object(switcher, "_read_account_credentials", return_value=""), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
+            payload = switcher.list_accounts(json_output=True)
+
+        by_num = {a["number"]: a for a in payload["accounts"]}
+        assert by_num[1]["alias"] == "dev"
+        assert "alias" not in by_num[2]
+
     def test_usage_status_no_credentials_and_unavailable(
         self, temp_home: Path, mock_claude_config: Path,
         sample_sequence_data: dict,

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -127,6 +127,11 @@ def test_format_account_label():
     assert label == "2  loc@papaya.asia  5h 42% · 7d 18% · $ 30%"
 
 
+def test_format_account_label_with_alias():
+    label = menubar.format_account_label(2, "loc@papaya.asia", _USAGE, alias="dev")
+    assert label == "2  dev (loc@papaya.asia)  5h 42% · 7d 18% · $ 30%"
+
+
 # --- usage logging -------------------------------------------------------------
 
 def test_format_usage_log_full():
@@ -169,6 +174,12 @@ def test_usage_log_key_ignores_clock_tracks_pct():
 def test_format_title_name_and_5h():
     s = menubar.MenuBarSettings(show_account_name=True, title_pct="5h")
     assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄ loc · 42%"
+
+
+def test_format_title_prefers_alias_over_local_part():
+    s = menubar.MenuBarSettings(show_account_name=True, title_pct="5h")
+    got = menubar.format_title("loc@papaya.asia", _USAGE, s, active_alias="dev")
+    assert got == "⇄ dev · 42%"
 
 
 def test_format_title_name_only_when_pct_off():
@@ -332,11 +343,12 @@ class _FakeEntry:
 
 
 class _FakeAcct:
-    def __init__(self, number, email, is_active, usage):
+    def __init__(self, number, email, is_active, usage, alias=None):
         self.number = number
         self.email = email
         self.is_active = is_active
         self.usage = usage
+        self.alias = alias
 
 
 class _FakeSnap:
@@ -364,12 +376,21 @@ def test_adapt_snapshot_shape_and_active_selection():
     snap = menubar._adapt_snapshot(_FakeSnap(accts))
     assert snap["active_email"] == "a@x.com"
     assert snap["active_usage"] == lg
-    # (num, email, is_active, display_usage, last_good)
-    assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg)
+    assert snap["active_alias"] is None
+    # (num, email, is_active, display_usage, last_good, alias)
+    assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg, None)
     # sentinel account: display is the human note, last_good is None
     assert snap["accounts"][1] == (
-        "2", "b@x.com", False, menubar.SENTINEL_NOTES[USAGE_API_KEY], None,
+        "2", "b@x.com", False, menubar.SENTINEL_NOTES[USAGE_API_KEY], None, None,
     )
+
+
+def test_adapt_snapshot_carries_active_alias():
+    lg = {"five_hour": {"pct": 10.0}}
+    accts = [_FakeAcct("1", "a@x.com", True, _FakeEntry(last_good=lg), alias="dev")]
+    snap = menubar._adapt_snapshot(_FakeSnap(accts))
+    assert snap["active_alias"] == "dev"
+    assert snap["accounts"][0][5] == "dev"
 
 
 def test_adapt_snapshot_empty():

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -547,7 +547,7 @@ class TestFetchAccountUsageSessionProfile:
     """
 
     def _info(self, backup_creds: str) -> tuple:
-        return (2, "test@example.com", "Org", "org-uuid", False, backup_creds)
+        return (2, "test@example.com", "Org", "org-uuid", False, backup_creds, None)
 
     def test_fresh_session_credentials_fetch_read_only(self, temp_home: Path):
         """Profile creds are used with is_active=True (no refresh, no persist)."""
@@ -751,6 +751,31 @@ class TestListAccountsUsage:
         assert "└ 7d:" in output
         assert "10%" in output
         assert "50%" in output
+
+    def test_list_shows_alias_before_email_keeping_num_prefix(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        """Issue #110: an aliased account renders 'alias (email)' after the
+        '  {num}: ' prefix — the prefix itself must survive intact, since the
+        TUI watch view (tui._watch_account_rows) parses it for quick-switch."""
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        sample_sequence_data["accounts"]["1"]["alias"] = "dev"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
+            switcher.list_accounts()
+
+        output = capsys.readouterr().out
+        assert "  1: dev (test@example.com) [personal] (active)" in output
+        # unaliased account 2 keeps rendering plain email, not "None (...)"
+        assert "  2: account2@example.com" in output
 
     def test_list_shows_usage_null_reset(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
@@ -1389,7 +1414,7 @@ class TestActiveAccountRefresh:
             {"1": FetchRecord(usage={"five_hour": {"pct": 25.0}})},
             {"1": ("test@example.com", "")},
         )
-        info = (1, "test@example.com", "", "", True, self._EXPIRED)
+        info = (1, "test@example.com", "", "", True, self._EXPIRED, None)
 
         with patch.object(switcher, "_active_cc_running", return_value=True), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
@@ -2284,7 +2309,7 @@ class TestDeadTokenQuarantine:
         switcher = ClaudeAccountSwitcher()
         switcher._setup_directories()
         self._make_dead(switcher)
-        info = [(2, "test@example.com", "Org", "", False, self._dead_creds())]
+        info = [(2, "test@example.com", "Org", "", False, self._dead_creds(), None)]
 
         with patch("claude_swap.oauth.try_fetch_usage_for_account") as fetch:
             entries = switcher._collect_usage_entries(info)
@@ -2300,7 +2325,7 @@ class TestDeadTokenQuarantine:
         from claude_swap.usage_store import FetchRecord
         switcher = ClaudeAccountSwitcher()
         switcher._setup_directories()
-        info = [(2, "test@example.com", "Org", "", False, self._dead_creds())]
+        info = [(2, "test@example.com", "Org", "", False, self._dead_creds(), None)]
 
         with patch.object(
             switcher, "_run_usage_fetches",
@@ -2458,6 +2483,210 @@ class TestResolveIdentifierAmbiguity:
         (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data))
         switcher = ClaudeAccountSwitcher()
         assert switcher._resolve_account_identifier("account1@example.com") == "1"
+
+
+# ── Issue #110: per-account aliases ──────────────────────────────────────────
+
+class TestAccountAliases:
+    """set_alias/unset_alias/list_aliases and identifier resolution via alias."""
+
+    def _switcher(self, sample_sequence_data):
+        backup_dir = get_backup_root()
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        (backup_dir / "sequence.json").write_text(json.dumps(sample_sequence_data))
+        return ClaudeAccountSwitcher()
+
+    def test_set_alias_round_trips_by_number(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        num, normalized = switcher.set_alias("1", "Dev-Box")
+        assert num == "1"
+        assert normalized == "dev-box"  # lowercased
+        assert switcher._resolve_account_identifier("dev-box") == "1"
+        assert switcher._resolve_account_identifier("Dev-Box") == "1"  # case-insensitive lookup too
+
+    def test_set_alias_by_email(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        num, _ = switcher.set_alias("account2@example.com", "content")
+        assert num == "2"
+        assert switcher._resolve_account_identifier("content") == "2"
+
+    def test_number_precedence_over_alias(self, temp_home, sample_sequence_data):
+        """A purely-numeric alias can never be set, so a slot number always
+        resolves as a slot number, never as a collision with an alias."""
+        switcher = self._switcher(sample_sequence_data)
+        with pytest.raises(ValidationError):
+            switcher.set_alias("1", "2")
+
+    def test_alias_precedence_over_email(self, temp_home, sample_sequence_data):
+        """An alias that happens to look like an unrelated email string still
+        resolves as the alias it is (aliases are checked before email match)."""
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("1", "dev")
+        assert switcher._resolve_account_identifier("dev") == "1"
+
+    def test_duplicate_alias_rejected(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("1", "dev")
+        with pytest.raises(ConfigError, match="already used"):
+            switcher.set_alias("2", "dev")
+
+    def test_rename_via_existing_alias_identifier(self, temp_home, sample_sequence_data):
+        """cswap alias <old> <new> — identifier can itself be an alias."""
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("1", "dev")
+        num, normalized = switcher.set_alias("dev", "prod")
+        assert num == "1"
+        assert normalized == "prod"
+        assert switcher._resolve_account_identifier("prod") == "1"
+        assert switcher._resolve_account_identifier("dev") is None
+
+    def test_purely_numeric_alias_rejected(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        with pytest.raises(ValidationError, match="numeric"):
+            switcher.set_alias("1", "123")
+
+    def test_alias_with_invalid_characters_rejected(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        with pytest.raises(ValidationError):
+            switcher.set_alias("1", "has space")
+        with pytest.raises(ValidationError):
+            switcher.set_alias("1", "has@at")
+
+    def test_alias_normalized_lowercase_and_trimmed(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        _, normalized = switcher.set_alias("1", "  Dev_Box.1  ")
+        assert normalized == "dev_box.1"
+
+    def test_set_alias_unknown_identifier_raises(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        with pytest.raises(AccountNotFoundError):
+            switcher.set_alias("999", "dev")
+
+    def test_unset_alias_clears_and_resolution_reverts(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("1", "dev")
+        num = switcher.unset_alias("1")
+        assert num == "1"
+        assert switcher._resolve_account_identifier("dev") is None
+        assert switcher._resolve_account_identifier("1") == "1"  # slot number unaffected
+
+    def test_unset_alias_idempotent(self, temp_home, sample_sequence_data):
+        """Clearing an already-unset alias must not raise."""
+        switcher = self._switcher(sample_sequence_data)
+        switcher.unset_alias("1")  # never set — should be a silent no-op
+        switcher.unset_alias("1")
+
+    def test_list_aliases_sequence_order(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("2", "content")
+        switcher.set_alias("1", "dev")
+        assert switcher.list_aliases() == [
+            ("1", "dev", "account1@example.com"),
+            ("2", "content", "account2@example.com"),
+        ]
+
+    def test_list_aliases_empty(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        assert switcher.list_aliases() == []
+
+    def test_switch_to_accepts_alias_without_email_format_error(
+        self, temp_home, sample_sequence_data
+    ):
+        """The real bug this feature guards against: switch_to used to gate
+        every non-digit identifier through _validate_email before it ever
+        reached _resolve_account_identifier, so `cswap switch dev` failed
+        with 'Invalid email format' instead of resolving the alias."""
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("2", "dev")
+        with pytest.raises(SwitchError, match="no stored credentials"):
+            # Gets past identifier resolution (no ValidationError) and fails
+            # later for an unrelated, expected reason: no stored credentials
+            # for this synthetic fixture account.
+            switcher.switch_to("dev")
+
+    def test_remove_account_accepts_alias_without_email_format_error(
+        self, temp_home, sample_sequence_data
+    ):
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("2", "dev")
+        with patch("builtins.input", return_value="n"):
+            switcher.remove_account("dev", assume_yes=False)
+        # Reaching the confirmation path (not a ValidationError) proves the
+        # alias resolved; the account is still present since input() was "n".
+        data = switcher._get_sequence_data()
+        assert "2" in data["accounts"]
+
+    def test_add_account_preserves_alias_on_reslot(self, temp_home, sample_sequence_data):
+        """Moving an aliased account to a new explicit slot must not silently
+        drop its alias (the gap the maintainer flagged for `cswap add`)."""
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("1", "dev")
+
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "at", "refreshToken": "rt"}})
+        config_path = temp_home / ".claude.json"
+        config_path.write_text(json.dumps({
+            "oauthAccount": {"emailAddress": "account1@example.com", "accountUuid": "u"}
+        }))
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"):
+            switcher.add_account(slot=3, assume_yes=True)
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["3"]["alias"] == "dev"
+        assert "1" not in data["accounts"]
+
+    def test_add_account_alias_kwarg_sets_alias_on_new_account(
+        self, temp_home, sample_sequence_data
+    ):
+        """cswap add --alias dev convenience."""
+        switcher = self._switcher(sample_sequence_data)
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "at", "refreshToken": "rt"}})
+        config_path = temp_home / ".claude.json"
+        config_path.write_text(json.dumps({
+            "oauthAccount": {"emailAddress": "new@example.com", "accountUuid": "u"}
+        }))
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"):
+            switcher.add_account(alias="newbie")
+
+        data = switcher._get_sequence_data()
+        num = switcher._find_account_slot(data, "new@example.com", "")
+        assert data["accounts"][num]["alias"] == "newbie"
+
+    def test_add_account_alias_collision_raises(self, temp_home, sample_sequence_data):
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("1", "dev")
+
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "at", "refreshToken": "rt"}})
+        config_path = temp_home / ".claude.json"
+        config_path.write_text(json.dumps({
+            "oauthAccount": {"emailAddress": "new@example.com", "accountUuid": "u"}
+        }))
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             pytest.raises(ConfigError, match="already used"):
+            switcher.add_account(alias="dev")
+
+    def test_add_account_refresh_in_place_never_touches_alias(
+        self, temp_home, sample_sequence_data
+    ):
+        """Re-running `cswap add` for an already-managed account (the
+        refresh-credentials-in-place branch) must leave its alias untouched —
+        it never even looks at the alias field."""
+        switcher = self._switcher(sample_sequence_data)
+        switcher.set_alias("1", "dev")
+
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "at2", "refreshToken": "rt2"}})
+        config_path = temp_home / ".claude.json"
+        config_path.write_text(json.dumps({
+            "oauthAccount": {"emailAddress": "account1@example.com", "accountUuid": "u"}
+        }))
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"):
+            switcher.add_account()
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["alias"] == "dev"
 
 
 # ── Task 7: list_accounts org display ────────────────────────────────────────
@@ -5254,8 +5483,8 @@ class TestDuplicateAccountDetection:
             "accessToken": "sk", "refreshToken": "rt-shared",
         }})
         info = [
-            (1, "account1@example.com", "", "", True, same),
-            (2, "account2@example.com", "", "", False, same),
+            (1, "account1@example.com", "", "", True, same, None),
+            (2, "account2@example.com", "", "", False, same, None),
         ]
         warnings = switcher._duplicate_account_warnings(info)
         assert len(warnings) == 1
@@ -5267,8 +5496,8 @@ class TestDuplicateAccountDetection:
         sample_sequence_data["accounts"]["2"]["uuid"] = "uuid-1"
         switcher = self._switcher(temp_home, sample_sequence_data)
         info = [
-            (1, "account1@example.com", "", "", True, "creds-a"),
-            (2, "account2@example.com", "", "", False, "creds-b"),
+            (1, "account1@example.com", "", "", True, "creds-a", None),
+            (2, "account2@example.com", "", "", False, "creds-b", None),
         ]
         warnings = switcher._duplicate_account_warnings(info)
         assert len(warnings) == 1
@@ -5282,8 +5511,8 @@ class TestDuplicateAccountDetection:
         sample_sequence_data["accounts"]["2"]["uuid"] = ""
         switcher = self._switcher(temp_home, sample_sequence_data)
         info = [
-            (1, "setup-token-1@token.local", "", "", True, "creds-a"),
-            (2, "setup-token-2@token.local", "", "", False, "creds-b"),
+            (1, "setup-token-1@token.local", "", "", True, "creds-a", None),
+            (2, "setup-token-2@token.local", "", "", False, "creds-b", None),
         ]
         assert switcher._duplicate_account_warnings(info) == []
 
@@ -5293,9 +5522,9 @@ class TestDuplicateAccountDetection:
         switcher = self._switcher(temp_home, sample_sequence_data)
         info = [
             (1, "account1@example.com", "", "", True,
-             json.dumps({"claudeAiOauth": {"refreshToken": "rt-1"}})),
+             json.dumps({"claudeAiOauth": {"refreshToken": "rt-1"}}), None),
             (2, "account2@example.com", "", "", False,
-             json.dumps({"claudeAiOauth": {"refreshToken": "rt-2"}})),
+             json.dumps({"claudeAiOauth": {"refreshToken": "rt-2"}}), None),
         ]
         assert switcher._duplicate_account_warnings(info) == []
 
@@ -5314,7 +5543,7 @@ class TestLockstepUsageDetection:
     @staticmethod
     def _info(n=2):
         return [
-            (i, f"account{i}@example.com", "", "", i == 1, f"creds-{i}")
+            (i, f"account{i}@example.com", "", "", i == 1, f"creds-{i}", None)
             for i in range(1, n + 1)
         ]
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -50,6 +50,7 @@ def _seed_account(
     org_name: str = "",
     creds: dict | None = None,
     config: dict | None = None,
+    alias: str | None = None,
 ) -> None:
     """Write an account to backup + sequence.json."""
     creds_obj = creds if creds is not None else {**SAMPLE_CREDS, "_marker": email}
@@ -77,6 +78,8 @@ def _seed_account(
         "organizationName": org_name,
         "added": "2024-01-01T00:00:00Z",
     }
+    if alias:
+        data["accounts"][str(num)]["alias"] = alias
     if num not in data["sequence"]:
         data["sequence"].append(num)
         data["sequence"].sort()
@@ -156,6 +159,107 @@ class TestRoundTrip:
                 import_accounts(dst, str(out_file))
                 final = dst._get_sequence_data()
                 assert final["activeAccountNumber"] == 9  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Issue #110: alias export/import
+# ---------------------------------------------------------------------------
+
+
+class TestAliasTransfer:
+    def test_alias_round_trips(self, temp_home: Path):
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com", alias="dev")
+        _seed_account(src, 2, "bob@example.com")  # no alias
+
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+        envelope = json.loads(out_file.read_text())
+        by_email = {a["email"]: a for a in envelope["accounts"]}
+        assert by_email["alice@example.com"]["alias"] == "dev"
+        assert "alias" not in by_email["bob@example.com"]
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                import_accounts(dst, str(out_file))
+                seq = dst._get_sequence_data()
+                assert seq["accounts"]["1"]["alias"] == "dev"
+                assert "alias" not in seq["accounts"]["2"]
+
+    def test_invalid_alias_in_export_rejected(self, temp_home: Path):
+        """A malformed alias in a hand-edited/corrupted export file must fail
+        validation cleanly, not silently corrupt the destination's sequence.json."""
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com")
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+
+        envelope = json.loads(out_file.read_text())
+        envelope["accounts"][0]["alias"] = "123"  # purely numeric: invalid
+        out_file.write_text(json.dumps(envelope))
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                with pytest.raises(TransferError, match="invalid alias"):
+                    import_accounts(dst, str(out_file))
+
+    def test_alias_colliding_with_existing_local_account_dropped_with_warning(
+        self, temp_home: Path
+    ):
+        """Alias is display sugar, not critical data: a collision with an
+        alias already present at the destination must not abort the whole
+        import — the account still imports, just without that name."""
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com", alias="dev")
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                _seed_account(dst, 9, "existing@example.com", alias="dev")
+
+                import_accounts(dst, str(out_file))
+
+                seq = dst._get_sequence_data()
+                imported_num = next(
+                    n for n, acc in seq["accounts"].items()
+                    if acc["email"] == "alice@example.com"
+                )
+                assert "alias" not in seq["accounts"][imported_num]
+                # The pre-existing local alias is untouched.
+                assert seq["accounts"]["9"]["alias"] == "dev"
+
+    def test_duplicate_alias_within_one_export_rejected(self, temp_home: Path):
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com")
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+        envelope = json.loads(out_file.read_text())
+        # Hand-craft a second account entry sharing the same alias.
+        second = dict(envelope["accounts"][0])
+        second["number"] = 2
+        second["email"] = "bob@example.com"
+        envelope["accounts"][0]["alias"] = "dev"
+        second["alias"] = "dev"
+        envelope["accounts"].append(second)
+        out_file.write_text(json.dumps(envelope))
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                with pytest.raises(TransferError, match="duplicate alias"):
+                    import_accounts(dst, str(out_file))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -77,6 +77,7 @@ def make_account(
     kind: str = "oauth",
     entry: UsageEntry | None = None,
     email: str | None = None,
+    alias: str | None = None,
 ) -> AccountSnapshot:
     return AccountSnapshot(
         number=str(number),
@@ -87,6 +88,7 @@ def make_account(
         kind=kind,
         switchable=switchable,
         usage=entry if entry is not None else make_entry(),
+        alias=alias,
     )
 
 
@@ -267,6 +269,25 @@ class TestFormatting:
             80,
         ).plain
         assert "last seen" not in api_key
+
+    def test_account_card_and_mini_text_show_alias_before_email(self):
+        """Issue #110: aliased accounts render 'alias (email)' in both the
+        full card (dashboard) and the minimized line (inactive accounts)."""
+        from claude_swap.tui.widgets import account_card_text, mini_account_text
+
+        aliased = make_account(1, active=True, email="dev@example.com", alias="dev")
+        card = account_card_text(aliased, 80).plain
+        assert "dev (dev@example.com)" in card
+
+        unaliased = make_account(2, email="plain@example.com")
+        card2 = account_card_text(unaliased, 80).plain
+        assert "plain@example.com" in card2
+        assert "(plain@example.com)" not in card2  # no spurious parens without an alias
+
+        mini = mini_account_text(
+            make_account(3, email="mini@example.com", alias="short"), time.time()
+        ).plain
+        assert "short (mini@example.com)" in mini
 
     def test_window_helpers(self):
         entry = make_entry(pct5=47.0)


### PR DESCRIPTION
Closes #110.

## What this adds

```
cswap alias 2 dev            # set (also: cswap alias user@example.com dev)
cswap alias dev prod         # rename (identifier can itself be an alias)
cswap alias 2 --unset        # remove
cswap alias                  # list current aliases
cswap add --alias dev        # convenience at add time
```

Aliases work anywhere an identifier does: `cswap switch dev`, `cswap remove dev`, `cswap run dev`.

## Following the spec worked out in the issue thread

Resolution precedence is **number → alias → email**. Validation: letters/digits/`-`/`_`/`.`, non-empty, normalized to lowercase, never purely numeric (reserved for slot numbers), unique across accounts.

The issue thread flagged three specific gaps in a first-draft design, all addressed here:

1. **`switch`/`remove` would reject aliases before resolution.** Both `switch_to` and `remove_account` validate a non-digit identifier with `_validate_email()` *before* `_resolve_account_identifier` is ever called, so `cswap switch dev` would fail with "Invalid email format". Both now check `_is_known_alias()` first and skip that gate for a recognized alias.
2. **The real display plumbing is the `accounts_info` 7-tuple (now, was 6), not `AccountInfo`.** Threaded through `_build_accounts_info` → `list_accounts`'s print loop (alias renders as `alias (email)` *after* the `  {num}: ` prefix the TUI watch-view parser depends on, never replacing it), `AccountSnapshot` (TUI account cards + remove menu), `account_row` in `json_output.py`, and the menu bar's `format_title`/`format_account_label`/dropdown/remove menu.
3. **Export/import and `add` re-run.** `transfer.py` carries `alias` through export and validates it on import (rejects a malformed alias, rejects a duplicate alias within one export file; a collision against an *already-present local* alias warns and drops just the alias rather than aborting the whole import, since alias is display sugar, not critical account data). Re-running `cswap add` on an already-managed account (the refresh-in-place branch) never touches the alias field at all; moving an aliased account to a new explicit `--slot` preserves it instead of silently wiping it.

## Storage

An optional `alias` field on each account record in `sequence.json`, alongside the existing `email`/`uuid`/`organizationUuid`/`organizationName`/`added`. Missing/`null` for every pre-existing account, so no migration is needed.

## Tests

45 new tests:
- `test_switcher.py` (`TestAccountAliases`, 20 tests): set/unset/list, number/alias/email resolution precedence, duplicate/numeric/invalid-character rejection, rename via an existing alias as the identifier, `switch_to`/`remove_account` no longer gate aliases on email format, `add_account` preserves alias across a re-slot and via `--alias`, refresh-in-place never touches it.
- `test_cli.py` (`TestAliasCommand` + `TestAddAliasFlag`, 15 tests): the full `cswap alias` command including usage-error argument combinations, root guard, main() dispatch, and an end-to-end `cswap switch dev` drive proving the identifier reaches `main()` without an "Invalid email format" error.
- `test_json_output.py`: `alias` present when set, absent (not null) when unset.
- `test_tui.py`: `account_card_text`/`mini_account_text` render `alias (email)`.
- `test_menubar.py`: `format_account_label`/`format_title` prefer alias; `_adapt_snapshot` carries it through.
- `test_transfer.py` (`TestAliasTransfer`, 4 tests): round-trip, invalid-alias rejection, same-export duplicate rejection, cross-machine collision drops the alias without aborting the import.

Full suite: 1250 passed, 3 skipped (up from 1205 passed on main).