### PR TITLE
feat: mirror user-scope MCP servers into session profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,16 @@ cswap run 2 -- --resume         # everything after '--' is forwarded to claude
 cswap run 2 --share-history     # share your chat history with this account too
 ```
 
-Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, etc.), but each account keeps its own chat history. Pass `--share-history` if you want your accounts to continue the same conversations — a session started under one account shows up in `--resume` under the others, and nothing already saved is lost. Not supported on Windows yet.
+Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP servers, etc.), but each account keeps its own chat history. Not supported on Windows yet.
+
+<details>
+<summary>Sharing details — MCP servers & chat history</summary>
+
+- Pass `--share-history` if you want your accounts to continue the same conversations — a session started under one account shows up in `--resume` under the others, and nothing already saved is lost.
+- User-scope MCP servers (`claude mcp add -s user`) are mirrored from your default profile on every launch — manage them there; changes made inside a session don't persist. Definitions are copied as-is (including inline `env`/`headers` values), but MCP OAuth logins are not — HTTP servers may ask you to authenticate once per profile via `/mcp`.
+- `--no-share` turns sharing off and removes the mirrored MCP config (profiles that never mirrored are left alone).
+
+</details>
 
 <details>
 <summary>Map accounts to directories — auto-pick per repo</summary>

--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -53,6 +53,20 @@ def get_global_config_path() -> Path:
     return base / ".claude.json"
 
 
+def get_default_global_config_path() -> Path:
+    """Return the global config path of the *default* profile.
+
+    Same legacy fallback as :func:`get_global_config_path`, but deliberately
+    ignores ``CLAUDE_CONFIG_DIR``: callers that mirror the user's real profile
+    (session sharing) must not source from another session when invoked from
+    inside one.
+    """
+    legacy = Path.home() / ".claude" / ".config.json"
+    if legacy.exists():
+        return legacy
+    return Path.home() / ".claude.json"
+
+
 def get_credentials_path() -> Path:
     """Return the path to the Claude credentials file."""
     return get_claude_config_home() / ".credentials.json"

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -48,13 +48,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
 from claude_swap import macos_keychain
-from claude_swap.exceptions import SessionError
+from claude_swap.claude_locks import proper_lockfile
+from claude_swap.exceptions import ClaudeCodeLockTimeout, SessionError
 from claude_swap.macos_keychain import KeychainError
 from claude_swap.locking import FileLock
 from claude_swap.models import Platform
 from claude_swap.oauth import refresh_oauth_credentials
+from claude_swap.paths import get_default_global_config_path
 from claude_swap.printer import accent, dimmed, muted, warning
 from claude_swap.process_detection import ClaudeSession, list_sessions
+from claude_swap.settings import atomic_write_json
 
 if TYPE_CHECKING:
     from claude_swap.switcher import ClaudeAccountSwitcher
@@ -64,6 +67,8 @@ if TYPE_CHECKING:
 # sessions/, ide/, .claude.json, .credentials.json, statsig/ and other
 # telemetry. projects/ and history.jsonl are per-account by default and move
 # to HISTORY_ITEMS sharing only with the opt-in --share-history flag.
+# .claude.json stays excluded as a file, but its one user-scoped key —
+# top-level mcpServers — is mirrored separately by _sync_mcp_servers.
 SHARED_ITEMS = (
     "settings.json",
     "keybindings.json",
@@ -89,6 +94,18 @@ SHARE_MANIFEST = ".cswap-shared.json"
 # profile must be re-bootstrapped on the next non-live `cswap run` even if it
 # still passes the local reuse check.
 STALE_MARKER = ".cswap-stale-credentials"
+
+# The user-scope MCP key mirrored from the default profile's .claude.json.
+MCP_KEY = "mcpServers"
+
+# Adoption marker: this profile's mcpServers is (or was) cswap-mirrored. Gates
+# both the one-time migration stash and --no-share's removal of the key, so
+# pre-feature session-local definitions are never silently destroyed.
+MCP_MIRROR_MARKER = ".cswap-mcp-mirror-v1"
+
+# One-time migration stash: session-local MCP definitions displaced by the
+# first mirror land here (write-once) instead of vanishing.
+MCP_DISPLACED_STASH = ".cswap-mcp-displaced.json"
 
 
 def mark_session_stale(session_dir: Path) -> None:
@@ -612,18 +629,22 @@ class SessionManager:
     ) -> None:
         """Mirror shared items from ~/.claude into the profile (or undo it).
 
-        ``share`` governs SHARED_ITEMS (customizations); ``share_history``
-        governs HISTORY_ITEMS (conversation history) — independent concerns,
-        so ``--no-share --share-history`` gives a bare profile with unified
-        history. Idempotent; runs on every launch. Deliberately sources from
-        the default ``~/.claude`` (not ``get_claude_config_home()``): sharing
+        ``share`` governs SHARED_ITEMS (customizations) and the mcpServers
+        mirror (see ``_sync_mcp_servers`` — its --no-share removal is gated
+        on the adoption marker); ``share_history`` governs HISTORY_ITEMS
+        (conversation history) — independent concerns, so ``--no-share
+        --share-history`` gives a bare profile with unified history.
+        Idempotent; runs on every launch. Deliberately sources from the
+        default ``~/.claude`` (not ``get_claude_config_home()``): sharing
         always mirrors the default profile, even when ``CLAUDE_CONFIG_DIR``
-        is set in the invoking environment. Lock-free on the reuse path:
-        concurrent runs with different flags are last-writer-wins and
-        self-heal on the next launch.
+        is set in the invoking environment. File/dir sharing is lock-free on
+        the reuse path — concurrent runs with different flags are last-writer-
+        wins and self-heal on the next launch; only the MCP mirror takes
+        Claude's config lock, and only when it needs to write.
         """
         if not session_dir.is_dir():
             return
+        self._sync_mcp_servers(session_dir, share)
         # History links are POSIX-only (run() rejects the flag on Windows;
         # this also drops any links left by a POSIX→Windows profile move).
         if self.switcher.platform == Platform.WINDOWS:
@@ -713,6 +734,196 @@ class SessionManager:
         # write the manifest atomically so a concurrent reader never sees a
         # truncated file.
         self._write_manifest(manifest_path, new_managed)
+
+    def _sync_mcp_servers(self, session_dir: Path, share: bool) -> None:
+        """Mirror the default profile's user-scope ``mcpServers`` (issue #139).
+
+        Pure mirror: the default profile is the single source of truth, so
+        adds, edits, and deletions all propagate, and MCP changes made inside
+        a session are overwritten the next time cswap prepares the profile.
+        Nothing ever flows back into the default config, and per-project
+        (``projects[…].mcpServers``) entries are untouched on both sides.
+
+        ``share=False`` removes the mirrored key — but only from profiles
+        that have adopted mirroring (MCP_MIRROR_MARKER), so ``--no-share``
+        can never destroy pre-feature session-local definitions. The first
+        mirror on an unadopted profile stashes any definitions it would
+        displace into MCP_DISPLACED_STASH (write-once) before resetting.
+
+        Fail-open throughout: an unreadable or malformed file on either side,
+        a symlinked target, or a contended lock leaves the profile untouched
+        and never blocks the launch. The adopted in-sync steady state takes
+        no lock and writes nothing; first adoption always goes through the
+        lock so the marker can never certify a state a concurrent claude
+        changed between the read and the touch.
+        """
+        config_path = session_dir / ".claude.json"
+        marker = session_dir / MCP_MIRROR_MARKER
+
+        if share:
+            source = self._read_mcp_source()
+            if source is None:
+                return
+        elif marker.exists():
+            source = {}  # remove what we mirrored; restored on a share run
+        else:
+            return  # never adopted: --no-share must not touch local data
+
+        # Type-check before reading: reading a FIFO would hang the launch,
+        # and a symlinked target must never be written through or replaced.
+        if not config_path.exists():
+            return  # bootstrap/validation owns a missing config
+        if config_path.is_symlink() or not config_path.is_file():
+            self._logger.warning(
+                f"Not syncing MCP servers: {config_path} is not a regular file."
+            )
+            return
+
+        existing = self._load_json_object(config_path)
+        if existing is None:
+            return  # bootstrap/validation owns a broken config
+        target = existing.get(MCP_KEY, {})
+        if not isinstance(target, dict):
+            self._logger.warning(
+                f"Not syncing MCP servers: the profile's {MCP_KEY} is not "
+                "an object."
+            )
+            return
+        if target == source and (not share or marker.exists()):
+            return
+
+        # The same lock a claude running in this profile takes for its own
+        # .claude.json writes (CLAUDE_CONFIG_DIR is the session dir), so the
+        # splice below never interleaves with its config writes.
+        lock_dir = config_path.parent / (config_path.name + ".lock")
+        try:
+            with proper_lockfile(lock_dir):
+                # Re-read both sides: a writer that waited here must not
+                # clobber a newer mirror with its stale pre-lock snapshot.
+                if share:
+                    source = self._read_mcp_source()
+                    if source is None:
+                        return
+                if config_path.is_symlink() or not config_path.is_file():
+                    return
+                existing = self._load_json_object(config_path)
+                if existing is None:
+                    return
+                target = existing.get(MCP_KEY, {})
+                if not isinstance(target, dict):
+                    return
+                if target == source:
+                    if share:
+                        self._ensure_mcp_marker(marker)
+                    return
+                if share and not marker.exists():
+                    displaced = {
+                        name: value
+                        for name, value in target.items()
+                        if name not in source or source[name] != value
+                    }
+                    if displaced and not self._stash_displaced_mcp(
+                        session_dir, displaced
+                    ):
+                        return  # never destroy the only copy
+                if source:
+                    existing[MCP_KEY] = source
+                else:
+                    # Claude itself strips default-valued keys; match it.
+                    existing.pop(MCP_KEY, None)
+                try:
+                    atomic_write_json(config_path, existing)
+                except OSError as e:
+                    self._logger.warning(f"Could not sync MCP servers: {e}")
+                    return
+                if share:
+                    # Only after a successful write: an unadopted profile
+                    # whose marker fails to land simply retries next launch,
+                    # by then already in sync so nothing can be mis-stashed.
+                    self._ensure_mcp_marker(marker)
+        except (ClaudeCodeLockTimeout, OSError) as e:
+            # OSError covers lock-machinery failures (mkdir on a read-only
+            # or full filesystem); everything inside handles its own.
+            self._logger.warning(
+                f"Could not sync MCP servers ({e}) — skipping this launch."
+            )
+
+    @staticmethod
+    def _read_mcp_source() -> dict | None:
+        """The default profile's user-scope mcpServers, or None if unusable.
+
+        ``{}`` and ``None`` are distinct: a readable config without the key
+        genuinely has no user servers (``{}`` propagates the removal), while
+        a missing/corrupt config or a non-dict key returns ``None`` so the
+        caller leaves the profile untouched. Reads the default-home path
+        (ignoring CLAUDE_CONFIG_DIR — a nested `cswap run` must not source
+        from another session); no lock needed, claude's writes are atomic.
+        """
+        config = SessionManager._load_json_object(get_default_global_config_path())
+        if config is None:
+            return None
+        value = config.get(MCP_KEY, {})
+        return value if isinstance(value, dict) else None
+
+    @staticmethod
+    def _load_json_object(path: Path) -> dict | None:
+        # ValueError covers both JSONDecodeError and UnicodeDecodeError.
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _ensure_mcp_marker(self, marker: Path) -> None:
+        if marker.exists():
+            return
+        try:
+            marker.touch()
+        except OSError as e:
+            self._logger.warning(f"Could not write {marker.name}: {e}")
+
+    def _stash_displaced_mcp(self, session_dir: Path, displaced: dict) -> bool:
+        """Save definitions the first mirror would displace; False aborts it.
+
+        Write-once: a stash left by an earlier interrupted adoption is the
+        pre-feature data and must not be overwritten with mirror noise. But
+        only a *valid* stash counts as a saved copy — a directory, symlink,
+        or unrelated file squatting on the name must block the reset, not
+        green-light it.
+        """
+        stash = session_dir / MCP_DISPLACED_STASH
+        if stash.is_symlink() or stash.exists():
+            if self._is_valid_stash(stash):
+                return True
+            self._logger.warning(
+                f"{stash.name} exists but is not a valid stash; leaving "
+                "the profile's MCP servers in place."
+            )
+            return False
+        try:
+            atomic_write_json(
+                stash, {"schemaVersion": 1, MCP_KEY: displaced}
+            )
+        except OSError as e:
+            self._logger.warning(
+                f"Could not stash the profile's MCP servers ({e}); "
+                "leaving them in place."
+            )
+            return False
+        print(
+            dimmed(
+                "Session MCP servers now mirror your default profile; the "
+                f"profile's previous definitions were saved to {stash.name}."
+            )
+        )
+        return True
+
+    @staticmethod
+    def _is_valid_stash(stash: Path) -> bool:
+        if stash.is_symlink() or not stash.is_file():
+            return False
+        data = SessionManager._load_json_object(stash)
+        return data is not None and isinstance(data.get(MCP_KEY), dict)
 
     def _prepare_history_share(
         self, src: Path, dest: Path, session_dir: Path

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -17,6 +17,8 @@ from claude_swap import session as session_mod
 from claude_swap.exceptions import AccountNotFoundError, SessionError
 from claude_swap.models import Platform
 from claude_swap.session import (
+    MCP_DISPLACED_STASH,
+    MCP_MIRROR_MARKER,
     SHARE_MANIFEST,
     SessionManager,
     _probe_env,
@@ -677,6 +679,326 @@ class TestSharingWindowsMode:
 
         assert not (session_dir / "settings.json").exists()
         assert not (session_dir / "skills").exists()
+
+
+# ---------------------------------------------------------------------------
+# mcpServers mirror (issue #139)
+# ---------------------------------------------------------------------------
+
+GITHUB_MCP = {"type": "stdio", "command": "gh-mcp", "env": {"TOKEN": "abc"}}
+LOCAL_MCP = {"type": "stdio", "command": "mine"}
+
+
+@pytest.fixture
+def mcp_setup(temp_home: Path, seeded_switcher):
+    """A fake live default config and a session profile with its own config."""
+    default_config = temp_home / ".claude.json"
+    default_config.write_text(
+        json.dumps(
+            {
+                "oauthAccount": {"emailAddress": "default@example.com"},
+                "mcpServers": {"github": GITHUB_MCP},
+                "projects": {"/repo": {"mcpServers": {"proj-local": {}}}},
+            }
+        )
+    )
+    session_dir = session_dir_for(
+        seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+    )
+    session_dir.mkdir(parents=True)
+    (session_dir / ".claude.json").write_text(
+        json.dumps(
+            {
+                "oauthAccount": {"emailAddress": ACCOUNT_EMAIL},
+                "theme": "light",
+                "projects": {"/w": {"allowedTools": []}},
+            }
+        )
+    )
+    return default_config, session_dir, SessionManager(seeded_switcher)
+
+
+def _session_config(session_dir: Path) -> dict:
+    return json.loads((session_dir / ".claude.json").read_text())
+
+
+def _set_default_mcp(default_config: Path, servers: dict | None) -> None:
+    data = json.loads(default_config.read_text())
+    if servers is None:
+        data.pop("mcpServers", None)
+    else:
+        data["mcpServers"] = servers
+    default_config.write_text(json.dumps(data))
+
+
+class TestMcpMirror:
+    def test_bootstrap_launch_mirrors(
+        self, temp_home, manager, auth_status_tracks_seed, refresh_rotates
+    ):
+        (temp_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"github": GITHUB_MCP}})
+        )
+        session_dir, _, _ = manager.setup_session("2", share=True)
+
+        config = _session_config(session_dir)
+        assert config["mcpServers"] == {"github": GITHUB_MCP}
+        assert config["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
+        assert (session_dir / MCP_MIRROR_MARKER).exists()
+        assert not (session_dir / MCP_DISPLACED_STASH).exists()  # nothing displaced
+
+    def test_mirror_preserves_other_keys(self, mcp_setup):
+        default_config, session_dir, mgr = mcp_setup
+        mgr._sync_sharing(session_dir, share=True)
+
+        config = _session_config(session_dir)
+        assert config["mcpServers"] == {"github": GITHUB_MCP}
+        assert config["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
+        assert config["theme"] == "light"
+        assert config["projects"] == {"/w": {"allowedTools": []}}
+
+    def test_edit_and_delete_propagate(self, mcp_setup):
+        default_config, session_dir, mgr = mcp_setup
+        mgr._sync_sharing(session_dir, share=True)
+
+        edited = {"github": {**GITHUB_MCP, "env": {"TOKEN": "rotated"}}, "new": {}}
+        _set_default_mcp(default_config, edited)
+        mgr._sync_sharing(session_dir, share=True)
+        assert _session_config(session_dir)["mcpServers"] == edited
+
+        _set_default_mcp(default_config, {"new": {}})
+        mgr._sync_sharing(session_dir, share=True)
+        assert _session_config(session_dir)["mcpServers"] == {"new": {}}
+
+    def test_default_without_key_removes_key(self, mcp_setup):
+        default_config, session_dir, mgr = mcp_setup
+        mgr._sync_sharing(session_dir, share=True)
+        _set_default_mcp(default_config, None)
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert "mcpServers" not in _session_config(session_dir)
+
+    def test_legacy_config_json_source(self, mcp_setup, temp_home):
+        default_config, session_dir, mgr = mcp_setup
+        legacy = temp_home / ".claude" / ".config.json"
+        legacy.write_text(json.dumps({"mcpServers": {"legacy-src": {}}}))
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert _session_config(session_dir)["mcpServers"] == {"legacy-src": {}}
+
+    def test_session_local_change_reset_without_stash(self, mcp_setup):
+        default_config, session_dir, mgr = mcp_setup
+        mgr._sync_sharing(session_dir, share=True)  # adopt
+
+        config = _session_config(session_dir)
+        config["mcpServers"]["mine"] = LOCAL_MCP
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert _session_config(session_dir)["mcpServers"] == {"github": GITHUB_MCP}
+        # Post-adoption resets are documented behavior, never stashed.
+        assert not (session_dir / MCP_DISPLACED_STASH).exists()
+
+    def test_migration_stashes_displaced_only(self, mcp_setup, capsys):
+        default_config, session_dir, mgr = mcp_setup
+        config = _session_config(session_dir)
+        config["mcpServers"] = {"pre-feature": LOCAL_MCP, "github": GITHUB_MCP}
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert _session_config(session_dir)["mcpServers"] == {"github": GITHUB_MCP}
+        stash = json.loads((session_dir / MCP_DISPLACED_STASH).read_text())
+        # Only the displaced entry — github matched the default and is not
+        # duplicated into the stash.
+        assert stash == {"schemaVersion": 1, "mcpServers": {"pre-feature": LOCAL_MCP}}
+        assert "saved to" in capsys.readouterr().out
+        assert (session_dir / MCP_MIRROR_MARKER).exists()
+
+    def test_stash_is_write_once(self, mcp_setup):
+        """A stash from an interrupted adoption is never overwritten."""
+        default_config, session_dir, mgr = mcp_setup
+        stash_path = session_dir / MCP_DISPLACED_STASH
+        original = {"schemaVersion": 1, "mcpServers": {"real-pre-feature": {}}}
+        stash_path.write_text(json.dumps(original))
+        config = _session_config(session_dir)
+        config["mcpServers"] = {"drift": {}}  # would look displaced
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert _session_config(session_dir)["mcpServers"] == {"github": GITHUB_MCP}
+        assert json.loads(stash_path.read_text()) == original
+
+    def test_invalid_stash_blocks_reset(self, mcp_setup):
+        """A squatter on the stash name must not count as a saved copy."""
+        default_config, session_dir, mgr = mcp_setup
+        (session_dir / MCP_DISPLACED_STASH).mkdir()  # directory, not a stash
+        config = _session_config(session_dir)
+        config["mcpServers"] = {"pre-feature": LOCAL_MCP}
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert _session_config(session_dir)["mcpServers"] == {
+            "pre-feature": LOCAL_MCP
+        }
+        assert not (session_dir / MCP_MIRROR_MARKER).exists()
+
+    def test_null_valued_entry_is_stashed(self, mcp_setup):
+        """Membership check: a JSON-null entry absent upstream still stashes."""
+        default_config, session_dir, mgr = mcp_setup
+        config = _session_config(session_dir)
+        config["mcpServers"] = {"weird": None, "github": GITHUB_MCP}
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        stash = json.loads((session_dir / MCP_DISPLACED_STASH).read_text())
+        assert stash["mcpServers"] == {"weird": None}
+        assert _session_config(session_dir)["mcpServers"] == {"github": GITHUB_MCP}
+
+    def test_stash_failure_aborts_reset(self, mcp_setup, monkeypatch):
+        default_config, session_dir, mgr = mcp_setup
+        config = _session_config(session_dir)
+        config["mcpServers"] = {"pre-feature": LOCAL_MCP}
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+        real_write = session_mod.atomic_write_json
+
+        def flaky(path, data):
+            if path.name == MCP_DISPLACED_STASH:
+                raise OSError("disk full")
+            real_write(path, data)
+
+        monkeypatch.setattr(session_mod, "atomic_write_json", flaky)
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert _session_config(session_dir)["mcpServers"] == {
+            "pre-feature": LOCAL_MCP
+        }
+        assert not (session_dir / MCP_MIRROR_MARKER).exists()
+
+    def test_in_sync_first_run_adopts_without_write(self, mcp_setup):
+        default_config, session_dir, mgr = mcp_setup
+        config_path = session_dir / ".claude.json"
+        config = _session_config(session_dir)
+        config["mcpServers"] = {"github": GITHUB_MCP}
+        config_path.write_text(json.dumps(config))
+        before = config_path.read_bytes()
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert config_path.read_bytes() == before  # no rewrite
+        assert not (config_path.parent / ".claude.json.lock").exists()  # released
+        assert (session_dir / MCP_MIRROR_MARKER).exists()
+
+    def test_adopted_in_sync_run_takes_no_lock(self, mcp_setup, monkeypatch):
+        """The steady state must stay lock-free (only first adoption locks)."""
+        default_config, session_dir, mgr = mcp_setup
+        mgr._sync_sharing(session_dir, share=True)  # adopt + mirror
+
+        def boom(*args, **kwargs):
+            raise AssertionError("lock taken on the adopted in-sync path")
+
+        monkeypatch.setattr(session_mod, "proper_lockfile", boom)
+        mgr._sync_sharing(session_dir, share=True)  # must not raise
+
+    @pytest.mark.parametrize(
+        "source_state",
+        ["missing", "corrupt", "non_dict_root", "non_dict_key", "binary"],
+    )
+    def test_fail_open_on_bad_source(self, mcp_setup, source_state):
+        default_config, session_dir, mgr = mcp_setup
+        if source_state == "missing":
+            default_config.unlink()
+        elif source_state == "corrupt":
+            default_config.write_text("{not json")
+        elif source_state == "non_dict_root":
+            default_config.write_text("[]")
+        elif source_state == "non_dict_key":
+            default_config.write_text(json.dumps({"mcpServers": ["bad"]}))
+        else:
+            default_config.write_bytes(b"\xff\xfe not utf-8 \x00")
+        before = (session_dir / ".claude.json").read_bytes()
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / ".claude.json").read_bytes() == before
+        assert not (session_dir / MCP_MIRROR_MARKER).exists()
+
+    @pytest.mark.parametrize("bad_value", ["null", "[]", '"a-string"'])
+    def test_fail_open_on_bad_target_mcp(self, mcp_setup, bad_value):
+        """A malformed profile mcpServers must skip, never crash the launch."""
+        default_config, session_dir, mgr = mcp_setup
+        config = _session_config(session_dir)
+        config["mcpServers"] = json.loads(bad_value)
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+        before = (session_dir / ".claude.json").read_bytes()
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / ".claude.json").read_bytes() == before
+        assert not (session_dir / MCP_MIRROR_MARKER).exists()
+
+    def test_corrupt_session_config_skipped(self, mcp_setup):
+        default_config, session_dir, mgr = mcp_setup
+        (session_dir / ".claude.json").write_text("{broken")
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / ".claude.json").read_text() == "{broken"
+        assert not (session_dir / MCP_MIRROR_MARKER).exists()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink target check")
+    def test_symlinked_session_config_skipped(self, mcp_setup, temp_home):
+        default_config, session_dir, mgr = mcp_setup
+        elsewhere = temp_home / "elsewhere.json"
+        (session_dir / ".claude.json").rename(elsewhere)
+        (session_dir / ".claude.json").symlink_to(elsewhere)
+        before = elsewhere.read_bytes()
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / ".claude.json").is_symlink()
+        assert elsewhere.read_bytes() == before
+
+    def test_held_lock_fails_open(self, mcp_setup, monkeypatch):
+        from claude_swap import claude_locks
+
+        monkeypatch.setattr(claude_locks, "DEFAULT_TIMEOUT_S", 0.3)
+        default_config, session_dir, mgr = mcp_setup
+        (session_dir / ".claude.json.lock").mkdir()  # fresh mtime: live holder
+        before = (session_dir / ".claude.json").read_bytes()
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / ".claude.json").read_bytes() == before
+
+    def test_no_share_before_adoption_untouched(self, mcp_setup):
+        default_config, session_dir, mgr = mcp_setup
+        config = _session_config(session_dir)
+        config["mcpServers"] = {"pre-feature": LOCAL_MCP}
+        (session_dir / ".claude.json").write_text(json.dumps(config))
+
+        mgr._sync_sharing(session_dir, share=False)
+
+        assert _session_config(session_dir)["mcpServers"] == {
+            "pre-feature": LOCAL_MCP
+        }
+
+    def test_no_share_after_adoption_removes_then_restores(self, mcp_setup):
+        default_config, session_dir, mgr = mcp_setup
+        mgr._sync_sharing(session_dir, share=True)  # adopt
+
+        mgr._sync_sharing(session_dir, share=False)
+        config = _session_config(session_dir)
+        assert "mcpServers" not in config
+        assert config["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
+        assert (session_dir / MCP_MIRROR_MARKER).exists()  # adoption is history
+
+        mgr._sync_sharing(session_dir, share=True)
+        assert _session_config(session_dir)["mcpServers"] == {"github": GITHUB_MCP}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Ref #139

Session profiles never inherited user-scope MCP servers: they live in the top-level `mcpServers` key of `~/.claude.json`, which is rightly excluded from sharing as a file. This adds a targeted key mirror instead.

## Behavior

- The default profile is the single source of truth: on every `cswap run` with sharing on, the session's top-level `mcpServers` is reset to match the live default config (adds, edits, and deletions all propagate — including changes from tools like ToolHive that only write the default config).
- MCP changes made inside a session work for that run but are overwritten the next time the profile is prepared. Nothing ever flows back into the default config; `projects[…].mcpServers` is untouched on both sides.
- `--no-share` removes the mirrored key — but only from profiles that adopted mirroring (`.cswap-mcp-mirror-v1` marker), so pre-feature session-local definitions are never destroyed.
- The first mirror on an existing profile stashes any definitions it would displace into `.cswap-mcp-displaced.json` (write-once, validated; a failed or invalid stash aborts the reset) and prints a notice.

## Implementation notes

- Sourced from the live default config via a new `get_default_global_config_path()` (keeps the legacy `.config.json` fallback, ignores `CLAUDE_CONFIG_DIR` so nested runs can't source from another session). The issue's `_bootstrap` one-liner wouldn't work — the account backup config is stripped to `oauthAccount` and never contains `mcpServers`.
- Writes are a key-level read-modify-write under Claude Code's own `proper-lockfile` protocol on the profile's `.claude.json.lock`, with both sides re-read under the lock; the adopted in-sync steady state takes no lock and writes nothing.
- Fail-open throughout: missing/corrupt/malformed configs on either side, a symlinked or non-regular target, and lock contention or lock-machinery errors all skip the sync and never block the launch.
- MCP OAuth logins are not copied (they're per-profile in the credential store); README documents that HTTP servers may need `/mcp` auth once per profile.

## Tests

22 new tests in `tests/test_session.py` (`TestMcpMirror`) covering propagation, migration stash + adoption marker, `--no-share` both sides of adoption, the fail-open matrix (bad source/target, symlink, held lock, stash squatter), and the lock-free steady state. Full suite: 1315 passed, 3 skipped.