### PR TITLE
fix: preserve MCP OAuth sessions across account switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ The original flag spellings (`cswap --switch`, `cswap --list`, ...) keep working
 ## How it works
 
 - Backs up OAuth tokens and config when you add an account
-- Swaps credentials when you switch accounts
+- Swaps only the account-specific Claude login when you switch accounts;
+  live account-independent OAuth state (such as MCP server logins) is
+  preserved instead of being overwritten by a slot's older snapshot
 - Account credentials stored securely using platform-appropriate methods
 - Switches (manual and automatic) hold Claude Code's own credential locks while writing, so a swap never interleaves with a token refresh
 - Auto-switch freshens a target's token before activating it, and quarantines accounts whose refresh token has died (recover by re-adding it with `cswap add --slot N`, or by replacing its stored credentials from a known-good export with `cswap import backup.cswap --force`)

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -99,6 +99,54 @@ def looks_like_api_key(credentials: str | None) -> bool:
     return text.startswith("sk-ant-api") and not text.startswith("{")
 
 
+def _credential_object(credentials: str | None) -> dict | None:
+    """Parse a JSON credential object, excluding managed API keys."""
+    if not credentials or looks_like_api_key(credentials):
+        return None
+    try:
+        data = json.loads(credentials)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def shared_credential_fields(credentials: str | None) -> dict | None:
+    """Return account-independent fields from a Claude OAuth credential object.
+
+    Claude Code keeps machine-shared OAuth integrations (notably ``mcpOAuth``)
+    as siblings of the slot-owned ``claudeAiOauth`` field in one object.
+    ``None`` means the input is not a JSON credential object (missing,
+    malformed, or a managed API key). A dictionary — including ``{}`` — is
+    authoritative: every sibling of ``claudeAiOauth`` is machine-shared.
+    """
+    data = _credential_object(credentials)
+    if data is None:
+        return None
+    return {
+        key: value
+        for key, value in data.items()
+        if key != "claudeAiOauth"
+    }
+
+
+def merge_shared_credential_fields(
+    target_credentials: str, shared_fields: dict
+) -> str:
+    """Compose a target Claude login with independently-owned shared fields.
+
+    Returns ``target_credentials`` unchanged when it is not a JSON credential
+    object carrying a Claude login (managed API keys and opaque legacy shapes
+    stay activatable verbatim).
+    """
+    target = _credential_object(target_credentials)
+    if target is None or "claudeAiOauth" not in target:
+        return target_credentials
+
+    composed = dict(shared_fields)
+    composed["claudeAiOauth"] = target["claudeAiOauth"]
+    return json.dumps(composed)
+
+
 def approved_form(api_key: str) -> str:
     """The value Claude Code stores in ``customApiKeyResponses.approved``.
 

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -110,40 +110,62 @@ def _credential_object(credentials: str | None) -> dict | None:
     return data if isinstance(data, dict) else None
 
 
-def shared_credential_fields(credentials: str | None) -> dict | None:
-    """Return account-independent fields from a Claude OAuth credential object.
+# The credential object's siblings of claudeAiOauth are not uniformly owned:
+# these keys hold machine-shared OAuth integrations that rotate independently
+# of any account slot, so on activation the live copy is authoritative.
+# Everything else — known (trustedDeviceToken is enrolled per-account and
+# re-enrolled on every login) or unknown — stays with the target slot: a
+# stale restore of an unlisted shared field merely re-prompts for auth,
+# while carrying a live account-bound field across a switch would present
+# one account's credential under another.
+SHARED_CREDENTIAL_KEYS = frozenset({
+    "mcpOAuth",
+    "mcpOAuthClientConfig",
+    "mcpXaaIdp",
+    "mcpXaaIdpConfig",
+    "pluginSecrets",
+})
 
-    Claude Code keeps machine-shared OAuth integrations (notably ``mcpOAuth``)
-    as siblings of the slot-owned ``claudeAiOauth`` field in one object.
-    ``None`` means the input is not a JSON credential object (missing,
-    malformed, or a managed API key). A dictionary — including ``{}`` — is
-    authoritative: every sibling of ``claudeAiOauth`` is machine-shared.
+
+def shared_credential_fields(credentials: str | None) -> dict | None:
+    """Return the machine-shared fields of a Claude OAuth credential object.
+
+    Only the ``SHARED_CREDENTIAL_KEYS`` allowlist is machine-shared; other
+    siblings of ``claudeAiOauth`` are account-scoped or unknown and stay
+    slot-owned. ``None`` means the input is not a JSON credential object
+    (missing, malformed, or a managed API key). A dictionary — including
+    ``{}`` — is authoritative for every allowlisted key: a key absent here
+    is absent from the machine's current shared state.
     """
     data = _credential_object(credentials)
     if data is None:
         return None
-    return {
-        key: value
-        for key, value in data.items()
-        if key != "claudeAiOauth"
-    }
+    return {key: data[key] for key in SHARED_CREDENTIAL_KEYS if key in data}
 
 
 def merge_shared_credential_fields(
     target_credentials: str, shared_fields: dict
 ) -> str:
-    """Compose a target Claude login with independently-owned shared fields.
+    """Compose a target Claude login with the machine's shared fields.
 
-    Returns ``target_credentials`` unchanged when it is not a JSON credential
-    object carrying a Claude login (managed API keys and opaque legacy shapes
-    stay activatable verbatim).
+    The allowlisted keys are wholly live-owned, presence and absence alike:
+    the target's copies are discarded and ``shared_fields`` supplies the
+    current generation, so a shared key the machine no longer holds is not
+    resurrected from the slot's snapshot. All other target fields pass
+    through untouched. Returns ``target_credentials`` unchanged when it is
+    not a JSON credential object carrying a Claude login (managed API keys
+    and opaque legacy shapes stay activatable verbatim).
     """
     target = _credential_object(target_credentials)
     if target is None or "claudeAiOauth" not in target:
         return target_credentials
 
-    composed = dict(shared_fields)
-    composed["claudeAiOauth"] = target["claudeAiOauth"]
+    composed = {
+        key: value
+        for key, value in target.items()
+        if key not in SHARED_CREDENTIAL_KEYS
+    }
+    composed.update(shared_fields)
     return json.dumps(composed)
 
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -417,15 +417,18 @@ class ClaudeAccountSwitcher:
     ) -> str:
         """Compose the credential to activate from its two owners.
 
-        The destination slot authoritatively owns only its ``claudeAiOauth``
-        login. Its sibling fields (machine-shared OAuth integrations such as
-        ``mcpOAuth``) are frozen at backup time and may hold rotated-out
-        refresh tokens, while the live credential's siblings are by
-        definition the current generation — so the live siblings win.
+        The machine-shared OAuth integrations (the ``SHARED_CREDENTIAL_KEYS``
+        allowlist, notably ``mcpOAuth``) are frozen in the slot at backup
+        time and may hold rotated-out refresh tokens, while the live
+        credential's copies are by definition the current generation — so
+        for those keys the live credential wins, absence included. Every
+        other field the destination slot stored travels with the slot:
+        account-bound state such as ``trustedDeviceToken`` — and any field
+        cswap does not recognize — must not leak across an account switch.
 
-        When there is no live JSON credential object to take siblings from
-        (fresh machine, or a managed API key is active), the stored blob
-        activates unchanged, exactly as before.
+        When there is no live JSON credential object to take shared fields
+        from (fresh machine, or a managed API key is active), the stored
+        blob activates unchanged, exactly as before.
         """
         live_shared = shared_credential_fields(live_credentials)
         if live_shared is None:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -42,6 +42,8 @@ from claude_swap.credentials import (  # noqa: F401  (constants re-exported for 
     ActiveCredentials,
     CredentialStore,
     looks_like_api_key,
+    merge_shared_credential_fields,
+    shared_credential_fields,
 )
 from claude_swap.locking import FileLock
 from claude_swap.logging_config import setup_logging
@@ -409,6 +411,26 @@ class ClaudeAccountSwitcher:
 
     def _write_credentials(self, credentials: str) -> None:
         self._store._write_credentials(credentials)
+
+    def _prepare_credentials_for_activation(
+        self, target_credentials: str, live_credentials: str | None
+    ) -> str:
+        """Compose the credential to activate from its two owners.
+
+        The destination slot authoritatively owns only its ``claudeAiOauth``
+        login. Its sibling fields (machine-shared OAuth integrations such as
+        ``mcpOAuth``) are frozen at backup time and may hold rotated-out
+        refresh tokens, while the live credential's siblings are by
+        definition the current generation — so the live siblings win.
+
+        When there is no live JSON credential object to take siblings from
+        (fresh machine, or a managed API key is active), the stored blob
+        activates unchanged, exactly as before.
+        """
+        live_shared = shared_credential_fields(live_credentials)
+        if live_shared is None:
+            return target_credentials
+        return merge_shared_credential_fields(target_credentials, live_shared)
 
     def _uses_file_backup_backend(self) -> bool:
         return self._store._uses_file_backup_backend()
@@ -4077,7 +4099,11 @@ class ClaudeAccountSwitcher:
                 creds_written = False
                 config_written = False
                 try:
-                    self._write_credentials(target_creds)
+                    self._write_credentials(
+                        self._prepare_credentials_for_activation(
+                            target_creds, rollback_creds
+                        )
+                    )
                     creds_written = True
 
                     # Mirror the normal switch path: preserve existing local
@@ -4294,7 +4320,11 @@ class ClaudeAccountSwitcher:
                     )
 
                 # Step 3: Activate target account - credentials
-                self._write_credentials(target_creds)
+                self._write_credentials(
+                    self._prepare_credentials_for_activation(
+                        target_creds, original_creds
+                    )
+                )
                 transaction.record_step("credentials_written")
                 self._logger.info("Wrote target credentials")
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -5875,6 +5875,164 @@ class TestDirectActivationPreservation:
         assert json.loads(live)["claudeAiOauth"]["accessToken"] == "sk-one"
 
 
+class TestSharedOAuthCredentialPreservation:
+    """Activation must not overwrite live machine-shared OAuth state
+    (mcpOAuth et al.) with the destination slot's stale snapshot (#135)."""
+
+    API_KEY = "sk-ant-api03-" + "a1b2c3d4e5" * 4
+    _setup_two_accounts = TestPerformSwitchPostDisplay._setup_two_accounts
+    _install_store_patches = staticmethod(
+        TestPerformSwitchPostDisplay._install_store_patches
+    )
+
+    def test_live_siblings_win_over_stale_target_siblings(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+            "targetOnlyOAuth": {"refreshToken": "stale"},
+        })
+        live = json.dumps({
+            "claudeAiOauth": {"accessToken": "live"},
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+            "designOauth": {"refreshToken": "current"},
+        })
+
+        composed = json.loads(
+            switcher._prepare_credentials_for_activation(target, live)
+        )
+
+        assert composed == {
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+            "designOauth": {"refreshToken": "current"},
+        }
+
+    def test_api_key_live_state_activates_target_verbatim(self, temp_home):
+        # While a managed API key is active there is no live OAuth object to
+        # take siblings from; the stored blob activates unchanged (the
+        # pre-existing behavior — the API-key round trip is out of scope).
+        switcher = ClaudeAccountSwitcher()
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+        })
+
+        assert (
+            switcher._prepare_credentials_for_activation(target, self.API_KEY)
+            == target
+        )
+
+    def test_absent_live_state_activates_target_verbatim(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "old"}},
+        })
+
+        assert (
+            switcher._prepare_credentials_for_activation(target, "") == target
+        )
+        assert (
+            switcher._prepare_credentials_for_activation(target, None)
+            == target
+        )
+
+    def test_api_key_target_is_never_composed(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        live = json.dumps({
+            "claudeAiOauth": {"accessToken": "live"},
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+
+        assert (
+            switcher._prepare_credentials_for_activation(self.API_KEY, live)
+            == self.API_KEY
+        )
+
+    def test_opaque_target_credential_activates_verbatim(self, temp_home):
+        # Opaque/legacy JSON shapes without a claudeAiOauth login are
+        # activated byte-for-byte, as before.
+        switcher = ClaudeAccountSwitcher()
+        target = json.dumps({
+            "accessToken": "legacy", "refreshToken": "legacy-rt",
+        })
+        live = json.dumps({
+            "claudeAiOauth": {"accessToken": "live"},
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+
+        assert (
+            switcher._prepare_credentials_for_activation(target, live)
+            == target
+        )
+
+    def test_normal_switch_preserves_live_shared_state(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        live = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-live-1", "refreshToken": "rt-live-1",
+            },
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+        target = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-target-2", "refreshToken": "rt-target-2",
+            },
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+        })
+        creds_store[("1", "test@example.com")] = live
+        creds_store[("2", "account2@example.com")] = target
+        live_state = {"creds": live}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+
+        try:
+            with patch.object(switcher, "list_accounts"):
+                switcher._perform_switch("2", emit_output=False)
+        finally:
+            for p in patches:
+                p.stop()
+
+        activated = json.loads(live_state["creds"])
+        assert activated["claudeAiOauth"]["accessToken"] == "sk-target-2"
+        assert activated["mcpOAuth"] == {
+            "server": {"refreshToken": "current"}
+        }
+
+    def test_direct_activation_preserves_live_shared_state(self, temp_home):
+        switcher, _ = TestDirectActivationPreservation()._setup(temp_home)
+        live_path = temp_home / ".claude" / ".credentials.json"
+        live = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-unmanaged", "refreshToken": "rt-unmanaged",
+            },
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+        live_path.write_text(live)
+        target = json.loads(
+            switcher._read_account_credentials("1", "one@example.com")
+        )
+        target["mcpOAuth"] = {"server": {"refreshToken": "stale"}}
+        switcher._write_account_credentials(
+            "1", "one@example.com", json.dumps(target)
+        )
+
+        with patch.object(switcher, "list_accounts"):
+            switcher._perform_switch("1", emit_output=False)
+
+        activated = json.loads(live_path.read_text())
+        assert activated["claudeAiOauth"]["accessToken"] == "sk-one"
+        assert activated["mcpOAuth"] == {
+            "server": {"refreshToken": "current"}
+        }
+
+
 class TestUuidConflictClassification:
     """An email+org match with a conflicting uuid is a different account
     wearing a recycled email — never the slot."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -5885,17 +5885,17 @@ class TestSharedOAuthCredentialPreservation:
         TestPerformSwitchPostDisplay._install_store_patches
     )
 
-    def test_live_siblings_win_over_stale_target_siblings(self, temp_home):
+    def test_live_shared_keys_win_over_stale_target_copies(self, temp_home):
         switcher = ClaudeAccountSwitcher()
         target = json.dumps({
             "claudeAiOauth": {"accessToken": "target"},
             "mcpOAuth": {"server": {"refreshToken": "stale"}},
-            "targetOnlyOAuth": {"refreshToken": "stale"},
+            "mcpOAuthClientConfig": {"server": {"clientId": "stale"}},
         })
         live = json.dumps({
             "claudeAiOauth": {"accessToken": "live"},
             "mcpOAuth": {"server": {"refreshToken": "current"}},
-            "designOauth": {"refreshToken": "current"},
+            "mcpOAuthClientConfig": {"server": {"clientId": "current"}},
         })
 
         composed = json.loads(
@@ -5905,8 +5905,57 @@ class TestSharedOAuthCredentialPreservation:
         assert composed == {
             "claudeAiOauth": {"accessToken": "target"},
             "mcpOAuth": {"server": {"refreshToken": "current"}},
-            "designOauth": {"refreshToken": "current"},
+            "mcpOAuthClientConfig": {"server": {"clientId": "current"}},
         }
+
+    def test_account_bound_and_unknown_siblings_stay_target_owned(
+        self, temp_home
+    ):
+        # trustedDeviceToken is enrolled per-account, and a field cswap does
+        # not recognize could be too — neither may cross an account switch.
+        # Only the SHARED_CREDENTIAL_KEYS allowlist is taken from live.
+        switcher = ClaudeAccountSwitcher()
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "trustedDeviceToken": "device-token-b",
+            "someFutureField": {"value": "target-owned"},
+        })
+        live = json.dumps({
+            "claudeAiOauth": {"accessToken": "live"},
+            "trustedDeviceToken": "device-token-a",
+            "someFutureField": {"value": "live"},
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        })
+
+        composed = json.loads(
+            switcher._prepare_credentials_for_activation(target, live)
+        )
+
+        assert composed == {
+            "claudeAiOauth": {"accessToken": "target"},
+            "trustedDeviceToken": "device-token-b",
+            "someFutureField": {"value": "target-owned"},
+            "mcpOAuth": {"server": {"refreshToken": "current"}},
+        }
+
+    def test_shared_key_absent_from_live_is_not_resurrected(self, temp_home):
+        # Shared keys are live-owned in absence too: if the machine no
+        # longer holds an MCP session, the slot's stale copy must not
+        # reintroduce it.
+        switcher = ClaudeAccountSwitcher()
+        target = json.dumps({
+            "claudeAiOauth": {"accessToken": "target"},
+            "mcpOAuth": {"server": {"refreshToken": "stale"}},
+        })
+        live = json.dumps({
+            "claudeAiOauth": {"accessToken": "live"},
+        })
+
+        composed = json.loads(
+            switcher._prepare_credentials_for_activation(target, live)
+        )
+
+        assert composed == {"claudeAiOauth": {"accessToken": "target"}}
 
     def test_api_key_live_state_activates_target_verbatim(self, temp_home):
         # While a managed API key is active there is no live OAuth object to


### PR DESCRIPTION
## Problem

Switching Claude accounts replaces the entire active credential object with the destination slot's saved copy. Claude Code stores both the account login and machine-shared OAuth integrations (notably `mcpOAuth`, the MCP server logins) in that one object.

If an MCP refresh token rotates after the destination slot was backed up, activating that slot restores the older token generation, and the affected MCP servers demand re-authentication.

## Root cause

The credential object contains state with two different owners and lifetimes:

- `claudeAiOauth` is owned by an account slot
- sibling fields, currently including `mcpOAuth`, are shared by the machine and may rotate independently

A destination slot can authoritatively supply its `claudeAiOauth`, but its sibling fields are frozen at backup time. The live credential's siblings are by definition the current generation.

## Change

One commit, ~85 production lines: compose every activation from the two owners instead of copying the stored blob verbatim.

- the destination slot supplies only its `claudeAiOauth` login
- the sibling fields come from the live credential (live wins over the slot's stale snapshot)
- when there is no live JSON credential object to take siblings from (fresh machine, or a managed API key is active), the stored blob activates unchanged — exactly the pre-existing behavior
- managed API keys and opaque legacy credential shapes are never composed; they activate byte-for-byte as before

Both activation paths (normal switch and direct activation) go through the same composer. Account backups, exports, imports, and session profiles are untouched.

## Out of scope (unchanged behavior)

Preserving MCP state across an **OAuth → managed API key → OAuth round trip** needs an account-independent snapshot store, since there is no live OAuth object to take siblings from while the API key is active. That is a larger change (new storage identity, its own failure modes); a complete, tested implementation exists on [`feat/shared-oauth-store`](https://github.com/pencount/claude-swap/tree/feat/shared-oauth-store) and I'm happy to follow up with it if you want that case covered.

## Validation

- unit: live siblings win over stale target siblings; API-key live state, absent live state, API-key targets, and opaque legacy shapes all activate verbatim
- end-to-end: a normal switch and a direct activation both preserve the live `mcpOAuth` over the slot's stale copy
- `uv run pytest -q` — 1,355 passed, 3 skipped
- `uv run python -m compileall -q src`
- `git diff --check`

Closes #135