### PR TITLE
fix: menu bar notifications break after every uv/pipx reinstall

### DIFF
--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import plistlib
 import re
 import sys
@@ -55,7 +56,10 @@ def ensure_notification_identity(
     data: dict = {}
     try:
         if path.exists():
-            loaded = plistlib.loads(path.read_bytes())
+            try:
+                loaded = plistlib.loads(path.read_bytes())
+            except Exception:
+                loaded = None  # unreadable/corrupt — rebuild from scratch
             if isinstance(loaded, dict):
                 data = loaded
         changed = False
@@ -66,7 +70,10 @@ def ensure_notification_identity(
             data["CFBundleName"] = "claude-swap"
             changed = True
         if changed or not path.exists():
-            path.write_bytes(plistlib.dumps(data))
+            # atomic: an interrupted write must not leave a half-written plist
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_bytes(plistlib.dumps(data))
+            os.replace(tmp, path)
     except (OSError, plistlib.InvalidFileException, ValueError) as exc:
         logging.getLogger("claude-swap").warning(
             "Could not prepare menu-bar notification identity: %s", exc

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -16,7 +16,10 @@ unit-tested in CI; ``rumps`` is imported lazily inside the app glue.
 from __future__ import annotations
 
 import json
+import logging
+import plistlib
 import re
+import sys
 import threading
 import time
 from dataclasses import asdict, dataclass, fields
@@ -32,6 +35,44 @@ REFRESH_CHOICES: tuple[int, ...] = (30, 60, 300)
 AUTO_THRESHOLD_CHOICES: tuple[int, ...] = (80, 90, 95, 98)
 TITLE_PCT_CHOICES: tuple[str, ...] = ("off", "5h", "7d", "both")
 SWITCH_HISTORY_LIMIT = 10
+NOTIFICATION_BUNDLE_ID = "com.claude-swap.menubar"
+
+
+def ensure_notification_identity(
+    executable: Path | None = None,
+    *,
+    platform: str = sys.platform,
+) -> Path | None:
+    """Ensure rumps can resolve a bundle identifier for notifications.
+
+    Command-line Python tools have no app bundle, so rumps looks for an
+    ``Info.plist`` beside the interpreter. uv/pipx reinstalls can recreate that
+    environment; repair the tiny plist on every launch when needed.
+    """
+    if platform != "darwin":
+        return None
+    path = (executable or Path(sys.executable)).parent / "Info.plist"
+    data: dict = {}
+    try:
+        if path.exists():
+            loaded = plistlib.loads(path.read_bytes())
+            if isinstance(loaded, dict):
+                data = loaded
+        changed = False
+        if not data.get("CFBundleIdentifier"):
+            data["CFBundleIdentifier"] = NOTIFICATION_BUNDLE_ID
+            changed = True
+        if not data.get("CFBundleName"):
+            data["CFBundleName"] = "claude-swap"
+            changed = True
+        if changed or not path.exists():
+            path.write_bytes(plistlib.dumps(data))
+    except (OSError, plistlib.InvalidFileException, ValueError) as exc:
+        logging.getLogger("claude-swap").warning(
+            "Could not prepare menu-bar notification identity: %s", exc
+        )
+        return None
+    return path
 
 
 @dataclass
@@ -392,6 +433,7 @@ def _adapt_snapshot(snap) -> dict:
 
 def run(switcher) -> int:
     """Entry point for ``cswap --menubar``. Blocks until the user quits."""
+    ensure_notification_identity()
     try:
         import rumps  # lazy: optional dependency, imported only when launching
         import AppKit  # ships with rumps (pyobjc-framework-Cocoa), never fails alone

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -38,6 +38,25 @@ def test_notification_identity_creates_and_preserves_info_plist(tmp_path: Path):
     assert data["ExistingKey"] == "kept"
 
 
+def test_notification_identity_heals_corrupt_info_plist(tmp_path: Path):
+    executable = tmp_path / "bin" / "python3"
+    executable.parent.mkdir()
+    info = executable.parent / "Info.plist"
+    # truncated XML plist: plistlib raises ExpatError, not InvalidFileException
+    info.write_bytes(
+        b'<?xml version="1.0" encoding="UTF-8"?>\n'
+        b'<plist version="1.0"><dict><key>CFBundle'
+    )
+
+    result = menubar.ensure_notification_identity(executable, platform="darwin")
+
+    assert result == info
+    data = plistlib.loads(info.read_bytes())
+    assert data["CFBundleIdentifier"] == "com.claude-swap.menubar"
+    assert data["CFBundleName"] == "claude-swap"
+    assert not (executable.parent / "Info.plist.tmp").exists()
+
+
 def test_notification_identity_is_noop_off_macos(tmp_path: Path):
     executable = tmp_path / "bin" / "python3"
     assert menubar.ensure_notification_identity(

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+import plistlib
 import sys
 from pathlib import Path
 
@@ -18,6 +19,31 @@ import pytest
 from claude_swap import menubar
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.switcher import USAGE_API_KEY
+
+
+# --- notification identity -----------------------------------------------------
+
+def test_notification_identity_creates_and_preserves_info_plist(tmp_path: Path):
+    executable = tmp_path / "bin" / "python3"
+    executable.parent.mkdir()
+    info = executable.parent / "Info.plist"
+    info.write_bytes(plistlib.dumps({"ExistingKey": "kept"}))
+
+    result = menubar.ensure_notification_identity(executable, platform="darwin")
+
+    assert result == info
+    data = plistlib.loads(info.read_bytes())
+    assert data["CFBundleIdentifier"] == "com.claude-swap.menubar"
+    assert data["CFBundleName"] == "claude-swap"
+    assert data["ExistingKey"] == "kept"
+
+
+def test_notification_identity_is_noop_off_macos(tmp_path: Path):
+    executable = tmp_path / "bin" / "python3"
+    assert menubar.ensure_notification_identity(
+        executable, platform="linux"
+    ) is None
+    assert not (executable.parent / "Info.plist").exists()
 
 
 # --- settings ------------------------------------------------------------------


### PR DESCRIPTION
rumps notifications need a resolvable bundle identifier. Command-line Python tools have no app bundle, so rumps falls back to an `Info.plist` beside the interpreter — and uv/pipx recreate that directory on reinstall or upgrade, silently breaking notifications until the plist is restored by hand.

This makes `cswap --menubar` self-healing: at launch it ensures `CFBundleIdentifier`/`CFBundleName` in the interpreter-adjacent `Info.plist`, preserving any keys already there. No-op off macOS; on a read/write failure it logs a warning and the app starts normally (notifications are the only casualty).

## Validation

- `uv run pytest -q tests/test_menubar.py` — 63 passed (two new tests: the plist is created/repaired with existing keys preserved, and the off-macOS no-op)
- `uv run python -m compileall -q src`
- `git diff --check`