### PR TITLE
fix: set the Accessory activation policy so the menu bar app stays out of the Dock

### DIFF
--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -369,6 +369,16 @@ def run(switcher) -> int:
     """Entry point for ``cswap --menubar``. Blocks until the user quits."""
     import rumps  # lazy: optional dependency, imported only when launching
 
+    import AppKit
+
+    # rumps never sets an activation policy, so under a framework Python the
+    # process launches as a regular app and parks a "Python" icon in the Dock
+    # for as long as the menu bar runs. Accessory keeps the status item and
+    # dialog windows but stays out of the Dock and the Cmd-Tab switcher.
+    AppKit.NSApplication.sharedApplication().setActivationPolicy_(
+        AppKit.NSApplicationActivationPolicyAccessory
+    )
+
     from claude_swap.autoswitch import AutoSwitchEngine
     from claude_swap.settings import load_settings, set_setting
     from claude_swap.snapshot_source import SnapshotSource

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -367,9 +367,18 @@ def _adapt_snapshot(snap) -> dict:
 
 def run(switcher) -> int:
     """Entry point for ``cswap --menubar``. Blocks until the user quits."""
-    import rumps  # lazy: optional dependency, imported only when launching
-
-    import AppKit
+    try:
+        import rumps  # lazy: optional dependency, imported only when launching
+        import AppKit  # ships with rumps (pyobjc-framework-Cocoa), never fails alone
+    except ImportError as e:
+        # This module is import-safe without rumps by design, so the CLI's
+        # guard around ``from claude_swap.menubar import run`` can never see a
+        # missing extra — the failure lands here at call time. Raise the
+        # error type the CLI already renders cleanly instead of a traceback.
+        raise ClaudeSwitchError(
+            "Menu bar mode requires 'rumps'. "
+            "Install with: pip install 'claude-swap[menubar]'"
+        ) from e
 
     # rumps never sets an activation policy, so under a framework Python the
     # process launches as a regular app and parks a "Python" icon in the Dock

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+import sys
 from pathlib import Path
 
+import pytest
+
 from claude_swap import menubar
+from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.switcher import USAGE_API_KEY
 
 
@@ -438,3 +442,19 @@ def test_format_title_reflects_passed_weekly_reset():
     s = menubar.MenuBarSettings(show_account_name=False, title_pct="7d")
     usage = {"seven_day": {"pct": 95.0, "resets_at": _iso(-86400)}}
     assert menubar.format_title("a@x.com", usage, s, _NOW) == "⇄ 0%"
+
+
+# --- run() app glue ------------------------------------------------------------
+
+def test_run_without_rumps_raises_clean_error(monkeypatch):
+    """A missing menubar extra surfaces as ClaudeSwitchError, not a traceback.
+
+    The module is import-safe without rumps, so the CLI's ImportError guard
+    around ``from claude_swap.menubar import run`` can never fire — the import
+    failure happens inside ``run()``. Blocking the import (a ``None`` entry in
+    ``sys.modules`` makes ``import rumps`` raise) checks that ``run()`` turns
+    it into the error type the CLI renders with the install hint.
+    """
+    monkeypatch.setitem(sys.modules, "rumps", None)
+    with pytest.raises(ClaudeSwitchError, match=r"claude-swap\[menubar\]"):
+        menubar.run(switcher=None)


### PR DESCRIPTION
## Problem

Running `cswap menubar` under a framework Python (e.g. the python.org installer, where the interpreter execs `Python.app/Contents/MacOS/Python`) parks a permanent **"Python" icon in the Dock** for as long as the menu bar runs. Quitting it from the Dock doesn't help either — anyone running the menu bar from a KeepAlive launchd agent just gets it respawned.

## Root cause

rumps (0.4.0) never sets an `NSApplication` activation policy, so macOS treats the process as a regular foreground app: Dock icon, Cmd-Tab entry, the works. A menu-bar-only app should be an *accessory* app.

## Fix

Set `NSApplicationActivationPolicyAccessory` at the top of `menubar.run()`, before the rumps app starts. Accessory (rather than Prohibited) is deliberate: the "Add from setup-token" flow activates the app to show `rumps.Window` dialogs, and accessory apps can still be activated and present windows — they just never appear in the Dock or the Cmd-Tab switcher.

The import stays inside `run()` alongside the lazy `rumps` import, so the module remains import-safe without AppKit and the pure-helper tests keep running on Linux/Windows CI.

## Verification

On macOS (Darwin 25.5.0, Python 3.12.8 framework build), with the menu bar relaunched from its launchd agent:

- `lsappinfo info` for the process now reports `type="UIElement"` (was a regular app before)
- System Events reports `background only = true`
- No Dock icon; the ⇄ status item, dropdown menu, account switching, and the add-from-token dialogs all still work
- `uv run pytest`: no new failures vs `main` (identical pass/fail set, 1346 passed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)