### PR TITLE
feat: surface and toggle disabled state in the TUI and menu bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ cswap auto --dry-run           # log what it would do, never switch
 - Usage polling is adaptive — a couple of accounts per check, busy alternates watched more closely, exhausted ones left alone until they reset — so API traffic stays flat no matter how many accounts you manage.
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you log in with it and re-run `cswap add --slot N`. API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
-- To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`.
+- To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
 
@@ -223,7 +223,7 @@ uv tool install 'claude-swap[menubar]'   # or: pipx install 'claude-swap[menubar
 cswap menubar
 ```
 
-Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / remove / refresh actions. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
+Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
 
 </details>
 

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -211,10 +211,12 @@ def format_account_label(
     usage: dict | str | None,
     now: float | None = None,
     alias: str | None = None,
+    disabled: bool = False,
 ) -> str:
     """Build one account row's menu label."""
     label = f"{alias}  ({email})" if alias else email
-    return f"{num}  {label}  {usage_summary(usage, now)}"
+    marker = "  (disabled)" if disabled else ""
+    return f"{num}  {label}{marker}  {usage_summary(usage, now)}"
 
 
 def _local_part(email: str, limit: int = 12) -> str:
@@ -338,7 +340,7 @@ EMPTY_SNAPSHOT: dict = {
 def _adapt_snapshot(snap) -> dict:
     """Adapt an ``AccountsSnapshot`` to the menu bar's render dict.
 
-    Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good, alias), ...],
+    Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good, alias, disabled), ...],
     "active_email": str | None, "active_usage": dict | str | None,
     "active_alias": str | None}``. The snapshot itself is produced by
     ``SnapshotSource`` (the paced read path), so this is a pure transform — no
@@ -351,7 +353,7 @@ def _adapt_snapshot(snap) -> dict:
     for acc in snap.accounts:
         display = _account_display_usage(acc.usage)
         accounts.append(
-            (acc.number, acc.email, acc.is_active, display, acc.usage.last_good, acc.alias)
+            (acc.number, acc.email, acc.is_active, display, acc.usage.last_good, acc.alias, acc.disabled)
         )
         if acc.is_active:
             active_email, active_usage, active_alias = acc.email, display, acc.alias
@@ -444,7 +446,7 @@ def run(switcher) -> int:
             but de-dupes per account on the (5h, 7d) percentages so an idle
             machine doesn't churn the rotating log with identical lines.
             """
-            for num, email, _is_active, _display, last_good, _alias in snap["accounts"]:
+            for num, email, _is_active, _display, last_good, _alias, _disabled in snap["accounts"]:
                 key = _usage_log_key(last_good)
                 if key == (None, None) or self._last_usage_log.get(num) == key:
                     continue
@@ -561,9 +563,9 @@ def run(switcher) -> int:
             )
             self.menu.clear()
             account_items = []
-            for num, email, is_active, display, _last_good, alias in self.snapshot["accounts"]:
+            for num, email, is_active, display, _last_good, alias, disabled in self.snapshot["accounts"]:
                 item = rumps.MenuItem(
-                    format_account_label(num, email, display, alias=alias),
+                    format_account_label(num, email, display, alias=alias, disabled=disabled),
                     callback=self._make_switch_to(num),
                 )
                 item.state = 1 if is_active else 0
@@ -579,6 +581,7 @@ def run(switcher) -> int:
                 rumps.MenuItem("Next available", callback=self._switch("next-available")),
                 None,
                 self._add_menu(rumps),
+                self._disable_menu(rumps),
                 self._remove_menu(rumps),
                 rumps.MenuItem("Refresh current credentials", callback=self.on_refresh_creds),
                 self._history_menu(rumps),
@@ -600,9 +603,25 @@ def run(switcher) -> int:
             accounts = self.snapshot["accounts"]
             if not accounts:
                 menu.add(rumps.MenuItem("No managed accounts", callback=None))
-            for num, email, _is_active, _display, _last_good, alias in accounts:
+            for num, email, _is_active, _display, _last_good, alias, _disabled in accounts:
                 label = f"{num}  {alias}  ({email})" if alias else f"{num}  {email}"
                 menu.add(rumps.MenuItem(label, callback=self._make_remove(num)))
+            return menu
+
+        def _disable_menu(self, rumps):
+            menu = rumps.MenuItem("Disable / enable account")
+            accounts = self.snapshot["accounts"]
+            if not accounts:
+                menu.add(rumps.MenuItem("No managed accounts", callback=None))
+            for num, email, _is_active, _display, _last_good, alias, disabled in accounts:
+                name = f"{alias}  ({email})" if alias else email
+                item = rumps.MenuItem(
+                    f"{num}  {name}", callback=self._make_toggle_disabled(num, disabled)
+                )
+                # A check-mark reads as "held out of rotation" — same glyph the
+                # active row uses, but here it means disabled, not selected.
+                item.state = 1 if disabled else 0
+                menu.add(item)
             return menu
 
         def _history_menu(self, rumps):
@@ -709,6 +728,16 @@ def run(switcher) -> int:
                 ) == 1:  # 1 == OK
                     if self._guard(lambda: self.switcher.remove_account(str(num), assume_yes=True)):
                         self.refresh_async()
+            return cb
+
+        def _make_toggle_disabled(self, num, disabled):
+            # `disabled` is this row's current state; selecting it flips it.
+            target = not disabled
+            def cb(_sender):
+                if self._guard(
+                    lambda: self.switcher.set_account_disabled(str(num), target)
+                ):
+                    self.refresh_async()
             return cb
 
         def on_add_login(self, _sender):

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -139,6 +139,7 @@ class AccountSnapshot:
     switchable: bool
     usage: UsageEntry
     alias: str = ""
+    disabled: bool = False  # held out of auto-rotation (still a valid explicit target)
 
     @property
     def display_tag(self) -> str:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -738,6 +738,7 @@ class ClaudeAccountSwitcher:
         """
         accounts_info = self._build_accounts_info()
         entries = self._collect_usage_entries(accounts_info, fetch=fetch)
+        seq_data = self._get_sequence_data() or {}
         active_number: str | None = None
         accounts: list[AccountSnapshot] = []
         for num, email, org_name, org_uuid, is_active, _creds, alias in accounts_info:
@@ -755,6 +756,7 @@ class ClaudeAccountSwitcher:
                     switchable=self._account_is_switchable(n),
                     usage=entries[n],
                     alias=alias,
+                    disabled=self._disabled_from_data(seq_data, n),
                 )
             )
         return AccountsSnapshot(

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -180,6 +180,22 @@ class CswapApp(App):
             partial(self.switcher.switch, strategy="best", json_output=True),
         )
 
+    def do_toggle_disabled(self, number: str) -> None:
+        """Hold the account out of auto-rotation, or return it — reads its
+        current state from the live snapshot to pick the direction."""
+        snap = self.snapshot
+        acc = next(
+            (a for a in (snap.accounts if snap else ()) if a.number == number), None
+        )
+        if acc is None:
+            return
+        target = not acc.disabled
+        verb = "Disable" if target else "Enable"
+        self._start_action(
+            f"{verb} account {number}",
+            partial(self.switcher.set_account_disabled, number, target),
+        )
+
     def confirm_remove(self, number: str, email: str) -> None:
         self.push_screen(
             ConfirmModal(

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -78,6 +78,7 @@ class DashboardScreen(Screen):
             ("Watch accounts", "watch"),
             ("Auto-switch view", "auto"),
             ("Add account…", "add-menu"),
+            ("Disable / enable account…", "disable-menu"),
             ("Remove account…", "remove-menu"),
             ("Quit", "quit"),
         ]
@@ -99,6 +100,21 @@ class DashboardScreen(Screen):
             )
             for acc in (snap.accounts if snap else ())
         ]
+        entries.append(_BACK)
+        return entries
+
+    def _disable_entries(self) -> MenuEntries:
+        """One row per account, labelled with its current state and the action
+        selecting it will take (enable a disabled one, disable an active one)."""
+        snap = self.app.snapshot
+        entries: MenuEntries = []
+        for acc in (snap.accounts if snap else ()):
+            name = f"{acc.alias} ({acc.email})" if acc.alias else acc.email
+            action = "→ enable" if acc.disabled else "→ disable"
+            state = "  (disabled)" if acc.disabled else ""
+            entries.append(
+                (f"{acc.number}  {name}{state}   {action}", f"disable:{acc.number}")
+            )
         entries.append(_BACK)
         return entries
 
@@ -152,6 +168,12 @@ class DashboardScreen(Screen):
                 "?",
             )
             app.confirm_remove(number, email)
+        elif action_id == "disable-menu":
+            await self._push_menu("disable / enable", self._disable_entries())
+        elif action_id.startswith("disable:"):
+            number = action_id.split(":", 1)[1]
+            app.do_toggle_disabled(number)
+            await self._pop_menu()
         else:
             actions[action_id]()
 

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -165,6 +165,8 @@ def account_card_text(
     text.append(f"  [{acc.display_tag}]", style=MUTED)
     if acc.is_active:
         text.append("   ● active", style=f"bold {ACCENT}")
+    if acc.disabled:
+        text.append("   (disabled)", style=MUTED)
     age = data.format_age(acc.usage.age_s)
     if age:
         text.append(f"   {age}", style=MUTED)
@@ -233,6 +235,8 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
     else:
         text.append(acc.email, style=FOREGROUND)
     text.append(f"  [{acc.display_tag}]", style=MUTED)
+    if acc.disabled:
+        text.append("  (disabled)", style=MUTED)
     text.append("   ")
 
     sentinel = acc.usage.sentinel

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -132,6 +132,11 @@ def test_format_account_label_with_alias():
     assert label == "2  dev  (loc@papaya.asia)  5h 42% · 7d 18% · $ 30%"
 
 
+def test_format_account_label_disabled_marker():
+    label = menubar.format_account_label(2, "loc@papaya.asia", _USAGE, disabled=True)
+    assert label == "2  loc@papaya.asia  (disabled)  5h 42% · 7d 18% · $ 30%"
+
+
 # --- usage logging -------------------------------------------------------------
 
 def test_format_usage_log_full():
@@ -342,12 +347,13 @@ class _FakeEntry:
 
 
 class _FakeAcct:
-    def __init__(self, number, email, is_active, usage, alias=""):
+    def __init__(self, number, email, is_active, usage, alias="", disabled=False):
         self.number = number
         self.email = email
         self.is_active = is_active
         self.usage = usage
         self.alias = alias
+        self.disabled = disabled
 
 
 class _FakeSnap:
@@ -370,17 +376,17 @@ def test_adapt_snapshot_shape_and_active_selection():
     lg = {"five_hour": {"pct": 10.0}, "seven_day": {"pct": 20.0}}
     accts = [
         _FakeAcct("1", "a@x.com", True, _FakeEntry(last_good=lg)),
-        _FakeAcct("2", "b@x.com", False, _FakeEntry(sentinel=USAGE_API_KEY)),
+        _FakeAcct("2", "b@x.com", False, _FakeEntry(sentinel=USAGE_API_KEY), disabled=True),
     ]
     snap = menubar._adapt_snapshot(_FakeSnap(accts))
     assert snap["active_email"] == "a@x.com"
     assert snap["active_usage"] == lg
     assert snap["active_alias"] == ""
-    # (num, email, is_active, display_usage, last_good, alias)
-    assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg, "")
-    # sentinel account: display is the human note, last_good is None
+    # (num, email, is_active, display_usage, last_good, alias, disabled)
+    assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg, "", False)
+    # sentinel account: display is the human note, last_good is None; disabled carried through
     assert snap["accounts"][1] == (
-        "2", "b@x.com", False, menubar.SENTINEL_NOTES[USAGE_API_KEY], None, "",
+        "2", "b@x.com", False, menubar.SENTINEL_NOTES[USAGE_API_KEY], None, "", True,
     )
 
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -6284,6 +6284,22 @@ class TestDisableEnableAccount:
 
         assert s.is_account_disabled("2") is True
 
+    def test_disable_and_enable_by_alias(self, temp_home):
+        """An alias resolves the same as a number/email (issue: disable/enable
+        must accept aliases now that the alias feature has landed)."""
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        s.set_alias("2", "dev")
+
+        s.set_account_disabled("dev", True)
+        assert s.is_account_disabled("2") is True
+        assert s.switchable_account_numbers() == ["1"]
+
+        s.set_account_disabled("dev", False)
+        assert s.is_account_disabled("2") is False
+        assert s.switchable_account_numbers() == ["1", "2"]
+
     def test_repeated_disable_is_noop(self, temp_home, capsys):
         s = self._setup(temp_home)
         self._seed(s, 1, "a@example.com")

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -78,6 +78,7 @@ def make_account(
     entry: UsageEntry | None = None,
     email: str | None = None,
     alias: str = "",
+    disabled: bool = False,
 ) -> AccountSnapshot:
     return AccountSnapshot(
         number=str(number),
@@ -89,6 +90,7 @@ def make_account(
         switchable=switchable,
         usage=entry if entry is not None else make_entry(),
         alias=alias,
+        disabled=disabled,
     )
 
 
@@ -145,6 +147,17 @@ class FakeSwitcher:
         self.calls.append(("remove", str(identifier), assume_yes))
         self._accounts = [a for a in self._accounts if a.number != str(identifier)]
         print(f"Removed account {identifier}")
+
+    def set_account_disabled(self, identifier: str, disabled: bool) -> None:
+        self.calls.append(("set_disabled", str(identifier), disabled))
+        self._accounts = [
+            dataclasses.replace(a, disabled=disabled)
+            if a.number == str(identifier)
+            else a
+            for a in self._accounts
+        ]
+        verb = "Disabled" if disabled else "Enabled"
+        print(f"{verb} Account-{identifier}")
 
     def add_account(self, slot: int | None = None, assume_yes: bool = False) -> None:
         self.calls.append(("add", slot, assume_yes))
@@ -482,6 +495,27 @@ class TestDashboard:
             mini_part = panel.split("user2@example.com", 1)[1]
             assert "━" not in mini_part
 
+    async def test_disabled_marker_on_active_card_and_mini(self, tmp_path):
+        # A disabled account is still shown; it's just annotated so the user
+        # can see it's held out of auto-rotation — on the full card when it's
+        # the active login, and on the one-line form otherwise.
+        fake = FakeSwitcher(
+            [
+                make_account(1, active=True, disabled=True),
+                make_account(2, disabled=True),
+            ],
+            tmp_path,
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 32)) as pilot:
+            await settle(pilot)
+            from claude_swap.tui.widgets import AccountsPanel
+
+            panel = app.screen.query_one(AccountsPanel).render().plain
+            assert "● active" in panel  # still the active card
+            # both the active card and the mini row carry the marker
+            assert panel.count("(disabled)") == 2
+
     async def test_active_card_skips_absent_window_and_shows_scoped(self, tmp_path):
         fake = FakeSwitcher(
             [
@@ -538,6 +572,7 @@ class TestDashboard:
                 "watch",
                 "auto",
                 "add-menu",
+                "disable-menu",
                 "remove-menu",
                 "quit",
             ]
@@ -676,6 +711,51 @@ class TestDashboard:
             await pilot.press("n")
             await settle(pilot)
             assert not any(call[0] == "remove" for call in fake.calls)
+
+    async def test_disable_via_menu_toggles_without_confirm(self, tmp_path):
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 32)) as pilot:
+            await settle(pilot)
+            await menu_select(pilot, "disable-menu")
+            await menu_select(pilot, "disable:2")  # no modal — direct action
+            await settle(pilot)
+            assert ("set_disabled", "2", True) in fake.calls
+            # the submenu pops back to root after the toggle
+            from textual.widgets import ListView
+
+            from claude_swap.tui.widgets import MenuItem
+
+            menu = app.screen.query_one("#menu", ListView)
+            ids = [item.action_id for item in menu.query(MenuItem)]
+            assert ids[0] == "switch"
+
+    async def test_disable_menu_row_reflects_state_and_re_enables(self, tmp_path):
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2, disabled=True)],
+            tmp_path,
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 32)) as pilot:
+            await settle(pilot)
+            await menu_select(pilot, "disable-menu")
+            from textual.widgets import ListView, Static
+
+            from claude_swap.tui.widgets import MenuItem
+
+            menu = app.screen.query_one("#menu", ListView)
+            labels = [
+                item.query_one(Static).render().plain for item in menu.query(MenuItem)
+            ]
+            # the already-disabled account offers to enable; the active one to disable
+            assert any("(disabled)" in label and "enable" in label for label in labels)
+            assert any("disable" in label and "(disabled)" not in label for label in labels)
+            # selecting the disabled account flips it back on
+            await menu_select(pilot, "disable:2")
+            await settle(pilot)
+            assert ("set_disabled", "2", False) in fake.calls
 
     async def test_modal_arrow_keys_choose_button(self, tmp_path):
         fake = FakeSwitcher(


### PR DESCRIPTION
Follow-up to #130. That PR added `cswap disable` / `enable` to hold accounts out of auto-rotation, and the interactive surfaces already **respected** the flag (their switch actions call the same `switch()` paths) — but they didn't yet **surface** a `(disabled)` marker or offer an in-app toggle. As the #130 description put it:

> The TUI/menu-bar automatically respect disabled state … but don't yet surface a `(disabled)` marker or an in-app toggle — a natural next step.

This is that next step.

## What changed

- **Snapshot** — `AccountSnapshot.disabled`, populated by `accounts_snapshot` from the sequence store, so every interactive view reads the flag in the same coherent one-pass view as usage and active-detection (no second read that could disagree).
- **TUI** — a `(disabled)` marker on the active account card and on the inactive one-line rows, plus a **Disable / enable account…** submenu. Selecting an account toggles it in place: the action reads the live state to pick the direction, and there's no confirm modal since it's fully reversible.
- **Menu bar (macOS)** — the same `(disabled)` marker on each account row, and a **Disable / enable account** submenu whose rows are check-marked when disabled.
- Both toggles route through the existing `set_account_disabled`, i.e. the same path the CLI uses — so number/alias/email resolution and the JSON store stay identical across surfaces.

## Behavior notes

- Disabled accounts remain fully managed and stay a valid **explicit** switch target from these menus (matching the CLI: only *auto*-rotation skips them). The marker is informational; the toggle is the only new mutation.
- No new keybindings — the toggle lives in the menu, consistent with the dashboard's "actions live in the nested menu" design.

## Tests

- TUI: `(disabled)` marker on card + mini rows; submenu toggle disables without a modal and pops back to root; a disabled row offers *enable* and flips back on.
- Menu bar: `format_account_label` disabled marker; `_adapt_snapshot` tuple carries `disabled` through.
- Switcher: disable/enable by alias resolves like number/email.

Full suite green (`uv run pytest`): 1287 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)