### PR TITLE
fix: preserve MCP OAuth sessions across account switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ The original flag spellings (`cswap --switch`, `cswap --list`, ...) keep working
 ## How it works
 
 - Backs up OAuth tokens and config when you add an account
-- Swaps credentials when you switch accounts
+- Swaps only the account-specific Claude login when you switch accounts
+- Preserves account-independent OAuth state (such as MCP server logins) in a
+  separate shared credential store, including across managed API-key switches
 - Account credentials stored securely using platform-appropriate methods
 - Switches (manual and automatic) hold Claude Code's own credential locks while writing, so a swap never interleaves with a token refresh
 - Auto-switch freshens a target's token before activating it, and quarantines accounts whose refresh token has died (recover by re-adding it with `cswap add --slot N`, or by replacing its stored credentials from a known-good export with `cswap import backup.cswap --force`)

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -1,6 +1,7 @@
 """Credential storage layer for claude-swap.
 
-Owns *where* credentials live and *how* they are read/written — the macOS
+Owns *where* credentials live and *how* they are read/written — the active
+credential, per-account backups, account-independent shared OAuth state, macOS
 Keychain-vs-file routing, per-process capability detection and sticky fallback,
 and the ``.enc``-wins backup reconciliation that landed in #66. Split out of
 ``switcher.py`` so the switcher reads as account orchestration again.
@@ -40,6 +41,12 @@ from claude_swap.paths import (
 # CLI on macOS. Deliberately distinct from KEYRING_SERVICE so old keyring items and
 # new security items coexist during migration (safe write → verify → delete).
 SECURITY_SERVICE = "claude-swap"
+
+# Account-independent siblings of ``claudeAiOauth`` live under this separate
+# backup identity. Keeping them outside every account slot lets them survive
+# auth-axis changes (notably OAuth → managed API key → OAuth) without making a
+# stale destination-slot snapshot authoritative again.
+SHARED_CREDENTIALS_USERNAME = "shared-oauth"
 
 # Service name of Claude Code's *active* OAuth credential in the macOS Keychain
 # (read by Claude Code itself; we read/write it when switching accounts).
@@ -99,6 +106,53 @@ def looks_like_api_key(credentials: str | None) -> bool:
     return text.startswith("sk-ant-api") and not text.startswith("{")
 
 
+def _credential_object(credentials: str | None) -> dict | None:
+    """Parse a JSON credential object, excluding managed API keys."""
+    if not credentials or looks_like_api_key(credentials):
+        return None
+    try:
+        data = json.loads(credentials)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def has_claude_oauth(credentials: str | None) -> bool:
+    """Whether credentials contain the slot-owned Claude OAuth field."""
+    data = _credential_object(credentials)
+    return data is not None and "claudeAiOauth" in data
+
+
+def shared_credential_fields(credentials: str | None) -> dict | None:
+    """Return account-independent fields from a Claude OAuth credential object.
+
+    ``None`` means the input is not a JSON credential object (missing, malformed,
+    or a managed API key). A dictionary — including ``{}`` — is authoritative:
+    every sibling of ``claudeAiOauth`` belongs to the shared store.
+    """
+    data = _credential_object(credentials)
+    if data is None:
+        return None
+    return {
+        key: value
+        for key, value in data.items()
+        if key != "claudeAiOauth"
+    }
+
+
+def merge_shared_credential_fields(
+    target_credentials: str, shared_fields: dict
+) -> str:
+    """Compose a target Claude login with independently-owned shared fields."""
+    target = _credential_object(target_credentials)
+    if target is None or "claudeAiOauth" not in target:
+        return target_credentials
+
+    composed = dict(shared_fields)
+    composed["claudeAiOauth"] = target["claudeAiOauth"]
+    return json.dumps(composed)
+
+
 def approved_form(api_key: str) -> str:
     """The value Claude Code stores in ``customApiKeyResponses.approved``.
 
@@ -123,7 +177,7 @@ class _StoreHost(Protocol):
 
 
 class CredentialStore:
-    """Owns the active and per-account backup credential stores.
+    """Owns the active, per-account, and shared credential stores.
 
     One store per switcher: the capability cache is per-process, learned from real
     ``security`` calls, and a fresh process re-evaluates from scratch.
@@ -634,6 +688,111 @@ class CredentialStore:
         regardless (see ``_read_account_credentials``).
         """
         return not self._use_keychain()
+
+    # -- account-independent shared credential backup ----------------------
+    #
+    # Claude Code stores its account login and shared OAuth integrations in one
+    # active blob. The account login is slot-owned; every sibling field is not.
+    # This store keeps those siblings alive while the active OAuth blob is absent
+    # (for example, while a managed API key is active). It follows the same
+    # Keychain-with-.enc-fallback policy as account backups.
+
+    def _shared_credentials_path(self) -> Path:
+        return self._host.credentials_dir / ".shared-oauth.enc"
+
+    def _read_shared_credentials(self) -> str | None:
+        """Read shared credential fields.
+
+        Returns their JSON object string, ``""`` when no independent snapshot has
+        been initialized, or ``None`` when a present snapshot/backend could not be
+        read safely. The distinction prevents an unavailable Keychain or corrupt
+        fallback file from being mistaken for an empty shared state.
+        """
+        enc_file = self._shared_credentials_path()
+        file_failed = False
+        if enc_file.exists():
+            try:
+                encoded = enc_file.read_text(encoding="utf-8").strip()
+                decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+            except Exception as e:
+                self._host._logger.warning(
+                    f"Failed to read shared credentials file: {e}"
+                )
+                file_failed = True
+            else:
+                if decoded:
+                    return decoded
+                file_failed = True
+
+        if self._host.platform == Platform.MACOS:
+            if not self._use_keychain():
+                return None
+            try:
+                credentials = self._kc_call(
+                    macos_keychain.get_password,
+                    SECURITY_SERVICE,
+                    SHARED_CREDENTIALS_USERNAME,
+                )
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                self._host._logger.warning(
+                    f"Failed to read shared credentials from Keychain: {e}"
+                )
+                return None
+            if credentials:
+                return credentials
+
+        return None if file_failed else ""
+
+    def _write_shared_credentials(self, credentials: str) -> None:
+        """Persist shared credential fields independently of account slots."""
+        if self._use_keychain():
+            try:
+                self._kc_call(
+                    macos_keychain.set_password,
+                    SECURITY_SERVICE,
+                    SHARED_CREDENTIALS_USERNAME,
+                    credentials,
+                )
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                self._host._logger.warning(
+                    f"Shared-credential Keychain write failed, "
+                    f"falling back to file: {e}"
+                )
+            else:
+                self._reconcile_shared_file_after_keychain_write(credentials)
+                return
+
+        try:
+            self._atomic_b64_write(self._shared_credentials_path(), credentials)
+        except Exception as e:
+            self._host._logger.warning(
+                f"Failed to write shared credentials file: {e}"
+            )
+            raise
+        if self._host.platform == Platform.MACOS:
+            try:
+                macos_keychain.delete_password(
+                    SECURITY_SERVICE, SHARED_CREDENTIALS_USERNAME
+                )
+            except Exception:
+                pass
+
+    def _reconcile_shared_file_after_keychain_write(
+        self, credentials: str
+    ) -> None:
+        """Stop a fallback file from shadowing a fresh shared Keychain value."""
+        enc_file = self._shared_credentials_path()
+        if not enc_file.exists():
+            return
+        try:
+            enc_file.unlink()
+            return
+        except Exception as e:
+            self._host._logger.warning(
+                f"Could not delete shared .enc after Keychain write ({e}); "
+                "rewriting it with the fresh credentials"
+            )
+        self._atomic_b64_write(enc_file, credentials)
 
     # -- backup credential backends ---------------------------------------
     #

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -410,6 +410,32 @@ class ClaudeAccountSwitcher:
     def _write_credentials(self, credentials: str) -> None:
         self._store._write_credentials(credentials)
 
+    @staticmethod
+    def _credentials_for_activation(
+        target_credentials: str, live_credentials: str | None
+    ) -> str:
+        """Use the target Claude login without restoring stale shared OAuth state."""
+        if looks_like_api_key(target_credentials):
+            return target_credentials
+
+        try:
+            target = json.loads(target_credentials)
+        except (json.JSONDecodeError, TypeError):
+            return target_credentials
+        if not isinstance(target, dict) or "claudeAiOauth" not in target:
+            return target_credentials
+
+        try:
+            live = json.loads(live_credentials) if live_credentials else {}
+        except (json.JSONDecodeError, TypeError):
+            live = {}
+        if not isinstance(live, dict):
+            live = {}
+
+        live.pop("claudeAiOauth", None)
+        live["claudeAiOauth"] = target["claudeAiOauth"]
+        return json.dumps(live)
+
     def _uses_file_backup_backend(self) -> bool:
         return self._store._uses_file_backup_backend()
 
@@ -4016,18 +4042,18 @@ class ClaudeAccountSwitcher:
                 if not target_oauth:
                     raise SwitchError("Invalid oauthAccount in backup")
 
-                # Snapshot live state so a mid-operation failure can be undone.
-                # When a live session exists, fail fast if the snapshot is
-                # unreadable rather than proceeding to overwrite without a
-                # safety net. The fresh-machine case has nothing to restore.
-                rollback_creds: str | None = None
+                # Read live state even without a Claude identity: the credential
+                # object may still contain MCP OAuth tokens that must survive the
+                # activation and be restored if a later step fails.
+                active_creds = self._read_active_credentials()
+                live_creds = active_creds.value
+                if live_creds is None or active_creds.keychain_unavailable:
+                    raise CredentialReadError(
+                        "Cannot snapshot live credentials before activation"
+                    )
+                rollback_creds = live_creds or None
                 rollback_config_text: str | None = None
                 if current_identity is not None:
-                    rollback_creds = self._read_credentials()
-                    if rollback_creds is None:
-                        raise CredentialReadError(
-                            "Cannot snapshot live credentials before activation"
-                        )
                     if config_path.exists():
                         try:
                             rollback_config_text = config_path.read_text(
@@ -4077,7 +4103,9 @@ class ClaudeAccountSwitcher:
                 creds_written = False
                 config_written = False
                 try:
-                    self._write_credentials(target_creds)
+                    self._write_credentials(
+                        self._credentials_for_activation(target_creds, live_creds)
+                    )
                     creds_written = True
 
                     # Mirror the normal switch path: preserve existing local
@@ -4294,7 +4322,9 @@ class ClaudeAccountSwitcher:
                     )
 
                 # Step 3: Activate target account - credentials
-                self._write_credentials(target_creds)
+                self._write_credentials(
+                    self._credentials_for_activation(target_creds, original_creds)
+                )
                 transaction.record_step("credentials_written")
                 self._logger.info("Wrote target credentials")
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -39,9 +39,13 @@ from claude_swap.json_output import (
 from claude_swap.credentials import (  # noqa: F401  (constants re-exported for migrations/tests)
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     SECURITY_SERVICE,
+    SHARED_CREDENTIALS_USERNAME,
     ActiveCredentials,
     CredentialStore,
+    has_claude_oauth,
     looks_like_api_key,
+    merge_shared_credential_fields,
+    shared_credential_fields,
 )
 from claude_swap.locking import FileLock
 from claude_swap.logging_config import setup_logging
@@ -255,9 +259,9 @@ class ClaudeAccountSwitcher:
         self._poll_inputs_cache: tuple[float | None, tuple[float, tuple[str, ...]]] | None = None
         self._poll_inputs_override: tuple[float, tuple[str, ...]] | None = None
 
-        # The credential storage layer (active + per-account backup stores, macOS
-        # Keychain-vs-file routing, the per-process capability cache). Reads its
-        # live config (platform, _logger, credentials_dir) back off this switcher.
+        # The credential storage layer (active, per-account, and shared stores;
+        # macOS Keychain-vs-file routing; the per-process capability cache). Reads
+        # its live config (platform, _logger, credentials_dir) back off this switcher.
         # Constructed BEFORE run_migrations(), which performs storage ops on macOS.
         # One store per switcher: the capability cache is per-process.
         self._store = CredentialStore(self)
@@ -363,7 +367,7 @@ class ClaudeAccountSwitcher:
 
     # -- credential storage (delegates to CredentialStore) ----------------
     #
-    # The active and per-account backup credential stores live in
+    # The active, per-account backup, and shared credential stores live in
     # ``CredentialStore`` (credentials.py). The methods below are thin delegators
     # kept so existing call sites (migrations, transfer, models, session, tests)
     # keep working unchanged. The store reads platform / _logger / credentials_dir
@@ -410,31 +414,58 @@ class ClaudeAccountSwitcher:
     def _write_credentials(self, credentials: str) -> None:
         self._store._write_credentials(credentials)
 
-    @staticmethod
-    def _credentials_for_activation(
-        target_credentials: str, live_credentials: str | None
+    def _prepare_credentials_for_activation(
+        self, target_credentials: str, live_credentials: str | None
     ) -> str:
-        """Use the target Claude login without restoring stale shared OAuth state."""
+        """Persist shared state, then compose the credential to activate.
+
+        A live JSON object is authoritative and refreshes the independent shared
+        snapshot before any active credential is overwritten. When OAuth is
+        currently absent (notably while a managed API key is active), restore that
+        snapshot. Destination-slot siblings are never authoritative: if no live or
+        stored shared state exists, initialize an empty snapshot.
+        """
+        live_shared = shared_credential_fields(live_credentials)
+        if live_shared is not None:
+            self._write_shared_credentials(json.dumps(live_shared))
+
         if looks_like_api_key(target_credentials):
             return target_credentials
 
-        try:
-            target = json.loads(target_credentials)
-        except (json.JSONDecodeError, TypeError):
-            return target_credentials
-        if not isinstance(target, dict) or "claudeAiOauth" not in target:
+        if not has_claude_oauth(target_credentials):
             return target_credentials
 
-        try:
-            live = json.loads(live_credentials) if live_credentials else {}
-        except (json.JSONDecodeError, TypeError):
-            live = {}
-        if not isinstance(live, dict):
-            live = {}
+        if live_shared is None:
+            stored = self._read_shared_credentials()
+            if stored is None:
+                raise CredentialReadError(
+                    "Cannot read shared OAuth credentials before activation"
+                )
+            if stored:
+                try:
+                    live_shared = json.loads(stored)
+                except json.JSONDecodeError as e:
+                    raise CredentialReadError(
+                        f"Stored shared OAuth credentials are invalid: {e}"
+                    ) from e
+                if not isinstance(live_shared, dict):
+                    raise CredentialReadError(
+                        "Stored shared OAuth credentials are not a JSON object"
+                    )
+            else:
+                # There is no trustworthy source once the live OAuth blob is gone.
+                # In particular, a target slot's sibling fields may contain
+                # rotated-out refresh tokens — the bug this store exists to avoid.
+                live_shared = {}
+                self._write_shared_credentials(json.dumps(live_shared))
 
-        live.pop("claudeAiOauth", None)
-        live["claudeAiOauth"] = target["claudeAiOauth"]
-        return json.dumps(live)
+        return merge_shared_credential_fields(target_credentials, live_shared)
+
+    def _read_shared_credentials(self) -> str | None:
+        return self._store._read_shared_credentials()
+
+    def _write_shared_credentials(self, credentials: str) -> None:
+        self._store._write_shared_credentials(credentials)
 
     def _uses_file_backup_backend(self) -> bool:
         return self._store._uses_file_backup_backend()
@@ -4104,7 +4135,9 @@ class ClaudeAccountSwitcher:
                 config_written = False
                 try:
                     self._write_credentials(
-                        self._credentials_for_activation(target_creds, live_creds)
+                        self._prepare_credentials_for_activation(
+                            target_creds, live_creds
+                        )
                     )
                     creds_written = True
 
@@ -4323,7 +4356,9 @@ class ClaudeAccountSwitcher:
 
                 # Step 3: Activate target account - credentials
                 self._write_credentials(
-                    self._credentials_for_activation(target_creds, original_creds)
+                    self._prepare_credentials_for_activation(
+                        target_creds, original_creds
+                    )
                 )
                 transaction.record_step("credentials_written")
                 self._logger.info("Wrote target credentials")
@@ -4417,10 +4452,10 @@ class ClaudeAccountSwitcher:
         """Remove all traces of claude-swap from the system.
 
         This removes:
-        - All stored account credentials (``.enc`` files on Linux/WSL/Windows; on
-          macOS both the Keychain items via ``security`` and any fallback ``.enc``
-          files), plus a best-effort sweep of any pre-migration keyring / Windows
-          Credential Manager entries left behind
+        - All stored account and shared OAuth credentials (``.enc`` files on
+          Linux/WSL/Windows; on macOS both the Keychain items via ``security`` and
+          any fallback ``.enc`` files), plus a best-effort sweep of any
+          pre-migration keyring / Windows Credential Manager entries left behind
         - The active backup directory (XDG path on Linux/WSL, ~/.claude-swap-backup elsewhere)
         - Any stale legacy ~/.claude-swap-backup directory left around from
           before the XDG migration
@@ -4458,9 +4493,12 @@ class ClaudeAccountSwitcher:
         if legacy_distinct and legacy.exists():
             print(f"  - Legacy backup directory: {legacy}")
         if self.platform == Platform.MACOS:
-            print("  - All stored account credentials (macOS Keychain and/or files)")
+            print(
+                "  - All stored account and shared OAuth credentials "
+                "(macOS Keychain and/or files)"
+            )
         else:
-            print("  - All stored account credential files")
+            print("  - All stored account and shared OAuth credential files")
         if session_dirs:
             print("  - All session profiles and their Keychain entries")
         print()
@@ -4510,6 +4548,15 @@ class ClaudeAccountSwitcher:
                 # never used a keyring backend.
                 if self.platform in (Platform.MACOS, Platform.WINDOWS):
                     _sweep_legacy_keyring(usernames, removed_items)
+
+        if self.platform == Platform.MACOS:
+            try:
+                macos_keychain.delete_password(
+                    SECURITY_SERVICE, SHARED_CREDENTIALS_USERNAME
+                )
+                removed_items.append("Shared OAuth credentials")
+            except Exception:
+                pass
 
         # Session-profile keychain entries must go BEFORE the backup dir:
         # the hashed service names are derived from the dir paths and can't

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -1716,6 +1716,9 @@ class TestPerformSwitchPostDisplay:
         def read_live():
             return live_state.get("creds", "")
 
+        def read_active():
+            return ActiveCredentials(read_live(), False)
+
         def write_live(creds):
             live_state["creds"] = creds
 
@@ -1725,6 +1728,7 @@ class TestPerformSwitchPostDisplay:
             patch.object(switcher, "_read_account_config", side_effect=read_cfg),
             patch.object(switcher, "_write_account_config", side_effect=write_cfg),
             patch.object(switcher, "_read_credentials", side_effect=read_live),
+            patch.object(switcher, "_read_active_credentials", side_effect=read_active),
             patch.object(switcher, "_write_credentials", side_effect=write_live),
         ]
         for p in patches:
@@ -2229,7 +2233,8 @@ class TestPerformSwitchPostDisplay:
 
         try:
             with patch.object(
-                switcher, "_read_credentials", return_value=None,
+                switcher, "_read_active_credentials",
+                return_value=ActiveCredentials(None, False),
             ), pytest.raises(CredentialReadError, match="snapshot"):
                 switcher._perform_switch("1")
         finally:
@@ -5873,6 +5878,162 @@ class TestDirectActivationPreservation:
         assert any("--force" in w for w in op["warnings"])
         live = (temp_home / ".claude" / ".credentials.json").read_text()
         assert json.loads(live)["claudeAiOauth"]["accessToken"] == "sk-one"
+
+
+class TestSharedOAuthCredentialPreservation:
+    """Account activation must not restore stale account-independent tokens."""
+
+    _setup_two_accounts = TestPerformSwitchPostDisplay._setup_two_accounts
+    _install_store_patches = staticmethod(
+        TestPerformSwitchPostDisplay._install_store_patches
+    )
+
+    def test_composition_takes_only_claude_login_from_target(self):
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+            "targetOnlyOAuth": {"refreshToken": "stale"},
+        })
+        live = json.dumps({
+            "claudeAiOauth": {"accessToken": "live"},
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+            "designOauth": {"refreshToken": "current"},
+        })
+
+        composed = json.loads(
+            ClaudeAccountSwitcher._credentials_for_activation(target, live)
+        )
+
+        assert composed == {
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+            "designOauth": {"refreshToken": "current"},
+        }
+
+    def test_composition_does_not_restore_shared_state_without_live_credentials(self):
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+        })
+
+        composed = json.loads(
+            ClaudeAccountSwitcher._credentials_for_activation(target, "")
+        )
+
+        assert composed == {"claudeAiOauth": {"accessToken": "target"}}
+
+    def test_composition_leaves_managed_api_keys_unchanged(self):
+        api_key = "sk-ant-api03-" + "a1b2c3d4e5" * 4
+        live = json.dumps({
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+
+        assert (
+            ClaudeAccountSwitcher._credentials_for_activation(api_key, live)
+            == api_key
+        )
+
+    def test_direct_activation_refuses_unreadable_keychain(self, temp_home):
+        switcher, unmanaged = TestDirectActivationPreservation()._setup(temp_home)
+
+        with patch.object(
+            switcher,
+            "_read_active_credentials",
+            return_value=ActiveCredentials("", True),
+        ), pytest.raises(CredentialReadError, match="snapshot"):
+            switcher._perform_switch("1", emit_output=False)
+
+        live = (temp_home / ".claude" / ".credentials.json").read_text()
+        assert live == unmanaged
+
+    def test_normal_switch_preserves_live_shared_state(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        live = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-live-1", "refreshToken": "rt-live-1",
+            },
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+        target = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-target-2", "refreshToken": "rt-target-2",
+            },
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+        })
+        creds_store[("1", "test@example.com")] = live
+        creds_store[("2", "account2@example.com")] = target
+        live_state = {"creds": live}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+
+        try:
+            with patch.object(switcher, "list_accounts"):
+                switcher._perform_switch("2", emit_output=False)
+        finally:
+            for p in patches:
+                p.stop()
+
+        activated = json.loads(live_state["creds"])
+        assert activated["claudeAiOauth"]["accessToken"] == "sk-target-2"
+        assert activated["mcpOAuth"] == {
+            "server": {"refreshToken": "current"}
+        }
+
+    def test_direct_activation_preserves_and_rolls_back_mcp_only_state(
+        self, temp_home,
+    ):
+        switcher, _ = TestDirectActivationPreservation()._setup(temp_home)
+        config_path = temp_home / ".claude.json"
+        config_path.write_text("{}")
+        live_path = temp_home / ".claude" / ".credentials.json"
+        mcp_only = json.dumps({
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+        live_path.write_text(mcp_only)
+
+        target = json.loads(
+            switcher._read_account_credentials("1", "one@example.com")
+        )
+        target["mcpOAuth"] = {"server": {"refreshToken": "stale"}}
+        switcher._write_account_credentials(
+            "1", "one@example.com", json.dumps(target)
+        )
+
+        original_write_json = switcher._write_json
+
+        def fail_sequence_write(path, data):
+            if path == switcher.sequence_file and data.get(
+                "activeAccountNumber"
+            ) == 1:
+                raise OSError("disk full")
+            return original_write_json(path, data)
+
+        writes = []
+        original_write_credentials = switcher._write_credentials
+
+        def record_write(credentials):
+            writes.append(json.loads(credentials))
+            original_write_credentials(credentials)
+
+        with patch.object(
+            switcher, "_write_json", side_effect=fail_sequence_write,
+        ), patch.object(
+            switcher, "_write_credentials", side_effect=record_write,
+        ), pytest.raises(OSError, match="disk full"):
+            switcher._perform_switch("1", emit_output=False)
+
+        assert writes[0] == {
+            "claudeAiOauth": {
+                "accessToken": "sk-one", "refreshToken": "rt-one",
+            },
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        }
+        assert live_path.read_text() == mcp_only
 
 
 class TestUuidConflictClassification:

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -32,6 +32,7 @@ from claude_swap.switcher import (
     ClaudeAccountSwitcher,
     SECURITY_SERVICE,
     SETUP_TOKEN_SCOPES,
+    SHARED_CREDENTIALS_USERNAME,
     _format_usage_lines,
 )
 
@@ -3539,6 +3540,7 @@ class TestPurge:
         mock_kc.delete_password.assert_has_calls([
             call("claude-swap", "account-1-user@example.com"),
             call("claude-swap", "account-None-user@example.com"),
+            call("claude-swap", SHARED_CREDENTIALS_USERNAME),
         ])
         # Best-effort legacy keyring cleanup of the old claude-code service.
         mock_keyring.delete_password.assert_has_calls([
@@ -4712,6 +4714,46 @@ class TestMacosKeychainFallback:
         assert not s._backup_enc_path("1", "a@example.com").exists()
         assert (SECURITY_SERVICE, "account-1-a@example.com") not in block_real_keychain.data
 
+    def test_shared_store_keychain_write_reconciles_fallback_file(
+        self, temp_home: Path, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        s._store._atomic_b64_write(
+            s._store._shared_credentials_path(), '{"mcpOAuth":{"old":true}}'
+        )
+
+        s._write_shared_credentials('{"mcpOAuth":{"current":true}}')
+
+        assert not s._store._shared_credentials_path().exists()
+        assert block_real_keychain.data[
+            (SECURITY_SERVICE, SHARED_CREDENTIALS_USERNAME)
+        ] == '{"mcpOAuth":{"current":true}}'
+        assert s._read_shared_credentials() == '{"mcpOAuth":{"current":true}}'
+
+    def test_shared_store_file_fallback_wins_over_stale_keychain(
+        self, temp_home: Path, monkeypatch, block_real_keychain
+    ):
+        s = self._macos_switcher()
+        block_real_keychain.data[
+            (SECURITY_SERVICE, SHARED_CREDENTIALS_USERNAME)
+        ] = '{"mcpOAuth":{"stale":true}}'
+        monkeypatch.setattr(macos_keychain, "set_password", _raise_locked)
+
+        s._write_shared_credentials('{"mcpOAuth":{"current":true}}')
+
+        assert s._read_shared_credentials() == '{"mcpOAuth":{"current":true}}'
+        assert (
+            SECURITY_SERVICE, SHARED_CREDENTIALS_USERNAME
+        ) not in block_real_keychain.data
+
+    def test_shared_store_unavailable_is_not_missing(
+        self, temp_home: Path, monkeypatch
+    ):
+        s = self._macos_switcher()
+        monkeypatch.setattr(macos_keychain, "get_password", _raise_locked)
+
+        assert s._read_shared_credentials() is None
+
     # -- healthy-Mac no-op guard & follow-up ------------------------------
 
     def test_healthy_mac_reads_create_no_files(
@@ -5883,12 +5925,16 @@ class TestDirectActivationPreservation:
 class TestSharedOAuthCredentialPreservation:
     """Account activation must not restore stale account-independent tokens."""
 
+    API_KEY = "sk-ant-api03-" + "a1b2c3d4e5" * 4
     _setup_two_accounts = TestPerformSwitchPostDisplay._setup_two_accounts
     _install_store_patches = staticmethod(
         TestPerformSwitchPostDisplay._install_store_patches
     )
 
-    def test_composition_takes_only_claude_login_from_target(self):
+    def test_live_shared_state_is_snapshotted_before_composition(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
         target = json.dumps({
             "claudeAiOauth": {"accessToken": "target"},
             "mcpOAuth": {"server": {"refreshToken": "stale"}},
@@ -5901,7 +5947,7 @@ class TestSharedOAuthCredentialPreservation:
         })
 
         composed = json.loads(
-            ClaudeAccountSwitcher._credentials_for_activation(target, live)
+            switcher._prepare_credentials_for_activation(target, live)
         )
 
         assert composed == {
@@ -5909,29 +5955,137 @@ class TestSharedOAuthCredentialPreservation:
             "mcpOAuth": {"server": {"refreshToken": "current"}},
             "designOauth": {"refreshToken": "current"},
         }
+        assert json.loads(switcher._read_shared_credentials()) == {
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+            "designOauth": {"refreshToken": "current"},
+        }
 
-    def test_composition_does_not_restore_shared_state_without_live_credentials(self):
+    def test_managed_key_never_promotes_legacy_target_shared_state(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
         target = json.dumps({
             "claudeAiOauth": {"accessToken": "target"},
             "mcpOAuth": {"server": {"refreshToken": "stale"}},
         })
 
         composed = json.loads(
-            ClaudeAccountSwitcher._credentials_for_activation(target, "")
+            switcher._prepare_credentials_for_activation(target, self.API_KEY)
+        )
+
+        assert composed == {"claudeAiOauth": {"accessToken": "target"}}
+        assert json.loads(switcher._read_shared_credentials()) == {}
+
+        other_target = json.dumps({
+            "claudeAiOauth": {"accessToken": "other-target"},
+            "mcpOAuth": {"server": {"refreshToken": "other-stale"}},
+        })
+        recomposed = json.loads(
+            switcher._prepare_credentials_for_activation(
+                other_target, self.API_KEY
+            )
+        )
+        assert recomposed == {
+            "claudeAiOauth": {"accessToken": "other-target"},
+        }
+
+    def test_fresh_activation_discards_legacy_slot_siblings(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+        })
+
+        composed = json.loads(
+            switcher._prepare_credentials_for_activation(target, "")
+        )
+
+        assert composed == {"claudeAiOauth": {"accessToken": "target"}}
+        assert json.loads(switcher._read_shared_credentials()) == {}
+
+    def test_initialized_empty_store_discards_legacy_slot_siblings(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
+        switcher._write_shared_credentials("{}")
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+        })
+
+        composed = json.loads(
+            switcher._prepare_credentials_for_activation(target, "")
         )
 
         assert composed == {"claudeAiOauth": {"accessToken": "target"}}
 
-    def test_composition_leaves_managed_api_keys_unchanged(self):
-        api_key = "sk-ant-api03-" + "a1b2c3d4e5" * 4
+    def test_managed_api_key_activation_snapshots_live_shared_state(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
         live = json.dumps({
             "mcpOAuth": {"server": {"refreshToken": "current"}},
         })
 
         assert (
-            ClaudeAccountSwitcher._credentials_for_activation(api_key, live)
-            == api_key
+            switcher._prepare_credentials_for_activation(self.API_KEY, live)
+            == self.API_KEY
         )
+        assert json.loads(switcher._read_shared_credentials()) == {
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        }
+
+    def test_unreadable_shared_store_aborts_oauth_activation(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+        })
+
+        with patch.object(
+            switcher, "_read_shared_credentials", return_value=None,
+        ), pytest.raises(CredentialReadError, match="shared OAuth"):
+            switcher._prepare_credentials_for_activation(target, self.API_KEY)
+
+    def test_shared_snapshot_failure_prevents_active_overwrite(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        live = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-live-1", "refreshToken": "rt-live-1",
+            },
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+        creds_store[("1", "test@example.com")] = live
+        creds_store[("2", "account2@example.com")] = self.API_KEY
+        sample_sequence_data["accounts"]["2"]["kind"] = "api_key"
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+        live_state = {"creds": live}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+
+        try:
+            with patch.object(
+                switcher,
+                "_write_shared_credentials",
+                side_effect=OSError("disk full"),
+            ), pytest.raises(OSError, match="disk full"):
+                switcher._perform_switch(
+                    "2",
+                    emit_output=False,
+                    provenance={"live": live, "resolved": None},
+                )
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert live_state["creds"] == live
 
     def test_direct_activation_refuses_unreadable_keychain(self, temp_home):
         switcher, unmanaged = TestDirectActivationPreservation()._setup(temp_home)
@@ -5982,6 +6136,93 @@ class TestSharedOAuthCredentialPreservation:
         assert activated["claudeAiOauth"]["accessToken"] == "sk-target-2"
         assert activated["mcpOAuth"] == {
             "server": {"refreshToken": "current"}
+        }
+
+    def test_oauth_api_key_oauth_round_trip_preserves_shared_state(
+        self, temp_home,
+    ):
+        switcher = ClaudeAccountSwitcher()
+        switcher.platform = Platform.LINUX
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, {
+            "activeAccountNumber": 1,
+            "lastUpdated": "2024-01-01T00:00:00Z",
+            "sequence": [1, 2],
+            "accounts": {
+                "1": {
+                    "email": "oauth@example.com",
+                    "uuid": "uuid-oauth",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                },
+                "2": {
+                    "email": "api-key-2@token.local",
+                    "uuid": "",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                    "added": "2024-01-01T00:00:00Z",
+                    "kind": "api_key",
+                },
+            },
+        })
+        live = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-oauth", "refreshToken": "rt-oauth",
+            },
+            "mcpOAuth": {"server": {"refreshToken": "mcp-current"}},
+        })
+        switcher._write_account_credentials(
+            "1", "oauth@example.com", live
+        )
+        switcher._write_account_config(
+            "1", "oauth@example.com", json.dumps({
+                "oauthAccount": {
+                    "emailAddress": "oauth@example.com",
+                    "accountUuid": "uuid-oauth",
+                },
+            })
+        )
+        switcher._write_account_credentials(
+            "2", "api-key-2@token.local", self.API_KEY
+        )
+        switcher._write_account_config(
+            "2", "api-key-2@token.local", json.dumps({
+                "oauthAccount": {
+                    "emailAddress": "api-key-2@token.local",
+                    "accountUuid": "",
+                },
+            })
+        )
+        (temp_home / ".claude" / ".credentials.json").write_text(live)
+        (temp_home / ".claude.json").write_text(json.dumps({
+            "oauthAccount": {
+                "emailAddress": "oauth@example.com",
+                "accountUuid": "uuid-oauth",
+            },
+        }))
+
+        switcher._perform_switch(
+            "2",
+            emit_output=False,
+            provenance={"live": live, "resolved": None},
+        )
+        assert json.loads(switcher._read_shared_credentials()) == {
+            "mcpOAuth": {"server": {"refreshToken": "mcp-current"}},
+        }
+
+        switcher._perform_switch(
+            "1",
+            emit_output=False,
+            provenance={"live": self.API_KEY, "resolved": None},
+        )
+
+        restored = json.loads(
+            (temp_home / ".claude" / ".credentials.json").read_text()
+        )
+        assert restored["claudeAiOauth"]["accessToken"] == "sk-oauth"
+        assert restored["mcpOAuth"] == {
+            "server": {"refreshToken": "mcp-current"},
         }
 
     def test_direct_activation_preserves_and_rolls_back_mcp_only_state(


### PR DESCRIPTION
## Problem

Switching Claude accounts currently replaces the entire active credential object with the destination slot's saved copy. Claude Code stores both the account login and machine-shared OAuth integrations in that object.

If an MCP refresh token rotates after the destination slot was backed up, activating that slot restores the older token generation. The affected MCP server then requires reauthentication.

## Root cause

The credential object contains state with two different owners and lifetimes:

- `claudeAiOauth` is owned by an account slot
- sibling fields, currently including `mcpOAuth`, are shared by the machine and may rotate independently

A destination slot can authoritatively supply its `claudeAiOauth`, but it cannot establish that its sibling fields are current. Only the live credential or an independently maintained shared snapshot can do that. Treating the whole saved object as slot-owned therefore allows an old account backup to roll shared refresh tokens backward.

Existing account backups continue storing the full object for compatibility with exports, imports, and session profiles. During activation, however, only their `claudeAiOauth` field is authoritative.

## Change

- snapshot the live credential's sibling fields before replacing the active credential
- persist those fields under a dedicated shared-store identity
- combine the shared snapshot with the destination slot's `claudeAiOauth` during activation
- preserve shared state across OAuth-to-OAuth switches and OAuth → managed API key → OAuth transitions
- never initialize shared state from a destination slot's potentially stale sibling fields
- fail closed before activation when present shared state cannot be read
- remove the shared credential during `cswap purge`

The shared store follows the existing account-backup storage and reconciliation rules:

- macOS Keychain: service/account `claude-swap` / `shared-oauth`
- fallback and non-macOS: `credentials/.shared-oauth.enc`
- a valid `.enc` remains authoritative over a stale Keychain copy

## Upgrade behavior

When an OAuth credential is live during the first switch after upgrading, its sibling fields initialize or refresh the shared store before any overwrite.

If a managed API key is already active at upgrade time, there is no trustworthy way to determine which legacy account slot contains the newest shared tokens. The first OAuth activation therefore initializes an empty shared snapshot instead of resurrecting a potentially rotated-out destination copy. This may require one-time MCP reauthentication, but subsequent API-key round trips preserve the shared state.

## Validation

Targeted coverage verifies that:

- live shared state wins over stale destination-slot state
- OAuth → managed API key → OAuth restores shared state
- first activation never promotes legacy destination siblings
- unreadable shared storage aborts before active credentials are overwritten
- failed activation restores MCP-only live state
- Keychain fallback reconciliation and purge include the shared credential

Full validation:

- `uv run pytest -q` — 1,362 passed, 3 skipped
- `uv run python -m compileall -q src`
- `git diff --check`

Closes #135
