### PR TITLE
feat: per-window switch triggers + soonest-reset strategy

### DIFF
--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -48,7 +48,10 @@ from claude_swap.locking import FileLock
 from claude_swap.poll_policy import (
     ESCALATION_MARGIN_PCT,
     RESET_SLACK_S,
+    account_landing_ok,
+    account_triggered,
     binding_pct,
+    soonest_7d_reset_ts,
 )
 from claude_swap.settings import AutoSwitchSettings, atomic_write_json, parse_model_names
 from claude_swap.switcher import ClaudeAccountSwitcher
@@ -707,16 +710,24 @@ class AutoSwitchEngine:
         if active_headroom is not None:
             self._unhealthy_ticks = 0
             self._idle_hold_since = None
-            utilization = 100.0 - active_headroom
-            if utilization < settings.threshold:
+            active_value = usage.get(current)
+            # Per-window OR'd trigger: switch when 5h >= threshold_5h OR
+            # 7d >= threshold_7d (OR a folded model window >= threshold),
+            # rather than the single binding-window (max) threshold.
+            if not account_triggered(
+                active_value if isinstance(active_value, dict) else None,
+                self._models,
+                settings.threshold_5h,
+                settings.threshold_7d,
+                settings.threshold,
+            ):
                 self._emit(
                     NoSwitchEvent(
                         reason="below-threshold",
-                        # Both sides through pct_label: .0f utilization could
-                        # display an impossible "100% < 99.9%".
                         detail=(
-                            f"{pct_label(utilization)}% < "
-                            f"{pct_label(settings.threshold)}%"
+                            f"5h/7d below "
+                            f"{pct_label(settings.threshold_5h)}%/"
+                            f"{pct_label(settings.threshold_7d)}%"
                         ),
                     )
                 )
@@ -814,13 +825,39 @@ class AutoSwitchEngine:
                 # on the very next tick. At-limit and failover are escapes —
                 # any account with real headroom beats a blocked or dead one
                 # (and you can't flap back onto an account at 100%).
-                if (100.0 - h) >= settings.threshold:
-                    continue
+                cand_value = usage.get(num)
+                if not account_landing_ok(
+                    cand_value if isinstance(cand_value, dict) else None,
+                    self._models,
+                    settings.threshold_5h,
+                    settings.threshold_7d,
+                    settings.threshold,
+                ):
+                    continue  # at/over a per-window threshold — would re-trigger
                 if h - active_headroom < settings.hysteresis_pct:
                     continue  # not provably better than where we are
             qualifying.append((h, num))
-        # Best headroom first; list order (sequence order) breaks ties.
-        qualifying.sort(key=lambda t: -t[0])
+        if settings.strategy == "soonest-reset":
+            # Burn the most-perishable weekly budget first: order eligible
+            # accounts by soonest future 7d reset (ascending). Accounts with
+            # a readable future 7d reset come first, soonest first; any
+            # without one fall back after them, ordered by headroom. sort()
+            # is stable, so sequence order breaks any remaining ties.
+            now_ts = self.clock()
+
+            def _soonest_key(t: tuple[float, str]) -> tuple[int, float]:
+                h, num = t
+                cand_value = usage.get(num)
+                ts = soonest_7d_reset_ts(
+                    cand_value if isinstance(cand_value, dict) else None, now_ts
+                )
+                return (0, ts) if ts is not None else (1, -h)
+
+            qualifying.sort(key=_soonest_key)
+        else:
+            # "best": most binding-window headroom first; sequence order
+            # breaks ties.
+            qualifying.sort(key=lambda t: -t[0])
         ordered = [num for _, num in qualifying]
         if not ordered and api_key_candidates:
             # Last resort: metered API-key accounts (unmeasurable headroom).
@@ -1178,8 +1215,16 @@ class AutoSwitchEngine:
         """Session override from the TUI: retarget the trigger and poll
         cadence mid-run. Threshold only — the model axes (and their derived
         state) are fixed at construction. The frozen-settings swap is atomic
-        and each tick snapshots ``self.settings`` once, so no locking."""
-        self.settings = replace(self.settings, threshold=threshold)
+        and each tick snapshots ``self.settings`` once, so no locking. The
+        slider is a uniform "switch more/less eagerly" control, so it
+        retargets both per-window (5h/7d) triggers as well as the base
+        threshold (which still governs model windows + cadence escalation)."""
+        self.settings = replace(
+            self.settings,
+            threshold=threshold,
+            threshold_5h=threshold,
+            threshold_7d=threshold,
+        )
         self.switcher.set_poll_policy_inputs(threshold, self._models)
 
     def _next_delay(self, outcome: TickOutcome) -> float:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -468,8 +468,9 @@ Defaults live in settings.json in the backup root; flags override them.
         type=float,
         metavar="PCT",
         help=(
-            "Switch when the active account's binding 5h/7d window reaches "
-            "this utilization (50-99.9; default 90)"
+            "Uniform switch trigger for this run: retarget BOTH the 5h and "
+            "7d windows to this utilization (50-99.9). Omit to use the "
+            "per-window defaults (5h 95 / 7d 98)"
         ),
     )
     parser.add_argument(
@@ -550,7 +551,9 @@ Defaults live in settings.json in the backup root; flags override them.
         if not args.json:
             print(
                 dimmed(
-                    f"Auto-switch running: threshold {settings.threshold:.0f}%, "
+                    "Auto-switch running: switch at 5h/7d "
+                    f"{settings.threshold_5h:.0f}%/{settings.threshold_7d:.0f}%, "
+                    f"strategy {settings.strategy}, "
                     f"every {settings.interval_seconds:.0f}s"
                     f"{' (dry-run)' if args.dry_run else ''} — Ctrl-C to stop"
                 )

--- a/src/claude_swap/poll_policy.py
+++ b/src/claude_swap/poll_policy.py
@@ -137,6 +137,75 @@ def parse_reset_ts(resets_at: str | None) -> float | None:
         return None
 
 
+def window_threshold(
+    label: str, threshold_5h: float, threshold_7d: float, base: float
+) -> float:
+    """The switch threshold for one window label.
+
+    5h/7d get their own per-window thresholds; any other (folded model)
+    window falls back to the account-wide ``base`` threshold.
+    """
+    if label == "5h":
+        return threshold_5h
+    if label == "7d":
+        return threshold_7d
+    return base
+
+
+def account_triggered(
+    usage: dict | None,
+    models: tuple[str, ...],
+    threshold_5h: float,
+    threshold_7d: float,
+    base: float,
+) -> bool:
+    """True if ANY relevant window is at/above its per-window threshold.
+
+    The OR'd per-window switch trigger: 5h>=threshold_5h OR 7d>=threshold_7d
+    OR any folded model window >= base. ``usage`` must be a decision-value
+    dict (unknown/sentinel usage yields no windows → not triggered; the
+    caller handles unknown-usage separately).
+    """
+    for label, pct, _ in oauth.relevant_windows(usage, models):
+        if pct >= window_threshold(label, threshold_5h, threshold_7d, base):
+            return True
+    return False
+
+
+def account_landing_ok(
+    usage: dict | None,
+    models: tuple[str, ...],
+    threshold_5h: float,
+    threshold_7d: float,
+    base: float,
+) -> bool:
+    """True if a candidate is a healthy landing: usage is known AND no
+    relevant window is at/above its threshold (so it won't re-trigger the
+    switch on the very next tick). Unknown usage (no windows) is never a
+    healthy landing.
+    """
+    if not oauth.relevant_windows(usage, models):
+        return False
+    return not account_triggered(
+        usage, models, threshold_5h, threshold_7d, base
+    )
+
+
+def soonest_7d_reset_ts(usage: dict | None, now: float) -> float | None:
+    """Future epoch when this account's 7-day window resets, or None.
+
+    The ordering key for the ``soonest-reset`` strategy — burn the account
+    whose weekly (7d) budget expires soonest first. A missing/past/unparseable
+    reset yields None (sorted last by the caller, never chosen preferentially).
+    """
+    for label, _, resets_at in oauth.relevant_windows(usage):
+        if label == "7d":
+            ts = parse_reset_ts(resets_at)
+            if ts is not None and ts > now:
+                return ts
+    return None
+
+
 def plan_after_fetch(
     *,
     prev_interval_s: float | None,

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -43,10 +43,26 @@ class AutoSwitchSettings:
     """
 
     threshold: float = 90.0
+    # Per-window switch triggers (OR'd): switch when 5h >= threshold_5h OR
+    # 7d >= threshold_7d (OR any folded model window >= threshold). The 7d
+    # window is the costly one (a week-long lockout), so it is squeezed
+    # closer to the wall (98) than the self-refilling 5h window (95). These
+    # supersede the single binding-window ``threshold`` for the 5h/7d
+    # trigger + landing checks; ``threshold`` still governs model windows
+    # and poll-cadence escalation. Keep the per-window values at or above
+    # ``threshold`` (the defaults 95/98 vs base 90 do): a per-window
+    # threshold set far *below* ``threshold`` can trigger before the
+    # candidate-refresh/urgent-poll escalation band opens, so a switch may
+    # run on a slightly stale candidate snapshot.
+    threshold_5h: float = 95.0
+    threshold_7d: float = 98.0
     interval_seconds: float = 60.0
     cooldown_seconds: float = 300.0
     hysteresis_pct: float = 10.0
-    strategy: str = "best"  # reserved for future strategies; only "best" in v1
+    # "best" = most binding-window headroom (stock). "soonest-reset" = among
+    # eligible accounts, the one whose 7-day window resets soonest (burn the
+    # most-perishable weekly budget first).
+    strategy: str = "best"
     include_api_key_accounts: bool = False
     unhealthy_ticks: int = 3
     # Comma-separated model display name(s) (e.g. "Fable" or "Fable,Opus"),
@@ -92,7 +108,16 @@ SETTING_SPECS: dict[str, SettingSpec] = {
     for spec in (
         SettingSpec(
             "autoswitch", "threshold", "threshold", "float", 50.0, 99.9,
-            help="Switch when the binding 5h/7d window reaches this pct",
+            help="Base threshold for folded model windows + poll-cadence "
+            "escalation (the 5h/7d trigger uses threshold5h/threshold7d)",
+        ),
+        SettingSpec(
+            "autoswitch", "threshold5h", "threshold_5h", "float", 50.0, 99.9,
+            help="Switch when the 5-hour window reaches this pct (OR'd with 7d)",
+        ),
+        SettingSpec(
+            "autoswitch", "threshold7d", "threshold_7d", "float", 50.0, 99.9,
+            help="Switch when the 7-day window reaches this pct (OR'd with 5h)",
         ),
         SettingSpec(
             "autoswitch", "intervalSeconds", "interval_seconds", "float", 15.0, 3600.0,
@@ -107,8 +132,9 @@ SETTING_SPECS: dict[str, SettingSpec] = {
             help="A target must beat the active account by this many pct",
         ),
         SettingSpec(
-            "autoswitch", "strategy", "strategy", "choice", choices=("best",),
-            help="How auto-switch picks the target account",
+            "autoswitch", "strategy", "strategy", "choice",
+            choices=("best", "soonest-reset"),
+            help="How auto-switch picks the target account (best | soonest-reset)",
         ),
         SettingSpec(
             "autoswitch", "includeApiKeyAccounts", "include_api_key_accounts", "bool",
@@ -384,7 +410,6 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
     """Overlay non-None CLI overrides (argparse Namespace) onto settings."""
     overrides = {}
     for attr, field in (
-        ("threshold", "threshold"),
         ("interval", "interval_seconds"),
         ("cooldown", "cooldown_seconds"),
         ("include_api_key_accounts", "include_api_key_accounts"),
@@ -393,6 +418,15 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
         value = getattr(args, attr, None)
         if value is not None:
             overrides[field] = value
+    threshold = getattr(args, "threshold", None)
+    if threshold is not None:
+        # --threshold is a uniform "switch more/less eagerly" override for
+        # this run (mirroring the TUI slider): retarget both per-window
+        # (5h/7d) triggers as well as the base threshold, so the flag isn't
+        # silently inert against the per-window trigger it advertises.
+        overrides["threshold"] = threshold
+        overrides["threshold_5h"] = threshold
+        overrides["threshold_7d"] = threshold
     if not overrides:
         return settings
     return _clamped(dataclasses.replace(settings, **overrides))

--- a/src/claude_swap/tui/autoview.py
+++ b/src/claude_swap/tui/autoview.py
@@ -179,7 +179,15 @@ class AutoScreen(Screen):
     def _set_threshold(self, value: float) -> None:
         if value == self._settings.threshold:
             return
-        self._settings = replace(self._settings, threshold=value)
+        # Mirror onto the per-window triggers too, matching
+        # engine.apply_threshold — otherwise a dry<->live restart rebuilds the
+        # engine from this object and silently drops the session override.
+        self._settings = replace(
+            self._settings,
+            threshold=value,
+            threshold_5h=value,
+            threshold_7d=value,
+        )
         if self._engine is not None:
             self._engine.apply_threshold(value)
         self.app.threshold_pct = value

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -68,6 +68,12 @@ class EngineHarness:
         self.switcher.platform = Platform.LINUX
         self.switcher._setup_directories()
         self.switcher._init_sequence_file()
+        # A test that sets a single ``threshold`` means it as the uniform
+        # switch point; mirror it onto the per-window 5h/7d thresholds unless
+        # the test sets those explicitly. Production defaults stay 95/98.
+        if "threshold" in settings_kwargs:
+            settings_kwargs.setdefault("threshold_5h", settings_kwargs["threshold"])
+            settings_kwargs.setdefault("threshold_7d", settings_kwargs["threshold"])
         self.settings = AutoSwitchSettings(**settings_kwargs)
         self.events: list = []
         self.clock = FakeClock()
@@ -378,9 +384,10 @@ class TestDecisionTable:
         assert harness.active_number() == 2
 
     def test_candidate_not_better_than_active_is_skipped(self, harness):
-        # Active 91% used (9 headroom); candidates worse or equal → exhausted.
+        # Active 96% 5h (triggers the 95 per-window threshold); candidates at
+        # or over a threshold → not valid landings → exhausted/blocked.
         outcome = harness.tick_with_usage({
-            "1": _usage(91), "2": _usage(95), "3": _usage(99),
+            "1": _usage(96), "2": _usage(95), "3": _usage(99),
         })
         assert outcome is TickOutcome.BLOCKED
         assert harness.active_number() == 1
@@ -1399,13 +1406,14 @@ class TestPctLabel:
         details = [
             e.detail for e in h.events if isinstance(e, NoSwitchEvent)
         ]
-        assert details == ["50% < 99.9%"]
+        assert details == ["5h/7d below 99.9%/99.9%"]
 
     def test_below_threshold_detail_never_shows_impossible_comparison(
         self, temp_home
     ):
-        # utilization 99.85 with threshold 99.9: .0f on the left side used
-        # to render the logically impossible "100% < 99.9%".
+        # The per-window "below X%/Y%" detail states the thresholds, not a
+        # left-side utilization, so it can never render the logically
+        # impossible "100% < 99.9%" the old single-threshold detail could.
         h = EngineHarness(temp_home, threshold=99.9)
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
@@ -1414,7 +1422,7 @@ class TestPctLabel:
         details = [
             e.detail for e in h.events if isinstance(e, NoSwitchEvent)
         ]
-        assert details == ["99.85% < 99.9%"]
+        assert details == ["5h/7d below 99.9%/99.9%"]
 
 
 class TestTokenIdentity:
@@ -1876,3 +1884,102 @@ class TestModelAwareSwitch:
             "3": _model_usage(5, 10),
         })
         assert not any(isinstance(e, ConfigWarningEvent) for e in h.events)
+
+
+def _win(five_h: float, seven_d: float, seven_d_reset: str | None = None) -> dict:
+    """Usage dict with independent 5h and 7d windows (7d may carry a reset)."""
+    seven: dict = {"pct": seven_d}
+    if seven_d_reset:
+        seven["resets_at"] = seven_d_reset
+    return {"five_hour": {"pct": five_h}, "seven_day": seven}
+
+
+def _iso(ts: float) -> str:
+    from datetime import datetime, timezone
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+class TestPerWindowTrigger:
+    """The OR'd per-window switch trigger: 5h>=95 OR 7d>=98."""
+
+    def test_seven_day_below_98_does_not_trigger(self, harness):
+        # 7d=96 would cross a single binding threshold (90) but must NOT
+        # trigger under the per-window 7d threshold (98).
+        outcome = harness.tick_with_usage({
+            "1": _win(10.0, 96.0), "2": _win(10.0, 10.0), "3": _win(10.0, 10.0),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert harness.active_number() == 1
+
+    def test_seven_day_at_98_triggers_switch(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _win(10.0, 98.0), "2": _win(10.0, 10.0), "3": _win(10.0, 10.0),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() != 1
+
+    def test_five_hour_at_95_triggers_switch(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _win(95.0, 10.0), "2": _win(10.0, 10.0), "3": _win(10.0, 10.0),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() != 1
+
+    def test_candidate_at_seven_day_threshold_is_not_a_landing(self, harness):
+        # Active triggers on 5h; the only real-headroom candidate is at its
+        # 7d threshold (98) → not a valid landing → blocked, stay put.
+        outcome = harness.tick_with_usage({
+            "1": _win(96.0, 10.0), "2": _win(10.0, 98.0), "3": _win(10.0, 99.0),
+        })
+        assert outcome is TickOutcome.BLOCKED
+        assert harness.active_number() == 1
+
+
+class TestSoonestResetStrategy:
+    """strategy=soonest-reset targets the soonest-resetting 7d window."""
+
+    def _seed3(self, temp_home, strategy):
+        h = EngineHarness(temp_home, strategy=strategy)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_picks_soonest_resetting_over_most_headroom(self, temp_home):
+        h = self._seed3(temp_home, "soonest-reset")
+        soon = _iso(1_000_000 + 7200)    # 2h
+        later = _iso(1_000_000 + 36000)  # 10h
+        outcome = h.tick_with_usage({
+            "1": _win(96.0, 10.0),               # active triggers on 5h
+            "2": _win(10.0, 10.0, later),        # MOST headroom, resets later
+            "3": _win(10.0, 50.0, soon),         # less headroom, resets SOONEST
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3  # soonest-reset, not most-headroom "2"
+
+    def test_best_strategy_picks_most_headroom(self, temp_home):
+        h = self._seed3(temp_home, "best")
+        soon = _iso(1_000_000 + 7200)
+        later = _iso(1_000_000 + 36000)
+        outcome = h.tick_with_usage({
+            "1": _win(96.0, 10.0),
+            "2": _win(10.0, 10.0, later),        # most headroom
+            "3": _win(10.0, 50.0, soon),         # soonest reset
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2  # most headroom, ignores reset timing
+
+    def test_missing_reset_falls_back_after_known(self, temp_home):
+        h = self._seed3(temp_home, "soonest-reset")
+        soon = _iso(1_000_000 + 7200)
+        # "2" has a known soon reset; "3" has no 7d reset → "2" chosen.
+        outcome = h.tick_with_usage({
+            "1": _win(96.0, 10.0),
+            "2": _win(10.0, 40.0, soon),
+            "3": _win(10.0, 10.0),               # no reset → after known
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -50,7 +50,7 @@ class TestConfigList:
             "autoswitch.model",
         ):
             assert key in out
-        assert out.count("(default)") == 8
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -77,7 +77,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 8
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_poll_policy.py
+++ b/tests/test_poll_policy.py
@@ -199,3 +199,79 @@ class TestBudgetInvariants:
         # (which absorbs any overshoot) is considered.
         polls = poll_policy.ESCALATION_MARGIN_PCT / poll_policy.MOVEMENT_DELTA_PCT
         assert polls < 27
+
+
+def _win(five_h: float, seven_d: float, seven_d_reset: str | None = None) -> dict:
+    """Usage dict with independent 5h and 7d windows."""
+    seven: dict = {"pct": seven_d}
+    if seven_d_reset:
+        seven["resets_at"] = seven_d_reset
+    return {"five_hour": {"pct": five_h}, "seven_day": seven}
+
+
+class TestWindowThreshold:
+    def test_per_window_labels(self):
+        assert poll_policy.window_threshold("5h", 95.0, 98.0, 90.0) == 95.0
+        assert poll_policy.window_threshold("7d", 95.0, 98.0, 90.0) == 98.0
+        # A folded model window falls back to the base threshold.
+        assert poll_policy.window_threshold("Fable", 95.0, 98.0, 90.0) == 90.0
+
+
+class TestAccountTriggered:
+    def test_five_hour_triggers_alone(self):
+        assert poll_policy.account_triggered(_win(95.0, 10.0), (), 95.0, 98.0, 90.0)
+
+    def test_seven_day_triggers_alone(self):
+        assert poll_policy.account_triggered(_win(10.0, 98.0), (), 95.0, 98.0, 90.0)
+
+    def test_both_below_does_not_trigger(self):
+        assert not poll_policy.account_triggered(_win(94.9, 97.9), (), 95.0, 98.0, 90.0)
+
+    def test_seven_day_between_base_and_its_threshold_does_not_trigger(self):
+        # 7d=96 would have crossed a single binding threshold of 90, but must
+        # NOT trigger under the per-window 7d threshold of 98 (the whole point
+        # of squeezing the precious weekly budget closer to the wall).
+        assert not poll_policy.account_triggered(_win(10.0, 96.0), (), 95.0, 98.0, 90.0)
+
+    def test_unknown_usage_not_triggered(self):
+        assert not poll_policy.account_triggered(None, (), 95.0, 98.0, 90.0)
+        assert not poll_policy.account_triggered("token-expired", (), 95.0, 98.0, 90.0)
+
+    def test_model_window_uses_base_threshold(self):
+        usage = {
+            "five_hour": {"pct": 10.0}, "seven_day": {"pct": 10.0},
+            "scoped": [{"name": "Fable", "pct": 91.0}],
+        }
+        # Fable at 91 >= base 90 → triggered when the model is folded in.
+        assert poll_policy.account_triggered(usage, ("Fable",), 95.0, 98.0, 90.0)
+        # ...but not when no model is folded (only 5h/7d count).
+        assert not poll_policy.account_triggered(usage, (), 95.0, 98.0, 90.0)
+
+
+class TestAccountLandingOk:
+    def test_healthy_landing(self):
+        assert poll_policy.account_landing_ok(_win(50.0, 50.0), (), 95.0, 98.0, 90.0)
+
+    def test_at_threshold_is_not_a_healthy_landing(self):
+        assert not poll_policy.account_landing_ok(_win(10.0, 98.0), (), 95.0, 98.0, 90.0)
+
+    def test_unknown_usage_never_a_healthy_landing(self):
+        assert not poll_policy.account_landing_ok(None, (), 95.0, 98.0, 90.0)
+
+
+class TestSoonest7dReset:
+    def test_returns_future_seven_day_reset(self):
+        soon = datetime.fromtimestamp(NOW + 3600, tz=timezone.utc)
+        ts = poll_policy.soonest_7d_reset_ts(
+            _win(10.0, 10.0, soon.isoformat().replace("+00:00", "Z")), NOW
+        )
+        assert ts == pytest.approx(NOW + 3600)
+
+    def test_missing_reset_is_none(self):
+        assert poll_policy.soonest_7d_reset_ts(_win(10.0, 10.0), NOW) is None
+
+    def test_past_reset_is_ignored(self):
+        past = datetime.fromtimestamp(NOW - 3600, tz=timezone.utc)
+        assert poll_policy.soonest_7d_reset_ts(
+            _win(10.0, 10.0, past.isoformat().replace("+00:00", "Z")), NOW
+        ) is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -217,6 +217,21 @@ class TestMergedWithCli:
         assert merged.interval_seconds == 30.0
         assert merged.cooldown_seconds == 10.0  # untouched
 
+    def test_threshold_flag_mirrors_onto_per_window_triggers(self):
+        # --threshold is a uniform override: it must retarget both the 5h and
+        # 7d per-window triggers, not just the base threshold — otherwise the
+        # flag is silently inert against the trigger it advertises.
+        base = AutoSwitchSettings()  # per-window defaults 95/98
+        merged = merged_with_cli(base, _args(threshold=70.0))
+        assert merged.threshold == 70.0
+        assert merged.threshold_5h == 70.0
+        assert merged.threshold_7d == 70.0
+
+    def test_no_threshold_flag_leaves_per_window_defaults(self):
+        merged = merged_with_cli(AutoSwitchSettings(), _args(interval=30.0))
+        assert merged.threshold_5h == 95.0
+        assert merged.threshold_7d == 98.0
+
     def test_cli_values_are_clamped(self):
         merged = merged_with_cli(AutoSwitchSettings(), _args(interval=1.0))
         assert merged.interval_seconds == 15.0


### PR DESCRIPTION
## Summary

Two additive, backward-compatible `autoswitch` options:

**1. Per-window OR'd switch triggers** — new `threshold5h` / `threshold7d` settings (defaults 95 / 98). Switch when the **5h** window **or** the **7d** window crosses its *own* threshold, rather than a single `threshold` on the binding (max) window. The 7d window is a week-long limit, so it's useful to let it sit closer to the wall than the self-refilling 5h window. Landing eligibility, the `--threshold` flag, and the TUI slider all honor the per-window model; the existing `threshold` still governs folded per-model windows and poll-cadence escalation.

**2. `strategy = "soonest-reset"`** — among eligible target accounts, switch to the one whose **7-day window resets soonest** (burn the most-perishable weekly budget first), instead of `"best"` (most headroom). `"best"` remains the default, so existing behavior is unchanged unless opted in.

## Why

With several accounts, "switch to the account with the most quota left" isn't always what you want — it preferentially spends the budget that's *furthest* from resetting. `soonest-reset` spends the most-perishable weekly budget first. And a single binding-window threshold can't express "ride the 5h window to X% but switch the precious 7d window earlier."

## Compatibility

- Fully additive. `"best"` stays the default; unset per-window keys inherit sensible defaults.
- Downgrade-safe: the settings loader already ignores unknown keys and degrades an unknown `strategy` value to the default with a logged warning, so reverting to an older version is clean.

## Tests

Adds unit tests (`test_poll_policy.py`: per-window trigger/landing helpers, soonest-reset ordering incl. missing/past reset timestamps) and engine-level tests (`test_autoswitch.py`: per-window trigger asymmetry, `soonest-reset` vs `best` selection). Full suite passes.
