### PR TITLE
feat: per-account aliases (short names)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Or switch to a specific account:
 ```bash
 cswap switch 2
 cswap switch user@example.com
+cswap switch dev                # or by alias, once set with `cswap alias 2 dev`
 ```
 
 Not sure which one? `cswap list` is the dashboard — every account's 5-hour and 7-day usage and reset times at a glance:
@@ -168,7 +169,11 @@ cswap config                    # Show or edit settings (see Configuration below
 cswap list                      # Show all accounts with 5h/7d usage and reset times
 cswap status                    # Show current account
 cswap add --slot 3              # Add account to a specific slot (prompts before overwrite)
+cswap add --alias dev           # Add account and give it a short alias
 cswap remove 2                  # Remove an account
+cswap alias 2 dev               # Give an account a short alias (usable anywhere NUM|EMAIL is)
+cswap alias 2 --unset           # Remove an account's alias
+cswap alias                     # List all aliases
 cswap tui                       # Interactive dashboard (also: bare `cswap`)
 cswap watch                     # Dashboard, opened on the live watch page
 cswap upgrade                   # Upgrade claude-swap to the latest version
@@ -286,6 +291,8 @@ cswap switch 2 --json
 Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
 
 Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is.
+
+An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
 
 </details>
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -372,6 +372,8 @@ Examples:
 
     if args.unset and args.alias_name:
         parser.error("--unset does not take a NAME argument")
+    if args.unset and args.account is None:
+        parser.error("NUM|EMAIL is required with --unset")
     if args.account is not None and not args.unset and not args.alias_name:
         parser.error("NAME is required (or pass --unset to remove the alias)")
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -12,6 +12,7 @@ from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
 from claude_swap.printer import (
     accent,
+    bolded,
     dimmed,
     error,
     force_utf8_output,
@@ -382,13 +383,21 @@ Examples:
         _guard_root(switcher)
 
         if args.account is None:
-            switcher.list_aliases()
+            rows = switcher.list_aliases()
+            if not rows:
+                print(dimmed("No aliases set"))
+                return
+            print(bolded("Aliases:"))
+            for num, alias_name, email in rows:
+                print(f"  {num}: {alias_name} {muted(f'({email})')}")
             return
 
         if args.unset:
-            switcher.alias(args.account, unset=True)
+            account_num = switcher.unset_alias(args.account)
+            print(f"{accent('Removed alias')} for Account {account_num}")
         else:
-            switcher.alias(args.account, args.alias_name)
+            account_num, normalized = switcher.set_alias(args.account, args.alias_name)
+            print(f"{accent('Set alias')} '{normalized}' for Account {account_num}")
     except ClaudeSwitchError as e:
         error(f"Error: {e}")
         sys.exit(1)

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -330,6 +330,71 @@ def _unmap_command(argv: list[str]) -> None:
         sys.exit(130)
 
 
+def _alias_command(argv: list[str]) -> None:
+    """Handle `cswap alias [NUM|EMAIL] [NAME] [--unset]`.
+
+    With no arguments, lists all aliases. Otherwise sets (or, with --unset,
+    removes) the alias for the given account. Pre-dispatched before the main
+    parser for the same reason as `map` (the main parser's required
+    mutually-exclusive group can't hold a positional subcommand).
+    """
+    parser = argparse.ArgumentParser(
+        prog="cswap alias",
+        description=(
+            "Set, remove, or list a short display alias for an account. "
+            "Once set, the alias can be used anywhere an account number or "
+            "email is accepted (switch, remove, run, map)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap alias 2 dev
+  cswap alias user@example.com dev
+  cswap alias 2 --unset
+  cswap alias                         # list all aliases
+        """,
+    )
+    parser.add_argument(
+        "account",
+        nargs="?",
+        metavar="NUM|EMAIL",
+        help="Account to alias (number or email). Omit to list aliases.",
+    )
+    parser.add_argument(
+        "alias_name",
+        nargs="?",
+        metavar="NAME",
+        help="Alias to set (letters, digits, ., -, _; not purely numeric).",
+    )
+    parser.add_argument("--unset", action="store_true", help="Remove the account's alias")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    if args.unset and args.alias_name:
+        parser.error("--unset does not take a NAME argument")
+    if args.account is not None and not args.unset and not args.alias_name:
+        parser.error("NAME is required (or pass --unset to remove the alias)")
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+
+        if args.account is None:
+            switcher.list_aliases()
+            return
+
+        if args.unset:
+            switcher.alias(args.account, unset=True)
+        else:
+            switcher.alias(args.account, args.alias_name)
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
 def _auto_command(argv: list[str]) -> None:
     """Handle `cswap auto [--once] [--json] [...]`.
 
@@ -684,6 +749,9 @@ def main() -> None:
     if argv and argv[0] == "unmap":
         _unmap_command(argv[1:])
         return
+    if argv and argv[0] == "alias":
+        _alias_command(argv[1:])
+        return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like
     # lazygit/k9s). TTY-gated on both ends so scripts and pipes keep getting
@@ -715,6 +783,9 @@ Commands:
   %(prog)s map <num|email> [path]     map a directory to an account
   %(prog)s map                        list directory mappings
   %(prog)s unmap [path]               remove a directory mapping
+  %(prog)s alias <num|email> <name>   set a short alias for an account
+  %(prog)s alias <num|email> --unset  remove an account's alias
+  %(prog)s alias                      list all aliases
   %(prog)s auto                       auto-switch when nearing rate limits
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s export <path>              export accounts
@@ -805,6 +876,11 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         "--account",
         metavar="NUM|EMAIL",
         help="Limit export to one account (use with 'export')",
+    )
+    parser.add_argument(
+        "--alias",
+        metavar="NAME",
+        help="Set a short display alias for the account (use with 'add')",
     )
     parser.add_argument(
         "--force",
@@ -957,6 +1033,9 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.account is not None and not args.export:
         parser.error("--account can only be used with 'export'")
 
+    if args.alias is not None and not args.add_account:
+        parser.error("--alias can only be used with 'add'")
+
     if args.force and not (args.import_ or args.switch_to):
         parser.error("--force can only be used with 'import' or 'switch <num|email>'")
 
@@ -991,7 +1070,7 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
                 sys.exit(1)
 
         if args.add_account:
-            switcher.add_account(slot=args.slot)
+            switcher.add_account(slot=args.slot, alias=args.alias)
         elif args.add_token is not None:
             switcher.add_account_from_token(
                 token=args.add_token,

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -146,6 +146,7 @@ def account_row(
     *,
     usage_fetched_at: float | None = None,
     usage_age_s: float | None = None,
+    alias: str = "",
 ) -> dict:
     """A full account row for ``--list``."""
     status, usage = usage_fields(usage_entry)
@@ -159,6 +160,8 @@ def account_row(
         "usageStatus": status,
         "usage": usage,
     }
+    if alias:
+        row["alias"] = alias
     if usage is not None:
         row.update(usage_freshness_fields(usage_fetched_at, usage_age_s))
     return row

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -206,10 +206,15 @@ def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
 
 
 def format_account_label(
-    num, email: str, usage: dict | str | None, now: float | None = None
+    num,
+    email: str,
+    usage: dict | str | None,
+    now: float | None = None,
+    alias: str | None = None,
 ) -> str:
     """Build one account row's menu label."""
-    return f"{num}  {email}  {usage_summary(usage, now)}"
+    label = f"{alias}  ({email})" if alias else email
+    return f"{num}  {label}  {usage_summary(usage, now)}"
 
 
 def _local_part(email: str, limit: int = 12) -> str:
@@ -225,6 +230,7 @@ def format_title(
     active_usage: dict | str | None,
     settings: MenuBarSettings,
     now: float | None = None,
+    alias: str | None = None,
 ) -> str:
     """Build the menu-bar title from the active account and settings."""
     if active_email is None:
@@ -233,7 +239,7 @@ def format_title(
         now = time.time()
     segments: list[str] = []
     if settings.show_account_name:
-        segments.append(_local_part(active_email))
+        segments.append(alias if alias else _local_part(active_email))
     if settings.title_pct in ("5h", "both"):
         p = _window_pct(active_usage, "five_hour")
         if p is not None:
@@ -321,29 +327,39 @@ def _account_display_usage(entry) -> dict | str | None:
     return entry.last_good
 
 
-EMPTY_SNAPSHOT: dict = {"accounts": [], "active_email": None, "active_usage": None}
+EMPTY_SNAPSHOT: dict = {
+    "accounts": [],
+    "active_email": None,
+    "active_usage": None,
+    "active_alias": None,
+}
 
 
 def _adapt_snapshot(snap) -> dict:
     """Adapt an ``AccountsSnapshot`` to the menu bar's render dict.
 
-    Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good), ...],
-    "active_email": str | None, "active_usage": dict | str | None}``. The snapshot
-    itself is produced by ``SnapshotSource`` (the paced read path), so this is a
-    pure transform — no fetching, no I/O.
+    Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good, alias), ...],
+    "active_email": str | None, "active_usage": dict | str | None,
+    "active_alias": str | None}``. The snapshot itself is produced by
+    ``SnapshotSource`` (the paced read path), so this is a pure transform — no
+    fetching, no I/O.
     """
     accounts = []
     active_email = None
     active_usage = None
+    active_alias = None
     for acc in snap.accounts:
         display = _account_display_usage(acc.usage)
-        accounts.append((acc.number, acc.email, acc.is_active, display, acc.usage.last_good))
+        accounts.append(
+            (acc.number, acc.email, acc.is_active, display, acc.usage.last_good, acc.alias)
+        )
         if acc.is_active:
-            active_email, active_usage = acc.email, display
+            active_email, active_usage, active_alias = acc.email, display, acc.alias
     return {
         "accounts": accounts,
         "active_email": active_email,
         "active_usage": active_usage,
+        "active_alias": active_alias,
     }
 
 
@@ -428,7 +444,7 @@ def run(switcher) -> int:
             but de-dupes per account on the (5h, 7d) percentages so an idle
             machine doesn't churn the rotating log with identical lines.
             """
-            for num, email, _is_active, _display, last_good in snap["accounts"]:
+            for num, email, _is_active, _display, last_good, _alias in snap["accounts"]:
                 key = _usage_log_key(last_good)
                 if key == (None, None) or self._last_usage_log.get(num) == key:
                     continue
@@ -538,13 +554,16 @@ def run(switcher) -> int:
         # ---- menu construction -----------------------------------------------
         def rebuild_menu(self):
             self.title = format_title(
-                self.snapshot["active_email"], self.snapshot["active_usage"], self.settings
+                self.snapshot["active_email"],
+                self.snapshot["active_usage"],
+                self.settings,
+                alias=self.snapshot.get("active_alias"),
             )
             self.menu.clear()
             account_items = []
-            for num, email, is_active, display, _last_good in self.snapshot["accounts"]:
+            for num, email, is_active, display, _last_good, alias in self.snapshot["accounts"]:
                 item = rumps.MenuItem(
-                    format_account_label(num, email, display),
+                    format_account_label(num, email, display, alias=alias),
                     callback=self._make_switch_to(num),
                 )
                 item.state = 1 if is_active else 0
@@ -581,8 +600,9 @@ def run(switcher) -> int:
             accounts = self.snapshot["accounts"]
             if not accounts:
                 menu.add(rumps.MenuItem("No managed accounts", callback=None))
-            for num, email, _is_active, _display, _last_good in accounts:
-                menu.add(rumps.MenuItem(f"{num}  {email}", callback=self._make_remove(num)))
+            for num, email, _is_active, _display, _last_good, alias in accounts:
+                label = f"{num}  {alias}  ({email})" if alias else f"{num}  {email}"
+                menu.add(rumps.MenuItem(label, callback=self._make_remove(num)))
             return menu
 
         def _history_menu(self, rumps):

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -108,6 +108,7 @@ class AccountSnapshot:
     kind: str  # "oauth" | "api_key"
     switchable: bool
     usage: UsageEntry
+    alias: str = ""
 
     @property
     def display_tag(self) -> str:

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -15,6 +16,35 @@ from claude_swap.usage_store import UsageEntry
 
 if TYPE_CHECKING:
     from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+#: Alias validation: letters/digits/-/_/., non-empty, not purely digits (so an
+#: alias can never collide with a slot number in _resolve_account_identifier),
+#: and not leading with '-' (argparse would treat it as an option, making the
+#: alias impossible to pass back into any command once set).
+_ALIAS_RE = re.compile(r"^[a-z0-9_.-]+$")
+
+
+def normalize_alias(name: str) -> str:
+    """Lowercase and validate a proposed alias; raise ValueError if invalid.
+
+    Shared by the CLI (``cswap alias``), ``cswap add --alias``, and import
+    validation so every path enforces identical rules.
+    """
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("alias cannot be empty")
+    if normalized.isdigit():
+        raise ValueError(f"alias '{name}' cannot be purely numeric (reserved for slot numbers)")
+    if normalized.startswith("-"):
+        raise ValueError(
+            f"alias '{name}' cannot start with '-' (would be read as a command flag)"
+        )
+    if not _ALIAS_RE.match(normalized):
+        raise ValueError(
+            f"alias '{name}' may only contain letters, digits, '-', '_', and '.'"
+        )
+    return normalized
 
 
 class Platform(Enum):

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -324,8 +324,15 @@ class ClaudeAccountSwitcher:
         return bool(re.match(pattern, email))
 
     def _validate_alias(self, alias: str) -> bool:
-        """Validate alias format: letters/digits/-/_/. only, not purely digits."""
+        """Validate alias format: letters/digits/-/_/. only, not purely digits.
+
+        Must not start with '-': argparse treats a leading-hyphen positional
+        as an option, so such an alias could never be passed back in on the
+        command line once set.
+        """
         if not re.match(r"^[A-Za-z0-9._-]+$", alias):
+            return False
+        if alias.startswith("-"):
             return False
         return not alias.isdigit()
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -51,6 +51,7 @@ from claude_swap.models import (
     Platform,
     SwitchTransaction,
     get_timestamp,
+    normalize_alias,
 )
 from claude_swap.printer import (
     abbreviate_path,
@@ -323,19 +324,6 @@ class ClaudeAccountSwitcher:
         pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
         return bool(re.match(pattern, email))
 
-    def _validate_alias(self, alias: str) -> bool:
-        """Validate alias format: letters/digits/-/_/. only, not purely digits.
-
-        Must not start with '-': argparse treats a leading-hyphen positional
-        as an option, so such an alias could never be passed back in on the
-        command line once set.
-        """
-        if not re.match(r"^[A-Za-z0-9._-]+$", alias):
-            return False
-        if alias.startswith("-"):
-            return False
-        return not alias.isdigit()
-
     def _setup_directories(self) -> None:
         """Create backup directories with proper permissions."""
         for directory in [self.backup_dir, self.configs_dir, self.credentials_dir]:
@@ -574,18 +562,52 @@ class ClaudeAccountSwitcher:
             record.get("organizationUuid", "") or "",
         )
 
-    def alias(self, identifier: str, alias: str | None = None, *, unset: bool = False) -> None:
-        """Set or unset the display alias for an account.
+    def set_alias(self, identifier: str, alias: str) -> tuple[str, str]:
+        """Set (or rename) the alias for the account matching identifier.
 
-        Args:
-            identifier: NUM|ALIAS|EMAIL identifying the account.
-            alias: New alias to set. Required unless ``unset`` is True.
-            unset: When True, remove the account's existing alias instead.
+        ``identifier`` is a slot number, email, or existing alias (so a
+        typo'd alias can be corrected with ``cswap alias <old> <new>`` as
+        well as by number/email). Returns ``(account_num, normalized_alias)``.
 
         Raises:
             AccountNotFoundError: identifier doesn't match any account.
             ValidationError: alias format is invalid.
-            ConfigError: alias is already used by another account.
+            ConfigError: the normalized alias is already used by another account.
+        """
+        try:
+            normalized = normalize_alias(alias)
+        except ValueError as e:
+            raise ValidationError(str(e)) from e
+
+        self._get_sequence_data_migrated()
+        account_num = self._resolve_account_identifier(identifier)
+        if not account_num:
+            raise AccountNotFoundError(
+                f"No account found with identifier: {identifier}"
+            )
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(account_num)
+        if not record:
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+
+        conflict = self._alias_in_use(normalized, exclude_num=account_num)
+        if conflict is not None:
+            raise ConfigError(f"Alias '{normalized}' is already used by account {conflict}")
+
+        record["alias"] = normalized
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        return account_num, normalized
+
+    def unset_alias(self, identifier: str) -> str:
+        """Clear the alias for the account matching identifier.
+
+        Returns the account number. Idempotent: clearing an already-unset
+        alias succeeds silently (no error), matching ``cswap config unset``'s
+        posture of "the end state is what you asked for".
+
+        Raises:
+            AccountNotFoundError: identifier doesn't match any account.
         """
         self._get_sequence_data_migrated()
         account_num = self._resolve_account_identifier(identifier)
@@ -598,33 +620,14 @@ class ClaudeAccountSwitcher:
         if not record:
             raise AccountNotFoundError(f"Account-{account_num} does not exist")
 
-        if unset:
-            if "alias" in record:
-                del record["alias"]
-                data["lastUpdated"] = get_timestamp()
-                self._write_json(self.sequence_file, data)
-            print(f"{accent('Removed alias')} for Account {account_num} ({record.get('email', '')})")
-            return
+        if "alias" in record:
+            del record["alias"]
+            data["lastUpdated"] = get_timestamp()
+            self._write_json(self.sequence_file, data)
+        return account_num
 
-        if not alias:
-            raise ValidationError("Alias name is required (use --unset to remove one)")
-        if not self._validate_alias(alias):
-            raise ValidationError(f"Invalid alias: {alias}")
-        normalized = alias.lower()
-        conflict = self._alias_in_use(normalized, exclude_num=account_num)
-        if conflict is not None:
-            raise ConfigError(f"Alias '{normalized}' is already used by account {conflict}")
-
-        record["alias"] = normalized
-        data["lastUpdated"] = get_timestamp()
-        self._write_json(self.sequence_file, data)
-        print(
-            f"{accent('Set alias')} '{normalized}' for Account {account_num} "
-            f"({record.get('email', '')})"
-        )
-
-    def list_aliases(self) -> None:
-        """Print all accounts that currently have an alias set."""
+    def list_aliases(self) -> list[tuple[str, str, str]]:
+        """Every set alias as ``(account_num, alias, email)``, slot-number order."""
         data = self._get_sequence_data_migrated()
         accounts = (data or {}).get("accounts", {})
         rows = [
@@ -632,11 +635,7 @@ class ClaudeAccountSwitcher:
             for num, acc in accounts.items()
             if acc.get("alias")
         ]
-        if not rows:
-            print(dimmed("No aliases set"))
-            return
-        for num, alias_name, email in sorted(rows, key=lambda r: int(r[0])):
-            print(f"  {num}: {alias_name} {muted(f'({email})')}")
+        return sorted(rows, key=lambda r: int(r[0]))
 
     def slot_for_directory(self, directory: str | Path) -> tuple[str | None, str | None]:
         """Resolve a directory to its mapped account slot, for `cswap run`.
@@ -1090,7 +1089,14 @@ class ClaudeAccountSwitcher:
         return org_name if org_name else "personal"
 
     def _find_account_by_alias(self, alias: str) -> str | None:
-        """Return the account number whose alias matches (case-insensitive), if any."""
+        """Return the account number whose alias matches (case-insensitive), if any.
+
+        An empty ``alias`` never matches: accounts without one store no
+        ``alias`` key, and comparing against an empty string would otherwise
+        match the first aliasless account.
+        """
+        if not alias:
+            return None
         data = self._get_sequence_data()
         if not data:
             return None
@@ -1243,9 +1249,10 @@ class ClaudeAccountSwitcher:
         self._migrate_org_fields()
 
         if alias is not None:
-            if not self._validate_alias(alias):
-                raise ValidationError(f"Invalid alias: {alias}")
-            alias = alias.lower()
+            try:
+                alias = normalize_alias(alias)
+            except ValueError as e:
+                raise ValidationError(str(e)) from e
 
         identity = self._get_current_account()
         if identity is None:
@@ -2506,12 +2513,12 @@ class ClaudeAccountSwitcher:
         print(bolded("Accounts:"))
         for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
-            alias_part = f" {muted(f'[{alias}]')}" if alias else ""
+            label = f"{accent(alias)} ({email})" if alias else email
             if is_active:
                 marker = f" {bold_accent('(active)')}"
-                print(f"  {num}: {email}{alias_part} {muted(f'[{tag}]')}{marker}")
+                print(f"  {num}: {label} {muted(f'[{tag}]')}{marker}")
             else:
-                print(f"  {num}: {email}{alias_part} {muted(f'[{tag}]')}")
+                print(f"  {num}: {label} {muted(f'[{tag}]')}")
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -323,6 +323,12 @@ class ClaudeAccountSwitcher:
         pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
         return bool(re.match(pattern, email))
 
+    def _validate_alias(self, alias: str) -> bool:
+        """Validate alias format: letters/digits/-/_/. only, not purely digits."""
+        if not re.match(r"^[A-Za-z0-9._-]+$", alias):
+            return False
+        return not alias.isdigit()
+
     def _setup_directories(self) -> None:
         """Create backup directories with proper permissions."""
         for directory in [self.backup_dir, self.configs_dir, self.credentials_dir]:
@@ -561,6 +567,70 @@ class ClaudeAccountSwitcher:
             record.get("organizationUuid", "") or "",
         )
 
+    def alias(self, identifier: str, alias: str | None = None, *, unset: bool = False) -> None:
+        """Set or unset the display alias for an account.
+
+        Args:
+            identifier: NUM|ALIAS|EMAIL identifying the account.
+            alias: New alias to set. Required unless ``unset`` is True.
+            unset: When True, remove the account's existing alias instead.
+
+        Raises:
+            AccountNotFoundError: identifier doesn't match any account.
+            ValidationError: alias format is invalid.
+            ConfigError: alias is already used by another account.
+        """
+        self._get_sequence_data_migrated()
+        account_num = self._resolve_account_identifier(identifier)
+        if not account_num:
+            raise AccountNotFoundError(
+                f"No account found with identifier: {identifier}"
+            )
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(account_num)
+        if not record:
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+
+        if unset:
+            if "alias" in record:
+                del record["alias"]
+                data["lastUpdated"] = get_timestamp()
+                self._write_json(self.sequence_file, data)
+            print(f"{accent('Removed alias')} for Account {account_num} ({record.get('email', '')})")
+            return
+
+        if not alias:
+            raise ValidationError("Alias name is required (use --unset to remove one)")
+        if not self._validate_alias(alias):
+            raise ValidationError(f"Invalid alias: {alias}")
+        normalized = alias.lower()
+        conflict = self._alias_in_use(normalized, exclude_num=account_num)
+        if conflict is not None:
+            raise ConfigError(f"Alias '{normalized}' is already used by account {conflict}")
+
+        record["alias"] = normalized
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        print(
+            f"{accent('Set alias')} '{normalized}' for Account {account_num} "
+            f"({record.get('email', '')})"
+        )
+
+    def list_aliases(self) -> None:
+        """Print all accounts that currently have an alias set."""
+        data = self._get_sequence_data_migrated()
+        accounts = (data or {}).get("accounts", {})
+        rows = [
+            (num, acc.get("alias"), acc.get("email", ""))
+            for num, acc in accounts.items()
+            if acc.get("alias")
+        ]
+        if not rows:
+            print(dimmed("No aliases set"))
+            return
+        for num, alias_name, email in sorted(rows, key=lambda r: int(r[0])):
+            print(f"  {num}: {alias_name} {muted(f'({email})')}")
+
     def slot_for_directory(self, directory: str | Path) -> tuple[str | None, str | None]:
         """Resolve a directory to its mapped account slot, for `cswap run`.
 
@@ -664,7 +734,7 @@ class ClaudeAccountSwitcher:
         entries = self._collect_usage_entries(accounts_info, fetch=fetch)
         active_number: str | None = None
         accounts: list[AccountSnapshot] = []
-        for num, email, org_name, org_uuid, is_active, _creds in accounts_info:
+        for num, email, org_name, org_uuid, is_active, _creds, alias in accounts_info:
             n = str(num)
             if is_active:
                 active_number = n
@@ -678,6 +748,7 @@ class ClaudeAccountSwitcher:
                     kind=self._account_kind(n),
                     switchable=self._account_is_switchable(n),
                     usage=entries[n],
+                    alias=alias,
                 )
             )
         return AccountsSnapshot(
@@ -1011,8 +1082,28 @@ class ClaudeAccountSwitcher:
         """Return display tag for an account's org context."""
         return org_name if org_name else "personal"
 
+    def _find_account_by_alias(self, alias: str) -> str | None:
+        """Return the account number whose alias matches (case-insensitive), if any."""
+        data = self._get_sequence_data()
+        if not data:
+            return None
+        alias_key = alias.lower()
+        for num, account in data.get("accounts", {}).items():
+            if (account.get("alias") or "").lower() == alias_key:
+                return num
+        return None
+
+    def _alias_in_use(self, alias: str, *, exclude_num: str | None = None) -> str | None:
+        """Return the account number already using ``alias`` (other than ``exclude_num``), if any."""
+        num = self._find_account_by_alias(alias)
+        if num is not None and num == exclude_num:
+            return None
+        return num
+
     def _resolve_account_identifier(self, identifier: str) -> str | None:
-        """Resolve account identifier (number or email) to account number.
+        """Resolve account identifier (number, alias, or email) to account number.
+
+        Resolution precedence: number -> alias -> email.
 
         Raises:
             ConfigError: if the email matches multiple accounts (ambiguous).
@@ -1023,6 +1114,10 @@ class ClaudeAccountSwitcher:
         data = self._get_sequence_data()
         if not data:
             return None
+
+        alias_match = self._find_account_by_alias(identifier)
+        if alias_match is not None:
+            return alias_match
 
         matches = [
             num for num, account in data.get("accounts", {}).items()
@@ -1118,7 +1213,12 @@ class ClaudeAccountSwitcher:
             data["lastUpdated"] = get_timestamp()
             self._write_json(self.sequence_file, data)
 
-    def add_account(self, slot: int | None = None, assume_yes: bool = False) -> None:
+    def add_account(
+        self,
+        slot: int | None = None,
+        assume_yes: bool = False,
+        alias: str | None = None,
+    ) -> None:
         """Add current account to managed accounts.
 
         Args:
@@ -1128,10 +1228,17 @@ class ClaudeAccountSwitcher:
                   is already occupied by a different account.
             assume_yes: Skip that overwrite prompt (callers with their own
                   confirmation UI, e.g. the TUI, confirm before calling).
+            alias: Optional short display alias to set on this account.
+                  When omitted, an existing alias on the slot is preserved.
         """
         self._setup_directories()
         self._init_sequence_file()
         self._migrate_org_fields()
+
+        if alias is not None:
+            if not self._validate_alias(alias):
+                raise ValidationError(f"Invalid alias: {alias}")
+            alias = alias.lower()
 
         identity = self._get_current_account()
         if identity is None:
@@ -1143,6 +1250,13 @@ class ClaudeAccountSwitcher:
             seq = self._get_sequence_data()
             account_num = self._find_account_slot(seq, current_email, current_org_uuid)
             matched_org_name = seq["accounts"][account_num].get("organizationName", "") if account_num else ""
+
+            if alias is not None:
+                conflict = self._alias_in_use(alias, exclude_num=account_num)
+                if conflict is not None:
+                    raise ValidationError(
+                        f"Alias '{alias}' is already used by account {conflict}"
+                    )
 
             current_creds = self._read_credentials()
             if current_creds is None:
@@ -1164,6 +1278,9 @@ class ClaudeAccountSwitcher:
             self._usage_store.clear_dead_token(
                 [account_num], {account_num: (current_email, current_org_uuid)}
             )
+
+            if alias is not None:
+                seq["accounts"][account_num]["alias"] = alias
 
             seq["activeAccountNumber"] = int(account_num)
             seq["lastUpdated"] = get_timestamp()
@@ -1229,6 +1346,26 @@ class ClaudeAccountSwitcher:
         else:
             account_num = str(self._get_next_account_number())
 
+        # Capture any alias to carry forward before destructive cleanup below
+        # deletes the old record (same account moving slots, or refreshing in place).
+        existing_alias = None
+        if slot is not None:
+            prior = data.get("accounts", {}).get(account_num) or {}
+            if (
+                prior.get("email") == current_email
+                and prior.get("organizationUuid", "") == current_org_uuid
+            ):
+                existing_alias = prior.get("alias")
+            if migrate_from:
+                existing_alias = data["accounts"][migrate_from].get("alias") or existing_alias
+
+        if alias is not None:
+            conflict = self._alias_in_use(alias, exclude_num=account_num)
+            if conflict is not None:
+                raise ValidationError(
+                    f"Alias '{alias}' is already used by account {conflict}"
+                )
+
         # Read new account credentials BEFORE any destructive operations
         current_creds = self._read_credentials()
         if current_creds is None:
@@ -1288,6 +1425,9 @@ class ClaudeAccountSwitcher:
             "organizationName": organization_name,
             "added": get_timestamp(),
         }
+        carried_alias = alias if alias is not None else existing_alias
+        if carried_alias:
+            data["accounts"][account_num]["alias"] = carried_alias
         if int(account_num) not in data["sequence"]:
             data["sequence"].append(int(account_num))
             data["sequence"].sort()
@@ -1522,30 +1662,33 @@ class ClaudeAccountSwitcher:
 
         # Resolve identifier
         if not identifier.isdigit():
-            if not self._validate_email(identifier):
-                raise ValidationError(f"Invalid email format: {identifier}")
+            is_alias = self._find_account_by_alias(identifier) is not None
+            if not is_alias and not self._validate_email(identifier):
+                raise ValidationError(f"Invalid account identifier: {identifier}")
 
-            # For email identifiers, handle ambiguous matches interactively
-            data = self._get_sequence_data()
-            matches = [
-                num for num, acc in (data or {}).get("accounts", {}).items()
-                if acc.get("email") == identifier
-            ]
-            if len(matches) > 1:
-                print(f"Multiple accounts found for '{identifier}':")
-                for num in matches:
-                    acc = data["accounts"][num]
-                    tag = self._get_display_tag(
-                        acc.get("email", ""),
-                        acc.get("organizationName", ""),
-                        acc.get("organizationUuid", ""),
-                    )
-                    print(f"  {num}: {identifier} {muted(f'[{tag}]')}")
-                choice = input("Enter account number to remove: ").strip()
-                if not choice.isdigit() or choice not in matches:
-                    print(dimmed("Cancelled"))
-                    return
-                identifier = choice
+            # For email identifiers, handle ambiguous matches interactively.
+            # Aliases are unique by construction, so they never hit this.
+            if not is_alias:
+                data = self._get_sequence_data()
+                matches = [
+                    num for num, acc in (data or {}).get("accounts", {}).items()
+                    if acc.get("email") == identifier
+                ]
+                if len(matches) > 1:
+                    print(f"Multiple accounts found for '{identifier}':")
+                    for num in matches:
+                        acc = data["accounts"][num]
+                        tag = self._get_display_tag(
+                            acc.get("email", ""),
+                            acc.get("organizationName", ""),
+                            acc.get("organizationUuid", ""),
+                        )
+                        print(f"  {num}: {identifier} {muted(f'[{tag}]')}")
+                    choice = input("Enter account number to remove: ").strip()
+                    if not choice.isdigit() or choice not in matches:
+                        print(dimmed("Cancelled"))
+                        return
+                    identifier = choice
 
         account_num = self._resolve_account_identifier(identifier)
         if not account_num:
@@ -1592,8 +1735,8 @@ class ClaudeAccountSwitcher:
 
         self._prune_mappings(email, account_info.get("organizationUuid", ""))
 
-    def _build_accounts_info(self) -> list[tuple[int, str, str, str, bool, str]]:
-        """Build per-account (num, email, org_name, org_uuid, is_active, creds).
+    def _build_accounts_info(self) -> list[tuple[int, str, str, str, bool, str, str]]:
+        """Build per-account (num, email, org_name, org_uuid, is_active, creds, alias).
 
         Shared by list_accounts and the usage-aware switch helpers so the active
         slot is detected and credentials are read in exactly one place. The
@@ -1609,7 +1752,7 @@ class ClaudeAccountSwitcher:
             current_email, current_org_uuid = current_identity
             active_num = self._find_account_slot(data, current_email, current_org_uuid)
 
-        accounts_info: list[tuple[int, str, str, str, bool, str]] = []
+        accounts_info: list[tuple[int, str, str, str, bool, str, str]] = []
         # Reset each build; set below only when the active slot's OAuth Keychain
         # read failed with no fallback. Read by _static_usage_sentinel (main
         # thread writes it here before the fetch pool starts → no data race).
@@ -1619,6 +1762,7 @@ class ClaudeAccountSwitcher:
             email = account.get("email", "unknown")
             org_name = account.get("organizationName", "") or ""
             org_uuid = account.get("organizationUuid", "") or ""
+            alias = account.get("alias", "") or ""
             is_active = str(num) == active_num
 
             if is_active:
@@ -1628,7 +1772,7 @@ class ClaudeAccountSwitcher:
             else:
                 creds = self._read_account_credentials(str(num), email)
 
-            accounts_info.append((num, email, org_name, org_uuid, is_active, creds))
+            accounts_info.append((num, email, org_name, org_uuid, is_active, creds, alias))
         return accounts_info
 
     def _active_cc_running(self) -> bool:
@@ -1786,14 +1930,14 @@ class ClaudeAccountSwitcher:
         )
 
     def _static_usage_sentinel(
-        self, account_info: tuple[int, str, str, str, bool, str]
+        self, account_info: tuple[int, str, str, str, bool, str, str]
     ) -> str | None:
         """Sentinel state derivable without any network call, or ``None``.
 
         Re-derived on every collect pass (never persisted), so it can't
         outlive the condition that produced it.
         """
-        num, email, _, _, is_active, creds = account_info
+        num, email, _, _, is_active, creds, _alias = account_info
         if looks_like_api_key(creds):
             # Managed API-key account: no subscription quota to fetch.
             return USAGE_API_KEY
@@ -1821,10 +1965,10 @@ class ClaudeAccountSwitcher:
         return None
 
     def _fetch_account_usage(
-        self, account_info: tuple[int, str, str, str, bool, str]
+        self, account_info: tuple[int, str, str, str, bool, str, str]
     ) -> FetchRecord:
         """One network fetch for one account. Never raises."""
-        num, email, _, org_uuid, is_active, creds = account_info
+        num, email, _, org_uuid, is_active, creds, _alias = account_info
 
         # The active/default account owns the live credential — route it through
         # the owner-aware path that refreshes only when no Claude Code/session is
@@ -1901,12 +2045,12 @@ class ClaudeAccountSwitcher:
         )
 
     def _run_usage_fetches(
-        self, infos: list[tuple[int, str, str, str, bool, str]]
+        self, infos: list[tuple[int, str, str, str, bool, str, str]]
     ) -> dict[str, FetchRecord]:
         """Fetch the given accounts in parallel, staggering request starts so
         N accounts never hit the endpoint in the same instant."""
         def fetch_one(
-            idx_info: tuple[int, tuple[int, str, str, str, bool, str]]
+            idx_info: tuple[int, tuple[int, str, str, str, bool, str, str]]
         ) -> tuple[str, FetchRecord]:
             idx, info = idx_info
             if idx and _FETCH_STAGGER_S:
@@ -1918,7 +2062,7 @@ class ClaudeAccountSwitcher:
 
     def _collect_usage_entries(
         self,
-        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        accounts_info: list[tuple[int, str, str, str, bool, str, str]],
         fetch: set[str] | None = None,
     ) -> dict[str, UsageEntry]:
         """Store-backed usage collection: one :class:`UsageEntry` per account.
@@ -1939,7 +2083,7 @@ class ClaudeAccountSwitcher:
         store = self._usage_store
         identities = {
             str(num): (email, org_uuid or "")
-            for num, email, _org_name, org_uuid, _active, _creds in accounts_info
+            for num, email, _org_name, org_uuid, _active, _creds, _alias in accounts_info
         }
         info_by_num = {str(info[0]): info for info in accounts_info}
         sentinels: dict[str, str] = {}
@@ -2168,7 +2312,7 @@ class ClaudeAccountSwitcher:
         return None, "stay"
 
     def _duplicate_account_warnings(
-        self, accounts_info: list[tuple[int, str, str, str, bool, str]]
+        self, accounts_info: list[tuple[int, str, str, str, bool, str, str]]
     ) -> list[str]:
         """Slots that provably authenticate as the same account.
 
@@ -2192,7 +2336,7 @@ class ClaudeAccountSwitcher:
         by_fp: dict[str, str] = {}
         by_identity: dict[tuple[str, str], str] = {}
         out: list[str] = []
-        for num, email, _org_name, org_uuid, _is_active, creds in accounts_info:
+        for num, email, _org_name, org_uuid, _is_active, creds, _alias in accounts_info:
             snum = str(num)
             fp = oauth.credential_fingerprint(creds) if creds else None
             if fp:
@@ -2221,7 +2365,7 @@ class ClaudeAccountSwitcher:
 
     def _lockstep_usage_warnings(
         self,
-        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        accounts_info: list[tuple[int, str, str, str, bool, str, str]],
         entries: dict[str, UsageEntry],
     ) -> list[str]:
         """Heuristic: slots whose usage moves in perfect lockstep.
@@ -2247,7 +2391,7 @@ class ClaudeAccountSwitcher:
         """
         seen: dict[tuple, str] = {}
         out: list[str] = []
-        for num, _email, _org_name, _org_uuid, _is_active, _creds in accounts_info:
+        for num, _email, _org_name, _org_uuid, _is_active, _creds, _alias in accounts_info:
             snum = str(num)
             entry = entries.get(snum)
             usage = entry.decision_value() if entry else None
@@ -2277,13 +2421,13 @@ class ClaudeAccountSwitcher:
 
     def _build_list_payload(
         self,
-        accounts_info: list[tuple[int, str, str, str, bool, str]],
+        accounts_info: list[tuple[int, str, str, str, bool, str, str]],
         entries: dict[str, UsageEntry],
     ) -> dict:
         """Build the ``--list --json`` payload from gathered account + usage data."""
         active_num: int | None = None
         accounts = []
-        for num, email, org_name, org_uuid, is_active, _ in accounts_info:
+        for num, email, org_name, org_uuid, is_active, _, alias in accounts_info:
             if is_active:
                 active_num = num
             entry = entries[str(num)]
@@ -2297,6 +2441,7 @@ class ClaudeAccountSwitcher:
                     entry.decision_value(),
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
+                    alias=alias,
                 )
             )
         payload = {
@@ -2352,17 +2497,14 @@ class ClaudeAccountSwitcher:
             return self._build_list_payload(accounts_info, entries)
 
         print(bolded("Accounts:"))
-        for i, (num, email, org_name, org_uuid, is_active, _) in enumerate(accounts_info):
+        for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
-            # NOTE: the TUI watch view (tui._watch_account_rows) parses this
-            # output to map rows to accounts for quick-switch: it relies on the
-            # uncolored ``  {num}: `` prefix and the ``(active)`` marker below.
-            # Keep them intact when tweaking this line, or update that parser.
+            alias_part = f" {muted(f'[{alias}]')}" if alias else ""
             if is_active:
                 marker = f" {bold_accent('(active)')}"
-                print(f"  {num}: {email} {muted(f'[{tag}]')}{marker}")
+                print(f"  {num}: {email}{alias_part} {muted(f'[{tag}]')}{marker}")
             else:
-                print(f"  {num}: {email} {muted(f'[{tag}]')}")
+                print(f"  {num}: {email}{alias_part} {muted(f'[{tag}]')}")
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
 
@@ -2432,7 +2574,7 @@ class ClaudeAccountSwitcher:
         active = self._read_active_credentials()
         creds = active.value or ""
         self._active_keychain_unavailable = active.keychain_unavailable
-        info = (int(account_num), current_email, "", org_uuid or "", True, creds)
+        info = (int(account_num), current_email, "", org_uuid or "", True, creds, "")
         return self._collect_usage_entries([info])[str(account_num)]
 
     def _build_status_payload(self) -> dict:
@@ -2459,6 +2601,7 @@ class ClaudeAccountSwitcher:
         acct = data["accounts"][account_num]
         org_name = acct.get("organizationName", "") or ""
         org_uuid = acct.get("organizationUuid", "") or ""
+        alias = acct.get("alias", "") or ""
         entry = self._active_account_usage(account_num, current_email, org_uuid)
         # Decision-grade projection, same rule as the --list payload: stale
         # beyond STALE_OK_S reports unavailable, not "ok" with old numbers.
@@ -2473,6 +2616,8 @@ class ClaudeAccountSwitcher:
             "usageStatus": status,
             "usage": usage,
         }
+        if alias:
+            active["alias"] = alias
         if usage is not None:
             active.update(usage_freshness_fields(entry.fetched_at, entry.age_s))
         return {
@@ -2987,14 +3132,16 @@ class ClaudeAccountSwitcher:
 
         # Resolve identifier
         if not identifier.isdigit():
-            if not self._validate_email(identifier):
-                raise ValidationError(f"Invalid email format: {identifier}")
+            is_alias = self._find_account_by_alias(identifier) is not None
+            if not is_alias and not self._validate_email(identifier):
+                raise ValidationError(f"Invalid account identifier: {identifier}")
 
             # For email identifiers, handle ambiguous matches interactively —
             # except in JSON mode, where we never prompt. There we fall through
             # to _resolve_account_identifier, which raises a ConfigError listing
             # the matching slots (+ org labels) → structured error envelope.
-            if not json_output:
+            # Aliases are unique by construction, so they never hit this.
+            if not json_output and not is_alias:
                 data = self._get_sequence_data()
                 matches = [
                     num for num, acc in (data or {}).get("accounts", {}).items()

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -316,8 +316,10 @@ def import_accounts(
     # Pass 1: validate every account before any writes. A malformed account
     # later in the list must not leave earlier accounts half-imported.
     local_data = switcher._get_sequence_data_migrated() or {}
-    local_aliases = {
-        (acc.get("alias") or "").lower()
+    local_aliases: dict[str, tuple[str, str]] = {
+        (acc.get("alias") or "").lower(): (
+            acc.get("email", ""), acc.get("organizationUuid", "") or "",
+        )
         for acc in local_data.get("accounts", {}).values()
         if acc.get("alias")
     }
@@ -359,10 +361,11 @@ def import_accounts(
             if alias_key in seen_aliases:
                 raise TransferError(f"duplicate alias in export: {alias_key}")
             seen_aliases.add(alias_key)
-            if alias_key in local_aliases:
+            owner = local_aliases.get(alias_key)
+            if owner is not None and owner != (email, org_uuid):
                 _eprint(
                     f"Warning: alias '{alias_key}' for {email} already used by an "
-                    "existing account — dropping the imported alias"
+                    "existing account, dropping the imported alias"
                 )
                 alias = None
 

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -77,12 +77,16 @@ def _validate_imported_account(switcher: ClaudeAccountSwitcher, account: dict) -
     # Org/uuid/added must be strings (or absent). A list/dict here would
     # otherwise blow up downstream (unhashable in seen_keys, broken composite
     # key matching, garbage in sequence.json).
-    for field in ("organizationUuid", "organizationName", "uuid", "added"):
+    for field in ("organizationUuid", "organizationName", "uuid", "added", "alias"):
         if field in account and account[field] is not None:
             if not isinstance(account[field], str):
                 raise TransferError(
                     f"{field} for {email} must be a string, got {type(account[field]).__name__}"
                 )
+
+    alias = account.get("alias")
+    if isinstance(alias, str) and not switcher._validate_alias(alias):
+        raise TransferError(f"invalid alias for {email}: {alias!r}")
 
     return email, str(raw_number)
 
@@ -220,6 +224,8 @@ def export_accounts(
         }
         if is_api_key:
             entry["kind"] = "api_key"
+        if record.get("alias"):
+            entry["alias"] = record["alias"]
         accounts_payload.append(entry)
 
     if not accounts_payload:
@@ -309,8 +315,15 @@ def import_accounts(
 
     # Pass 1: validate every account before any writes. A malformed account
     # later in the list must not leave earlier accounts half-imported.
+    local_data = switcher._get_sequence_data_migrated() or {}
+    local_aliases = {
+        (acc.get("alias") or "").lower()
+        for acc in local_data.get("accounts", {}).values()
+        if acc.get("alias")
+    }
     normalized: list[dict[str, Any]] = []
     seen_keys: set[tuple[str, str]] = set()
+    seen_aliases: set[str] = set()
     for raw in accounts:
         email, exported_num = _validate_imported_account(switcher, raw)
         org_uuid = raw.get("organizationUuid", "") or ""
@@ -339,6 +352,20 @@ def import_accounts(
                 f"duplicate account in export: {email} (org={org_uuid or 'personal'})"
             )
         seen_keys.add(key)
+
+        alias = raw.get("alias") or None
+        if alias:
+            alias_key = alias.lower()
+            if alias_key in seen_aliases:
+                raise TransferError(f"duplicate alias in export: {alias_key}")
+            seen_aliases.add(alias_key)
+            if alias_key in local_aliases:
+                _eprint(
+                    f"Warning: alias '{alias_key}' for {email} already used by an "
+                    "existing account — dropping the imported alias"
+                )
+                alias = None
+
         normalized.append(
             {
                 "email": email,
@@ -348,6 +375,7 @@ def import_accounts(
                 "uuid": raw.get("uuid", "") or "",
                 "added": raw.get("added") or get_timestamp(),
                 "kind": "api_key" if is_api_key else "oauth",
+                "alias": alias,
                 "creds_text": creds_text,
                 "config_text": json.dumps(config_obj, indent=2),
             }
@@ -440,6 +468,8 @@ def import_accounts(
         }
         if entry["kind"] == "api_key":
             new_record["kind"] = "api_key"
+        if entry.get("alias"):
+            new_record["alias"] = entry["alias"]
         data["accounts"][target_num] = new_record
         if int(target_num) not in data["sequence"]:
             data["sequence"].append(int(target_num))

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -21,7 +21,7 @@ from claude_swap.exceptions import (
     CredentialReadError,
     TransferError,
 )
-from claude_swap.models import Platform, get_timestamp
+from claude_swap.models import Platform, get_timestamp, normalize_alias
 
 if TYPE_CHECKING:
     from claude_swap.switcher import ClaudeAccountSwitcher
@@ -85,8 +85,11 @@ def _validate_imported_account(switcher: ClaudeAccountSwitcher, account: dict) -
                 )
 
     alias = account.get("alias")
-    if isinstance(alias, str) and not switcher._validate_alias(alias):
-        raise TransferError(f"invalid alias for {email}: {alias!r}")
+    if isinstance(alias, str):
+        try:
+            normalize_alias(alias)
+        except ValueError as e:
+            raise TransferError(f"invalid alias for {email}: {e}") from e
 
     return email, str(raw_number)
 
@@ -357,7 +360,7 @@ def import_accounts(
 
         alias = raw.get("alias") or None
         if alias:
-            alias_key = alias.lower()
+            alias_key = normalize_alias(alias)  # already validated in pass-1 above
             if alias_key in seen_aliases:
                 raise TransferError(f"duplicate alias in export: {alias_key}")
             seen_aliases.add(alias_key)
@@ -368,6 +371,8 @@ def import_accounts(
                     "existing account, dropping the imported alias"
                 )
                 alias = None
+            else:
+                alias = alias_key
 
         normalized.append(
             {

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -92,7 +92,11 @@ class DashboardScreen(Screen):
     def _remove_entries(self) -> MenuEntries:
         snap = self.app.snapshot
         entries: MenuEntries = [
-            (f"{acc.number}  {acc.email}  [{acc.display_tag}]", f"remove:{acc.number}")
+            (
+                f"{acc.number}  {f'{acc.alias} ({acc.email})' if acc.alias else acc.email}"
+                f"  [{acc.display_tag}]",
+                f"remove:{acc.number}",
+            )
             for acc in (snap.accounts if snap else ())
         ]
         entries.append(_BACK)

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -158,6 +158,8 @@ def account_card_text(
     text = Text()
     text.append(f"{acc.number:>2}  ", style=f"bold {FOREGROUND}")
     text.append(acc.email, style=FOREGROUND)
+    if acc.alias:
+        text.append(f"  ({acc.alias})", style=MUTED)
     text.append(f"  [{acc.display_tag}]", style=MUTED)
     if acc.is_active:
         text.append("   ● active", style=f"bold {ACCENT}")
@@ -224,6 +226,8 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
     text = Text(no_wrap=True, overflow="ellipsis")
     text.append(f"{acc.number:>2}  ", style=f"bold {MUTED}")
     text.append(acc.email, style=FOREGROUND)
+    if acc.alias:
+        text.append(f"  ({acc.alias})", style=MUTED)
     text.append(f"  [{acc.display_tag}]", style=MUTED)
     text.append("   ")
 

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -157,9 +157,11 @@ def account_card_text(
 
     text = Text()
     text.append(f"{acc.number:>2}  ", style=f"bold {FOREGROUND}")
-    text.append(acc.email, style=FOREGROUND)
     if acc.alias:
-        text.append(f"  ({acc.alias})", style=MUTED)
+        text.append(acc.alias, style=f"bold {ACCENT}")
+        text.append(f" ({acc.email})", style=FOREGROUND)
+    else:
+        text.append(acc.email, style=FOREGROUND)
     text.append(f"  [{acc.display_tag}]", style=MUTED)
     if acc.is_active:
         text.append("   ● active", style=f"bold {ACCENT}")
@@ -225,9 +227,11 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
     """
     text = Text(no_wrap=True, overflow="ellipsis")
     text.append(f"{acc.number:>2}  ", style=f"bold {MUTED}")
-    text.append(acc.email, style=FOREGROUND)
     if acc.alias:
-        text.append(f"  ({acc.alias})", style=MUTED)
+        text.append(acc.alias, style=f"bold {ACCENT}")
+        text.append(f" ({acc.email})", style=FOREGROUND)
+    else:
+        text.append(acc.email, style=FOREGROUND)
     text.append(f"  [{acc.display_tag}]", style=MUTED)
     text.append("   ")
 

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -229,7 +229,7 @@ class TestUsageDisplay:
 
     def test_collect_usage_short_circuits(self, temp_home: Path):
         s = _linux_switcher()
-        info = [(2, "api-key-2@token.local", "", "", False, API_KEY)]
+        info = [(2, "api-key-2@token.local", "", "", False, API_KEY, "")]
         entries = s._collect_usage_entries(info)
         assert entries["2"].sentinel == USAGE_API_KEY
         assert entries["2"].decision_value() == USAGE_API_KEY

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -635,6 +635,15 @@ class TestRunCommand:
         )
         assert "run 2" in result.stdout
 
+    def test_main_help_mentions_alias(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "alias <num|email>" in result.stdout
+
     def test_session_error_exits_cleanly(self, capsys):
         class FailingSessionManager:
             def __init__(self, switcher):
@@ -1208,6 +1217,13 @@ class TestAliasCommand:
         with patch("os.geteuid", return_value=1000, create=True):
             with pytest.raises(SystemExit):
                 cli._alias_command(["2"])
+
+    def test_unset_without_account_errors(self, temp_home, capsys):
+        """`cswap alias --unset` with no target must error, not silently list."""
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit):
+                cli._alias_command(["--unset"])
 
     def test_unset_with_name_errors(self, temp_home, capsys):
         self._seeded_switcher_env(temp_home)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1143,6 +1143,129 @@ class TestMapCommand:
         assert "root" in capsys.readouterr().err
 
 
+class TestAliasCommand:
+    """`cswap alias` — set/unset/list a short display alias for an account."""
+
+    def _seeded_switcher_env(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["2"] = {
+            "email": "work@co.com",
+            "uuid": "u2",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [2]
+        switcher._write_json(switcher.sequence_file, data)
+        return switcher
+
+    def test_set_alias_by_number(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command(["2", "dev"])
+
+        data = ClaudeAccountSwitcher()._get_sequence_data()
+        assert data["accounts"]["2"]["alias"] == "dev"
+        assert "dev" in capsys.readouterr().out
+
+    def test_set_alias_by_email(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command(["work@co.com", "dev"])
+
+        data = ClaudeAccountSwitcher()._get_sequence_data()
+        assert data["accounts"]["2"]["alias"] == "dev"
+
+    def test_unset_alias(self, temp_home, capsys):
+        switcher = self._seeded_switcher_env(temp_home)
+        data = switcher._get_sequence_data()
+        data["accounts"]["2"]["alias"] = "dev"
+        switcher._write_json(switcher.sequence_file, data)
+
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command(["2", "--unset"])
+
+        data = ClaudeAccountSwitcher()._get_sequence_data()
+        assert "alias" not in data["accounts"]["2"]
+
+    def test_list_aliases(self, temp_home, capsys):
+        switcher = self._seeded_switcher_env(temp_home)
+        data = switcher._get_sequence_data()
+        data["accounts"]["2"]["alias"] = "dev"
+        switcher._write_json(switcher.sequence_file, data)
+
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._alias_command([])
+
+        out = capsys.readouterr().out
+        assert "dev" in out
+
+    def test_missing_name_errors(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit):
+                cli._alias_command(["2"])
+
+    def test_unset_with_name_errors(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit):
+                cli._alias_command(["2", "dev", "--unset"])
+
+    def test_invalid_alias_errors(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["2", "123"])
+        assert exc.value.code == 1
+        assert "Error" in capsys.readouterr().err
+
+    def test_unknown_account_errors(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=1000, create=True):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["999", "dev"])
+        assert exc.value.code == 1
+
+    def test_dispatched_from_main(self, temp_home):
+        with patch("claude_swap.cli._alias_command") as alias_fn, \
+             patch.object(sys, "argv", ["claude-swap", "alias", "2", "dev"]):
+            cli.main()
+        alias_fn.assert_called_once_with(["2", "dev"])
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="root guard is POSIX-only")
+    def test_alias_refuses_root(self, temp_home, capsys):
+        self._seeded_switcher_env(temp_home)
+        with patch("os.geteuid", return_value=0, create=True), \
+             patch.object(ClaudeAccountSwitcher, "_is_running_in_container", return_value=False):
+            with pytest.raises(SystemExit) as exc:
+                cli._alias_command(["2", "dev"])
+        assert exc.value.code == 1
+        assert "root" in capsys.readouterr().err
+
+    def test_add_with_alias_flag(self, temp_home, mock_claude_config, capsys):
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        with patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(ClaudeAccountSwitcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(ClaudeAccountSwitcher, "_write_account_credentials"), \
+             patch.object(sys, "argv", ["claude-swap", "add", "--alias", "dev"]):
+            cli.main()
+
+        data = ClaudeAccountSwitcher()._get_sequence_data()
+        assert data["accounts"]["1"]["alias"] == "dev"
+
+    def test_alias_flag_without_add_errors(self, temp_home, capsys):
+        with patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "list", "--alias", "dev"]):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code == 2
+        assert "--alias can only be used with 'add'" in capsys.readouterr().err
+
+
 class TestRunAutoResolve:
     """`cswap run` with no account resolves the cwd's directory mapping."""
 

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -121,6 +121,18 @@ class TestJsonHelpers:
             "error": {"type": "SwitchError", "message": "boom"},
         }
 
+    def test_account_row_includes_alias_when_set(self):
+        from claude_swap.json_output import account_row
+
+        row = account_row(1, "a@x.com", "", "", True, None, alias="dev")
+        assert row["alias"] == "dev"
+
+    def test_account_row_omits_alias_when_unset(self):
+        from claude_swap.json_output import account_row
+
+        row = account_row(1, "a@x.com", "", "", True, None)
+        assert "alias" not in row
+
 
 # --------------------------------------------------------------------------- #
 # --list --json
@@ -170,6 +182,28 @@ class TestListJson:
         assert acct1["active"] is True
         assert acct1["usageStatus"] == "ok"
         assert acct1["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
+
+    def test_list_payload_includes_alias(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        sample_sequence_data["accounts"]["1"]["alias"] = "dev"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
+             patch.object(switcher, "_read_account_credentials", return_value=""), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
+            payload = switcher.list_accounts(json_output=True)
+
+        by_num = {a["number"]: a for a in payload["accounts"]}
+        assert by_num[1]["alias"] == "dev"
+        assert "alias" not in by_num[2]
 
     def test_usage_status_no_credentials_and_unavailable(
         self, temp_home: Path, mock_claude_config: Path,
@@ -289,6 +323,25 @@ class TestStatusJson:
         assert active["usageStatus"] == "ok"
         assert active["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
         assert payload["totalManagedAccounts"] == 2
+
+    def test_status_managed_includes_alias(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        sample_sequence_data["accounts"]["1"]["alias"] = "dev"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
+            payload = switcher.status(json_output=True)
+
+        assert payload["active"]["alias"] == "dev"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -127,6 +127,11 @@ def test_format_account_label():
     assert label == "2  loc@papaya.asia  5h 42% · 7d 18% · $ 30%"
 
 
+def test_format_account_label_with_alias():
+    label = menubar.format_account_label(2, "loc@papaya.asia", _USAGE, alias="dev")
+    assert label == "2  dev  (loc@papaya.asia)  5h 42% · 7d 18% · $ 30%"
+
+
 # --- usage logging -------------------------------------------------------------
 
 def test_format_usage_log_full():
@@ -169,6 +174,11 @@ def test_usage_log_key_ignores_clock_tracks_pct():
 def test_format_title_name_and_5h():
     s = menubar.MenuBarSettings(show_account_name=True, title_pct="5h")
     assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄ loc · 42%"
+
+
+def test_format_title_prefers_alias_over_local_part():
+    s = menubar.MenuBarSettings(show_account_name=True, title_pct="off")
+    assert menubar.format_title("loc@papaya.asia", _USAGE, s, alias="dev") == "⇄ dev"
 
 
 def test_format_title_name_only_when_pct_off():
@@ -332,11 +342,12 @@ class _FakeEntry:
 
 
 class _FakeAcct:
-    def __init__(self, number, email, is_active, usage):
+    def __init__(self, number, email, is_active, usage, alias=""):
         self.number = number
         self.email = email
         self.is_active = is_active
         self.usage = usage
+        self.alias = alias
 
 
 class _FakeSnap:
@@ -364,11 +375,12 @@ def test_adapt_snapshot_shape_and_active_selection():
     snap = menubar._adapt_snapshot(_FakeSnap(accts))
     assert snap["active_email"] == "a@x.com"
     assert snap["active_usage"] == lg
-    # (num, email, is_active, display_usage, last_good)
-    assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg)
+    assert snap["active_alias"] == ""
+    # (num, email, is_active, display_usage, last_good, alias)
+    assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg, "")
     # sentinel account: display is the human note, last_good is None
     assert snap["accounts"][1] == (
-        "2", "b@x.com", False, menubar.SENTINEL_NOTES[USAGE_API_KEY], None,
+        "2", "b@x.com", False, menubar.SENTINEL_NOTES[USAGE_API_KEY], None, "",
     )
 
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -314,7 +314,7 @@ class TestAliasValidation:
 
     def test_invalid_aliases(self, temp_home: Path):
         switcher = ClaudeAccountSwitcher()
-        for alias in ["123", "dev@work", "dev work", "", "dev/work"]:
+        for alias in ["123", "dev@work", "dev work", "", "dev/work", "-dev"]:
             assert not switcher._validate_alias(alias), f"Expected {alias} to be invalid"
 
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -304,6 +304,163 @@ class TestResolveAccountIdentifier:
         assert switcher._resolve_account_identifier("999") == "999"  # Numbers pass through
 
 
+class TestAliasValidation:
+    """Test alias format validation."""
+
+    def test_valid_aliases(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        for alias in ["dev", "work-1", "client_a", "team.b", "DEV"]:
+            assert switcher._validate_alias(alias), f"Expected {alias} to be valid"
+
+    def test_invalid_aliases(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        for alias in ["123", "dev@work", "dev work", "", "dev/work"]:
+            assert not switcher._validate_alias(alias), f"Expected {alias} to be invalid"
+
+
+class TestResolveByAlias:
+    """Test resolving account identifiers via alias, and precedence."""
+
+    def _write(self, switcher, data):
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, data)
+
+    def test_resolve_by_alias(self, temp_home: Path, sample_sequence_data: dict):
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        assert switcher._resolve_account_identifier("dev") == "2"
+
+    def test_resolve_by_alias_case_insensitive(self, temp_home: Path, sample_sequence_data: dict):
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        assert switcher._resolve_account_identifier("DEV") == "2"
+
+    def test_number_takes_precedence_over_alias(self, temp_home: Path, sample_sequence_data: dict):
+        # An alias that happens to be numeric-looking can't occur (validation
+        # rejects it), but a plain numeric identifier must always resolve as
+        # a slot number, never fall through to alias matching.
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        assert switcher._resolve_account_identifier("1") == "1"
+
+    def test_alias_takes_precedence_over_unrelated_email(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        # Alias resolution happens before the email-match branch.
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        assert switcher._resolve_account_identifier("account1@example.com") == "1"
+        assert switcher._resolve_account_identifier("dev") == "2"
+
+    def test_resolve_account_public_wrapper_supports_alias(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """resolve_account (used by map/run) has no email-format gate, so it
+        already supports aliases once _resolve_account_identifier does."""
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        num, email, org_uuid = switcher.resolve_account("dev")
+        assert num == "2"
+        assert email == "account2@example.com"
+
+
+class TestAliasCommand:
+    """Test ClaudeAccountSwitcher.alias() / list_aliases()."""
+
+    def _write(self, switcher, data):
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, data)
+
+    def test_set_alias_by_number(self, temp_home: Path, sample_sequence_data: dict, capsys):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.alias("2", "dev")
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["2"]["alias"] == "dev"
+
+    def test_set_alias_normalizes_to_lowercase(
+        self, temp_home: Path, sample_sequence_data: dict, capsys
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.alias("2", "DEV")
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["2"]["alias"] == "dev"
+
+    def test_set_alias_by_email(self, temp_home: Path, sample_sequence_data: dict, capsys):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.alias("account2@example.com", "dev")
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["2"]["alias"] == "dev"
+
+    def test_set_invalid_alias_raises(self, temp_home: Path, sample_sequence_data: dict):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        with pytest.raises(ValidationError):
+            switcher.alias("2", "123")
+
+    def test_set_duplicate_alias_raises(self, temp_home: Path, sample_sequence_data: dict):
+        sample_sequence_data["accounts"]["1"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        with pytest.raises(ConfigError):
+            switcher.alias("2", "dev")
+
+    def test_unset_alias(self, temp_home: Path, sample_sequence_data: dict, capsys):
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.alias("2", unset=True)
+
+        data = switcher._get_sequence_data()
+        assert "alias" not in data["accounts"]["2"]
+
+    def test_alias_unknown_account_raises(self, temp_home: Path, sample_sequence_data: dict):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        with pytest.raises(AccountNotFoundError):
+            switcher.alias("999", "dev")
+
+    def test_list_aliases(self, temp_home: Path, sample_sequence_data: dict, capsys):
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.list_aliases()
+        out = capsys.readouterr().out
+        assert "dev" in out
+        assert "account2@example.com" in out
+
+    def test_list_aliases_empty(self, temp_home: Path, sample_sequence_data: dict, capsys):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.list_aliases()
+        out = capsys.readouterr().out
+        assert "No aliases set" in out
+
+
 class TestDirectorySetup:
     """Test directory setup."""
 
@@ -547,7 +704,7 @@ class TestFetchAccountUsageSessionProfile:
     """
 
     def _info(self, backup_creds: str) -> tuple:
-        return (2, "test@example.com", "Org", "org-uuid", False, backup_creds)
+        return (2, "test@example.com", "Org", "org-uuid", False, backup_creds, "")
 
     def test_fresh_session_credentials_fetch_read_only(self, temp_home: Path):
         """Profile creds are used with is_active=True (no refresh, no persist)."""
@@ -1389,7 +1546,7 @@ class TestActiveAccountRefresh:
             {"1": FetchRecord(usage={"five_hour": {"pct": 25.0}})},
             {"1": ("test@example.com", "")},
         )
-        info = (1, "test@example.com", "", "", True, self._EXPIRED)
+        info = (1, "test@example.com", "", "", True, self._EXPIRED, "")
 
         with patch.object(switcher, "_active_cc_running", return_value=True), \
              patch.object(switcher, "_live_session_pids", return_value=[]), \
@@ -2284,7 +2441,7 @@ class TestDeadTokenQuarantine:
         switcher = ClaudeAccountSwitcher()
         switcher._setup_directories()
         self._make_dead(switcher)
-        info = [(2, "test@example.com", "Org", "", False, self._dead_creds())]
+        info = [(2, "test@example.com", "Org", "", False, self._dead_creds(), "")]
 
         with patch("claude_swap.oauth.try_fetch_usage_for_account") as fetch:
             entries = switcher._collect_usage_entries(info)
@@ -2300,7 +2457,7 @@ class TestDeadTokenQuarantine:
         from claude_swap.usage_store import FetchRecord
         switcher = ClaudeAccountSwitcher()
         switcher._setup_directories()
-        info = [(2, "test@example.com", "Org", "", False, self._dead_creds())]
+        info = [(2, "test@example.com", "Org", "", False, self._dead_creds(), "")]
 
         with patch.object(
             switcher, "_run_usage_fetches",
@@ -5254,8 +5411,8 @@ class TestDuplicateAccountDetection:
             "accessToken": "sk", "refreshToken": "rt-shared",
         }})
         info = [
-            (1, "account1@example.com", "", "", True, same),
-            (2, "account2@example.com", "", "", False, same),
+            (1, "account1@example.com", "", "", True, same, ""),
+            (2, "account2@example.com", "", "", False, same, ""),
         ]
         warnings = switcher._duplicate_account_warnings(info)
         assert len(warnings) == 1
@@ -5267,8 +5424,8 @@ class TestDuplicateAccountDetection:
         sample_sequence_data["accounts"]["2"]["uuid"] = "uuid-1"
         switcher = self._switcher(temp_home, sample_sequence_data)
         info = [
-            (1, "account1@example.com", "", "", True, "creds-a"),
-            (2, "account2@example.com", "", "", False, "creds-b"),
+            (1, "account1@example.com", "", "", True, "creds-a", ""),
+            (2, "account2@example.com", "", "", False, "creds-b", ""),
         ]
         warnings = switcher._duplicate_account_warnings(info)
         assert len(warnings) == 1
@@ -5282,8 +5439,8 @@ class TestDuplicateAccountDetection:
         sample_sequence_data["accounts"]["2"]["uuid"] = ""
         switcher = self._switcher(temp_home, sample_sequence_data)
         info = [
-            (1, "setup-token-1@token.local", "", "", True, "creds-a"),
-            (2, "setup-token-2@token.local", "", "", False, "creds-b"),
+            (1, "setup-token-1@token.local", "", "", True, "creds-a", ""),
+            (2, "setup-token-2@token.local", "", "", False, "creds-b", ""),
         ]
         assert switcher._duplicate_account_warnings(info) == []
 
@@ -5293,9 +5450,9 @@ class TestDuplicateAccountDetection:
         switcher = self._switcher(temp_home, sample_sequence_data)
         info = [
             (1, "account1@example.com", "", "", True,
-             json.dumps({"claudeAiOauth": {"refreshToken": "rt-1"}})),
+             json.dumps({"claudeAiOauth": {"refreshToken": "rt-1"}}), ""),
             (2, "account2@example.com", "", "", False,
-             json.dumps({"claudeAiOauth": {"refreshToken": "rt-2"}})),
+             json.dumps({"claudeAiOauth": {"refreshToken": "rt-2"}}), ""),
         ]
         assert switcher._duplicate_account_warnings(info) == []
 
@@ -5314,7 +5471,7 @@ class TestLockstepUsageDetection:
     @staticmethod
     def _info(n=2):
         return [
-            (i, f"account{i}@example.com", "", "", i == 1, f"creds-{i}")
+            (i, f"account{i}@example.com", "", "", i == 1, f"creds-{i}", "")
             for i in range(1, n + 1)
         ]
 
@@ -5804,3 +5961,152 @@ class TestRemoveAccountPrunesMappings:
 
         assert store.get(temp_home) is not None
         assert switcher.slot_for_directory(str(temp_home)) == ("5", "a@x.com")
+
+
+class TestSwitchRemoveGatesAcceptAlias:
+    """Regression: switch_to/remove_account must accept an alias identifier
+    instead of rejecting it with 'Invalid email format' before resolution."""
+
+    def test_switch_to_by_alias_reaches_resolution(
+        self, temp_home: Path, sample_sequence_data: dict,
+    ):
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with patch.object(switcher, "_perform_switch", return_value={
+            "from": None, "to": {"number": 2}, "warnings": [],
+        }) as perform:
+            switcher.switch_to("dev")
+        perform.assert_called_once_with(
+            "2", emit_output=True, force_activate=False, provenance=None,
+        )
+
+    def test_switch_to_unknown_alias_raises_account_not_found_not_validation(
+        self, temp_home: Path, sample_sequence_data: dict,
+    ):
+        """An identifier that isn't a digit, alias, or valid email must still
+        raise ValidationError (format gate), but a well-formed alias that
+        just doesn't match anything must fall through to resolution and
+        raise AccountNotFoundError, not ValidationError."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with pytest.raises(ValidationError):
+            switcher.switch_to("not an email or alias!")
+
+    def test_remove_account_by_alias(
+        self, temp_home: Path, sample_sequence_data: dict, monkeypatch,
+    ):
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+        with patch.object(switcher, "_delete_account_files"):
+            switcher.remove_account("dev")
+
+        data = switcher._get_sequence_data()
+        assert "2" not in data["accounts"]
+        assert "1" in data["accounts"]
+
+    def test_remove_account_invalid_identifier_still_raises_validation(
+        self, temp_home: Path, sample_sequence_data: dict,
+    ):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with pytest.raises(ValidationError):
+            switcher.remove_account("not an email or alias!")
+
+
+class TestAddAccountAlias:
+    """Test the --alias convenience at add time, and preservation on re-add."""
+
+    def _config_switcher(self, temp_home, email):
+        config = {
+            "oauthAccount": {
+                "emailAddress": email,
+                "accountUuid": "uuid-" + email,
+                "organizationUuid": "",
+                "organizationName": "",
+            }
+        }
+        (temp_home / ".claude.json").write_text(json.dumps(config))
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        return switcher
+
+    def test_add_account_sets_alias(self, temp_home: Path):
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        switcher = self._config_switcher(temp_home, "a@x.com")
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account(alias="dev")
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["alias"] == "dev"
+
+    def test_readd_without_alias_preserves_existing(self, temp_home: Path):
+        """Re-running `cswap add` (refresh-in-place) without --alias must not
+        wipe a previously set alias."""
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        switcher = self._config_switcher(temp_home, "a@x.com")
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account(alias="dev")
+            switcher.add_account()  # refresh-in-place, no alias passed
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["alias"] == "dev"
+
+    def test_readd_refresh_in_place_applies_new_alias(self, temp_home: Path):
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        switcher = self._config_switcher(temp_home, "a@x.com")
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account()
+            switcher.add_account(alias="work")
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["alias"] == "work"
+
+    def test_explicit_slot_migration_preserves_alias(self, temp_home: Path):
+        """Moving an account to another slot (explicit --slot) carries its
+        alias forward instead of dropping it."""
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        switcher = self._config_switcher(temp_home, "a@x.com")
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account(alias="dev")  # lands in slot 1
+            switcher.add_account(slot=5)  # same identity, new slot, no alias passed
+
+        data = switcher._get_sequence_data()
+        assert "1" not in data["accounts"]
+        assert data["accounts"]["5"]["alias"] == "dev"
+
+    def test_add_account_duplicate_alias_raises(self, temp_home: Path):
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        switcher = self._config_switcher(temp_home, "a@x.com")
+        data = switcher._get_sequence_data()
+        data["accounts"]["9"] = {
+            "email": "other@x.com", "uuid": "u9", "alias": "dev",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [9]
+        switcher._write_json(switcher.sequence_file, data)
+
+        with patch.object(switcher, "_read_credentials", return_value=fake_creds), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            with pytest.raises(ValidationError):
+                switcher.add_account(alias="dev")

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -24,7 +24,7 @@ from claude_swap.exceptions import (
 )
 from claude_swap.usage_store import FetchRecord, UsageEntry, UsageStore
 from claude_swap.macos_keychain import KeychainError
-from claude_swap.models import Platform
+from claude_swap.models import Platform, normalize_alias
 from claude_swap.paths import get_backup_root, get_credentials_path
 from claude_swap.credentials import ActiveCredentials
 from claude_swap.switcher import (
@@ -305,17 +305,16 @@ class TestResolveAccountIdentifier:
 
 
 class TestAliasValidation:
-    """Test alias format validation."""
+    """Test alias format validation (models.normalize_alias)."""
 
     def test_valid_aliases(self, temp_home: Path):
-        switcher = ClaudeAccountSwitcher()
         for alias in ["dev", "work-1", "client_a", "team.b", "DEV"]:
-            assert switcher._validate_alias(alias), f"Expected {alias} to be valid"
+            normalize_alias(alias)  # must not raise
 
     def test_invalid_aliases(self, temp_home: Path):
-        switcher = ClaudeAccountSwitcher()
         for alias in ["123", "dev@work", "dev work", "", "dev/work", "-dev"]:
-            assert not switcher._validate_alias(alias), f"Expected {alias} to be invalid"
+            with pytest.raises(ValueError):
+                normalize_alias(alias)
 
 
 class TestResolveByAlias:
@@ -324,6 +323,17 @@ class TestResolveByAlias:
     def _write(self, switcher, data):
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, data)
+
+    def test_empty_identifier_never_matches_aliasless_account(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """An empty identifier must not silently resolve to whichever account
+        happens to have no alias set — it should just never match."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        assert switcher._find_account_by_alias("") is None
+        assert switcher._resolve_account_identifier("") is None
 
     def test_resolve_by_alias(self, temp_home: Path, sample_sequence_data: dict):
         sample_sequence_data["accounts"]["2"]["alias"] = "dev"
@@ -375,47 +385,66 @@ class TestResolveByAlias:
 
 
 class TestAliasCommand:
-    """Test ClaudeAccountSwitcher.alias() / list_aliases()."""
+    """Test ClaudeAccountSwitcher.set_alias()/unset_alias()/list_aliases()."""
 
     def _write(self, switcher, data):
         switcher._setup_directories()
         switcher._write_json(switcher.sequence_file, data)
 
-    def test_set_alias_by_number(self, temp_home: Path, sample_sequence_data: dict, capsys):
+    def test_set_alias_by_number(self, temp_home: Path, sample_sequence_data: dict):
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)
 
-        switcher.alias("2", "dev")
+        num, normalized = switcher.set_alias("2", "dev")
 
+        assert num == "2"
+        assert normalized == "dev"
         data = switcher._get_sequence_data()
         assert data["accounts"]["2"]["alias"] == "dev"
 
     def test_set_alias_normalizes_to_lowercase(
-        self, temp_home: Path, sample_sequence_data: dict, capsys
+        self, temp_home: Path, sample_sequence_data: dict
     ):
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)
 
-        switcher.alias("2", "DEV")
+        _, normalized = switcher.set_alias("2", "DEV")
 
+        assert normalized == "dev"
         data = switcher._get_sequence_data()
         assert data["accounts"]["2"]["alias"] == "dev"
 
-    def test_set_alias_by_email(self, temp_home: Path, sample_sequence_data: dict, capsys):
+    def test_set_alias_by_email(self, temp_home: Path, sample_sequence_data: dict):
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)
 
-        switcher.alias("account2@example.com", "dev")
+        num, _ = switcher.set_alias("account2@example.com", "dev")
 
+        assert num == "2"
         data = switcher._get_sequence_data()
         assert data["accounts"]["2"]["alias"] == "dev"
+
+    def test_rename_via_existing_alias_identifier(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """cswap alias <old> <new> — identifier can itself be an alias."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        switcher.set_alias("1", "dev")
+
+        num, normalized = switcher.set_alias("dev", "prod")
+
+        assert num == "1"
+        assert normalized == "prod"
+        assert switcher._resolve_account_identifier("prod") == "1"
+        assert switcher._resolve_account_identifier("dev") is None
 
     def test_set_invalid_alias_raises(self, temp_home: Path, sample_sequence_data: dict):
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)
 
         with pytest.raises(ValidationError):
-            switcher.alias("2", "123")
+            switcher.set_alias("2", "123")
 
     def test_set_duplicate_alias_raises(self, temp_home: Path, sample_sequence_data: dict):
         sample_sequence_data["accounts"]["1"]["alias"] = "dev"
@@ -423,42 +452,57 @@ class TestAliasCommand:
         self._write(switcher, sample_sequence_data)
 
         with pytest.raises(ConfigError):
-            switcher.alias("2", "dev")
+            switcher.set_alias("2", "dev")
 
-    def test_unset_alias(self, temp_home: Path, sample_sequence_data: dict, capsys):
+    def test_unset_alias(self, temp_home: Path, sample_sequence_data: dict):
         sample_sequence_data["accounts"]["2"]["alias"] = "dev"
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)
 
-        switcher.alias("2", unset=True)
+        num = switcher.unset_alias("2")
 
+        assert num == "2"
         data = switcher._get_sequence_data()
         assert "alias" not in data["accounts"]["2"]
+
+    def test_unset_alias_idempotent(self, temp_home: Path, sample_sequence_data: dict):
+        """Clearing an already-unset alias must not raise."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.unset_alias("2")  # never set — should be a silent no-op
+        switcher.unset_alias("2")
 
     def test_alias_unknown_account_raises(self, temp_home: Path, sample_sequence_data: dict):
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)
 
         with pytest.raises(AccountNotFoundError):
-            switcher.alias("999", "dev")
+            switcher.set_alias("999", "dev")
 
-    def test_list_aliases(self, temp_home: Path, sample_sequence_data: dict, capsys):
+    def test_list_aliases(self, temp_home: Path, sample_sequence_data: dict):
         sample_sequence_data["accounts"]["2"]["alias"] = "dev"
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)
 
-        switcher.list_aliases()
-        out = capsys.readouterr().out
-        assert "dev" in out
-        assert "account2@example.com" in out
+        assert switcher.list_aliases() == [("2", "dev", "account2@example.com")]
 
-    def test_list_aliases_empty(self, temp_home: Path, sample_sequence_data: dict, capsys):
+    def test_list_aliases_sequence_order(self, temp_home: Path, sample_sequence_data: dict):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        switcher.set_alias("2", "content")
+        switcher.set_alias("1", "dev")
+
+        assert switcher.list_aliases() == [
+            ("1", "dev", "account1@example.com"),
+            ("2", "content", "account2@example.com"),
+        ]
+
+    def test_list_aliases_empty(self, temp_home: Path, sample_sequence_data: dict):
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)
 
-        switcher.list_aliases()
-        out = capsys.readouterr().out
-        assert "No aliases set" in out
+        assert switcher.list_aliases() == []
 
 
 class TestDirectorySetup:
@@ -908,6 +952,32 @@ class TestListAccountsUsage:
         assert "└ 7d:" in output
         assert "10%" in output
         assert "50%" in output
+
+    def test_list_shows_alias_before_email(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys
+    ):
+        """An aliased account renders 'alias (email)', leading with the alias
+        — the whole point is not having to read full addresses to tell
+        similar-looking accounts apart."""
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        sample_sequence_data["accounts"]["1"]["alias"] = "dev"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        with patch.object(switcher, "_read_credentials", return_value=active_creds), \
+             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)):
+            switcher.list_accounts()
+
+        output = capsys.readouterr().out
+        assert "  1: dev (test@example.com) [personal] (active)" in output
+        # unaliased account keeps rendering plain email, no spurious parens
+        assert "  2: account2@example.com" in output
+        assert "(account2@example.com)" not in output
 
     def test_list_shows_usage_null_reset(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -209,6 +209,26 @@ class TestAliasTransfer:
                 )
                 assert "alias" not in seq["accounts"][imported_num]
 
+    def test_import_reexport_of_same_account_keeps_own_alias(self, temp_home: Path):
+        """Re-importing a backup of an account that already carries the same
+        alias locally must not be treated as a collision with itself."""
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com", alias="dev")
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                _seed_account(dst, 1, "alice@example.com", alias="dev")
+
+                import_accounts(dst, str(out_file), force=True)
+
+                seq = dst._get_sequence_data()
+                assert seq["accounts"]["1"]["alias"] == "dev"
+
     def test_import_duplicate_alias_within_export_rejected(self, temp_home: Path):
         src = _linux_switcher(temp_home)
         _seed_account(src, 1, "alice@example.com", alias="dev")

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -50,6 +50,7 @@ def _seed_account(
     org_name: str = "",
     creds: dict | None = None,
     config: dict | None = None,
+    alias: str | None = None,
 ) -> None:
     """Write an account to backup + sequence.json."""
     creds_obj = creds if creds is not None else {**SAMPLE_CREDS, "_marker": email}
@@ -77,6 +78,8 @@ def _seed_account(
         "organizationName": org_name,
         "added": "2024-01-01T00:00:00Z",
     }
+    if alias:
+        data["accounts"][str(num)]["alias"] = alias
     if num not in data["sequence"]:
         data["sequence"].append(num)
         data["sequence"].sort()
@@ -156,6 +159,94 @@ class TestRoundTrip:
                 import_accounts(dst, str(out_file))
                 final = dst._get_sequence_data()
                 assert final["activeAccountNumber"] == 9  # untouched
+
+
+class TestAliasTransfer:
+    """Alias round-trips through export/import, and collisions are handled."""
+
+    def test_alias_round_trips(self, temp_home: Path):
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com", alias="dev")
+        _seed_account(src, 2, "bob@example.com")
+
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+        envelope = json.loads(out_file.read_text())
+        by_email = {a["email"]: a for a in envelope["accounts"]}
+        assert by_email["alice@example.com"]["alias"] == "dev"
+        assert "alias" not in by_email["bob@example.com"]
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                import_accounts(dst, str(out_file))
+                seq = dst._get_sequence_data()
+                assert seq["accounts"]["1"]["alias"] == "dev"
+                assert "alias" not in seq["accounts"]["2"]
+
+    def test_import_alias_collision_with_local_drops_and_warns(self, temp_home: Path):
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com", alias="dev")
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                _seed_account(dst, 9, "existing@example.com", alias="dev")
+
+                import_accounts(dst, str(out_file))
+
+                seq = dst._get_sequence_data()
+                assert seq["accounts"]["9"]["alias"] == "dev"  # local kept
+                imported_num = next(
+                    n for n, acc in seq["accounts"].items()
+                    if acc["email"] == "alice@example.com"
+                )
+                assert "alias" not in seq["accounts"][imported_num]
+
+    def test_import_duplicate_alias_within_export_rejected(self, temp_home: Path):
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com", alias="dev")
+        _seed_account(src, 2, "bob@example.com", alias="dev")
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+        # Fabricate a duplicate alias in the exported envelope: export itself
+        # can't produce this (uniqueness enforced at set-time), but a
+        # hand-edited or foreign-tool-produced file could.
+        envelope = json.loads(out_file.read_text())
+        for acc in envelope["accounts"]:
+            acc["alias"] = "dev"
+        out_file.write_text(json.dumps(envelope))
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                with pytest.raises(TransferError):
+                    import_accounts(dst, str(out_file))
+
+    def test_import_invalid_alias_format_rejected(self, temp_home: Path):
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com")
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+        envelope = json.loads(out_file.read_text())
+        envelope["accounts"][0]["alias"] = "123"  # purely numeric — invalid
+        out_file.write_text(json.dumps(envelope))
+
+        dst_home = temp_home.parent / "dst"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                with pytest.raises(TransferError):
+                    import_accounts(dst, str(out_file))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -77,6 +77,7 @@ def make_account(
     kind: str = "oauth",
     entry: UsageEntry | None = None,
     email: str | None = None,
+    alias: str = "",
 ) -> AccountSnapshot:
     return AccountSnapshot(
         number=str(number),
@@ -87,6 +88,7 @@ def make_account(
         kind=kind,
         switchable=switchable,
         usage=entry if entry is not None else make_entry(),
+        alias=alias,
     )
 
 
@@ -548,6 +550,32 @@ class TestDashboard:
             await pilot.pause()
             ids = [item.action_id for item in menu.query(MenuItem)]
             assert ids[0] == "switch"
+
+    async def test_remove_menu_shows_alias_before_email(self, tmp_path):
+        fake = FakeSwitcher(
+            [
+                make_account(1, active=True, alias="dev"),
+                make_account(2, email="plain@example.com"),
+            ],
+            tmp_path,
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 32)) as pilot:
+            await settle(pilot)
+            from textual.widgets import ListView
+
+            from claude_swap.tui.widgets import MenuItem
+
+            await menu_select(pilot, "remove-menu")
+            from textual.widgets import Static
+
+            menu = app.screen.query_one("#menu", ListView)
+            labels = [
+                item.query_one(Static).render().plain for item in menu.query(MenuItem)
+            ]
+            assert any("dev (user1@example.com)" in label for label in labels)
+            assert any("plain@example.com" in label for label in labels)
+            assert not any("(plain@example.com)" in label for label in labels)
 
     async def test_back_menu_entry_pops_submenu(self, tmp_path):
         fake = FakeSwitcher([make_account(1, active=True)], tmp_path)


### PR DESCRIPTION
## Summary

Closes #110. Implements the alias design we proposed in the issue, refined per your feedback (thanks for the detailed review!):

```
cswap alias 2 dev          # set (also: cswap alias user@example.com dev)
cswap alias dev prod       # rename (identifier can itself be an alias)
cswap alias 2 --unset      # remove
cswap alias                # list current aliases
cswap add --alias dev      # convenience at add time
```

Resolution precedence is number → alias → email, matching the spec. Validation: `^[a-z0-9._-]+$` after lowercasing, not purely digits, no leading hyphen (argparse would read it as a flag), unique across accounts.

## The three gaps you flagged

1. **`switch_to`/`remove_account` gates**: both previously ran `_validate_email()` on any non-digit identifier before `_resolve_account_identifier` ever saw it, so `cswap switch dev` failed with "Invalid email format". Fixed by checking for an alias match first; the interactive duplicate-email prompt is now skipped for a resolved alias (aliases are unique by construction, so it never needs disambiguation).

2. **Display plumbing**: went through the real hot paths you named instead of the dead `AccountInfo.display_label`. Widened `_build_accounts_info`'s tuple (6 → 7, alias appended) and threaded it through `list_accounts`, `accounts_snapshot` → `AccountSnapshot` (TUI cards and the remove-account menu), `account_row` (JSON), and `_build_status_payload`. Menu bar's `format_title`/`format_account_label` prefer the alias over the email-derived label when set. Every surface leads with the alias ("alias (email)") since the whole point is not having to read full addresses to tell similar-looking accounts apart.
   - Also found the `list_accounts` print-loop comment claiming a `tui._watch_account_rows` parser depends on the exact output format was stale; that function no longer exists anywhere in the repo (it predates the Textual TUI rewrite). Removed the comment since there's no actual constraint left.

3. **Export/import + `add_account` alias preservation**: `alias` is carried through the export entry builder, import validation/normalization, and the `new_record` write. `add_account`'s explicit-slot full-record-write branch reads the existing record first and carries its alias forward instead of dropping it on refresh/migrate, and the refresh-in-place path applies a passed `--alias` immediately rather than ignoring it.
   - Import policy: an incoming alias that collides with an existing local alias is dropped with a warning rather than failing the whole import (aliases are a display nicety, not identity).

## Architecture

- `normalize_alias()` in `models.py` is the single source of truth for validation, shared by the CLI, `add_account`, and import validation.
- `set_alias()`/`unset_alias()` are dedicated methods with a clear API; `list_aliases()` returns structured `(num, alias, email)` tuples so the CLI (or any future caller) formats its own output rather than the switcher printing directly.

## Testing

- Full suite: 1205 → 1261 tests, all green.
- Coverage includes: alias validation, resolution precedence (including rename-via-alias), the gate-fix regressions, `add --alias` on fresh/refresh/migrate paths, export/import round-trip + collision handling (including a self-import edge case), JSON payload fields, menu bar and TUI formatting (including the remove-account menu), and a handful of edge-case fixes an independent review pass surfaced (leading-hyphen rejection, `--unset` with no target, and an empty-string identifier that could otherwise silently match an arbitrary account).
- Manually smoke-tested the CLI end-to-end.

## Test plan

- [x] `pytest tests/`: 1261 passed, 3 skipped
- [x] Manual: `cswap alias 1 dev`, `cswap alias`, `cswap list` (alias shown, leading), `cswap alias 2 dev` (duplicate, errors), `cswap alias dev prod` (rename via alias), `cswap remove dev`, `cswap alias 1 --unset`, `cswap alias --unset` (no target, errors), `cswap alias 1 -dev` (leading hyphen, errors)