### PR TITLE
feat: cswap move & swap — assign an account to any slot number

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ cswap enable 2                  # Return a disabled account to rotation
 cswap alias 2 dev               # Give an account a short alias (usable anywhere NUM|EMAIL is)
 cswap alias 2 --unset           # Remove an account's alias
 cswap alias                     # List all aliases
+cswap swap 1 2                  # Exchange two accounts' slot numbers (list order)
 cswap tui                       # Interactive dashboard (also: bare `cswap`)
 cswap watch                     # Dashboard, opened on the live watch page
 cswap upgrade                   # Upgrade claude-swap to the latest version

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ cswap alias 2 dev               # Give an account a short alias (usable anywhere
 cswap alias 2 --unset           # Remove an account's alias
 cswap alias                     # List all aliases
 cswap swap 1 2                  # Exchange two accounts' slot numbers (list order)
+cswap move 2 1                  # Assign an account to a slot (relocates to an empty slot, swaps if taken)
 cswap tui                       # Interactive dashboard (also: bare `cswap`)
 cswap watch                     # Dashboard, opened on the live watch page
 cswap upgrade                   # Upgrade claude-swap to the latest version

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -333,6 +333,51 @@ def _unmap_command(argv: list[str]) -> None:
         sys.exit(130)
 
 
+def _swap_command(argv: list[str]) -> None:
+    """Handle `cswap swap NUM|EMAIL|ALIAS NUM|EMAIL|ALIAS`.
+
+    Exchanges the two accounts' slot numbers (list order and numeric
+    targets). Pre-dispatched before the main parser for the same reason as
+    `alias` (the main parser's required mutually-exclusive group can't hold
+    a positional subcommand).
+    """
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} swap",
+        description=(
+            "Exchange two accounts' slot numbers, so they trade places in "
+            "`cswap list` and as numeric targets. Aliases, backups, and "
+            "session history move with their account."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap swap 1 2
+  cswap swap dev user@example.com
+        """,
+    )
+    parser.add_argument("first", metavar="NUM|EMAIL|ALIAS", help="One account")
+    parser.add_argument("second", metavar="NUM|EMAIL|ALIAS", help="The other account")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+        num_a, num_b = switcher.swap_accounts(args.first, args.second)
+        print(f"{accent('Swapped')} Account {num_a} and Account {num_b}:")
+        data = switcher._get_sequence_data() or {}
+        accounts = data.get("accounts", {})
+        for num in sorted((num_a, num_b), key=int):
+            email = accounts.get(num, {}).get("email", "")
+            print(f"  {num}: {email}")
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
 def _alias_command(argv: list[str]) -> None:
     """Handle `cswap alias [NUM|EMAIL] [NAME] [--unset]`.
 
@@ -765,6 +810,9 @@ def main() -> None:
     if argv and argv[0] == "alias":
         _alias_command(argv[1:])
         return
+    if argv and argv[0] == "swap":
+        _swap_command(argv[1:])
+        return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like
     # lazygit/k9s). TTY-gated on both ends so scripts and pipes keep getting
@@ -801,6 +849,7 @@ Commands:
   %(prog)s alias <num|email> <name>   set a short alias for an account
   %(prog)s alias <num|email> --unset  remove an account's alias
   %(prog)s alias                      list all aliases
+  %(prog)s swap <a> <b>               exchange two accounts' slot numbers
   %(prog)s auto                       auto-switch when nearing rate limits
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s export <path>              export accounts

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -378,6 +378,59 @@ Examples:
         sys.exit(130)
 
 
+def _move_command(argv: list[str]) -> None:
+    """Handle `cswap move NUM|EMAIL|ALIAS SLOT`.
+
+    Assigns an account to a specific slot number. If the slot is empty the
+    account is relocated there (its old slot is freed); if it is occupied the
+    two accounts trade places. `swap a b` is exactly `move a <b's slot>`.
+    Pre-dispatched before the main parser for the same reason as `alias`.
+    """
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} move",
+        description=(
+            "Assign an account to a slot number. An empty slot relocates the "
+            "account there and frees its old slot; an occupied slot swaps the "
+            "two. Aliases, backups, and session history move with the account."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap move user@example.com 1   move an account onto shortcut 1
+  cswap move dev 1                by alias
+  cswap move 2 1                  by number (swaps if slot 1 is taken)
+        """,
+    )
+    parser.add_argument("account", metavar="NUM|EMAIL|ALIAS", help="Account to move")
+    parser.add_argument("slot", metavar="SLOT", help="Destination slot number")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+        num_src, num_target, swapped = switcher.move_account(args.account, args.slot)
+        data = switcher._get_sequence_data() or {}
+        accounts = data.get("accounts", {})
+        if num_src == num_target:
+            email = accounts.get(num_target, {}).get("email", "")
+            print(f"{dimmed('Already in')} slot {num_target}: {email}")
+        elif swapped:
+            print(f"{accent('Swapped')} Account {num_src} and Account {num_target}:")
+            for num in sorted((num_src, num_target), key=int):
+                email = accounts.get(num, {}).get("email", "")
+                print(f"  {num}: {email}")
+        else:
+            email = accounts.get(num_target, {}).get("email", "")
+            print(f"{accent('Moved')} {email} to slot {num_target}")
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
 def _alias_command(argv: list[str]) -> None:
     """Handle `cswap alias [NUM|EMAIL] [NAME] [--unset]`.
 
@@ -813,6 +866,9 @@ def main() -> None:
     if argv and argv[0] == "swap":
         _swap_command(argv[1:])
         return
+    if argv and argv[0] == "move":
+        _move_command(argv[1:])
+        return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like
     # lazygit/k9s). TTY-gated on both ends so scripts and pipes keep getting
@@ -850,6 +906,7 @@ Commands:
   %(prog)s alias <num|email> --unset  remove an account's alias
   %(prog)s alias                      list all aliases
   %(prog)s swap <a> <b>               exchange two accounts' slot numbers
+  %(prog)s move <a> <slot>            assign an account to a slot (swaps if taken)
   %(prog)s auto                       auto-switch when nearing rate limits
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s export <path>              export accounts

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -637,6 +637,134 @@ class ClaudeAccountSwitcher:
         ]
         return sorted(rows, key=lambda r: int(r[0]))
 
+    def swap_accounts(self, first: str, second: str) -> tuple[str, str]:
+        """Exchange two accounts' slot numbers (list order / numeric targets).
+
+        Everything keyed by the slot number moves with the swap: the
+        sequence records (including aliases, which belong to the account),
+        the per-slot credential and config backups, the rotation order in
+        ``sequence``, ``activeAccountNumber``, and each slot's session
+        profile directory (history preserved). Directory mappings key on
+        (email, org) and are unaffected. Usage-cache rows key on the slot
+        number but carry the account identity, so a swapped row fails the
+        identity check and self-heals on the next poll.
+
+        Returns the two resolved slot numbers ``(first_num, second_num)``.
+        """
+        if not self.sequence_file.exists():
+            raise ConfigError("No accounts are managed yet")
+
+        self._get_sequence_data_migrated()
+
+        num_a = self._resolve_account_identifier(first)
+        if not num_a:
+            raise AccountNotFoundError(f"No account found with identifier: {first}")
+        num_b = self._resolve_account_identifier(second)
+        if not num_b:
+            raise AccountNotFoundError(f"No account found with identifier: {second}")
+        if num_a == num_b:
+            raise ValidationError("Cannot swap an account with itself")
+
+        data = self._get_sequence_data()
+        record_a = (data or {}).get("accounts", {}).get(num_a)
+        record_b = (data or {}).get("accounts", {}).get(num_b)
+        if not record_a:
+            raise AccountNotFoundError(f"Account-{num_a} does not exist")
+        if not record_b:
+            raise AccountNotFoundError(f"Account-{num_b} does not exist")
+
+        email_a = record_a.get("email", "")
+        email_b = record_b.get("email", "")
+
+        # Backups and session profiles are keyed by (slot, email); relocating
+        # them under a live session-mode claude would pull state out from
+        # under a running process.
+        self._ensure_no_live_session(num_a, email_a, "--swap-accounts")
+        self._ensure_no_live_session(num_b, email_b, "--swap-accounts")
+
+        # Read both slots' backup material up front so a read failure aborts
+        # before anything has been moved. Missing material reads as "" (an
+        # api-key or never-backed-up slot) and stays missing after the swap.
+        creds_a = self._read_account_credentials(num_a, email_a)
+        creds_b = self._read_account_credentials(num_b, email_b)
+        config_a = self._read_account_config(num_a, email_a)
+        config_b = self._read_account_config(num_b, email_b)
+
+        # Move each session profile to its owner's new slot key. When both
+        # accounts share an email the two paths swap directly, so stage the
+        # first through a temporary name.
+        self._swap_session_dirs(num_a, email_a, num_b, email_b)
+
+        # Write under the new keys, then clear the old ones. When the emails
+        # match, the "old" keys are exactly the keys just written, so there
+        # is nothing stale to delete.
+        if creds_a:
+            self._write_account_credentials(num_b, email_a, creds_a)
+        if config_a:
+            self._write_account_config(num_b, email_a, config_a)
+        if creds_b:
+            self._write_account_credentials(num_a, email_b, creds_b)
+        if config_b:
+            self._write_account_config(num_a, email_b, config_b)
+        if email_a != email_b:
+            self._delete_account_files(num_a, email_a)
+            self._delete_account_files(num_b, email_b)
+
+        data["accounts"][num_a], data["accounts"][num_b] = record_b, record_a
+        int_a, int_b = int(num_a), int(num_b)
+        data["sequence"] = [
+            int_b if n == int_a else int_a if n == int_b else n
+            for n in data.get("sequence", [])
+        ]
+        active = data.get("activeAccountNumber")
+        if active == int_a:
+            data["activeAccountNumber"] = int_b
+        elif active == int_b:
+            data["activeAccountNumber"] = int_a
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+
+        self._logger.info(
+            f"Swapped slots: {num_a} ({email_a}) <-> {num_b} ({email_b})"
+        )
+        return num_a, num_b
+
+    def _swap_session_dirs(
+        self, num_a: str, email_a: str, num_b: str, email_b: str
+    ) -> None:
+        """Exchange two slots' session profile directories, best effort.
+
+        A profile that cannot be moved is left behind rather than deleted:
+        setup_session re-bootstraps a missing profile from the (relocated)
+        backups, so the only cost of a skipped move is that slot's session
+        history.
+        """
+        dir_a = self._session_dir(num_a, email_a)
+        dir_b = self._session_dir(num_b, email_b)
+        new_a = self._session_dir(num_b, email_a)  # account A's new home
+        new_b = self._session_dir(num_a, email_b)  # account B's new home
+
+        staging = None
+        try:
+            if dir_a.exists():
+                staging = dir_a.with_name(dir_a.name + ".swapping")
+                os.replace(dir_a, staging)
+            if dir_b.exists() and not new_b.exists():
+                os.replace(dir_b, new_b)
+            if staging is not None and not new_a.exists():
+                os.replace(staging, new_a)
+                staging = None
+        except OSError as e:
+            self._logger.warning(f"Session profile move skipped during swap: {e}")
+        finally:
+            if staging is not None:
+                # Never strand a profile under the staging name.
+                try:
+                    if not dir_a.exists():
+                        os.replace(staging, dir_a)
+                except OSError:
+                    pass
+
     def slot_for_directory(self, directory: str | Path) -> tuple[str | None, str | None]:
         """Resolve a directory to its mapped account slot, for `cswap run`.
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -765,6 +765,113 @@ class ClaudeAccountSwitcher:
                 except OSError:
                     pass
 
+    def move_account(self, account: str, target: str) -> tuple[str, str, bool]:
+        """Assign ``account`` to slot number ``target`` (the general form of swap).
+
+        ``account`` is any ``NUM|EMAIL|ALIAS``; ``target`` is the destination
+        slot number. Three cases:
+
+        - target is the account's current slot -> no-op.
+        - target slot is empty -> the account is relocated there and its old
+          slot is freed. ``swap`` cannot express this (it needs two accounts).
+        - target slot is occupied -> the two accounts trade places, exactly
+          like ``swap account <occupant>``; the displaced account takes the
+          vacated slot, so nothing is ever lost.
+
+        Slot numbers may be sparse (``remove`` leaves gaps, ``add`` grows from
+        the max), so any positive number is a legal target.
+
+        Returns ``(source_num, target_num, swapped)`` where ``swapped`` is True
+        when an occupant was displaced.
+        """
+        if not self.sequence_file.exists():
+            raise ConfigError("No accounts are managed yet")
+
+        self._get_sequence_data_migrated()
+
+        target = target.strip()
+        if not target.isdigit() or int(target) < 1:
+            raise ValidationError(
+                f"Target slot must be a positive slot number, got: {target!r} "
+                f"(use `swap` to trade two accounts by identifier)"
+            )
+        target = str(int(target))  # normalize "01" -> "1"
+
+        num_src = self._resolve_account_identifier(account)
+        if not num_src:
+            raise AccountNotFoundError(f"No account found with identifier: {account}")
+
+        data = self._get_sequence_data()
+        if not (data or {}).get("accounts", {}).get(num_src):
+            raise AccountNotFoundError(f"Account-{num_src} does not exist")
+
+        if num_src == target:
+            return num_src, target, False
+
+        if data.get("accounts", {}).get(target):
+            # Occupied target: trade places. swap_accounts re-resolves by
+            # number, re-runs the migration guard, and is already tested.
+            self.swap_accounts(num_src, target)
+            return num_src, target, True
+
+        self._relocate_account(num_src, target)
+        return num_src, target, False
+
+    def _relocate_account(self, num_src: str, target: str) -> None:
+        """Move one account from ``num_src`` to the empty slot ``target``.
+
+        The one-way counterpart of :meth:`swap_accounts`: everything keyed by
+        the slot number (credential and config backups, session profile,
+        rotation position in ``sequence``, ``activeAccountNumber``) follows the
+        account to its new number, and ``num_src`` is left empty. The caller
+        guarantees ``target`` is unoccupied.
+        """
+        data = self._get_sequence_data()
+        record = data["accounts"][num_src]
+        email = record.get("email", "")
+
+        # Relocating backups/session under a live session-mode claude would
+        # pull state out from under a running process.
+        self._ensure_no_live_session(num_src, email, "--move-account")
+
+        # Read backup material up front so a read failure aborts before any
+        # move. Missing material reads as "" (api-key or never-backed-up slot).
+        creds = self._read_account_credentials(num_src, email)
+        config = self._read_account_config(num_src, email)
+
+        # Move the session profile to the account's new slot key, best effort:
+        # a profile that cannot be moved is left behind rather than deleted, and
+        # setup_session re-bootstraps a missing one from the relocated backups.
+        src_dir = self._session_dir(num_src, email)
+        dst_dir = self._session_dir(target, email)
+        if src_dir.exists() and not dst_dir.exists():
+            try:
+                os.replace(src_dir, dst_dir)
+            except OSError as e:
+                self._logger.warning(f"Session profile move skipped during move: {e}")
+
+        # Write under the new key first, then clear the old one. The session
+        # profile is already relocated, so _delete_account_files finds nothing
+        # to prune there and only drops the stale (num_src, email) backups.
+        if creds:
+            self._write_account_credentials(target, email, creds)
+        if config:
+            self._write_account_config(target, email, config)
+        self._delete_account_files(num_src, email)
+
+        data["accounts"][target] = record
+        del data["accounts"][num_src]
+        int_src, int_target = int(num_src), int(target)
+        data["sequence"] = [
+            int_target if n == int_src else n for n in data.get("sequence", [])
+        ]
+        if data.get("activeAccountNumber") == int_src:
+            data["activeAccountNumber"] = int_target
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+
+        self._logger.info(f"Moved slot: {num_src} ({email}) -> {target}")
+
     def slot_for_directory(self, directory: str | Path) -> tuple[str | None, str | None]:
         """Resolve a directory to its mapped account slot, for `cswap run`.
 

--- a/tests/test_move_accounts.py
+++ b/tests/test_move_accounts.py
@@ -1,0 +1,202 @@
+"""Tests for `cswap move` (ClaudeAccountSwitcher.move_account)."""
+
+from pathlib import Path
+
+import pytest
+
+from claude_swap.exceptions import (
+    AccountNotFoundError,
+    ValidationError,
+)
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class TestMoveAccount:
+    """Test ClaudeAccountSwitcher.move_account()."""
+
+    def _write(self, switcher, data):
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, data)
+
+    # -- relocation to an empty slot (what swap cannot do) ----------------
+
+    def test_move_to_empty_slot_relocates(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        num_src, num_target, swapped = switcher.move_account("2", "5")
+
+        assert (num_src, num_target, swapped) == ("2", "5", False)
+        data = switcher._get_sequence_data()
+        # Account 2 now lives in slot 5; its old slot is freed.
+        assert data["accounts"]["5"]["email"] == "account2@example.com"
+        assert "2" not in data["accounts"]
+        assert data["accounts"]["1"]["email"] == "account1@example.com"
+
+    def test_move_to_empty_slot_updates_rotation_sequence(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.move_account("2", "5")
+
+        data = switcher._get_sequence_data()
+        assert data["sequence"] == [1, 5]
+
+    def test_move_active_account_to_empty_slot_follows_active(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        assert sample_sequence_data["activeAccountNumber"] == 1
+
+        switcher.move_account("1", "9")
+
+        data = switcher._get_sequence_data()
+        assert data["activeAccountNumber"] == 9
+        assert data["accounts"]["9"]["email"] == "account1@example.com"
+
+    def test_move_by_email_and_alias(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        self._write(switcher, sample_sequence_data)
+
+        num_src, num_target, swapped = switcher.move_account("dev", "7")
+
+        assert (num_src, num_target, swapped) == ("2", "7", False)
+        data = switcher._get_sequence_data()
+        # The alias travels with its account into the new slot.
+        assert data["accounts"]["7"].get("alias") == "dev"
+        assert "2" not in data["accounts"]
+
+    def test_move_relocates_credential_and_config_backups(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        switcher._write_account_credentials("2", "account2@example.com", "creds-two")
+        switcher._write_account_config("2", "account2@example.com", "config-two")
+
+        switcher.move_account("2", "5")
+
+        assert (
+            switcher._read_account_credentials("5", "account2@example.com")
+            == "creds-two"
+        )
+        assert (
+            switcher._read_account_config("5", "account2@example.com") == "config-two"
+        )
+        # Old slot key is gone.
+        assert switcher._read_account_credentials("2", "account2@example.com") == ""
+        assert switcher._read_account_config("2", "account2@example.com") == ""
+
+    def test_move_relocates_session_profile(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        session = switcher._session_dir("2", "account2@example.com")
+        session.mkdir(parents=True)
+        (session / "marker.txt").write_text("history-of-account-two")
+
+        switcher.move_account("2", "5")
+
+        moved = switcher._session_dir("5", "account2@example.com")
+        assert (moved / "marker.txt").read_text() == "history-of-account-two"
+        assert not session.exists()
+
+    def test_move_to_empty_slot_with_missing_backups(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """A never-backed-up slot relocates cleanly and stays credential-less."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.move_account("2", "5")
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["5"]["email"] == "account2@example.com"
+        assert switcher._read_account_credentials("5", "account2@example.com") == ""
+
+    # -- occupied target behaves exactly like swap -----------------------
+
+    def test_move_to_occupied_slot_swaps(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        num_src, num_target, swapped = switcher.move_account("1", "2")
+
+        assert (num_src, num_target, swapped) == ("1", "2", True)
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["2"]["email"] == "account1@example.com"
+        assert data["accounts"]["1"]["email"] == "account2@example.com"
+
+    def test_move_is_general_form_of_swap(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """`move a <b's slot>` lands the same state as `swap a b`."""
+        move_switcher = ClaudeAccountSwitcher()
+        self._write(move_switcher, sample_sequence_data)
+        move_switcher.move_account("1", "2")
+        moved = move_switcher._get_sequence_data()["accounts"]
+
+        swap_switcher = ClaudeAccountSwitcher()
+        self._write(swap_switcher, sample_sequence_data)
+        swap_switcher.swap_accounts("1", "2")
+        swapped = swap_switcher._get_sequence_data()["accounts"]
+
+        assert moved["1"]["email"] == swapped["1"]["email"]
+        assert moved["2"]["email"] == swapped["2"]["email"]
+
+    # -- no-op and validation --------------------------------------------
+
+    def test_move_to_same_slot_is_noop(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        num_src, num_target, swapped = switcher.move_account("1", "1")
+
+        assert (num_src, num_target, swapped) == ("1", "1", False)
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["email"] == "account1@example.com"
+        assert data["accounts"]["2"]["email"] == "account2@example.com"
+
+    def test_move_normalizes_padded_target(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        num_src, num_target, swapped = switcher.move_account("2", "05")
+
+        assert num_target == "5"
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["5"]["email"] == "account2@example.com"
+
+    @pytest.mark.parametrize("bad", ["abc", "0", "-1", "1.5", ""])
+    def test_move_invalid_target_rejected(
+        self, temp_home: Path, sample_sequence_data: dict, bad: str
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        with pytest.raises(ValidationError):
+            switcher.move_account("1", bad)
+
+    def test_move_unknown_account_rejected(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        with pytest.raises(AccountNotFoundError):
+            switcher.move_account("nosuch@example.com", "5")

--- a/tests/test_swap_accounts.py
+++ b/tests/test_swap_accounts.py
@@ -1,0 +1,149 @@
+"""Tests for `cswap swap` (ClaudeAccountSwitcher.swap_accounts)."""
+
+from pathlib import Path
+
+import pytest
+
+from claude_swap.exceptions import (
+    AccountNotFoundError,
+    ValidationError,
+)
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class TestSwapAccounts:
+    """Test ClaudeAccountSwitcher.swap_accounts()."""
+
+    def _write(self, switcher, data):
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, data)
+
+    def test_swap_by_number(self, temp_home: Path, sample_sequence_data: dict):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        num_a, num_b = switcher.swap_accounts("1", "2")
+
+        assert (num_a, num_b) == ("1", "2")
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["1"]["email"] == "account2@example.com"
+        assert data["accounts"]["2"]["email"] == "account1@example.com"
+
+    def test_swap_moves_active_number_with_account(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        assert sample_sequence_data["activeAccountNumber"] == 1
+
+        switcher.swap_accounts("1", "2")
+
+        data = switcher._get_sequence_data()
+        # account1 was active and now lives in slot 2
+        assert data["activeAccountNumber"] == 2
+        assert data["accounts"]["2"]["email"] == "account1@example.com"
+
+    def test_swap_updates_rotation_sequence(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        switcher.swap_accounts("1", "2")
+
+        data = switcher._get_sequence_data()
+        assert data["sequence"] == [2, 1]
+
+    def test_swap_by_email_and_alias(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        sample_sequence_data["accounts"]["2"]["alias"] = "dev"
+        self._write(switcher, sample_sequence_data)
+
+        num_a, num_b = switcher.swap_accounts("account1@example.com", "dev")
+
+        assert (num_a, num_b) == ("1", "2")
+        data = switcher._get_sequence_data()
+        # The alias travels with its account into the new slot.
+        assert data["accounts"]["1"].get("alias") == "dev"
+        assert data["accounts"]["2"].get("alias") is None
+
+    def test_swap_moves_credential_and_config_backups(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        switcher._write_account_credentials("1", "account1@example.com", "creds-one")
+        switcher._write_account_config("1", "account1@example.com", "config-one")
+        switcher._write_account_credentials("2", "account2@example.com", "creds-two")
+        switcher._write_account_config("2", "account2@example.com", "config-two")
+
+        switcher.swap_accounts("1", "2")
+
+        assert (
+            switcher._read_account_credentials("2", "account1@example.com")
+            == "creds-one"
+        )
+        assert (
+            switcher._read_account_config("2", "account1@example.com") == "config-one"
+        )
+        assert (
+            switcher._read_account_credentials("1", "account2@example.com")
+            == "creds-two"
+        )
+        assert (
+            switcher._read_account_config("1", "account2@example.com") == "config-two"
+        )
+        # Old keys are gone.
+        assert switcher._read_account_credentials("1", "account1@example.com") == ""
+        assert switcher._read_account_credentials("2", "account2@example.com") == ""
+
+    def test_swap_with_one_slot_missing_backups(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """A never-backed-up slot swaps cleanly and stays credential-less."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        switcher._write_account_credentials("1", "account1@example.com", "creds-one")
+
+        switcher.swap_accounts("1", "2")
+
+        assert (
+            switcher._read_account_credentials("2", "account1@example.com")
+            == "creds-one"
+        )
+        assert switcher._read_account_credentials("1", "account2@example.com") == ""
+
+    def test_swap_same_account_rejected(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        with pytest.raises(ValidationError):
+            switcher.swap_accounts("1", "1")
+
+    def test_swap_unknown_identifier_rejected(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        with pytest.raises(AccountNotFoundError):
+            switcher.swap_accounts("1", "nosuch@example.com")
+
+    def test_swap_moves_session_profiles(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        session_a = switcher._session_dir("1", "account1@example.com")
+        session_a.mkdir(parents=True)
+        (session_a / "marker.txt").write_text("history-of-account-one")
+
+        switcher.swap_accounts("1", "2")
+
+        moved = switcher._session_dir("2", "account1@example.com")
+        assert (moved / "marker.txt").read_text() == "history-of-account-one"
+        assert not session_a.exists()


### PR DESCRIPTION
## What

A small `cswap swap <a> <b>` command that exchanges two accounts' slot numbers, so they trade places in `cswap list` and as numeric targets. Targets accept the usual NUM | EMAIL | ALIAS forms.

```
$ cswap swap 1 2
Swapped Account 1 and Account 2:
  1: work@example.com
  2: personal@example.com
```

## Why

Slot numbers become muscle memory (`cswap switch 1`, scripts, mappings read in list order), but they're assigned by add-order. After adding accounts in the "wrong" order the only way to reorder today is remove + re-add, which costs the stored credentials.

## How

Everything keyed by the slot number moves with the swap:

- sequence records themselves (aliases live inside the record, so they travel with their account)
- per-slot credential and config backups (read both slots up front, write under the new keys, delete the old keys — skipped when both accounts share an email, where old and new keys fully overlap)
- rotation order in `sequence` and `activeAccountNumber`
- each slot's session profile directory, so `cswap run` history survives (best-effort move staged through a temporary name for the shared-email case; a skipped move only costs that slot's session history, since setup re-bootstraps from the relocated backups)

Not touched, by design:

- directory mappings — they key on (email, org) precisely to survive renumbering
- usage-cache rows — they key on the slot number but carry the account identity, so a swapped row fails the identity check and self-heals on the next poll

Live session-mode instances block the swap, same as `--remove-account`.

## Tests

`tests/test_swap_accounts.py`: swap by number/email/alias, active-number follows the account, rotation order updated, backups relocated (including a one-sided/never-backed-up slot), session profile moved, same-account and unknown-identifier rejected. Full suite: 1324 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)