### PR TITLE
Add `disable`/`enable` to hold an account out of auto-rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ cswap auto --dry-run           # log what it would do, never switch
 - Usage polling is adaptive — a couple of accounts per check, busy alternates watched more closely, exhausted ones left alone until they reset — so API traffic stays flat no matter how many accounts you manage.
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you log in with it and re-run `cswap add --slot N`. API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
+- To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`.
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
 
@@ -171,6 +172,8 @@ cswap status                    # Show current account
 cswap add --slot 3              # Add account to a specific slot (prompts before overwrite)
 cswap add --alias dev           # Add account and give it a short alias
 cswap remove 2                  # Remove an account
+cswap disable 2                 # Hold an account out of auto-rotation (keeps its login)
+cswap enable 2                  # Return a disabled account to rotation
 cswap alias 2 dev               # Give an account a short alias (usable anywhere NUM|EMAIL is)
 cswap alias 2 --unset           # Remove an account's alias
 cswap alias                     # List all aliases
@@ -290,7 +293,7 @@ cswap switch 2 --json
 
 Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
 
-Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is.
+Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
 
 An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -55,6 +55,8 @@ _SUBCOMMAND_FLAGS = {
     "add-token": "--add-token",
     "remove": "--remove-account",
     "rm": "--remove-account",
+    "disable": "--disable-account",
+    "enable": "--enable-account",
     "export": "--export",
     "import": "--import",
     "purge": "--purge",
@@ -789,6 +791,8 @@ Commands:
   %(prog)s add                        add the current account
   %(prog)s add-token [TOKEN|-]        register a setup-token or API key
   %(prog)s remove <num|email>         remove an account
+  %(prog)s disable <num|email>        hold an account out of auto-rotation
+  %(prog)s enable <num|email>         return a disabled account to rotation
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s run                        run the current dir's mapped account
   %(prog)s map <num|email> [path]     map a directory to an account
@@ -926,6 +930,16 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         help=argparse.SUPPRESS,
     )
     group.add_argument(
+        "--disable-account",
+        metavar="NUM|EMAIL",
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
+        "--enable-account",
+        metavar="NUM|EMAIL",
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
         "--list",
         action="store_true",
         help=argparse.SUPPRESS,
@@ -1006,6 +1020,8 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         or args.menubar
         or args.upgrade
         or args.remove_account is not None
+        or args.disable_account is not None
+        or args.enable_account is not None
         or args.switch_to is not None
         or args.export is not None
         or args.import_ is not None
@@ -1090,6 +1106,10 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             )
         elif args.remove_account:
             switcher.remove_account(args.remove_account)
+        elif args.disable_account is not None:
+            switcher.set_account_disabled(args.disable_account, True)
+        elif args.enable_account is not None:
+            switcher.set_account_disabled(args.enable_account, False)
         elif args.list:
             payload = switcher.list_accounts(
                 show_token_status=args.token_status,

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -147,6 +147,7 @@ def account_row(
     usage_fetched_at: float | None = None,
     usage_age_s: float | None = None,
     alias: str = "",
+    disabled: bool = False,
 ) -> dict:
     """A full account row for ``--list``."""
     status, usage = usage_fields(usage_entry)
@@ -162,6 +163,10 @@ def account_row(
     }
     if alias:
         row["alias"] = alias
+    # Additive field: present only when the slot is held out of rotation, so
+    # existing consumers keying on the base schema are unaffected.
+    if disabled:
+        row["disabled"] = True
     if usage is not None:
         row.update(usage_freshness_fields(usage_fetched_at, usage_age_s))
     return row

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -812,13 +812,96 @@ class ClaudeAccountSwitcher:
         return inputs
 
     def switchable_account_numbers(self) -> list[str]:
-        """Account numbers in rotation order that have usable stored backups."""
+        """Account numbers in rotation order eligible for automatic selection.
+
+        Excludes slots without usable stored backups and slots the user has
+        disabled (``cswap disable``). Disabled slots stay managed and remain
+        valid explicit ``cswap switch <num|email>`` targets — they are only
+        held out of automatic rotation and the usage-aware strategies.
+        """
         data = self._get_sequence_data() or {}
         return [
             str(num)
             for num in data.get("sequence", [])
             if self._account_is_switchable(str(num))
+            and not self._disabled_from_data(data, str(num))
         ]
+
+    @staticmethod
+    def _disabled_from_data(data: dict, account_num: str) -> bool:
+        """Whether a slot is flagged out of rotation in already-loaded data."""
+        record = data.get("accounts", {}).get(str(account_num))
+        return bool(record and record.get("disabled"))
+
+    def is_account_disabled(self, account_num: str) -> bool:
+        """Whether a slot is currently held out of rotation."""
+        data = self._get_sequence_data() or {}
+        return self._disabled_from_data(data, str(account_num))
+
+    def disabled_account_numbers(self) -> list[str]:
+        """Managed slots the user has disabled, in sequence order."""
+        data = self._get_sequence_data() or {}
+        return [
+            str(num)
+            for num in data.get("sequence", [])
+            if self._disabled_from_data(data, str(num))
+        ]
+
+    def set_account_disabled(self, identifier: str, disabled: bool) -> None:
+        """Hold an account out of rotation (``disabled=True``) or return it.
+
+        Disabling only affects automatic selection — the auto-switch engine,
+        bare ``cswap switch`` rotation, and the ``best`` / ``next-available``
+        strategies all skip disabled slots. The account stays managed and is
+        still a valid explicit ``cswap switch <num|email>`` target, so you can
+        park an account without losing its stored login. Re-enabling restores
+        it to rotation in its original sequence position.
+
+        Raises:
+            ConfigError: no accounts are managed yet, or the email is ambiguous.
+            AccountNotFoundError: identifier doesn't match any account.
+        """
+        if not self.sequence_file.exists():
+            raise ConfigError("No accounts are managed yet")
+
+        # resolve_account migrates org fields and hard-errors on ambiguity.
+        account_num, email, _ = self.resolve_account(identifier)
+
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(account_num)
+        if not record:
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+
+        verb = "disabled" if disabled else "enabled"
+        if bool(record.get("disabled")) == disabled:
+            print(dimmed(f"Account-{account_num} ({email}) is already {verb}."))
+            return
+
+        if disabled:
+            record["disabled"] = True
+        else:
+            record.pop("disabled", None)
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        self._logger.info(f"{verb.capitalize()} account {account_num}: {email}")
+
+        print(f"{accent(verb.capitalize())} Account-{account_num} ({email}).")
+
+        if disabled:
+            active = data.get("activeAccountNumber")
+            if str(active) == account_num:
+                print(dimmed(
+                    "  It is the active account — it stays live until you switch "
+                    "away; it just won't be an automatic switch target."
+                ))
+            if not self.switchable_account_numbers():
+                warning(
+                    "  No accounts remain in rotation — auto-switch and bare "
+                    "switch have nothing to pick. Re-enable one with "
+                    "cswap enable <num|email>."
+                )
+        else:
+            print(dimmed("  It is back in the rotation."))
 
     def account_kind_for(self, account_num: str) -> str:
         """Public wrapper: ``"api_key"`` or ``"oauth"`` (setup-tokens read as oauth)."""
@@ -2291,7 +2374,9 @@ class ClaudeAccountSwitcher:
         data = self._get_sequence_data() or {}
         others = [
             str(n) for n in data.get("sequence", [])
-            if str(n) != str(current_num) and self._account_is_switchable(str(n))
+            if str(n) != str(current_num)
+            and self._account_is_switchable(str(n))
+            and not self._disabled_from_data(data, str(n))
         ]
         if not others:
             return None, "none"
@@ -2441,6 +2526,7 @@ class ClaudeAccountSwitcher:
         """Build the ``--list --json`` payload from gathered account + usage data."""
         active_num: int | None = None
         accounts = []
+        seq_data = self._get_sequence_data() or {}
         for num, email, org_name, org_uuid, is_active, _, alias in accounts_info:
             if is_active:
                 active_num = num
@@ -2456,6 +2542,7 @@ class ClaudeAccountSwitcher:
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
                     alias=alias,
+                    disabled=self._disabled_from_data(seq_data, str(num)),
                 )
             )
         payload = {
@@ -2510,15 +2597,21 @@ class ClaudeAccountSwitcher:
         if json_output:
             return self._build_list_payload(accounts_info, entries)
 
+        seq_data = self._get_sequence_data() or {}
         print(bolded("Accounts:"))
         for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
             label = f"{accent(alias)} ({email})" if alias else email
+            # NOTE: the TUI watch view (tui._watch_account_rows) parses this
+            # output to map rows to accounts for quick-switch: it relies on the
+            # uncolored ``  {num}: `` prefix and the ``(active)`` marker below.
+            # Keep them intact when tweaking this line, or update that parser.
+            markers = ""
             if is_active:
-                marker = f" {bold_accent('(active)')}"
-                print(f"  {num}: {label} {muted(f'[{tag}]')}{marker}")
-            else:
-                print(f"  {num}: {label} {muted(f'[{tag}]')}")
+                markers += f" {bold_accent('(active)')}"
+            if self._disabled_from_data(seq_data, str(num)):
+                markers += f" {muted('(disabled)')}"
+            print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
 
@@ -3021,6 +3114,12 @@ class ClaudeAccountSwitcher:
         skipped_exhausted: list[str] = []
         for offset in range(1, len(sequence)):
             candidate = str(sequence[(current_index + offset) % len(sequence)])
+            if self._disabled_from_data(data, candidate):
+                if json_output:
+                    warnings.append(f"Skipped Account-{candidate} (disabled)")
+                else:
+                    print(f"{accent('Skipping')} Account-{candidate} (disabled)")
+                continue
             if not self._account_is_switchable(candidate):
                 if json_output:
                     warnings.append(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1456,3 +1456,38 @@ class TestRunAutoResolve:
              patch.object(sys, "argv", ["claude-swap", "run", "--share-history"]):
             cli.main()
         assert ("run", "2", [], True, True) in calls
+
+
+class TestDisableEnableDispatch:
+    """`cswap disable`/`cswap enable` (and the legacy --disable-account /
+    --enable-account flags) forward to switcher.set_account_disabled."""
+
+    def _run(self, argv):
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", *argv]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+        return switcher_cls.return_value
+
+    def test_disable_subcommand_forwards(self):
+        switcher = self._run(["disable", "2"])
+        switcher.set_account_disabled.assert_called_once_with("2", True)
+
+    def test_enable_subcommand_forwards(self):
+        switcher = self._run(["enable", "user@example.com"])
+        switcher.set_account_disabled.assert_called_once_with("user@example.com", False)
+
+    def test_legacy_disable_flag_forwards(self):
+        switcher = self._run(["--disable-account", "3"])
+        switcher.set_account_disabled.assert_called_once_with("3", True)
+
+    def test_legacy_enable_flag_forwards(self):
+        switcher = self._run(["--enable-account", "3"])
+        switcher.set_account_disabled.assert_called_once_with("3", False)
+
+    def test_disable_without_target_errors(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "disable"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -13,6 +13,7 @@ from claude_swap import oauth
 from claude_swap.exceptions import ConfigError, SwitchError
 from claude_swap.json_output import (
     SCHEMA_VERSION,
+    account_row,
     error_envelope,
     usage_fields,
     usage_to_json,
@@ -575,3 +576,15 @@ class TestSwitchJson:
         assert result["switched"] is False
         assert result["reason"] == "unmanaged-account"
         assert result["from"] == {"number": None, "email": "test@example.com"}
+
+
+class TestAccountRowDisabled:
+    """The additive ``disabled`` field on --list rows."""
+
+    def test_disabled_true_included(self):
+        row = account_row(2, "b@example.com", "", "", False, None, disabled=True)
+        assert row["disabled"] is True
+
+    def test_disabled_absent_by_default(self):
+        row = account_row(1, "a@example.com", "", "", False, None)
+        assert "disabled" not in row

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -6180,3 +6180,251 @@ class TestAddAccountAlias:
              patch.object(switcher, "_delete_account_credentials"):
             with pytest.raises(ValidationError):
                 switcher.add_account(alias="dev")
+
+
+# ---------------------------------------------------------------------------
+# Disable / enable an account (hold it out of auto-rotation)
+# ---------------------------------------------------------------------------
+
+
+class TestDisableEnableAccount:
+    """`cswap disable`/`cswap enable`: park a managed account out of automatic
+    rotation without removing it. Disabled slots are skipped by the auto-switch
+    engine, bare `switch` rotation, and the usage-aware strategies, but stay
+    valid explicit `switch <num|email>` targets."""
+
+    def _setup(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.LINUX
+        s._setup_directories()
+        s._init_sequence_file()
+        return s
+
+    def _seed(self, s: ClaudeAccountSwitcher, num: int, email: str) -> None:
+        """Add a fully switchable slot (creds + config backups present)."""
+        s._write_account_credentials(
+            str(num),
+            email,
+            json.dumps({"claudeAiOauth": {
+                "accessToken": f"sk-{num}", "refreshToken": f"rt-{num}"}}),
+        )
+        s._write_account_config(
+            str(num),
+            email,
+            json.dumps({"oauthAccount": {
+                "emailAddress": email, "accountUuid": f"uuid-{num}"}}),
+        )
+        data = s._get_sequence_data() or {
+            "activeAccountNumber": None, "lastUpdated": "",
+            "sequence": [], "accounts": {},
+        }
+        data["accounts"][str(num)] = {
+            "email": email, "uuid": f"uuid-{num}",
+            "organizationUuid": "", "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+            data["sequence"].sort()
+        if data["activeAccountNumber"] is None:
+            data["activeAccountNumber"] = num
+        s._write_json(s.sequence_file, data)
+
+    def _make_live(self, temp_home: Path, email: str, num: int) -> None:
+        """Point the live login at a seeded account."""
+        (temp_home / ".claude" / ".credentials.json").write_text(
+            json.dumps({"claudeAiOauth": {
+                "accessToken": f"sk-live-{num}", "refreshToken": f"rt-live-{num}"}})
+        )
+        (temp_home / ".claude.json").write_text(json.dumps({
+            "oauthAccount": {"emailAddress": email, "accountUuid": f"uuid-{num}"}
+        }))
+
+    # -- flag storage + accessors ------------------------------------------
+
+    def test_disable_sets_flag_and_excludes_from_rotation(self, temp_home, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._seed(s, 3, "c@example.com")
+
+        s.set_account_disabled("2", True)
+
+        assert s.is_account_disabled("2") is True
+        assert s.disabled_account_numbers() == ["2"]
+        assert s.switchable_account_numbers() == ["1", "3"]
+        data = s._get_sequence_data()
+        assert data["accounts"]["2"]["disabled"] is True
+        assert "Disabled Account-2" in capsys.readouterr().out
+
+    def test_enable_clears_flag_and_restores_position(self, temp_home, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._seed(s, 3, "c@example.com")
+
+        s.set_account_disabled("2", True)
+        capsys.readouterr()
+        s.set_account_disabled("2", False)
+
+        assert s.is_account_disabled("2") is False
+        assert s.disabled_account_numbers() == []
+        # Restored in original sequence position, not appended at the end.
+        assert s.switchable_account_numbers() == ["1", "2", "3"]
+        data = s._get_sequence_data()
+        assert "disabled" not in data["accounts"]["2"]
+        assert "Enabled Account-2" in capsys.readouterr().out
+
+    def test_disable_by_email(self, temp_home):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+
+        s.set_account_disabled("b@example.com", True)
+
+        assert s.is_account_disabled("2") is True
+
+    def test_repeated_disable_is_noop(self, temp_home, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+
+        s.set_account_disabled("2", True)
+        capsys.readouterr()
+        s.set_account_disabled("2", True)  # already disabled
+
+        assert "already disabled" in capsys.readouterr().out
+        assert s.is_account_disabled("2") is True
+
+    def test_enable_when_not_disabled_is_noop(self, temp_home, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+
+        s.set_account_disabled("1", False)
+
+        assert "already enabled" in capsys.readouterr().out
+
+    def test_disable_unknown_account_raises(self, temp_home):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+
+        with pytest.raises(AccountNotFoundError):
+            s.set_account_disabled("99", True)
+
+    # -- effect on rotation / strategies -----------------------------------
+
+    def test_rotation_skips_disabled_slot(self, temp_home, capsys):
+        """active=1, slot 2 disabled — bare switch must land on 3."""
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._seed(s, 3, "c@example.com")
+        s.set_account_disabled("2", True)
+        capsys.readouterr()
+        self._make_live(temp_home, "a@example.com", 1)
+
+        with patch.object(s, "list_accounts"):
+            s.switch()
+
+        out = capsys.readouterr().out
+        assert "Skipping Account-2 (disabled)" in out
+        assert s._get_sequence_data()["activeAccountNumber"] == 3
+
+    def test_best_strategy_ignores_disabled_candidate(self, temp_home):
+        """The only other switchable account is disabled → no candidate."""
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        s.set_account_disabled("2", True)
+
+        target, note = s._select_best_switchable("1")
+
+        assert target is None
+        assert note == "none"
+
+    def test_explicit_switch_to_disabled_still_works(self, temp_home):
+        """Disabling only holds an account out of *automatic* selection;
+        an explicit `switch <num>` must still activate it."""
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        s.set_account_disabled("2", True)
+        self._make_live(temp_home, "a@example.com", 1)
+
+        with patch.object(s, "list_accounts"):
+            s.switch_to("2")
+
+        assert s._get_sequence_data()["activeAccountNumber"] == 2
+
+    def test_remove_then_readd_clears_disabled(self, temp_home):
+        """A disabled slot re-added later must not inherit the stale flag."""
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        s.set_account_disabled("2", True)
+
+        data = s._get_sequence_data()
+        del data["accounts"]["2"]
+        data["sequence"] = [n for n in data["sequence"] if n != 2]
+        s._write_json(s.sequence_file, data)
+        self._seed(s, 2, "b@example.com")  # re-add
+
+        assert s.is_account_disabled("2") is False
+
+    # -- warnings ----------------------------------------------------------
+
+    def test_disable_active_account_warns_but_sets_flag(self, temp_home, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")  # becomes active
+        self._seed(s, 2, "b@example.com")
+
+        s.set_account_disabled("1", True)
+
+        out = capsys.readouterr().out
+        assert "active account" in out
+        assert s.is_account_disabled("1") is True
+
+    def test_disable_last_rotation_account_warns(self, temp_home, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+
+        s.set_account_disabled("1", True)
+        capsys.readouterr()
+        s.set_account_disabled("2", True)  # now nothing left in rotation
+
+        assert "No accounts remain in rotation" in capsys.readouterr().out
+
+    # -- display -----------------------------------------------------------
+
+    def test_list_shows_disabled_marker(self, temp_home, capsys):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        s.set_account_disabled("2", True)
+        capsys.readouterr()
+
+        with patch.object(s, "_read_credentials", return_value=""), \
+             patch.object(s, "_read_account_credentials", return_value=""):
+            s.list_accounts()
+
+        out = capsys.readouterr().out
+        assert "(disabled)" in out
+        # Marker attaches to the disabled row, not the enabled one.
+        disabled_line = next(ln for ln in out.splitlines() if ln.strip().startswith("2:"))
+        assert "(disabled)" in disabled_line
+
+    def test_json_list_carries_disabled_field(self, temp_home):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        s.set_account_disabled("2", True)
+
+        with patch.object(s, "_read_credentials", return_value=""), \
+             patch.object(s, "_read_account_credentials", return_value=""):
+            payload = s.list_accounts(json_output=True)
+
+        rows = {r["number"]: r for r in payload["accounts"]}
+        assert rows[2].get("disabled") is True
+        # Additive: absent (not False) on enabled rows.
+        assert "disabled" not in rows[1]


### PR DESCRIPTION
## What

Adds two commands to park a managed account out of automatic rotation without removing it (and losing its stored login):

```bash
cswap disable <num|email>   # hold out of auto-rotation
cswap enable  <num|email>   # put it back
```

The legacy flag spellings `--disable-account` / `--enable-account` work too, matching the rest of the CLI.

## Why

There's currently no way to say "keep this account managed, but don't auto-switch onto it right now" — a work account you don't want touched, one you're resting, or a temporarily-flaky login. The only options are `remove` (destroys the stored login) or nothing. This adds a reversible toggle.

## Behavior

A disabled account is skipped by:
- the **auto-switch engine** (every candidate list routes through `switchable_account_numbers()`),
- bare **`cswap switch`** rotation, and
- the **`best`** and **`next-available`** strategies.

It stays fully managed and remains a valid **explicit** `cswap switch <num|email>` target — disabling only affects *automatic* selection, so you can still deliberately jump to a parked account. The fresh-machine bootstrap path (activating a login right after `--import`) is intentionally untouched.

`cswap list` shows a `(disabled)` marker; `--list --json` carries an additive `"disabled": true` on the row (absent otherwise, so existing consumers are unaffected).

## Implementation

- State is a per-account `disabled: true` flag in `sequence.json`. It's preserved across the org-field migration (which mutates records in place) and is naturally cleared when a slot is removed and re-added.
- New switcher API: `set_account_disabled()`, `is_account_disabled()`, `disabled_account_numbers()`, and a `_disabled_from_data()` helper. `switchable_account_numbers()`, `_select_best_switchable()`, and the `switch()` rotation loop gained the `and not disabled` predicate (rotation prints a `Skipping Account-N (disabled)` line / JSON warning, mirroring the existing broken-slot skip).
- Resolution reuses `resolve_account()` (NUM or EMAIL; hard error on ambiguous email or unknown account). Disabling the active account or the last remaining rotation target prints a heads-up but never blocks.

## Tests

21 new tests: flag storage + accessors, rotation/`best` exclusion, explicit `switch <num>` still activating a disabled slot, re-add clearing the flag, idempotent toggles, active-account / last-account warnings, the `(disabled)` list marker, the JSON field, and CLI dispatch for both the subcommands and legacy flags. Full suite green (`1226 passed, 3 skipped`).

## Follow-up (not in this PR)

The TUI/menu-bar automatically *respect* disabled state (their switch actions call the same `switch()` paths), but don't yet surface a `(disabled)` marker or an in-app toggle — a natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCcSh6s4UiLHrwKLd1UNaX