### PR TITLE
feat: weekly usage pace indicator (closes #125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ Usage is served from a per-account cache: when the usage API is briefly unreacha
 
 An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
 
+Weekly windows (`sevenDay` and any per-model `scoped` entry — never `fiveHour`) additively carry `expectedPct`/`aheadOfPace`/`projectedExhaustionAt`/`willLastToReset` once enough of the week has elapsed to make pace meaningful: `expectedPct` is the "on schedule" usage for how far into the week you are, `aheadOfPace` is `true` only when meaningfully over that (the same signal the human views show as a `(pace)`/`(ahead of pace)` marker), and `projectedExhaustionAt`/`willLastToReset` are a linear-projection ETA and its yes/no summary for whether usage stays under 100% before the next reset — `--json`-only, since the projection has wide error bars and would look falsely precise in `cswap list`/the TUI/the menu bar.
+
 </details>
 
 `cswap auto --json` emits an event *stream* instead — one JSON object per line (`{"schemaVersion":1,"event":"switch","ts":…, …}` with kinds like `poll`, `switch`, `no-switch`, `account-quarantined`, `all-exhausted`, `error`). The contract is additive: new kinds and fields may appear, so scripts should ignore unknown ones.

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from claude_swap import oauth
+from claude_swap import oauth, pace
 
 # Bump only on a breaking change to any payload shape. Scripts key off this.
 SCHEMA_VERSION = 1
@@ -50,24 +50,61 @@ def _window_to_json(entry: dict) -> dict:
     return out
 
 
-def _scoped_window_to_json(entry: dict) -> dict:
-    """Project a per-model scoped weekly window, carrying its model name."""
+def _pace_fields(entry: dict, fetched_at: float | None) -> dict:
+    """Weekly-window pace fields (issue #125): additive, JSON-only.
+
+    Emitted only when pace is computable and not suppressed (see
+    ``claude_swap.pace.compute_pace``). ``projectedExhaustionAt`` is a linear
+    ETA — wide error bars against real, bursty usage — so it's kept out of
+    every human-facing surface and only ever appears here.
+    """
+    if fetched_at is None:
+        return {}
+    result = pace.compute_pace(entry, fetched_at=fetched_at)
+    if result is None:
+        return {}
+    out: dict = {
+        "expectedPct": round(result.expected_pct, 1),
+        "aheadOfPace": result.ahead,
+    }
+    eta = pace.projected_exhaustion_ts(result, fetched_at=fetched_at)
+    if eta is not None:
+        out["projectedExhaustionAt"] = (
+            datetime.fromtimestamp(eta, tz=timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+        )
+    will_last = pace.will_last_to_reset(result)
+    if will_last is not None:
+        out["willLastToReset"] = will_last
+    return out
+
+
+def _weekly_window_to_json(entry: dict, fetched_at: float | None) -> dict:
+    """A 7d/scoped window's JSON projection, with pace fields layered in."""
     out = _window_to_json(entry)
+    out.update(_pace_fields(entry, fetched_at))
+    return out
+
+
+def _scoped_window_to_json(entry: dict, fetched_at: float | None) -> dict:
+    """Project a per-model scoped weekly window, carrying its model name."""
+    out = _weekly_window_to_json(entry, fetched_at)
     out["name"] = entry["name"]
     return out
 
 
-def usage_to_json(usage: dict) -> dict:
+def usage_to_json(usage: dict, fetched_at: float | None = None) -> dict:
     """Convert the internal usage dict to its camelCase JSON projection.
 
     Sub-keys are emitted only when present in the source (the API does not always
-    return every window or pay-as-you-go spend).
+    return every window or pay-as-you-go spend). ``fetched_at`` is the
+    measurement's fetch time; passing it adds pace fields to the weekly
+    windows (``seven_day``, ``scoped``) only — never ``five_hour`` (issue #125).
     """
     out: dict = {}
     if "five_hour" in usage:
         out["fiveHour"] = _window_to_json(usage["five_hour"])
     if "seven_day" in usage:
-        out["sevenDay"] = _window_to_json(usage["seven_day"])
+        out["sevenDay"] = _weekly_window_to_json(usage["seven_day"], fetched_at)
     if "spend" in usage:
         spend = usage["spend"]
         spend_out: dict = {
@@ -83,21 +120,24 @@ def usage_to_json(usage: dict) -> dict:
             spend_out["countdown"], spend_out["clock"] = cell
         out["spend"] = spend_out
     if "scoped" in usage:
-        out["scoped"] = [_scoped_window_to_json(w) for w in usage["scoped"]]
+        out["scoped"] = [_scoped_window_to_json(w, fetched_at) for w in usage["scoped"]]
     return out
 
 
-def usage_fields(entry: dict | str | None) -> tuple[str, dict | None]:
+def usage_fields(
+    entry: dict | str | None, fetched_at: float | None = None
+) -> tuple[str, dict | None]:
     """Map a collected usage entry to ``(usageStatus, usage|None)``.
 
     A collected entry is one of: a usage dict, the ``USAGE_TOKEN_EXPIRED`` sentinel
     (active token expired while Claude Code owns it), the ``USAGE_API_KEY`` sentinel
     (managed API-key account, no subscription quota), the
     ``USAGE_KEYCHAIN_UNAVAILABLE`` sentinel (active Keychain unreadable), the
-    ``USAGE_NO_CREDENTIALS`` sentinel, or ``None`` (fetch failed).
+    ``USAGE_NO_CREDENTIALS`` sentinel, or ``None`` (fetch failed). ``fetched_at``
+    is forwarded to ``usage_to_json`` for the weekly pace fields (issue #125).
     """
     if isinstance(entry, dict):
-        return "ok", usage_to_json(entry)
+        return "ok", usage_to_json(entry, fetched_at)
     if entry == USAGE_TOKEN_EXPIRED:
         return "token_expired", None
     if entry == USAGE_API_KEY:
@@ -150,7 +190,7 @@ def account_row(
     disabled: bool = False,
 ) -> dict:
     """A full account row for ``--list``."""
-    status, usage = usage_fields(usage_entry)
+    status, usage = usage_fields(usage_entry, usage_fetched_at)
     row = {
         "number": number,
         "email": email,

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -200,7 +200,7 @@ def usage_summary(
         if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)):
             seg = f"{label} {window['pct']:.0f}%"
             if key == "seven_day" and pace_result and pace_result.ahead:
-                seg += " (pace)"
+                seg += " (ahead)"
             countdown = _live_countdown(window, now)
             if countdown:
                 seg += f" ({countdown})"  # time until this window resets
@@ -214,7 +214,7 @@ def usage_summary(
             if window["pct"] >= 100:
                 seg += " (!)"  # maxed model — the usual reason to switch
             elif pace_result and pace_result.ahead:
-                seg += " (pace)"
+                seg += " (ahead)"
             countdown = _live_countdown(window, now)
             if countdown:
                 seg += f" ({countdown})"
@@ -355,7 +355,6 @@ EMPTY_SNAPSHOT: dict = {
     "active_email": None,
     "active_usage": None,
     "active_alias": None,
-    "active_usage_fetched_at": None,
 }
 
 
@@ -364,17 +363,15 @@ def _adapt_snapshot(snap) -> dict:
 
     Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good, alias, disabled, fetched_at), ...],
     "active_email": str | None, "active_usage": dict | str | None,
-    "active_alias": str | None, "active_usage_fetched_at": float | None}``. The
-    snapshot itself is produced by ``SnapshotSource`` (the paced read path), so
-    this is a pure transform — no fetching, no I/O. ``fetched_at`` is the
-    underlying measurement's fetch time, used only for the pace marker
-    (issue #125).
+    "active_alias": str | None}``. The snapshot itself is produced by
+    ``SnapshotSource`` (the paced read path), so this is a pure transform — no
+    fetching, no I/O. Per-account ``fetched_at`` is the underlying
+    measurement's fetch time, used only for the pace marker (issue #125).
     """
     accounts = []
     active_email = None
     active_usage = None
     active_alias = None
-    active_fetched_at = None
     for acc in snap.accounts:
         display = _account_display_usage(acc.usage)
         accounts.append(
@@ -385,13 +382,11 @@ def _adapt_snapshot(snap) -> dict:
         )
         if acc.is_active:
             active_email, active_usage, active_alias = acc.email, display, acc.alias
-            active_fetched_at = acc.usage.fetched_at
     return {
         "accounts": accounts,
         "active_email": active_email,
         "active_usage": active_usage,
         "active_alias": active_alias,
-        "active_usage_fetched_at": active_fetched_at,
     }
 
 

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -23,6 +23,7 @@ from dataclasses import asdict, dataclass, fields
 from datetime import datetime, timezone
 from pathlib import Path
 
+from claude_swap import pace
 from claude_swap.exceptions import ClaudeSwitchError, CredentialReadError
 from claude_swap.switcher import SENTINEL_NOTES
 
@@ -169,8 +170,15 @@ def _rolled_weekly_window(window: dict | None, now: float) -> dict | None:
     return rolled
 
 
-def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
-    """One-line usage summary for an account row (reset countdown computed live)."""
+def usage_summary(
+    usage: dict | str | None, now: float | None = None, fetched_at: float | None = None
+) -> str:
+    """One-line usage summary for an account row (reset countdown computed live).
+
+    ``fetched_at`` is the underlying measurement's fetch time (may be older
+    than ``now`` when serving last-good data) — used only to flag a weekly
+    window that's meaningfully ahead of pace (issue #125), never the 5h one.
+    """
     if isinstance(usage, str):
         return usage
     if usage is None:
@@ -180,10 +188,19 @@ def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
     parts: list[str] = []
     for key, label in (("five_hour", "5h"), ("seven_day", "7d")):
         window = usage.get(key)
+        pace_result = None
         if key == "seven_day":
             window = _rolled_weekly_window(window, now)  # reflect a passed weekly reset
+            # Pace against the rolled window, not the raw one: a stale window
+            # rolled to 0% has no current-cycle data to compare against, so
+            # its (correctly zeroed) pct naturally never reads as "ahead" —
+            # computing pace pre-roll would otherwise pair last cycle's high
+            # pct with this cycle's freshly-reset 0% display.
+            pace_result = pace.compute_pace(window, fetched_at=fetched_at)
         if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)):
             seg = f"{label} {window['pct']:.0f}%"
+            if key == "seven_day" and pace_result and pace_result.ahead:
+                seg += " (pace)"
             countdown = _live_countdown(window, now)
             if countdown:
                 seg += f" ({countdown})"  # time until this window resets
@@ -191,10 +208,13 @@ def usage_summary(usage: dict | str | None, now: float | None = None) -> str:
     # Per-model weekly limits (e.g. Fable), from the usage API's ``limits`` array.
     for window in usage.get("scoped") or []:
         window = _rolled_weekly_window(window, now)  # weekly cadence, same roll-forward
+        pace_result = pace.compute_pace(window, fetched_at=fetched_at)  # against the rolled window, see above
         if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)) and window.get("name"):
             seg = f"{window['name']} {window['pct']:.0f}%"
             if window["pct"] >= 100:
                 seg += " (!)"  # maxed model — the usual reason to switch
+            elif pace_result and pace_result.ahead:
+                seg += " (pace)"
             countdown = _live_countdown(window, now)
             if countdown:
                 seg += f" ({countdown})"
@@ -212,11 +232,12 @@ def format_account_label(
     now: float | None = None,
     alias: str | None = None,
     disabled: bool = False,
+    fetched_at: float | None = None,
 ) -> str:
     """Build one account row's menu label."""
     label = f"{alias}  ({email})" if alias else email
     marker = "  (disabled)" if disabled else ""
-    return f"{num}  {label}{marker}  {usage_summary(usage, now)}"
+    return f"{num}  {label}{marker}  {usage_summary(usage, now, fetched_at)}"
 
 
 def _local_part(email: str, limit: int = 12) -> str:
@@ -334,34 +355,43 @@ EMPTY_SNAPSHOT: dict = {
     "active_email": None,
     "active_usage": None,
     "active_alias": None,
+    "active_usage_fetched_at": None,
 }
 
 
 def _adapt_snapshot(snap) -> dict:
     """Adapt an ``AccountsSnapshot`` to the menu bar's render dict.
 
-    Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good, alias, disabled), ...],
+    Shape: ``{"accounts": [(num, email, is_active, display_usage, last_good, alias, disabled, fetched_at), ...],
     "active_email": str | None, "active_usage": dict | str | None,
-    "active_alias": str | None}``. The snapshot itself is produced by
-    ``SnapshotSource`` (the paced read path), so this is a pure transform — no
-    fetching, no I/O.
+    "active_alias": str | None, "active_usage_fetched_at": float | None}``. The
+    snapshot itself is produced by ``SnapshotSource`` (the paced read path), so
+    this is a pure transform — no fetching, no I/O. ``fetched_at`` is the
+    underlying measurement's fetch time, used only for the pace marker
+    (issue #125).
     """
     accounts = []
     active_email = None
     active_usage = None
     active_alias = None
+    active_fetched_at = None
     for acc in snap.accounts:
         display = _account_display_usage(acc.usage)
         accounts.append(
-            (acc.number, acc.email, acc.is_active, display, acc.usage.last_good, acc.alias, acc.disabled)
+            (
+                acc.number, acc.email, acc.is_active, display, acc.usage.last_good,
+                acc.alias, acc.disabled, acc.usage.fetched_at,
+            )
         )
         if acc.is_active:
             active_email, active_usage, active_alias = acc.email, display, acc.alias
+            active_fetched_at = acc.usage.fetched_at
     return {
         "accounts": accounts,
         "active_email": active_email,
         "active_usage": active_usage,
         "active_alias": active_alias,
+        "active_usage_fetched_at": active_fetched_at,
     }
 
 
@@ -465,7 +495,7 @@ def run(switcher) -> int:
             but de-dupes per account on the (5h, 7d) percentages so an idle
             machine doesn't churn the rotating log with identical lines.
             """
-            for num, email, _is_active, _display, last_good, _alias, _disabled in snap["accounts"]:
+            for num, email, _is_active, _display, last_good, _alias, _disabled, _fetched_at in snap["accounts"]:
                 key = _usage_log_key(last_good)
                 if key == (None, None) or self._last_usage_log.get(num) == key:
                     continue
@@ -582,9 +612,11 @@ def run(switcher) -> int:
             )
             self.menu.clear()
             account_items = []
-            for num, email, is_active, display, _last_good, alias, disabled in self.snapshot["accounts"]:
+            for num, email, is_active, display, _last_good, alias, disabled, fetched_at in self.snapshot["accounts"]:
                 item = rumps.MenuItem(
-                    format_account_label(num, email, display, alias=alias, disabled=disabled),
+                    format_account_label(
+                        num, email, display, alias=alias, disabled=disabled, fetched_at=fetched_at
+                    ),
                     callback=self._make_switch_to(num),
                 )
                 item.state = 1 if is_active else 0
@@ -622,7 +654,7 @@ def run(switcher) -> int:
             accounts = self.snapshot["accounts"]
             if not accounts:
                 menu.add(rumps.MenuItem("No managed accounts", callback=None))
-            for num, email, _is_active, _display, _last_good, alias, _disabled in accounts:
+            for num, email, _is_active, _display, _last_good, alias, _disabled, _fetched_at in accounts:
                 label = f"{num}  {alias}  ({email})" if alias else f"{num}  {email}"
                 menu.add(rumps.MenuItem(label, callback=self._make_remove(num)))
             return menu
@@ -632,7 +664,7 @@ def run(switcher) -> int:
             accounts = self.snapshot["accounts"]
             if not accounts:
                 menu.add(rumps.MenuItem("No managed accounts", callback=None))
-            for num, email, _is_active, _display, _last_good, alias, disabled in accounts:
+            for num, email, _is_active, _display, _last_good, alias, disabled, _fetched_at in accounts:
                 name = f"{alias}  ({email})" if alias else email
                 item = rumps.MenuItem(
                     f"{num}  {name}", callback=self._make_toggle_disabled(num, disabled)

--- a/src/claude_swap/pace.py
+++ b/src/claude_swap/pace.py
@@ -1,0 +1,150 @@
+"""Weekly usage pace (issue #125).
+
+A weekly window is "ahead of pace" when the account has used more of it than
+the fraction of the weekly reset cycle that has elapsed so far — e.g. 40% used
+at the 20%-through-the-week mark. Applies only to weekly windows (``seven_day``
+and every ``scoped`` per-model window); the 5h window is excluded because it
+resets too fast for pace to mean anything (it starts "ahead of pace" almost by
+definition early in the window, and the store's poll floor of ~3 minutes,
+drifting to ~10 minutes when idle, is a large fraction of a 5h window but
+negligible against a week — see issue #125 discussion).
+
+``compute_pace`` is a pure function: it consumes an already-fetched window
+dict and the snapshot's ``fetched_at``, never fetches anything itself, and has
+no influence on poll cadence (that stays entirely in ``poll_policy``). Elapsed
+time is measured against ``fetched_at`` rather than wall-clock ``now()``, so a
+snapshot served stale (last-good data re-served after a failed refetch) is
+evaluated against the clock it was actually measured at.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+# Weekly windows reset on a fixed 7-day cadence (matches menubar._WEEKLY_PERIOD_S).
+WEEKLY_PERIOD_S = 7 * 86400.0
+
+# Suppress the marker for this long after a weekly reset. Right after reset,
+# elapsed is tiny so `expected_pct` is near zero and almost any usage reads as
+# "far ahead" — a false positive, not a genuine pace warning. A plain
+# `elapsed == 0` guard isn't enough since a snapshot fetched shortly after
+# reset already has nonzero (if small) elapsed time.
+SUPPRESS_AFTER_RESET_S = 24 * 3600.0
+
+# Minimum (actual - expected) percentage-point gap before showing a marker.
+# Below this, "ahead of pace" is within normal usage variance and would just
+# add noise to already-dense usage rows.
+AHEAD_THRESHOLD_PCT = 15.0
+
+
+@dataclass(frozen=True)
+class PaceResult:
+    """One weekly window's pace at the moment its snapshot was fetched."""
+
+    expected_pct: float  # % of the week's budget "on schedule" usage would be at
+    actual_pct: float  # the window's actual pct
+    elapsed_s: float  # time since this window's current cycle started
+    period_s: float  # the window's full cycle length (e.g. 7 days)
+    ahead: bool  # actual_pct - expected_pct >= the "meaningfully ahead" threshold
+
+
+def _resets_at_ts(resets_at: object) -> float | None:
+    """POSIX timestamp of a ``resets_at`` ISO string, or None if missing/unparseable."""
+    if not isinstance(resets_at, str):
+        return None
+    try:
+        return datetime.fromisoformat(resets_at).timestamp()
+    except ValueError:
+        return None
+
+
+def compute_pace(
+    window: dict | None,
+    *,
+    fetched_at: float | None,
+    period_s: float = WEEKLY_PERIOD_S,
+    suppress_after_reset_s: float = SUPPRESS_AFTER_RESET_S,
+    ahead_threshold_pct: float = AHEAD_THRESHOLD_PCT,
+) -> PaceResult | None:
+    """Pace for one weekly usage window, or None when pace isn't computable/meaningful.
+
+    ``window`` is a raw window dict (``{"pct": ..., "resets_at": ...}``) as
+    stored in ``UsageEntry.last_good`` — the *next* reset, not the current
+    window's start, since that's the only timestamp the usage API provides.
+    The current window's start is derived by rolling ``resets_at`` by whole
+    ``period_s`` increments until it lands at or before ``fetched_at``; this
+    is correct however many cycles old ``resets_at`` is, including a
+    not-yet-rolled-forward stale value.
+
+    Returns None when: the window is missing/unparseable, ``pct``/``resets_at``
+    aren't usable, or elapsed time since the window's start is inside
+    ``suppress_after_reset_s``.
+    """
+    if not isinstance(window, dict) or fetched_at is None:
+        return None
+    pct = window.get("pct")
+    if not isinstance(pct, (int, float)):
+        return None
+    next_reset = _resets_at_ts(window.get("resets_at"))
+    if next_reset is None:
+        return None
+
+    # (next_reset - fetched_at) mod period_s == time remaining until the next
+    # reset, folded into [0, period_s). period_s minus that is elapsed time
+    # since the current window started — works regardless of how many whole
+    # cycles next_reset is ahead of or behind fetched_at.
+    remaining = (next_reset - fetched_at) % period_s
+    elapsed = 0.0 if remaining == 0 else period_s - remaining
+
+    if elapsed < suppress_after_reset_s:
+        return None
+
+    expected_pct = min(100.0, (elapsed / period_s) * 100.0)
+    ahead = (float(pct) - expected_pct) >= ahead_threshold_pct
+    return PaceResult(
+        expected_pct=expected_pct,
+        actual_pct=float(pct),
+        elapsed_s=elapsed,
+        period_s=period_s,
+        ahead=ahead,
+    )
+
+
+def projected_exhaustion_ts(pace: PaceResult, *, fetched_at: float) -> float | None:
+    """Linear-projection ETA (POSIX timestamp) for when usage would hit 100%.
+
+    JSON-only per issue #125: the projection assumes a constant burn rate,
+    which has wide error bars against real, bursty usage, and would look
+    falsely precise if surfaced in the UI. Returns None when there's no
+    measurable rate (no elapsed time, or usage isn't climbing).
+    """
+    if pace.elapsed_s <= 0 or pace.actual_pct <= 0:
+        return None
+    rate_pct_per_s = pace.actual_pct / pace.elapsed_s
+    if rate_pct_per_s <= 0:
+        return None
+    remaining_pct = 100.0 - pace.actual_pct
+    if remaining_pct <= 0:
+        return fetched_at
+    return fetched_at + remaining_pct / rate_pct_per_s
+
+
+def will_last_to_reset(pace: PaceResult) -> bool | None:
+    """Whether, at the current burn rate, usage stays under 100% through reset.
+
+    JSON-only (like ``projected_exhaustion_ts``): a boolean answer to "should I
+    worry" is safe to expose even though it's built from the same linear-rate
+    assumption, but it's still a projection with the same wide error bars
+    against bursty real usage, so it stays out of every human-facing surface.
+    Returns None when there's no measurable rate to extrapolate from.
+    """
+    if pace.actual_pct <= 0:
+        return True  # no usage yet — nothing to run out of before reset
+    if pace.elapsed_s <= 0:
+        return None
+    rate_pct_per_s = pace.actual_pct / pace.elapsed_s
+    if rate_pct_per_s <= 0:
+        return None
+    projected_total_pct = pace.actual_pct + rate_pct_per_s * (pace.period_s - pace.elapsed_s)
+    return projected_total_pct <= 100.0

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -22,7 +22,7 @@ from claude_swap.exceptions import (
     SwitchError,
     ValidationError,
 )
-from claude_swap import oauth
+from claude_swap import oauth, pace
 from claude_swap.claude_locks import claude_config_lock, claude_credentials_lock
 from claude_swap.json_output import (
     SCHEMA_VERSION,
@@ -106,7 +106,13 @@ _FETCH_STAGGER_S = 0.25
 _USAGE_AGE_NOTE_S = poll_policy.SERVE_TTL_S
 
 
-def _format_usage_lines(usage: dict) -> list[str]:
+def _pace_marker(window: dict, fetched_at: float | None) -> str:
+    """"  (ahead of pace)" when a weekly window is meaningfully ahead of pace, else ""."""
+    result = pace.compute_pace(window, fetched_at=fetched_at)
+    return "  (ahead of pace)" if result and result.ahead else ""
+
+
+def _format_usage_lines(usage: dict, fetched_at: float | None = None) -> list[str]:
     # Collect (label, body) rows first, then pad every label to the widest one so
     # per-model names (e.g. "Fable") don't shift the columns of the other lines.
     rows: list[tuple[str, str]] = []
@@ -122,16 +128,18 @@ def _format_usage_lines(usage: dict) -> list[str]:
             rows.append(("$$", f"{pct:>3.0f}%   ${used:,.2f} / ${limit:,.2f}"))
     for label, w in (("5h", usage.get("five_hour")), ("7d", usage.get("seven_day"))):
         if w:
+            # Pace only applies to the weekly (7d) window, never 5h (issue #125).
+            marker = _pace_marker(w, fetched_at) if label == "7d" else ""
             cell = oauth.fresh_reset_strings(w)
             if cell:
                 countdown, clock = cell
-                rows.append((label, f"{w['pct']:>3.0f}%   resets {clock:<12}  in {countdown}"))
+                rows.append((label, f"{w['pct']:>3.0f}%   resets {clock:<12}  in {countdown}{marker}"))
             else:
-                rows.append((label, f"{w['pct']:>3.0f}%"))
+                rows.append((label, f"{w['pct']:>3.0f}%{marker}"))
     for w in usage.get("scoped") or []:
         # Per-model weekly limits (e.g. Fable). Flag ones at/over the limit so a
         # maxed model — the usual reason to switch — stands out.
-        marker = "  (!)" if w["pct"] >= 100 else ""
+        marker = "  (!)" if w["pct"] >= 100 else _pace_marker(w, fetched_at)
         cell = oauth.fresh_reset_strings(w)
         if cell:
             countdown, clock = cell
@@ -187,7 +195,7 @@ def _usage_entry_lines(entry: UsageEntry) -> list[str]:
             out.append(f"{dimmed('└')} {muted(last_seen)}")
         return out
     if entry.last_good is not None:
-        lines = _format_usage_lines(entry.last_good)
+        lines = _format_usage_lines(entry.last_good, entry.fetched_at)
         if (
             lines
             and entry.age_s is not None
@@ -3286,7 +3294,7 @@ class ClaudeAccountSwitcher:
         entry = self._active_account_usage(account_num, current_email, org_uuid)
         # Decision-grade projection, same rule as the --list payload: stale
         # beyond STALE_OK_S reports unavailable, not "ok" with old numbers.
-        status, usage = usage_fields(entry.decision_value())
+        status, usage = usage_fields(entry.decision_value(), entry.fetched_at)
         active: dict = {
             "number": int(account_num),
             "email": current_email,

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -286,7 +286,7 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
         elif key == "seven_day":
             result = pace.compute_pace(window, fetched_at=fetched_at)
             if result and result.ahead:
-                text.append(" (pace)", style=SEV_WARN)
+                text.append(" (ahead)", style=SEV_WARN)
         parts += 1
     maxed = [
         w["name"]

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from rich.text import Text
 from textual.widgets import ListItem, Static
 
+from claude_swap import pace
 from claude_swap.json_output import USAGE_API_KEY
 from claude_swap.models import AccountSnapshot
 from claude_swap.usage_store import STALE_OK_S
@@ -106,8 +107,14 @@ def _reset_parts(window: dict, now: float) -> tuple[str | None, str | None]:
     return reset, f"{reset} · {clock}" if clock else reset
 
 
+def _pace_suffix(window: dict, fetched_at: float | None) -> str:
+    """"(ahead of pace)" when a weekly window is meaningfully ahead, else ""."""
+    result = pace.compute_pace(window, fetched_at=fetched_at)
+    return "(ahead of pace)" if result and result.ahead else ""
+
+
 def usage_rows(
-    last_good: dict | None, now: float
+    last_good: dict | None, now: float, fetched_at: float | None = None
 ) -> list[tuple[str, float, str, str]]:
     """(label, pct, suffix, suffix_full) rows mirroring the CLI's
     ``_format_usage_lines``.
@@ -117,7 +124,9 @@ def usage_rows(
     ``suffix``. Only windows the account actually has produce a row — an
     annual plan without a 7-day window simply has no 7d line. Order matches
     the CLI: spend, 5h, 7d, then per-model scoped windows (e.g. "Fable"),
-    the latter marked ``(!)`` at/over their limit.
+    the latter marked ``(!)`` at/over their limit. The weekly (7d) and scoped
+    rows also carry a "(ahead of pace)" marker when meaningfully ahead of the
+    week's expected usage (issue #125) — never the 5h row.
     """
     if not isinstance(last_good, dict):
         return []
@@ -133,7 +142,13 @@ def usage_rows(
         window = last_good.get(key)
         if window:
             reset, reset_full = _reset_parts(window, now)
-            rows.append((label, float(window["pct"]), reset or "", reset_full or ""))
+            suffix, suffix_full = reset or "", reset_full or ""
+            if key == "seven_day":
+                marker = _pace_suffix(window, fetched_at)
+                if marker:
+                    suffix = f"{suffix}  {marker}" if suffix else marker
+                    suffix_full = f"{suffix_full}  {marker}" if suffix_full else marker
+            rows.append((label, float(window["pct"]), suffix, suffix_full))
     for window in last_good.get("scoped") or []:
         pct = float(window["pct"])
         suffix, suffix_full = _reset_parts(window, now)
@@ -141,6 +156,11 @@ def usage_rows(
         if pct >= 100:
             suffix = f"{suffix}  (!)" if suffix else "(!)"
             suffix_full = f"{suffix_full}  (!)" if suffix_full else "(!)"
+        else:
+            marker = _pace_suffix(window, fetched_at)
+            if marker:
+                suffix = f"{suffix}  {marker}" if suffix else marker
+                suffix_full = f"{suffix_full}  {marker}" if suffix_full else marker
         rows.append((window["name"], pct, suffix, suffix_full))
     return rows
 
@@ -187,7 +207,7 @@ def account_card_text(
                 text.append(f"└ {last_seen}", style=MUTED)
         return text
 
-    rows = usage_rows(acc.usage.last_good, now)
+    rows = usage_rows(acc.usage.last_good, now, acc.usage.fetched_at)
     if not rows:
         text.append("\n    ")
         text.append("usage unavailable", style=MUTED)
@@ -246,6 +266,7 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
         return text
 
     last_good = acc.usage.last_good
+    fetched_at = acc.usage.fetched_at
     stale = acc.usage.age_s is not None and acc.usage.age_s > STALE_OK_S
     parts = 0
     for key, label in (("five_hour", "5h"), ("seven_day", "7d")):
@@ -262,6 +283,10 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
             reset = data.reset_text(window, now)
             if reset:
                 text.append(f" ({reset})", style=MUTED)
+        elif key == "seven_day":
+            result = pace.compute_pace(window, fetched_at=fetched_at)
+            if result and result.ahead:
+                text.append(" (pace)", style=SEV_WARN)
         parts += 1
     maxed = [
         w["name"]

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -98,6 +98,45 @@ class TestJsonHelpers:
         assert out["spend"]["countdown"] == countdown
         assert out["spend"]["clock"] == clock
 
+    def test_usage_to_json_adds_pace_fields_when_fetched_at_given(self):
+        # 1 day elapsed of the week, 50% used -> far ahead of the ~14% expected.
+        now = 1_700_000_000.0
+        resets_at = (datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(days=6)).isoformat()
+        usage = {"seven_day": {"pct": 50.0, "resets_at": resets_at}}
+        out = usage_to_json(usage, fetched_at=now)
+        assert out["sevenDay"]["aheadOfPace"] is True
+        assert out["sevenDay"]["expectedPct"] == pytest.approx(14.3, abs=0.1)
+        assert "projectedExhaustionAt" in out["sevenDay"]
+        assert out["sevenDay"]["willLastToReset"] is False  # 50% after 1/7 of the week won't last
+
+    def test_usage_to_json_pace_fields_on_scoped_windows(self):
+        now = 1_700_000_000.0
+        resets_at = (datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(days=6)).isoformat()
+        usage = {"scoped": [{"name": "Fable", "pct": 50.0, "resets_at": resets_at}]}
+        out = usage_to_json(usage, fetched_at=now)
+        assert out["scoped"][0]["aheadOfPace"] is True
+
+    def test_usage_to_json_five_hour_never_gets_pace_fields(self):
+        now = 1_700_000_000.0
+        resets_at = (datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(hours=4)).isoformat()
+        usage = {"five_hour": {"pct": 90.0, "resets_at": resets_at}}
+        out = usage_to_json(usage, fetched_at=now)
+        assert "aheadOfPace" not in out["fiveHour"]
+        assert "expectedPct" not in out["fiveHour"]
+
+    def test_usage_to_json_no_pace_fields_without_fetched_at(self):
+        usage = {"seven_day": {"pct": 50.0, "resets_at":
+                                (datetime.now(timezone.utc) + timedelta(days=6)).isoformat()}}
+        out = usage_to_json(usage)
+        assert "aheadOfPace" not in out["sevenDay"]
+
+    def test_usage_to_json_no_pace_fields_within_suppression_window(self):
+        now = 1_700_000_000.0
+        resets_at = (datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(days=7, hours=-1)).isoformat()
+        usage = {"seven_day": {"pct": 50.0, "resets_at": resets_at}}
+        out = usage_to_json(usage, fetched_at=now)
+        assert "aheadOfPace" not in out["sevenDay"]
+
     def test_usage_fields_variants(self):
         from claude_swap.json_output import (
             USAGE_KEYCHAIN_UNAVAILABLE,

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -130,51 +130,51 @@ def test_usage_summary_seven_day_ahead_of_pace_marker():
     # 1 day elapsed of the week, 50% used -> far ahead of the ~14% expected.
     usage = {"seven_day": {"pct": 50.0, "resets_at": _iso(6 * 86400)}}
     out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW)
-    assert out == "7d 50% (pace) (6d 0h)"
+    assert out == "7d 50% (ahead) (6d 0h)"
 
 
 def test_usage_summary_five_hour_never_shows_pace_marker():
     usage = {"five_hour": {"pct": 90.0, "resets_at": _iso(4 * 3600)}}
     out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW)
-    assert "pace" not in out
+    assert "ahead" not in out
 
 
 def test_usage_summary_scoped_ahead_of_pace_marker():
     usage = {"scoped": [{"name": "Fable", "pct": 50.0, "resets_at": _iso(6 * 86400)}]}
     out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW)
-    assert out == "Fable 50% (pace) (6d 0h)"
+    assert out == "Fable 50% (ahead) (6d 0h)"
 
 
 def test_usage_summary_maxed_scoped_marker_wins_over_pace():
-    # At/over the limit shows "(!)" — the more urgent signal — not "(pace)".
+    # At/over the limit shows "(!)" — the more urgent signal — not "(ahead)".
     usage = {"scoped": [{"name": "Fable", "pct": 100.0, "resets_at": _iso(6 * 86400)}]}
     out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW)
     assert "(!)" in out
-    assert "pace" not in out
+    assert "ahead" not in out
 
 
 def test_usage_summary_no_pace_marker_without_fetched_at():
     usage = {"seven_day": {"pct": 50.0, "resets_at": _iso(6 * 86400)}}
     out = menubar.usage_summary(usage, _NOW)
-    assert "pace" not in out
+    assert "ahead" not in out
 
 
 def test_usage_summary_no_pace_marker_on_window_rolled_to_zero():
     # A weekly window whose resets_at has already passed (stale cache, not
     # refetched since the actual reset) is rolled to a display pct of 0% —
     # pace must be computed against that rolled 0%, not the raw stale pct,
-    # or the display would show "7d 0% (pace)" (a marker paired with a
+    # or the display would show "7d 0% (ahead)" (a marker paired with a
     # percentage it doesn't correspond to).
     usage = {"seven_day": {"pct": 95.0, "resets_at": _iso(-3 * 86400)}}
     out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW - 4 * 86400)
-    assert "pace" not in out
+    assert "ahead" not in out
     assert "7d 0%" in out
 
 
 def test_usage_summary_scoped_no_pace_marker_on_window_rolled_to_zero():
     usage = {"scoped": [{"name": "Fable", "pct": 95.0, "resets_at": _iso(-3 * 86400)}]}
     out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW - 4 * 86400)
-    assert "pace" not in out
+    assert "ahead" not in out
     assert "Fable 0%" in out
 
 
@@ -439,7 +439,6 @@ def test_adapt_snapshot_shape_and_active_selection():
     assert snap["active_email"] == "a@x.com"
     assert snap["active_usage"] == lg
     assert snap["active_alias"] == ""
-    assert snap["active_usage_fetched_at"] == 123.0
     # (num, email, is_active, display_usage, last_good, alias, disabled, fetched_at)
     assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg, "", False, 123.0)
     # sentinel account: display is the human note, last_good/fetched_at are None; disabled carried through

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -126,6 +126,58 @@ def test_usage_summary_none():
     assert menubar.usage_summary(None) == "usage unavailable"
 
 
+def test_usage_summary_seven_day_ahead_of_pace_marker():
+    # 1 day elapsed of the week, 50% used -> far ahead of the ~14% expected.
+    usage = {"seven_day": {"pct": 50.0, "resets_at": _iso(6 * 86400)}}
+    out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW)
+    assert out == "7d 50% (pace) (6d 0h)"
+
+
+def test_usage_summary_five_hour_never_shows_pace_marker():
+    usage = {"five_hour": {"pct": 90.0, "resets_at": _iso(4 * 3600)}}
+    out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW)
+    assert "pace" not in out
+
+
+def test_usage_summary_scoped_ahead_of_pace_marker():
+    usage = {"scoped": [{"name": "Fable", "pct": 50.0, "resets_at": _iso(6 * 86400)}]}
+    out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW)
+    assert out == "Fable 50% (pace) (6d 0h)"
+
+
+def test_usage_summary_maxed_scoped_marker_wins_over_pace():
+    # At/over the limit shows "(!)" — the more urgent signal — not "(pace)".
+    usage = {"scoped": [{"name": "Fable", "pct": 100.0, "resets_at": _iso(6 * 86400)}]}
+    out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW)
+    assert "(!)" in out
+    assert "pace" not in out
+
+
+def test_usage_summary_no_pace_marker_without_fetched_at():
+    usage = {"seven_day": {"pct": 50.0, "resets_at": _iso(6 * 86400)}}
+    out = menubar.usage_summary(usage, _NOW)
+    assert "pace" not in out
+
+
+def test_usage_summary_no_pace_marker_on_window_rolled_to_zero():
+    # A weekly window whose resets_at has already passed (stale cache, not
+    # refetched since the actual reset) is rolled to a display pct of 0% —
+    # pace must be computed against that rolled 0%, not the raw stale pct,
+    # or the display would show "7d 0% (pace)" (a marker paired with a
+    # percentage it doesn't correspond to).
+    usage = {"seven_day": {"pct": 95.0, "resets_at": _iso(-3 * 86400)}}
+    out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW - 4 * 86400)
+    assert "pace" not in out
+    assert "7d 0%" in out
+
+
+def test_usage_summary_scoped_no_pace_marker_on_window_rolled_to_zero():
+    usage = {"scoped": [{"name": "Fable", "pct": 95.0, "resets_at": _iso(-3 * 86400)}]}
+    out = menubar.usage_summary(usage, _NOW, fetched_at=_NOW - 4 * 86400)
+    assert "pace" not in out
+    assert "Fable 0%" in out
+
+
 def test_format_account_label():
     label = menubar.format_account_label(2, "loc@papaya.asia", _USAGE)
     assert label == "2  loc@papaya.asia  5h 42% · 7d 18% · $ 30%"
@@ -345,9 +397,10 @@ def test_parse_switch_history_empty_or_no_matches():
 # --- snapshot adapter (fakes for AccountsSnapshot / UsageEntry) -----------------
 
 class _FakeEntry:
-    def __init__(self, sentinel=None, last_good=None):
+    def __init__(self, sentinel=None, last_good=None, fetched_at=None):
         self.sentinel = sentinel
         self.last_good = last_good
+        self.fetched_at = fetched_at
 
 
 class _FakeAcct:
@@ -379,18 +432,19 @@ def test_adapt_snapshot_shape_and_active_selection():
     # pacing now lives in SnapshotSource, tested separately).
     lg = {"five_hour": {"pct": 10.0}, "seven_day": {"pct": 20.0}}
     accts = [
-        _FakeAcct("1", "a@x.com", True, _FakeEntry(last_good=lg)),
+        _FakeAcct("1", "a@x.com", True, _FakeEntry(last_good=lg, fetched_at=123.0)),
         _FakeAcct("2", "b@x.com", False, _FakeEntry(sentinel=USAGE_API_KEY), disabled=True),
     ]
     snap = menubar._adapt_snapshot(_FakeSnap(accts))
     assert snap["active_email"] == "a@x.com"
     assert snap["active_usage"] == lg
     assert snap["active_alias"] == ""
-    # (num, email, is_active, display_usage, last_good, alias, disabled)
-    assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg, "", False)
-    # sentinel account: display is the human note, last_good is None; disabled carried through
+    assert snap["active_usage_fetched_at"] == 123.0
+    # (num, email, is_active, display_usage, last_good, alias, disabled, fetched_at)
+    assert snap["accounts"][0] == ("1", "a@x.com", True, lg, lg, "", False, 123.0)
+    # sentinel account: display is the human note, last_good/fetched_at are None; disabled carried through
     assert snap["accounts"][1] == (
-        "2", "b@x.com", False, menubar.SENTINEL_NOTES[USAGE_API_KEY], None, "", True,
+        "2", "b@x.com", False, menubar.SENTINEL_NOTES[USAGE_API_KEY], None, "", True, None,
     )
 
 

--- a/tests/test_pace.py
+++ b/tests/test_pace.py
@@ -1,0 +1,141 @@
+"""Unit tests for the weekly usage pace helper (issue #125)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from claude_swap import pace
+
+NOW = 1_000_000.0
+DAY = 86400.0
+WEEK = pace.WEEKLY_PERIOD_S
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _window(pct: float, resets_at_ts: float | None) -> dict:
+    window: dict = {"pct": pct}
+    if resets_at_ts is not None:
+        window["resets_at"] = _iso(resets_at_ts)
+    return window
+
+
+class TestComputePaceElapsed:
+    def test_one_day_into_the_week(self):
+        # Reset is 6 days away -> 1 day has elapsed since the window started.
+        window = _window(20.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert result.elapsed_s == DAY
+        assert result.expected_pct == (DAY / WEEK) * 100.0
+
+    def test_right_at_reset_boundary_is_suppressed(self):
+        # resets_at exactly one period ahead of fetched_at -> elapsed == 0.
+        window = _window(5.0, NOW + WEEK)
+        assert pace.compute_pace(window, fetched_at=NOW) is None
+
+    def test_stale_resets_at_multiple_cycles_in_the_past_still_resolves(self):
+        # resets_at is 2 full weeks + 1 day behind fetched_at (never rolled
+        # forward by a caller) -> current window still started 1 day ago.
+        window = _window(20.0, NOW - 2 * WEEK - DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert result.elapsed_s == DAY
+
+    def test_missing_fields_return_none(self):
+        assert pace.compute_pace(None, fetched_at=NOW) is None
+        assert pace.compute_pace({"pct": 10.0}, fetched_at=NOW) is None  # no resets_at
+        assert pace.compute_pace({"resets_at": _iso(NOW + DAY)}, fetched_at=NOW) is None  # no pct
+        assert pace.compute_pace(_window(10.0, NOW + DAY), fetched_at=None) is None
+        assert pace.compute_pace({"pct": 10.0, "resets_at": "not-a-date"}, fetched_at=NOW) is None
+
+
+class TestSuppressionWindow:
+    def test_just_inside_suppression_window_is_none(self):
+        elapsed = pace.SUPPRESS_AFTER_RESET_S - 1.0
+        window = _window(50.0, NOW + WEEK - elapsed)
+        assert pace.compute_pace(window, fetched_at=NOW) is None
+
+    def test_just_outside_suppression_window_is_not_none(self):
+        elapsed = pace.SUPPRESS_AFTER_RESET_S
+        window = _window(50.0, NOW + WEEK - elapsed)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert result.elapsed_s == elapsed
+
+
+class TestAheadThreshold:
+    def test_meaningfully_ahead_flags_true(self):
+        # 1 day elapsed (~14.3% expected); 50% actual is far ahead.
+        window = _window(50.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert result.ahead is True
+
+    def test_within_threshold_flags_false_but_still_returns(self):
+        # 1 day elapsed (~14.3% expected); 20% actual is close, not "ahead".
+        window = _window(20.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert result.ahead is False
+
+    def test_behind_pace_flags_false(self):
+        window = _window(5.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert result.ahead is False
+
+
+class TestProjectedExhaustionTs:
+    def test_linear_projection(self):
+        # 1 day elapsed, 50% used -> burn rate implies 100% at day 2.
+        window = _window(50.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        eta = pace.projected_exhaustion_ts(result, fetched_at=NOW)
+        assert eta is not None
+        assert eta == NOW + DAY  # one more day at the same rate exhausts it
+
+    def test_already_at_or_over_100_returns_fetched_at(self):
+        window = _window(120.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert pace.projected_exhaustion_ts(result, fetched_at=NOW) == NOW
+
+    def test_zero_usage_has_no_projection(self):
+        window = _window(0.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert pace.projected_exhaustion_ts(result, fetched_at=NOW) is None
+
+
+class TestWillLastToReset:
+    def test_sustainable_rate_will_last(self):
+        # 1 day elapsed, 10% used -> extrapolated to a full week is 70%, fine.
+        window = _window(10.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert pace.will_last_to_reset(result) is True
+
+    def test_unsustainable_rate_will_not_last(self):
+        # 1 day elapsed, 50% used -> extrapolated to a full week is 350%.
+        window = _window(50.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert pace.will_last_to_reset(result) is False
+
+    def test_zero_usage_will_last(self):
+        window = _window(0.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert pace.will_last_to_reset(result) is True
+
+    def test_comfortably_sustainable_rate_will_last(self):
+        # 1 day elapsed, actual slightly under the ~14.3% expected -> stays
+        # comfortably under 100% extrapolated across the full week.
+        window = _window(12.0, NOW + 6 * DAY)
+        result = pace.compute_pace(window, fetched_at=NOW)
+        assert result is not None
+        assert pace.will_last_to_reset(result) is True

--- a/tests/test_pace.py
+++ b/tests/test_pace.py
@@ -6,7 +6,8 @@ from datetime import datetime, timezone
 
 from claude_swap import pace
 
-NOW = 1_000_000.0
+NOW = 1_700_000_000.0  # a realistic epoch; keeps NOW-minus-several-weeks positive
+                        # (datetime.fromtimestamp rejects negative timestamps on Windows)
 DAY = 86400.0
 WEEK = pace.WEEKLY_PERIOD_S
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -4853,6 +4853,57 @@ class TestFormatUsageLines:
         lines = _format_usage_lines(usage)
         assert lines == ["5h:   7%   resets 20:39         in 1h 30m"]
 
+    def test_seven_day_ahead_of_pace_marker(self):
+        # 1 day elapsed of the week (resets_at 6 days out), 50% used -> far
+        # ahead of the ~14% expected at that point (issue #125).
+        from datetime import datetime, timedelta, timezone
+
+        now = 1_700_000_000.0
+        resets_at = datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(days=6)
+        usage = {"seven_day": {"pct": 50.0, "resets_at": resets_at.isoformat()}}
+        line = _format_usage_lines(usage, now)[0]
+        assert "(ahead of pace)" in line
+
+    def test_five_hour_never_shows_pace_marker(self):
+        # Pace applies only to weekly windows, never the 5h one (issue #125).
+        from datetime import datetime, timedelta, timezone
+
+        now = 1_700_000_000.0
+        resets_at = datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(hours=4)
+        usage = {"five_hour": {"pct": 90.0, "resets_at": resets_at.isoformat()}}
+        line = _format_usage_lines(usage, now)[0]
+        assert "pace" not in line
+
+    def test_scoped_ahead_of_pace_marker_when_under_limit(self):
+        from datetime import datetime, timedelta, timezone
+
+        now = 1_700_000_000.0
+        resets_at = datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(days=6)
+        usage = {"scoped": [{"name": "Fable", "pct": 50.0, "resets_at": resets_at.isoformat()}]}
+        line = _format_usage_lines(usage, now)[0]
+        assert "(ahead of pace)" in line
+        assert "(!)" not in line
+
+    def test_no_pace_marker_without_fetched_at(self):
+        # No fetched_at passed -> pace isn't computable, no marker (backward
+        # compatible with callers that don't supply it).
+        from datetime import datetime, timedelta, timezone
+
+        resets_at = datetime.now(timezone.utc) + timedelta(days=6)
+        usage = {"seven_day": {"pct": 50.0, "resets_at": resets_at.isoformat()}}
+        line = _format_usage_lines(usage)[0]
+        assert "pace" not in line
+
+    def test_no_pace_marker_within_suppression_window_after_reset(self):
+        # Just reset (elapsed ~0) -> suppressed even though pct looks "ahead".
+        from datetime import datetime, timedelta, timezone
+
+        now = 1_700_000_000.0
+        resets_at = datetime.fromtimestamp(now, tz=timezone.utc) + timedelta(days=7, hours=-1)
+        usage = {"seven_day": {"pct": 50.0, "resets_at": resets_at.isoformat()}}
+        line = _format_usage_lines(usage, now)[0]
+        assert "pace" not in line
+
 
 def _read_safety_copy(switcher, entry_id: str) -> str:
     """Decode a preserved credential entry straight from its file (the store

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -486,7 +486,7 @@ class TestMiniAccountText:
             age_s=0.0,
         )
         acc = make_account(1, entry=entry)
-        assert "(pace)" in mini_account_text(acc, now).plain
+        assert "(ahead)" in mini_account_text(acc, now).plain
 
     def test_five_hour_never_shows_pace_marker(self):
         from claude_swap.tui.widgets import mini_account_text

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -401,6 +401,49 @@ class TestUsageRows:
         assert usage_rows(None, time.time()) == []
         assert usage_rows({}, time.time()) == []
 
+    def test_seven_day_ahead_of_pace_marker(self):
+        # 1 day elapsed of the week, 50% used -> far ahead of the ~14% expected.
+        from claude_swap.tui.widgets import usage_rows
+
+        now = time.time()
+        last_good = {"seven_day": {"pct": 50.0, "resets_at": _iso_in(86400 * 6)}}
+        row = usage_rows(last_good, now, now)[0]
+        assert "(ahead of pace)" in row[2]
+        assert "(ahead of pace)" in row[3]
+
+    def test_five_hour_never_shows_pace_marker(self):
+        from claude_swap.tui.widgets import usage_rows
+
+        now = time.time()
+        last_good = {"five_hour": {"pct": 90.0, "resets_at": _iso_in(3600 * 4)}}
+        row = usage_rows(last_good, now, now)[0]
+        assert "pace" not in row[2]
+
+    def test_scoped_ahead_of_pace_marker(self):
+        from claude_swap.tui.widgets import usage_rows
+
+        now = time.time()
+        last_good = {"scoped": [{"name": "Fable", "pct": 50.0, "resets_at": _iso_in(86400 * 6)}]}
+        row = usage_rows(last_good, now, now)[0]
+        assert "(ahead of pace)" in row[2]
+
+    def test_maxed_scoped_marker_wins_over_pace(self):
+        from claude_swap.tui.widgets import usage_rows
+
+        now = time.time()
+        last_good = {"scoped": [{"name": "Fable", "pct": 100.0, "resets_at": _iso_in(86400 * 6)}]}
+        row = usage_rows(last_good, now, now)[0]
+        assert "(!)" in row[2]
+        assert "ahead of pace" not in row[2]
+
+    def test_no_pace_marker_without_fetched_at(self):
+        from claude_swap.tui.widgets import usage_rows
+
+        now = time.time()
+        last_good = {"seven_day": {"pct": 50.0, "resets_at": _iso_in(86400 * 6)}}
+        row = usage_rows(last_good, now)[0]
+        assert "pace" not in row[2]
+
     def test_card_shows_clock_only_where_it_fits(self):
         # Per-row degradation: the wide card shows every clock, a mid width
         # keeps 5h/7d clocks while the longer spend row falls back to its
@@ -430,6 +473,44 @@ class TestUsageRows:
 
         narrow = account_card_text(acc, 40).plain
         assert " · " not in narrow
+
+
+class TestMiniAccountText:
+    def test_seven_day_ahead_of_pace_marker(self):
+        from claude_swap.tui.widgets import mini_account_text
+
+        now = time.time()
+        entry = UsageEntry(
+            last_good={"seven_day": {"pct": 50.0, "resets_at": _iso_in(86400 * 6)}},
+            fetched_at=now,
+            age_s=0.0,
+        )
+        acc = make_account(1, entry=entry)
+        assert "(pace)" in mini_account_text(acc, now).plain
+
+    def test_five_hour_never_shows_pace_marker(self):
+        from claude_swap.tui.widgets import mini_account_text
+
+        now = time.time()
+        entry = UsageEntry(
+            last_good={"five_hour": {"pct": 90.0, "resets_at": _iso_in(3600 * 4)}},
+            fetched_at=now,
+            age_s=0.0,
+        )
+        acc = make_account(1, entry=entry)
+        assert "pace" not in mini_account_text(acc, now).plain
+
+    def test_no_pace_marker_without_fetched_at(self):
+        from claude_swap.tui.widgets import mini_account_text
+
+        now = time.time()
+        entry = UsageEntry(
+            last_good={"seven_day": {"pct": 50.0, "resets_at": _iso_in(86400 * 6)}},
+            fetched_at=None,
+            age_s=None,
+        )
+        acc = make_account(1, entry=entry)
+        assert "pace" not in mini_account_text(acc, now).plain
 
 
 class TestRunAction:


### PR DESCRIPTION
## Summary

Scoped to the pace indicator only. #125 had two separable asks (a used/remaining display toggle and the pace indicator), and I've left the toggle out here, matching the "skip it for now, revisit if more people ask" call in the thread (a `38% left` display next to a `switch at 90` threshold felt like a small permanent source of confusion for a cosmetic gain, and every usage surface would need to stay consistent with it).

The pace indicator itself follows the implementation notes from the thread:

- `compute_pace()` is a pure consumer of the stored snapshot: no fetching, no poll-cadence influence, and it computes elapsed against the snapshot's `fetched_at` rather than `now()`.
- Applies only to weekly windows, never 5h (that window is "ahead of pace" almost by definition early on, and poll staleness is negligible against a week but not against 5h).
- A marker shows only when meaningfully ahead (≥15pp over the expected-so-far percentage); on-track/behind stay silent to avoid noise in already-dense rows.
- Stage/delta stays in the UI; ETA numbers (`projectedExhaustionAt`, plus a `willLastToReset` boolean) are `--json`-only, since linear ETA has wide error bars and would look falsely precise in the UI.
- The first ~24h after a weekly reset is suppressed, since `elapsed == 0` alone isn't a sufficient guard against the near-zero-elapsed false positive.
- Workday filtering is left for v2.

## Implementation

- New `pace.py`: `compute_pace()`, `projected_exhaustion_ts()`, `will_last_to_reset()`, applies only to `seven_day` plus every `scoped` per-model window, never `five_hour`.
- Wired into every surface that renders weekly usage: `cswap list` / the TUI's shared row formatter, the TUI's full account card and minimized row, and the menu bar dropdown.
- `compute_pace()` also needed to stay correct when `resets_at` is several cycles stale (our poll-and-serve-last-good architecture can hand it genuinely old cached data). It derives the current window's start via modular arithmetic on `resets_at`, so it's correct no matter how many cycles behind the cached window is.

## Test plan

- [x] New `tests/test_pace.py`: pure fixed-clock tests for `compute_pace`/`projected_exhaustion_ts`/`will_last_to_reset` (elapsed math, suppression window, ahead threshold, stale/rolled resets_at handling)
- [x] Marker-injection tests added to `TestFormatUsageLines` (switcher), `test_menubar.py`, `test_tui.py`, `test_json_output.py`, including negative cases (no marker without `fetched_at`, no marker in the suppression window, no marker on 5h, `(!)` maxed marker wins over pace)
- [x] Full suite green on macOS/Linux/Windows (1406 passed; the only prior failures were 6 pre-existing, unrelated ones already present on `main` in `test_swap_accounts.py`/`test_move_accounts.py`)
- [x] Manually verified against my real accounts via `cswap list` / `cswap list --json` (no crashes, correctly showed nothing since my accounts are either behind pace or within the reset-suppression window), plus synthetic data through the actual rendering functions to confirm the marker text across all three surfaces
- [x] README's `--json` schema section updated to document the new additive fields
