### PR TITLE
fix: skip disabled accounts after fresh import

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -2910,23 +2910,40 @@ class ClaudeAccountSwitcher:
                 raise ConfigError("No accounts are managed yet")
 
             target = str(preferred)
-            if not self._account_is_switchable(target):
-                if json_output:
-                    warnings.append(
+            target_disabled = self._disabled_from_data(data, target)
+            if target_disabled or not self._account_is_switchable(target):
+                if target_disabled:
+                    message = f"Skipped Account-{target} (disabled)"
+                else:
+                    message = (
                         f"Skipped Account-{target} (no stored credentials/config)"
                     )
+                if json_output:
+                    warnings.append(message)
                 else:
-                    print(
-                        f"{accent('Skipping')} Account-{target} "
-                        f"(no stored credentials/config, re-add with "
-                        f"cswap --add-account --slot {target})"
-                    )
+                    if target_disabled:
+                        print(f"{accent('Skipping')} Account-{target} (disabled)")
+                    else:
+                        print(
+                            f"{accent('Skipping')} Account-{target} "
+                            f"(no stored credentials/config, re-add with "
+                            f"cswap --add-account --slot {target})"
+                        )
                 fallback = next(
                     (str(num) for num in sequence
-                     if str(num) != target and self._account_is_switchable(str(num))),
+                     if str(num) != target
+                     and not self._disabled_from_data(data, str(num))
+                     and self._account_is_switchable(str(num))),
                     None,
                 )
                 if not fallback:
+                    if any(
+                        self._account_is_switchable(str(num)) for num in sequence
+                    ):
+                        raise ConfigError(
+                            "No accounts remain in rotation. Re-enable one with: "
+                            "cswap enable <num|email>"
+                        )
                     raise ConfigError(
                         "No managed accounts have valid stored credentials/config. "
                         "Re-add a slot with: cswap --add-account --slot <number>"

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -3757,12 +3757,38 @@ class TestSwitchSkipsBrokenSlots:
         data = s._get_sequence_data()
         assert data["activeAccountNumber"] == 2
 
+    def test_fresh_machine_skips_disabled_preferred_target(
+        self, temp_home: Path, capsys
+    ):
+        """No live session — a disabled recorded active slot stays out of rotation."""
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        s.set_account_disabled("1", True)
+        capsys.readouterr()
+
+        with patch.object(s, "list_accounts"):
+            s.switch()
+
+        assert "Skipping Account-1 (disabled)" in capsys.readouterr().out
+        assert s._get_sequence_data()["activeAccountNumber"] == 2
+
     def test_fresh_machine_all_broken_raises(self, temp_home: Path):
         s = self._setup(temp_home)
         self._seed(s, 1, "a@example.com", creds=False)
         self._seed(s, 2, "b@example.com", config=False)
 
         with pytest.raises(ConfigError, match="No managed accounts have valid"):
+            s.switch()
+
+    def test_fresh_machine_all_disabled_raises(self, temp_home: Path):
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        s.set_account_disabled("1", True)
+        s.set_account_disabled("2", True)
+
+        with pytest.raises(ConfigError, match="No accounts remain in rotation"):
             s.switch()
 
 


### PR DESCRIPTION
## Summary

- Skip disabled slots when a fresh imported profile uses bare `cswap switch`.
- Return an actionable error when no enabled, switchable account remains.

## Root cause

The fresh-machine path checked backup integrity but not disabled state, unlike normal rotation.

## Validation

- `uv run pytest -q`
- `uv run python -m compileall -q src`
