### PR TITLE
Add a light theme (dark, light, auto) for the TUI and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usag
 
 <img src="assets/tui-watch.png" width="760" alt="cswap watch — live 5h/7d usage bars for every account, with reset times and the active account marked">
 
+### Theme
+
+The TUI ships a dark theme and a light theme, both WCAG AA-contrast checked, plus `auto` (the default), which follows the terminal's background via an OSC 11 query. Pick one from the root menu's **Theme…** entry (the current one is marked), press `Ctrl+T` inside the TUI to cycle `dark → light → auto` live, or set it up front:
+
+```bash
+cswap config set ui.theme light   # or: dark, auto
+```
+
+The plain CLI output (outside the TUI) follows the same `ui.theme` setting. With `auto`, if the terminal doesn't answer the OSC 11 query, cswap falls back to the dark palette. Inside `tmux` or `screen` (which don't pass the query through) it skips the probe entirely and uses dark, so `auto` never adds a startup delay there.
+
+Toggling the theme live inside the TUI only affects new output — auto-view log lines already printed keep the colors they were written with; only lines added after the switch pick up the new theme.
 
 ### Refresh expired tokens
 

--- a/src/claude_swap/appearance.py
+++ b/src/claude_swap/appearance.py
@@ -1,0 +1,200 @@
+"""Terminal appearance detection and theme resolution.
+
+Determines whether the terminal has a light or dark background by querying it
+with OSC 11 (``ESC ] 11 ; ? BEL``) and reading the ``rgb:…`` reply, then
+classifying by perceived luminance. Cross-cutting: both the CLI printer and the
+TUI resolve their theme through here.
+
+The query MUST happen while this process owns the terminal in cooked mode —
+before Textual's input driver starts — or the reply is reissued as keystrokes.
+Everything fails safe to ``None`` (→ resolved ``dark``): a terminal that doesn't
+answer, a pipe, Windows, or a parse failure never blocks and never errors.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import select
+import sys
+import time
+
+_QUERY = b"\x1b]11;?\x07"           # OSC 11, BEL-terminated
+_TIMEOUT_S = 0.15
+_MAX_REPLY = 64
+# The full `ESC ]11;` opener is required so interleaved or echoed input (e.g.
+# a shell echoing back a pasted escape sequence) can't be misparsed as a
+# background reply just because `]11;rgb:`/`]11;#` appears somewhere in the
+# buffer without the ESC that actually starts an OSC sequence.
+_RGB = re.compile(rb"\x1b\]11;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)")
+_HEX = re.compile(rb"\x1b\]11;#([0-9a-fA-F]{6})")
+
+# Cache: the terminal background can't change within a process, so query once.
+_UNSET = object()
+_cache: object | str | None = _UNSET
+
+
+def _reset_cache() -> None:
+    """Test helper: forget any cached detection result."""
+    global _cache
+    _cache = _UNSET
+
+
+def _parse_osc11(reply: bytes) -> tuple[float, float, float] | None:
+    """Parse an OSC 11 reply into (r, g, b) each normalised to 0..1."""
+    m = _RGB.search(reply)
+    if m:
+        return tuple(
+            int(h, 16) / (16 ** len(h) - 1) for h in m.groups()
+        )  # type: ignore[return-value]
+    m = _HEX.search(reply)
+    if m:
+        h = m.group(1).decode("ascii")
+        return tuple(int(h[i:i + 2], 16) / 255 for i in (0, 2, 4))  # type: ignore[return-value]
+    return None
+
+
+def _classify(reply: bytes) -> str | None:
+    """Light/dark from an OSC 11 reply, or None if unparseable."""
+    rgb = _parse_osc11(reply)
+    if rgb is None:
+        return None
+    r, g, b = rgb
+    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b  # BT.709-weighted brightness on gamma-encoded channels (approx.)
+    return "light" if luminance > 0.5 else "dark"
+
+
+def _query_terminal_background() -> bytes | None:
+    """Send OSC 11 and read the reply in cooked mode. None on any failure.
+
+    Isolated so tests can substitute a canned reply without a real tty.
+
+    tmux and screen don't give OSC 11 passthrough to the outer terminal by
+    default, so a query sent inside one would just wait out the timeout with
+    no reply; ``$TMUX``/``$STY`` short-circuit to ``None`` (resolving to
+    ``dark``) without probing. Fails safe either way.
+    """
+    if os.name == "nt":
+        return None
+    if os.environ.get("TMUX") or os.environ.get("STY"):
+        return None
+    try:
+        import termios
+        import tty
+    except ImportError:
+        return None
+    try:
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            return None
+    except (ValueError, OSError):
+        # isatty() can raise on a closed stream.
+        return None
+    try:
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+    except (termios.error, OSError):
+        return None
+    try:
+        # TCSANOW (not TCSADRAIN): draining first can block under terminal
+        # flow control, and there's no pending output to drain anyway.
+        tty.setcbreak(fd, termios.TCSANOW)
+        sys.stdout.write(_QUERY.decode("latin-1"))
+        sys.stdout.flush()
+        deadline = time.monotonic() + _TIMEOUT_S
+        buf = b""
+        while time.monotonic() < deadline and len(buf) < _MAX_REPLY:
+            remaining = deadline - time.monotonic()
+            ready, _, _ = select.select([fd], [], [], max(0.0, remaining))
+            if not ready:
+                break
+            chunk = os.read(fd, 32)
+            if not chunk:
+                break
+            buf += chunk
+            # Only stop early once the buffer holds a complete, parseable
+            # OSC-11 frame — a BEL/ST terminator alone could belong to an
+            # unrelated echoed sequence (e.g. our own query bouncing back)
+            # and end the read before the real reply arrives.
+            if (b"\x07" in buf or b"\x1b\\" in buf) and _parse_osc11(buf) is not None:
+                break
+        return buf or None
+    except (termios.error, OSError, ValueError):
+        return None
+    finally:
+        try:
+            termios.tcsetattr(fd, termios.TCSANOW, old)
+        except (termios.error, OSError):
+            pass
+
+
+def detect_terminal_background() -> str | None:
+    """'light' | 'dark' from the terminal background, or None if undetectable.
+
+    Cached per process. MUST be first called in cooked mode (before app.run()).
+    """
+    global _cache
+    if _cache is _UNSET:
+        reply = _query_terminal_background()
+        _cache = _classify(reply) if reply is not None else None
+    return _cache  # type: ignore[return-value]
+
+
+def resolve_theme(setting: str, detect=detect_terminal_background) -> str:
+    """Resolve a ui.theme setting to a concrete 'light'/'dark'.
+
+    'dark'/'light' pass through without probing; 'auto' follows ``detect()``,
+    falling back to 'dark' when detection yields None.
+    """
+    if setting in ("dark", "light"):
+        return setting
+    return detect() or "dark"
+
+
+def cli_should_probe(argv: list[str], *, colors_enabled: bool) -> bool:
+    """Whether the CLI should probe the terminal background before dispatch.
+
+    False when colors are off (nothing will render the theme anyway), when
+    the first token is ``run`` (execs a child that takes over the terminal),
+    or when ``--json`` is present (the OSC query must never precede
+    machine-readable output on stdout).
+    """
+    if not colors_enabled:
+        return False
+    if argv and argv[0] == "run":
+        return False
+    if "--json" in argv:
+        return False
+    return True
+
+
+def cli_theme(setting: str, *, detect=detect_terminal_background, colors: bool) -> str:
+    """Resolve a theme for a plain-CLI invocation: probe only when color will
+    actually be emitted; otherwise auto degrades to dark without a tty query."""
+    if setting == "auto" and not colors:
+        return "dark"
+    return resolve_theme(setting, detect=detect)
+
+
+def drain_stdin() -> None:
+    """Discard any pending terminal input (e.g. a late OSC reply) so it isn't
+    reissued as keystrokes once Textual takes over. Best-effort; POSIX only.
+
+    A reply that arrives after the detection deadline and after this drain
+    can, in principle, still reach the running app as stray keystrokes —
+    inherent to any finite-timeout OSC probe, not fully closeable here.
+    """
+    if os.name == "nt":
+        return
+    try:
+        import termios
+    except ImportError:
+        return
+    try:
+        if not sys.stdin.isatty():
+            return
+    except (ValueError, OSError):
+        return
+    try:
+        termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)
+    except (termios.error, OSError):
+        pass

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 
-from claude_swap import __version__
+from claude_swap import __version__, paths, printer
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
 from claude_swap.printer import (
@@ -19,6 +19,7 @@ from claude_swap.printer import (
     muted,
     warning,
 )
+from claude_swap.settings import load_ui_settings
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -843,6 +844,16 @@ def main() -> None:
     force_utf8_output()
     _use_native_tls()
     argv = sys.argv[1:]
+    try:
+        from claude_swap.appearance import cli_should_probe, cli_theme
+        # `run` execs a child that takes over the terminal, and `--json`
+        # must stay machine-readable — never probe (and emit the OSC query)
+        # in either case.
+        probe = cli_should_probe(argv, colors_enabled=printer.colors_enabled())
+        name = cli_theme(load_ui_settings(paths.get_backup_root()).theme, colors=probe)
+        printer.set_theme(name)
+    except Exception:
+        pass  # theme is cosmetic; never block the CLI on it
 
     # `run` and `auto` keep their dedicated pre-dispatch parsers.
     if argv and argv[0] == "run":

--- a/src/claude_swap/printer.py
+++ b/src/claude_swap/printer.py
@@ -13,16 +13,38 @@ import sys
 import time
 from pathlib import Path
 
-# ANSI escape codes
+# ANSI escape codes -- structural, theme-independent
 _RESET = "\033[0m"
 _BOLD = "\033[1m"
 _DIM = "\033[2m"
-_RED = "\033[31m"
-_YELLOW = "\033[33m"
-_ACCENT = "\033[38;5;173m"  # Warm salmon/terracotta
-_MUTED = "\033[38;5;250m"  # Soft gray -- readable, but quieter than normal
+
+_PALETTES: dict[str, dict[str, str]] = {
+    "dark": {
+        "accent": "\033[38;5;173m",  # warm salmon/terracotta (xterm 173)
+        "muted": "\033[38;5;250m",  # soft gray -- readable, but quieter than normal
+        "red": "\033[31m",
+        "yellow": "\033[33m",
+    },
+    "light": {
+        "accent": "\033[38;2;149;76;42m",  # #954c2a burnt sienna
+        "muted": "\033[38;2;99;93;85m",  # #635d55
+        "red": "\033[38;2;173;49;40m",  # #ad3128
+        "yellow": "\033[38;2;121;89;17m",  # #795911 deep ochre
+    },
+}
 
 _colors_enabled: bool | None = None  # lazy-initialized
+_theme: str = "dark"
+
+
+def set_theme(name: str) -> None:
+    """Select the CLI color palette. Unknown names fall back to dark."""
+    global _theme
+    _theme = name if name in _PALETTES else "dark"
+
+
+def _pal(key: str) -> str:
+    return _PALETTES[_theme][key]
 
 
 def _enable_windows_vt() -> bool:
@@ -115,12 +137,12 @@ def _style(text: str, *codes: str) -> str:
 
 def accent(text: str) -> str:
     """Warm accent color for important elements."""
-    return _style(text, _ACCENT)
+    return _style(text, _pal("accent"))
 
 
 def muted(text: str) -> str:
     """Slightly dimmer than normal -- for usage stats, org tags."""
-    return _style(text, _MUTED)
+    return _style(text, _pal("muted"))
 
 
 def dimmed(text: str) -> str:
@@ -135,12 +157,12 @@ def bolded(text: str) -> str:
 
 def bold_accent(text: str) -> str:
     """Bold + accent for key markers like (active)."""
-    return _style(text, _BOLD, _ACCENT)
+    return _style(text, _BOLD, _pal("accent"))
 
 
 def yellowed(text: str) -> str:
     """Yellow for warning-toned text (string form; ``warning()`` prints)."""
-    return _style(text, _YELLOW)
+    return _style(text, _pal("yellow"))
 
 
 # --- Line printers (call print() internally) ---
@@ -148,12 +170,12 @@ def yellowed(text: str) -> str:
 
 def error(msg: str) -> None:
     """Print an error message (red) to stderr."""
-    print(_style(msg, _RED), file=sys.stderr)
+    print(_style(msg, _pal("red")), file=sys.stderr)
 
 
 def warning(msg: str) -> None:
     """Print a warning message (yellow)."""
-    print(_style(msg, _YELLOW))
+    print(_style(msg, _pal("yellow")))
 
 
 # --- Display helpers for process detection ---

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -1,9 +1,9 @@
 """Tool settings persisted at ``<backup_root>/settings.json``.
 
 One versioned JSON file for user-tunable claude-swap preferences, written
-atomically with the backup dir's 0600/0700 modes. v1 carries only the
-``autoswitch`` section; other sections can be added additively. Unknown keys
-(future fields, other tools' experiments) survive a round trip.
+atomically with the backup dir's 0600/0700 modes. v1 carries the
+``autoswitch`` and ``ui`` sections; other sections can be added additively.
+Unknown keys (future fields, other tools' experiments) survive a round trip.
 
 Reading is forgiving — a missing or corrupt file yields defaults with a logged
 warning, never a crash — so a bad hand edit degrades to default behavior.
@@ -59,6 +59,17 @@ class AutoSwitchSettings:
 
 
 @dataclass(frozen=True)
+class UiSettings:
+    """Appearance preferences (``ui`` section). ``theme`` selects the TUI/CLI
+    color theme; ``auto`` follows terminal-background detection."""
+
+    theme: str = "auto"
+
+
+_SECTION_DEFAULT_SOURCES = {"autoswitch": AutoSwitchSettings, "ui": UiSettings}
+
+
+@dataclass(frozen=True)
 class SettingSpec:
     """Metadata for one user-tunable settings.json key.
 
@@ -67,7 +78,7 @@ class SettingSpec:
     (`parse_setting_value`) read from here, so the two can't drift.
     """
 
-    section: str  # top-level JSON section ("autoswitch")
+    section: str  # top-level JSON section ("autoswitch", "ui")
     json_key: str  # camelCase key inside the section
     field: str  # snake_case AutoSwitchSettings field
     kind: str  # "float" | "int" | "bool" | "choice"
@@ -82,7 +93,7 @@ class SettingSpec:
 
     @property
     def default(self):
-        return getattr(AutoSwitchSettings(), self.field)
+        return getattr(_SECTION_DEFAULT_SOURCES[self.section](), self.field)
 
 
 # settings.json uses camelCase (matching the repo's other JSON artifacts);
@@ -122,11 +133,17 @@ SETTING_SPECS: dict[str, SettingSpec] = {
             "autoswitch", "model", "model", "string",
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
         ),
+        SettingSpec(
+            "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
+            help="Color theme; auto follows the terminal background",
+        ),
     )
 }
 
 _AUTOSWITCH_KEYS: dict[str, str] = {
-    spec.field: spec.json_key for spec in SETTING_SPECS.values()
+    spec.field: spec.json_key
+    for spec in SETTING_SPECS.values()
+    if spec.section == "autoswitch"
 }
 
 
@@ -158,6 +175,8 @@ def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:
 
     kwargs = {}
     for spec in SETTING_SPECS.values():
+        if spec.section != "autoswitch":
+            continue
         value = getattr(settings, spec.field)
         if spec.kind in ("float", "int"):
             clamped = num(value, spec.default, spec.lo, spec.hi)
@@ -208,6 +227,23 @@ def load_settings(backup_root: Path) -> AutoSwitchSettings:
     except TypeError:
         settings = AutoSwitchSettings()
     return _clamped(settings)
+
+
+def load_ui_settings(backup_root: Path) -> UiSettings:
+    """Load the ui section; missing/corrupt file or unknown theme → default."""
+    raw = _read_raw(settings_path(backup_root))
+    section = raw.get("ui")
+    default = UiSettings()
+    if not isinstance(section, dict):
+        return default
+    theme = section.get("theme", default.theme)
+    if theme not in SETTING_SPECS["ui.theme"].choices:
+        _logger.warning(
+            "settings.json: unsupported ui.theme %r; using %r",
+            theme, default.theme,
+        )
+        return default
+    return UiSettings(theme=theme)
 
 
 def save_settings(backup_root: Path, settings: AutoSwitchSettings) -> None:
@@ -371,12 +407,15 @@ def effective_settings(backup_root: Path) -> list[tuple[SettingSpec, object, boo
     reflects the file, not value equality.
     """
     raw = _read_raw(settings_path(backup_root))
-    effective = load_settings(backup_root)
+    loaded = {
+        "autoswitch": load_settings(backup_root),
+        "ui": load_ui_settings(backup_root),
+    }
     rows = []
     for spec in SETTING_SPECS.values():
         section = raw.get(spec.section)
         is_set = isinstance(section, dict) and spec.json_key in section
-        rows.append((spec, getattr(effective, spec.field), is_set))
+        rows.append((spec, getattr(loaded[spec.section], spec.field), is_set))
     return rows
 
 

--- a/src/claude_swap/tui/__init__.py
+++ b/src/claude_swap/tui/__init__.py
@@ -20,8 +20,24 @@ def run(switcher: "ClaudeAccountSwitcher", start: str = "dashboard") -> int:
     ``start="watch"`` (the ``cswap watch`` command) opens directly on the
     live watch page, stacked over the dashboard.
     """
+    from claude_swap.appearance import detect_terminal_background, drain_stdin
     from claude_swap.tui.app import CswapApp
 
-    app = CswapApp(switcher, start=start)
+    # Sense the terminal background while we still own stdin in cooked mode
+    # (Textual's driver starts inside app.run()). Always detect so cycling to
+    # 'auto' works even when the initial theme is explicit. Both calls are
+    # meant to fail safe on their own, but they're wrapped here too: a
+    # detection bug must never crash the TUI launch.
+    try:
+        detected = detect_terminal_background()
+    except Exception:
+        detected = None
+    app = CswapApp(switcher, start=start, detected=detected)
+    # Drain any late OSC reply immediately before Textual's driver starts,
+    # so it isn't reissued as keystrokes once the app takes over the terminal.
+    try:
+        drain_stdin()
+    except Exception:
+        pass
     app.run()
     return app.return_code or 0

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -11,17 +11,19 @@ from __future__ import annotations
 from functools import partial
 
 from textual.app import App
+from textual.binding import Binding
 from textual.reactive import reactive
 from textual.worker import WorkerState
 
+from claude_swap import printer
 from claude_swap.models import AccountsSnapshot
-from claude_swap.settings import load_settings
+from claude_swap.settings import load_settings, load_ui_settings, set_setting
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui.autoview import AutoScreen
 from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
 from claude_swap.tui.data import ActionResult, SnapshotSource, run_action
 from claude_swap.tui.modals import AddTokenModal, ConfirmModal, OutputModal, TokenForm
-from claude_swap.tui.theme import CSWAP_DARK
+from claude_swap.tui.theme import CSWAP_DARK, CSWAP_LIGHT
 
 
 class CswapApp(App):
@@ -30,9 +32,9 @@ class CswapApp(App):
     TITLE = "claude-swap"
     CSS_PATH = "cswap.tcss"
     # No command palette: actions live in the dashboard's nested menu, in
-    # their own context — not in a global searchable list. This also drops
-    # Textual's system commands (theme picker included; there is one theme).
+    # their own context — not in a global searchable list.
     ENABLE_COMMAND_PALETTE = False
+    BINDINGS = [Binding("ctrl+t", "toggle_theme", "Theme")]
 
     POLL_INTERVAL_S = 3.0  # matches the old watch view's recapture cadence
 
@@ -40,11 +42,16 @@ class CswapApp(App):
     busy: reactive[bool] = reactive(False)
 
     def __init__(
-        self, switcher: ClaudeAccountSwitcher, *, start: str = "dashboard"
+        self,
+        switcher: ClaudeAccountSwitcher,
+        *,
+        start: str = "dashboard",
+        detected: str | None = None,
     ) -> None:
         super().__init__()
         self.switcher = switcher
         self._start = start  # "dashboard" | "watch" (`cswap watch`)
+        self._detected = detected  # terminal background sensed pre-driver, or None
         self.source = SnapshotSource(switcher)
         self._store_only = False
         self._full_next = False
@@ -58,10 +65,18 @@ class CswapApp(App):
             ).threshold
         except Exception:
             self.threshold_pct = None
+        try:
+            self._theme_name = load_ui_settings(switcher.backup_dir).theme
+        except Exception:
+            self._theme_name = "auto"
 
     def on_mount(self) -> None:
         self.register_theme(CSWAP_DARK)
-        self.theme = "cswap-dark"
+        self.register_theme(CSWAP_LIGHT)
+        resolved = self._resolved_theme()
+        # We own the theme; $TEXTUAL_THEME is intentionally not honoured.
+        self.theme = f"cswap-{resolved}"
+        printer.set_theme(resolved)
         self.push_screen(DashboardScreen())
         if self._start == "watch":
             # Stacked over the dashboard so Esc lands there, not on exit.
@@ -288,3 +303,31 @@ class CswapApp(App):
         if isinstance(self.screen, WatchScreen):
             return
         self.push_screen(WatchScreen())
+
+    # -- theme --------------------------------------------------------------
+
+    def _resolved_theme(self) -> str:
+        """Concrete 'dark'/'light' for the current setting; auto → detected → dark."""
+        if self._theme_name == "auto":
+            return self._detected or "dark"
+        return self._theme_name
+
+    def apply_theme(self, name: str) -> None:
+        """Switch the live theme: TUI + captured printer output + persistence.
+
+        ``name`` is the setting; ``auto`` resolves against the pre-driver
+        detection (never re-probes mid-session)."""
+        self._theme_name = name
+        resolved = self._resolved_theme()
+        self.theme = f"cswap-{resolved}"
+        printer.set_theme(resolved)
+        try:
+            set_setting(self.switcher.backup_dir, "ui.theme", name)
+        except Exception as exc:  # persistence is best-effort; never crash the UI
+            self.notify(f"Could not save theme: {exc}", severity="warning")
+
+    def action_toggle_theme(self) -> None:
+        order = ("dark", "light", "auto")
+        nxt = order[(order.index(self._theme_name) + 1) % len(order)]
+        self.apply_theme(nxt)
+        self.notify(f"Theme: {nxt}")

--- a/src/claude_swap/tui/autoview.py
+++ b/src/claude_swap/tui/autoview.py
@@ -34,35 +34,30 @@ from claude_swap.models import AccountsSnapshot
 from claude_swap.settings import SETTING_SPECS, load_settings, parse_model_names
 from claude_swap.tui import data
 from claude_swap.tui.modals import ConfirmModal
-from claude_swap.tui.theme import (
-    ACCENT,
-    FOREGROUND,
-    MUTED,
-    SEV_CRIT,
-    SEV_WARN,
-    severity_color,
-)
+from claude_swap.tui.theme import Palette
 from claude_swap.tui.widgets import AccountsPanel
 
 if TYPE_CHECKING:
     from claude_swap.tui.app import CswapApp
 
-_EVENT_STYLES = {
-    "switch": ACCENT,
-    "error": SEV_WARN,
-    "account-quarantined": SEV_WARN,
-    "all-exhausted": SEV_CRIT,
+_EVENT_ROLES = {
+    "switch": "accent",
+    "error": "sev_warn",
+    "account-quarantined": "sev_warn",
+    "all-exhausted": "sev_crit",
 }
 _QUIET_KINDS = {"poll", "no-switch", "sleep", "account-unquarantined"}
 
 
-def event_text(event: AutoSwitchEvent) -> Text:
+def event_text(event: AutoSwitchEvent, *, palette: Palette = Palette.DARK) -> Text:
     """Log line for one engine event, styled like the CLI's human renderer."""
-    style = _EVENT_STYLES.get(event.kind)
-    if style is None:
-        style = MUTED if event.kind in _QUIET_KINDS else FOREGROUND
+    role = _EVENT_ROLES.get(event.kind)
+    if role is not None:
+        style = getattr(palette, role)
+    else:
+        style = palette.muted if event.kind in _QUIET_KINDS else palette.foreground
     text = Text()
-    text.append(f"{data.clock_stamp()}  ", style=MUTED)
+    text.append(f"{data.clock_stamp()}  ", style=palette.muted)
     text.append(event.human(), style=style)
     return text
 
@@ -115,6 +110,7 @@ class AutoScreen(Screen):
         self.app.threshold_pct = self._settings.threshold
         self._update_summary()
         self.watch(self.app, "snapshot", self._on_snapshot)
+        self.watch(self.app, "theme", self._on_theme_change)
         self._start_engine(dry_run=True)
 
     def on_unmount(self) -> None:
@@ -126,6 +122,13 @@ class AutoScreen(Screen):
         if self._configured_threshold is not None:
             self.app.threshold_pct = self._configured_threshold
         self.app.set_store_only(False)
+
+    def _on_theme_change(self, _theme: str) -> None:
+        self._update_summary()
+        self._update_badge()
+        snap = self.app.snapshot
+        if snap is not None:
+            self._on_snapshot(snap)
 
     def action_back(self) -> None:
         if self._adjusting:
@@ -172,7 +175,7 @@ class AutoScreen(Screen):
             Text(
                 f"— threshold set to {pct_label(self._settings.threshold)}% "
                 "for this session —",
-                style=MUTED,
+                style=Palette.from_theme(self.app.current_theme).muted,
             )
         )
 
@@ -187,17 +190,18 @@ class AutoScreen(Screen):
         self._update_summary()
 
     def _update_summary(self) -> None:
+        palette = Palette.from_theme(self.app.current_theme)
         text = Text()
         text.append("auto-switch · ")
         text.append(
             f"threshold {pct_label(self._settings.threshold)}%",
-            style=ACCENT if self._adjusting else "",
+            style=palette.accent if self._adjusting else "",
         )
         if self._settings.threshold != self._configured_threshold:
-            text.append(" (session)", style=MUTED)
+            text.append(" (session)", style=palette.muted)
         text.append(f" · poll every {self._settings.interval_seconds:.0f}s")
         if self._adjusting:
-            text.append("   ← → adjust · enter done", style=MUTED)
+            text.append("   ← → adjust · enter done", style=palette.muted)
         self.query_one("#auto-summary", Static).update(text)
 
     # -- engine -------------------------------------------------------------
@@ -220,7 +224,12 @@ class AutoScreen(Screen):
         self._update_badge()
         log = self.query_one("#event-log", RichLog)
         mode = "DRY-RUN (watching only)" if dry_run else "LIVE (will switch accounts)"
-        log.write(Text(f"— engine started: {mode} —", style=MUTED))
+        log.write(
+            Text(
+                f"— engine started: {mode} —",
+                style=Palette.from_theme(self.app.current_theme).muted,
+            )
+        )
 
     def _emit_from_thread(self, event: AutoSwitchEvent) -> None:
         """Engine ``on_event`` callback — runs on the worker thread."""
@@ -233,7 +242,8 @@ class AutoScreen(Screen):
     def _on_engine_event(self, event: AutoSwitchEvent) -> None:
         if not self.is_attached:
             return
-        self.query_one("#event-log", RichLog).write(event_text(event))
+        palette = Palette.from_theme(self.app.current_theme)
+        self.query_one("#event-log", RichLog).write(event_text(event, palette=palette))
         if event.kind == "switch":
             self.app.request_refresh()
 
@@ -287,6 +297,7 @@ class AutoScreen(Screen):
         """Switch targets ranked by remaining headroom (best first)."""
         # Same window set as the engine (autoswitch.model included), so the
         # displayed ranking can never disagree with the account it picks.
+        palette = Palette.from_theme(self.app.current_theme)
         models = parse_model_names(self._settings.model) if self._settings else ()
         ranked: list[tuple[float, str]] = []  # (sort key: pct used, number)
         lines: dict[str, Text] = {}
@@ -295,25 +306,25 @@ class AutoScreen(Screen):
                 continue
             pct = binding_pct(acc.usage.last_good, models)
             entry = Text()
-            entry.append(f"\n  {acc.number:>2}  ", style=FOREGROUND)
-            entry.append(acc.email, style=FOREGROUND)
+            entry.append(f"\n  {acc.number:>2}  ", style=palette.foreground)
+            entry.append(acc.email, style=palette.foreground)
             if acc.usage.sentinel is not None:
                 entry.append(
-                    f"  {data.sentinel_label(acc.usage.sentinel)}", style=MUTED
+                    f"  {data.sentinel_label(acc.usage.sentinel)}", style=palette.muted
                 )
                 ranked.append((998.0, acc.number))
             elif pct is None:
-                entry.append("  usage unknown", style=MUTED)
+                entry.append("  usage unknown", style=palette.muted)
                 ranked.append((999.0, acc.number))
             else:
-                entry.append(f"  {pct:3.0f}% used", style=severity_color(pct))
+                entry.append(f"  {pct:3.0f}% used", style=palette.severity(pct))
                 ranked.append((pct, acc.number))
             lines[acc.number] = entry
 
         text = Text()
-        text.append("Next best", style=MUTED)
+        text.append("Next best", style=palette.muted)
         if not ranked:
-            text.append("\n  no other switchable accounts", style=MUTED)
+            text.append("\n  no other switchable accounts", style=palette.muted)
             return text
         for _pct, number in sorted(ranked):
             text.append(lines[number])

--- a/src/claude_swap/tui/cswap.tcss
+++ b/src/claude_swap/tui/cswap.tcss
@@ -64,6 +64,9 @@ Screen {
     background: $panel;
 }
 
+MenuItem Static { color: $foreground; }
+MenuItem Static.menu-item-muted { color: $secondary; }
+
 /* -- switch / watch screens --------------------------------------------------- */
 
 #list-title {

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -80,6 +80,7 @@ class DashboardScreen(Screen):
             ("Add account…", "add-menu"),
             ("Disable / enable account…", "disable-menu"),
             ("Remove account…", "remove-menu"),
+            ("Theme…", "theme-menu"),
             ("Quit", "quit"),
         ]
 
@@ -115,6 +116,16 @@ class DashboardScreen(Screen):
             entries.append(
                 (f"{acc.number}  {name}{state}   {action}", f"disable:{acc.number}")
             )
+        entries.append(_BACK)
+        return entries
+
+    def _theme_entries(self) -> MenuEntries:
+        """dark / light / auto, with the active setting marked."""
+        current = self.app._theme_name
+        entries: MenuEntries = [
+            (f"{'●' if name == current else ' '} {name}", f"theme:{name}")
+            for name in ("dark", "light", "auto")
+        ]
         entries.append(_BACK)
         return entries
 
@@ -168,6 +179,13 @@ class DashboardScreen(Screen):
                 "?",
             )
             app.confirm_remove(number, email)
+        elif action_id == "theme-menu":
+            await self._push_menu("theme", self._theme_entries())
+        elif action_id.startswith("theme:"):
+            name = action_id.split(":", 1)[1]
+            app.apply_theme(name)
+            app.notify(f"Theme: {name}")
+            await self._pop_menu()
         elif action_id == "disable-menu":
             await self._push_menu("disable / enable", self._disable_entries())
         elif action_id.startswith("disable:"):

--- a/src/claude_swap/tui/theme.py
+++ b/src/claude_swap/tui/theme.py
@@ -10,11 +10,14 @@ palette.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import ClassVar
+
 from textual.theme import Theme
 
 # Core palette (single source of truth — widgets import these for rich
 # renderables, the Theme below maps them onto Textual's design tokens).
-ACCENT = "#d7875f"  # warm terracotta, xterm 173 — matches printer._ACCENT
+ACCENT = "#d7875f"  # warm terracotta (xterm 173)
 FOREGROUND = "#e8e4de"  # soft, slightly warm off-white
 MUTED = "#8a8a8a"  # secondary text
 BACKGROUND = "#141414"
@@ -33,15 +36,46 @@ WARN_PCT = 70.0
 CRIT_PCT = 90.0
 
 
-def severity_color(pct: float | None) -> str:
-    """Bar/percentage color for a utilization percentage."""
-    if pct is None:
-        return MUTED
-    if pct >= CRIT_PCT:
-        return SEV_CRIT
-    if pct >= WARN_PCT:
-        return SEV_WARN
-    return SEV_OK
+@dataclass(frozen=True)
+class Palette:
+    """Resolved colors for Rich renderables, keyed to a Textual theme.
+
+    Rich renderables bake color into styles at render time, so they can't read
+    Textual's ``$variables`` the way the .tcss layer does. A Palette carries the
+    active theme's colors so the same render code paints correctly in either
+    theme. Resolve from the Theme object (never App.theme_variables, which lags
+    the deferred CSS refresh)."""
+
+    accent: str
+    foreground: str
+    muted: str
+    sev_ok: str
+    sev_warn: str
+    sev_crit: str
+    track: str
+
+    DARK: ClassVar["Palette"]
+
+    def severity(self, pct: float | None) -> str:
+        if pct is None:
+            return self.muted
+        if pct >= CRIT_PCT:
+            return self.sev_crit
+        if pct >= WARN_PCT:
+            return self.sev_warn
+        return self.sev_ok
+
+    @classmethod
+    def from_theme(cls, theme: Theme) -> "Palette":
+        return cls(
+            accent=theme.primary,
+            foreground=theme.foreground,
+            muted=theme.secondary,
+            sev_ok=theme.success,
+            sev_warn=theme.warning,
+            sev_crit=theme.error,
+            track=theme.variables.get("track", TRACK),
+        )
 
 
 CSWAP_DARK = Theme(
@@ -63,5 +97,45 @@ CSWAP_DARK = Theme(
         "block-cursor-background": PANEL,
         "block-cursor-foreground": FOREGROUND,
         "block-cursor-text-style": "none",
+        "track": TRACK,
     },
+)
+
+# Light companion palette (same intent, tuned for a warm near-white base).
+ACCENT_LIGHT = "#954c2a"  # burnt sienna — deepened for AA on panel (worst-case row bg)
+FOREGROUND_LIGHT = "#2b2723"
+MUTED_LIGHT = "#635d55"
+BACKGROUND_LIGHT = "#faf7f2"
+SURFACE_LIGHT = "#efeae1"
+PANEL_LIGHT = "#e2dbcf"  # most-elevated = darkest (inverted from dark)
+SEV_OK_LIGHT = "#3d6b3d"  # forest green — deepened for AA on panel
+SEV_WARN_LIGHT = "#795911"  # deep ochre — deepened for AA on panel
+SEV_CRIT_LIGHT = "#ad3128"  # brick red — deepened for AA on panel
+TRACK_LIGHT = "#cec7ba"
+
+CSWAP_LIGHT = Theme(
+    name="cswap-light",
+    primary=ACCENT_LIGHT,
+    secondary=MUTED_LIGHT,
+    accent=ACCENT_LIGHT,
+    foreground=FOREGROUND_LIGHT,
+    background=BACKGROUND_LIGHT,
+    surface=SURFACE_LIGHT,
+    panel=PANEL_LIGHT,
+    success=SEV_OK_LIGHT,
+    warning=SEV_WARN_LIGHT,
+    error=SEV_CRIT_LIGHT,
+    dark=False,
+    variables={
+        "footer-key-foreground": ACCENT_LIGHT,
+        "block-cursor-background": PANEL_LIGHT,
+        "block-cursor-foreground": FOREGROUND_LIGHT,
+        "block-cursor-text-style": "none",
+        "track": TRACK_LIGHT,
+    },
+)
+
+Palette.DARK = Palette(
+    accent=ACCENT, foreground=FOREGROUND, muted=MUTED,
+    sev_ok=SEV_OK, sev_warn=SEV_WARN, sev_crit=SEV_CRIT, track=TRACK,
 )

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -19,15 +19,7 @@ from claude_swap.json_output import USAGE_API_KEY
 from claude_swap.models import AccountSnapshot
 from claude_swap.usage_store import STALE_OK_S
 from claude_swap.tui import data
-from claude_swap.tui.theme import (
-    ACCENT,
-    FOREGROUND,
-    MUTED,
-    SEV_CRIT,
-    SEV_WARN,
-    TRACK,
-    severity_color,
-)
+from claude_swap.tui.theme import Palette
 
 if TYPE_CHECKING:
     from claude_swap.tui.app import CswapApp
@@ -44,11 +36,12 @@ def bar_cells(
     *,
     stale: bool = False,
     threshold: float | None = None,
+    palette: Palette = Palette.DARK,
 ) -> Text:
     """Just the bar glyphs: severity-colored fill, track, optional tick."""
     text = Text()
     if pct is None:
-        text.append(_BAR_EMPTY * width, style=TRACK)
+        text.append(_BAR_EMPTY * width, style=palette.track)
         return text
     frac = min(max(pct, 0.0), 100.0) / 100.0
     cells = frac * width
@@ -57,17 +50,17 @@ def bar_cells(
     tick_at: int | None = None
     if threshold is not None:
         tick_at = min(width - 1, max(0, round(threshold / 100.0 * width)))
-    color = severity_color(pct)
+    color = palette.severity(pct)
     fill_style = f"{color} dim" if stale else color
     for i in range(width):
         if tick_at is not None and i == tick_at:
-            text.append(_BAR_TICK, style=SEV_WARN)
+            text.append(_BAR_TICK, style=palette.sev_warn)
         elif i < full:
             text.append(_BAR_FILLED, style=fill_style)
         elif i == full and half:
             text.append(_BAR_HALF, style=fill_style)
         else:
-            text.append(_BAR_EMPTY, style=TRACK)
+            text.append(_BAR_EMPTY, style=palette.track)
     return text
 
 
@@ -79,18 +72,19 @@ def usage_bar(
     *,
     stale: bool = False,
     threshold: float | None = None,
+    palette: Palette = Palette.DARK,
 ) -> Text:
     """One full bar line: ``5h ━━━━╸────┃──  47%  resets 2h 13m · 20:39``."""
     text = Text()
-    text.append(f"{label} ", style=MUTED)
-    text.append(bar_cells(pct, width, stale=stale, threshold=threshold))
+    text.append(f"{label} ", style=palette.muted)
+    text.append(bar_cells(pct, width, stale=stale, threshold=threshold, palette=palette))
     if pct is None:
-        text.append("  usage unknown", style=MUTED)
+        text.append("  usage unknown", style=palette.muted)
     else:
-        color = severity_color(pct)
+        color = palette.severity(pct)
         text.append(f" {pct:3.0f}%", style=f"{color} dim" if stale else color)
     if suffix:
-        text.append(f"  {suffix}", style=MUTED)
+        text.append(f"  {suffix}", style=palette.muted)
     return text
 
 
@@ -171,30 +165,31 @@ def account_card_text(
     *,
     threshold: float | None = None,
     now: float | None = None,
+    palette: Palette = Palette.DARK,
 ) -> Text:
     """The full account card: header line + per-window bar rows."""
     now = now if now is not None else time.time()
 
     text = Text()
-    text.append(f"{acc.number:>2}  ", style=f"bold {FOREGROUND}")
+    text.append(f"{acc.number:>2}  ", style=f"bold {palette.foreground}")
     if acc.alias:
-        text.append(acc.alias, style=f"bold {ACCENT}")
-        text.append(f" ({acc.email})", style=FOREGROUND)
+        text.append(acc.alias, style=f"bold {palette.accent}")
+        text.append(f" ({acc.email})", style=palette.foreground)
     else:
-        text.append(acc.email, style=FOREGROUND)
-    text.append(f"  [{acc.display_tag}]", style=MUTED)
+        text.append(acc.email, style=palette.foreground)
+    text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.is_active:
-        text.append("   ● active", style=f"bold {ACCENT}")
+        text.append("   ● active", style=f"bold {palette.accent}")
     if acc.disabled:
-        text.append("   (disabled)", style=MUTED)
+        text.append("   (disabled)", style=palette.muted)
     age = data.format_age(acc.usage.age_s)
     if age:
-        text.append(f"   {age}", style=MUTED)
+        text.append(f"   {age}", style=palette.muted)
 
     sentinel = acc.usage.sentinel
     if sentinel is not None:
         text.append("\n    ")
-        style = MUTED if sentinel == USAGE_API_KEY else SEV_WARN
+        style = palette.muted if sentinel == USAGE_API_KEY else palette.sev_warn
         marker = "·" if sentinel == USAGE_API_KEY else "⚠"
         text.append(f"{marker} {data.sentinel_label(sentinel)}", style=style)
         # Same supplementary line `cswap list` prints: the last good
@@ -204,15 +199,15 @@ def account_card_text(
             last_seen = data.last_seen_note(acc.usage)
             if last_seen is not None:
                 text.append("\n    ")
-                text.append(f"└ {last_seen}", style=MUTED)
+                text.append(f"└ {last_seen}", style=palette.muted)
         return text
 
     rows = usage_rows(acc.usage.last_good, now, acc.usage.fetched_at)
     if not rows:
         text.append("\n    ")
-        text.append("usage unavailable", style=MUTED)
+        text.append("usage unavailable", style=palette.muted)
         if acc.usage.last_error:
-            text.append(f" · {acc.usage.last_error}", style=MUTED)
+            text.append(f" · {acc.usage.last_error}", style=palette.muted)
         return text
 
     stale = acc.usage.age_s is not None and acc.usage.age_s > STALE_OK_S
@@ -234,12 +229,15 @@ def account_card_text(
                 bar_width,
                 stale=stale,
                 threshold=threshold,
+                palette=palette,
             )
         )
     return text
 
 
-def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
+def mini_account_text(
+    acc: AccountSnapshot, now: float, *, palette: Palette = Palette.DARK
+) -> Text:
     """One minimized line for an inactive account.
 
     ``2  work@acme.dev [personal]   5h 92% · 7d 63%`` — pcts only, severity
@@ -248,20 +246,20 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
     their label instead.
     """
     text = Text(no_wrap=True, overflow="ellipsis")
-    text.append(f"{acc.number:>2}  ", style=f"bold {MUTED}")
+    text.append(f"{acc.number:>2}  ", style=f"bold {palette.muted}")
     if acc.alias:
-        text.append(acc.alias, style=f"bold {ACCENT}")
-        text.append(f" ({acc.email})", style=FOREGROUND)
+        text.append(acc.alias, style=f"bold {palette.accent}")
+        text.append(f" ({acc.email})", style=palette.foreground)
     else:
-        text.append(acc.email, style=FOREGROUND)
-    text.append(f"  [{acc.display_tag}]", style=MUTED)
+        text.append(acc.email, style=palette.foreground)
+    text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.disabled:
-        text.append("  (disabled)", style=MUTED)
+        text.append("  (disabled)", style=palette.muted)
     text.append("   ")
 
     sentinel = acc.usage.sentinel
     if sentinel is not None:
-        style = MUTED if sentinel == USAGE_API_KEY else SEV_WARN
+        style = palette.muted if sentinel == USAGE_API_KEY else palette.sev_warn
         text.append(data.sentinel_label(sentinel), style=style)
         return text
 
@@ -275,18 +273,18 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
             continue
         pct = float(window["pct"])
         if parts:
-            text.append(" · ", style=TRACK)
-        color = severity_color(pct)
-        text.append(f"{label} ", style=MUTED)
+            text.append(" · ", style=palette.track)
+        color = palette.severity(pct)
+        text.append(f"{label} ", style=palette.muted)
         text.append(f"{pct:.0f}%", style=f"{color} dim" if stale else color)
         if pct >= 100:
             reset = data.reset_text(window, now)
             if reset:
-                text.append(f" ({reset})", style=MUTED)
+                text.append(f" ({reset})", style=palette.muted)
         elif key == "seven_day":
             result = pace.compute_pace(window, fetched_at=fetched_at)
             if result and result.ahead:
-                text.append(" (ahead)", style=SEV_WARN)
+                text.append(" (ahead)", style=palette.sev_warn)
         parts += 1
     maxed = [
         w["name"]
@@ -295,11 +293,11 @@ def mini_account_text(acc: AccountSnapshot, now: float) -> Text:
     ]
     for name in maxed:
         if parts:
-            text.append(" · ", style=TRACK)
-        text.append(f"{name} (!)", style=SEV_CRIT)
+            text.append(" · ", style=palette.track)
+        text.append(f"{name} (!)", style=palette.sev_crit)
         parts += 1
     if not parts:
-        text.append("usage unknown", style=MUTED)
+        text.append("usage unknown", style=palette.muted)
     return text
 
 
@@ -314,18 +312,20 @@ class AccountsPanel(Static):
 
     def on_mount(self) -> None:
         self.watch(self.app, "snapshot", lambda _snap: self.refresh(layout=True))
+        self.watch(self.app, "theme", lambda _t: self.refresh(layout=True))
 
     def render(self) -> Text:
         app: "CswapApp" = self.app  # type: ignore[assignment]
+        palette = Palette.from_theme(app.current_theme)
         snap = app.snapshot
         if snap is None:
-            return Text("loading…", style=MUTED)
+            return Text("loading…", style=palette.muted)
         if not snap.accounts:
             return Text(
                 "No managed accounts yet.\n"
                 "Use the menu below: Add account — from your current "
                 "Claude Code login, or from a setup-token / API key.",
-                style=MUTED,
+                style=palette.muted,
             )
         now = time.time()
         width = (self.size.width or 80) - 2
@@ -334,13 +334,14 @@ class AccountsPanel(Static):
             if acc.is_active:
                 blocks.append(
                     account_card_text(
-                        acc, width, threshold=app.threshold_pct, now=now
+                        acc, width, threshold=app.threshold_pct, now=now,
+                        palette=palette,
                     )
                 )
             elif self._show_minis:
-                blocks.append(mini_account_text(acc, now))
+                blocks.append(mini_account_text(acc, now, palette=palette))
         if not blocks:
-            return Text("no active managed login", style=MUTED)
+            return Text("no active managed login", style=palette.muted)
         text = Text()
         previous_multiline = False
         for i, block in enumerate(blocks):
@@ -367,7 +368,8 @@ class AccountCard(Static):
 
     def render(self) -> Text:
         return account_card_text(
-            self._acc, self.size.width or 80, threshold=self._threshold
+            self._acc, self.size.width or 80, threshold=self._threshold,
+            palette=Palette.from_theme(self.app.current_theme),
         )
 
 
@@ -389,6 +391,8 @@ class MenuItem(ListItem):
     """One menu row: a label plus an action id the screen dispatches on."""
 
     def __init__(self, label: str, action_id: str, *, muted: bool = False) -> None:
-        style = MUTED if muted else FOREGROUND
-        super().__init__(Static(Text(label, style=style)))
+        item = Static(label, markup=False)
+        if muted:
+            item.add_class("menu-item-muted")
+        super().__init__(item)
         self.action_id = action_id

--- a/tests/test_appearance.py
+++ b/tests/test_appearance.py
@@ -1,0 +1,201 @@
+"""Tests for terminal-background detection and theme resolution."""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from claude_swap import appearance
+
+
+@pytest.fixture(autouse=True)
+def _reset_detect_cache():
+    appearance._reset_cache()
+    yield
+    appearance._reset_cache()
+
+
+class TestParseOsc11:
+    def test_parses_16bit_rgb(self):
+        assert appearance._parse_osc11(b"\x1b]11;rgb:ffff/ffff/ffff\x07") == (1.0, 1.0, 1.0)
+
+    def test_parses_8bit_rgb(self):
+        r, g, b = appearance._parse_osc11(b"\x1b]11;rgb:00/00/00\x1b\\")
+        assert (r, g, b) == (0.0, 0.0, 0.0)
+
+    def test_parses_hex(self):
+        r, _, b = appearance._parse_osc11(b"\x1b]11;#ff8000\x07")
+        assert r == pytest.approx(1.0) and b == pytest.approx(0.0)
+
+    def test_junk_returns_none(self):
+        assert appearance._parse_osc11(b"garbage") is None
+
+    def test_unframed_rgb_is_rejected(self):
+        # A bare "rgb:..." with no OSC-11 frame must not be mistaken for a
+        # reply (e.g. echoed/interleaved input containing similar text).
+        assert appearance._parse_osc11(b"rgb:ffff/ffff/ffff") is None
+
+    def test_rgb_without_leading_esc_is_rejected(self):
+        # "]11;rgb:..." without the ESC that actually opens an OSC sequence
+        # must not be mistaken for a reply (e.g. echoed/interleaved input).
+        assert appearance._parse_osc11(b"]11;rgb:ffff/ffff/ffff\x07") is None
+
+    def test_framed_rgb_parses(self):
+        assert appearance._parse_osc11(b"\x1b]11;rgb:ffff/ffff/ffff\x07") == (1.0, 1.0, 1.0)
+
+    def test_unframed_hex_is_rejected(self):
+        assert appearance._parse_osc11(b"#ff8000") is None
+
+    def test_framed_hex_parses(self):
+        r, _, b = appearance._parse_osc11(b"\x1b]11;#ff8000\x07")
+        assert r == pytest.approx(1.0) and b == pytest.approx(0.0)
+
+
+class TestClassify:
+    def test_white_is_light(self):
+        assert appearance._classify(b"\x1b]11;rgb:ffff/ffff/ffff\x07") == "light"
+
+    def test_black_is_dark(self):
+        assert appearance._classify(b"\x1b]11;rgb:0000/0000/0000\x07") == "dark"
+
+    def test_near_boundary_grey_cutoff_is_pinned(self):
+        # 0x8080 ≈ 0.502 luminance → just over the 0.5 cutoff → light.
+        assert appearance._classify(b"\x1b]11;rgb:8080/8080/8080\x07") == "light"
+        # 0x7f7f ≈ 0.498 → dark.
+        assert appearance._classify(b"\x1b]11;rgb:7f7f/7f7f/7f7f\x07") == "dark"
+
+    def test_unparseable_returns_none(self):
+        assert appearance._classify(b"nope") is None
+
+
+class TestResolveTheme:
+    def test_dark_passes_through_without_detecting(self):
+        def _boom():
+            raise AssertionError("detect must not be called for explicit theme")
+        assert appearance.resolve_theme("dark", detect=_boom) == "dark"
+        assert appearance.resolve_theme("light", detect=_boom) == "light"
+
+    def test_auto_follows_detection(self):
+        assert appearance.resolve_theme("auto", detect=lambda: "light") == "light"
+        assert appearance.resolve_theme("auto", detect=lambda: "dark") == "dark"
+
+    def test_auto_none_falls_back_to_dark(self):
+        assert appearance.resolve_theme("auto", detect=lambda: None) == "dark"
+
+
+class TestDetectGuards:
+    def test_non_tty_returns_none(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+        assert appearance.detect_terminal_background() is None
+
+    def test_result_is_cached(self, monkeypatch):
+        calls = {"n": 0}
+        def _fake_query():
+            calls["n"] += 1
+            return b"\x1b]11;rgb:ffff/ffff/ffff\x07"
+        monkeypatch.setattr(appearance, "_query_terminal_background", _fake_query)
+        assert appearance.detect_terminal_background() == "light"
+        assert appearance.detect_terminal_background() == "light"
+        assert calls["n"] == 1  # queried once, cached thereafter
+
+    def test_none_result_is_cached(self, monkeypatch):
+        calls = {"n": 0}
+        def _fake_query():
+            calls["n"] += 1
+            return None
+        monkeypatch.setattr(appearance, "_query_terminal_background", _fake_query)
+        assert appearance.detect_terminal_background() is None
+        assert appearance.detect_terminal_background() is None
+        assert calls["n"] == 1  # queried once, cached thereafter
+
+    def test_fileno_unsupported_operation_does_not_raise(self, monkeypatch):
+        import io
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+
+        def _boom():
+            raise io.UnsupportedOperation("fileno")
+        monkeypatch.setattr(sys.stdin, "fileno", _boom, raising=False)
+
+        assert appearance.detect_terminal_background() is None
+
+    def test_termios_error_during_setcbreak_does_not_raise(self, monkeypatch):
+        termios = pytest.importorskip("termios")
+        import tty
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(sys.stdin, "fileno", lambda: 0, raising=False)
+        monkeypatch.setattr(termios, "tcgetattr", lambda fd: [], raising=False)
+        monkeypatch.setattr(termios, "tcsetattr", lambda fd, when, attrs: None, raising=False)
+
+        def _boom(fd, when=None):
+            raise termios.error("device not configured")
+        monkeypatch.setattr(tty, "setcbreak", _boom)
+
+        assert appearance.detect_terminal_background() is None
+
+    def test_isatty_raising_does_not_raise(self, monkeypatch):
+        # isatty() can raise ValueError on a closed stream.
+        def _boom():
+            raise ValueError("I/O operation on closed file")
+        monkeypatch.setattr(sys.stdin, "isatty", _boom, raising=False)
+
+        assert appearance.detect_terminal_background() is None
+
+
+class TestDrainStdin:
+    def test_isatty_raising_does_not_raise(self, monkeypatch):
+        def _boom():
+            raise ValueError("I/O operation on closed file")
+        monkeypatch.setattr(sys.stdin, "isatty", _boom, raising=False)
+
+        appearance.drain_stdin()  # must not raise
+
+
+class TestCliThemeResolution:
+    def test_resolve_skips_detection_when_colors_disabled(self, monkeypatch):
+        # When colors are off, auto must resolve to dark WITHOUT probing.
+        def _boom():
+            raise AssertionError("must not probe when colors are off")
+        # resolve_theme itself doesn't gate — the caller does. This asserts the
+        # gating helper the CLI uses:
+        assert appearance.cli_theme("auto", detect=_boom, colors=False) == "dark"
+
+    def test_resolve_probes_when_colors_enabled(self):
+        assert appearance.cli_theme("auto", detect=lambda: "light", colors=True) == "light"
+
+    def test_explicit_never_probes(self):
+        def _boom():
+            raise AssertionError("explicit theme must not probe")
+        assert appearance.cli_theme("light", detect=_boom, colors=True) == "light"
+
+
+class TestCliShouldProbe:
+    def test_run_subcommand_never_probes(self):
+        # `run` execs a child that takes over the terminal.
+        assert appearance.cli_should_probe(["run", "2"], colors_enabled=True) is False
+
+    def test_json_flag_never_probes(self):
+        # --json must stay machine-readable; the OSC query can't precede it.
+        assert appearance.cli_should_probe(["list", "--json"], colors_enabled=True) is False
+
+    def test_colors_disabled_never_probes(self):
+        assert appearance.cli_should_probe(["list"], colors_enabled=False) is False
+
+    def test_plain_command_with_colors_probes(self):
+        assert appearance.cli_should_probe(["list"], colors_enabled=True) is True
+
+
+def test_query_short_circuits_under_tmux(monkeypatch):
+    """Inside tmux the OSC 11 probe is skipped (never waits out the timeout)."""
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1,0")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+
+    def _boom():
+        raise AssertionError("must not probe the tty under tmux")
+
+    monkeypatch.setattr(sys.stdin, "fileno", _boom, raising=False)
+    assert appearance._query_terminal_background() is None

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,9 +48,10 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 8
+        assert out.count("(default)") == 9
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -77,7 +78,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 8
+        assert len(by_key) == 9
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -14,8 +14,10 @@ from claude_swap import printer
 def _reset_color_cache():
     """Reset the color detection cache before each test."""
     printer._colors_enabled = None
+    printer._theme = "dark"
     yield
     printer._colors_enabled = None
+    printer._theme = "dark"
 
 
 class TestColorDetection:
@@ -107,6 +109,34 @@ class TestStyling:
         assert "\033[1m" in result
         assert "\033[38;5;173m" in result
         assert "(active)" in result
+
+
+class TestThemePalette:
+    """Tests for set_theme and the per-theme color palette."""
+
+    def test_light_theme_changes_accent(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        printer._colors_enabled = None
+        printer.set_theme("light")
+        assert "38;2;149;76;42" in printer.accent("x")   # #954c2a
+        printer.set_theme("dark")
+        assert "38;5;173" in printer.accent("x")
+
+    def test_light_theme_error_uses_light_red(self, monkeypatch, capsys):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        printer._colors_enabled = None
+        printer.set_theme("light")
+        printer.error("boom")
+        assert "38;2;173;49;40" in capsys.readouterr().err   # #ad3128
+
+    def test_unknown_theme_falls_back_to_dark(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        printer._colors_enabled = None
+        printer.set_theme("bogus")
+        assert "38;5;173" in printer.accent("x")
 
 
 class TestLinePrinters:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,8 +14,10 @@ from claude_swap.exceptions import ConfigError
 from claude_swap.settings import (
     SETTING_SPECS,
     AutoSwitchSettings,
+    UiSettings,
     effective_settings,
     load_settings,
+    load_ui_settings,
     merged_with_cli,
     save_settings,
     set_setting,
@@ -110,18 +112,50 @@ class TestSaveSettings:
         assert mode == 0o600
 
 
+class TestUiSettings:
+    def test_missing_file_defaults_to_auto(self, tmp_path: Path):
+        assert load_ui_settings(tmp_path) == UiSettings(theme="auto")
+
+    def test_reads_auto(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(json.dumps({"ui": {"theme": "auto"}}))
+        assert load_ui_settings(tmp_path).theme == "auto"
+
+    def test_reads_light(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(json.dumps({"ui": {"theme": "light"}}))
+        assert load_ui_settings(tmp_path).theme == "light"
+
+    def test_unknown_theme_clamps_to_default(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(json.dumps({"ui": {"theme": "purple"}}))
+        assert load_ui_settings(tmp_path).theme == "auto"
+
+    def test_set_and_unset_ui_theme(self, tmp_path: Path):
+        assert set_setting(tmp_path, "ui.theme", "light") == "light"
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert raw == {"schemaVersion": 1, "ui": {"theme": "light"}}
+        assert unset_setting(tmp_path, "ui.theme") is True
+        assert "ui" not in json.loads(settings_path(tmp_path).read_text())
+
+    def test_set_rejects_bad_choice(self, tmp_path: Path):
+        with pytest.raises(ConfigError, match="dark, light"):
+            set_setting(tmp_path, "ui.theme", "purple")
+
+
 class TestSettingSpecs:
     def test_registry_covers_every_dataclass_field(self):
-        spec_fields = {spec.field for spec in SETTING_SPECS.values()}
-        dataclass_fields = {
+        by_section: dict[str, set[str]] = {}
+        for spec in SETTING_SPECS.values():
+            by_section.setdefault(spec.section, set()).add(spec.field)
+        assert by_section["autoswitch"] == {
             f.name for f in AutoSwitchSettings.__dataclass_fields__.values()
         }
-        assert spec_fields == dataclass_fields
+        assert by_section["ui"] == {
+            f.name for f in UiSettings.__dataclass_fields__.values()
+        }
 
     def test_defaults_match_dataclass(self):
-        defaults = AutoSwitchSettings()
+        sources = {"autoswitch": AutoSwitchSettings(), "ui": UiSettings()}
         for spec in SETTING_SPECS.values():
-            assert spec.default == getattr(defaults, spec.field)
+            assert spec.default == getattr(sources[spec.section], spec.field)
 
 
 class TestSetUnsetSetting:

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,67 @@
+"""Tests for the Palette value object and the light/dark themes."""
+from __future__ import annotations
+
+from claude_swap.tui import theme
+from claude_swap.tui.theme import CSWAP_DARK, CSWAP_LIGHT, Palette
+
+
+def test_dark_palette_matches_constants():
+    p = Palette.DARK
+    assert (p.accent, p.foreground, p.muted, p.sev_ok, p.sev_warn, p.sev_crit, p.track) == (
+        theme.ACCENT,
+        theme.FOREGROUND,
+        theme.MUTED,
+        theme.SEV_OK,
+        theme.SEV_WARN,
+        theme.SEV_CRIT,
+        theme.TRACK,
+    )
+
+
+def test_from_theme_reads_theme_object_including_track():
+    p = Palette.from_theme(CSWAP_LIGHT)
+    assert p.accent == theme.ACCENT_LIGHT
+    assert p.sev_crit == theme.SEV_CRIT_LIGHT
+    assert p.track == theme.TRACK_LIGHT  # from Theme.variables["track"], not app cache
+
+
+def test_severity_ramp_and_none():
+    p = Palette.DARK
+    assert p.severity(None) == p.muted
+    assert p.severity(95.0) == p.sev_crit
+    assert p.severity(75.0) == p.sev_warn
+    assert p.severity(10.0) == p.sev_ok
+
+
+def test_both_themes_expose_track_variable():
+    assert CSWAP_DARK.variables["track"] == theme.TRACK
+    assert CSWAP_LIGHT.variables["track"] == theme.TRACK_LIGHT
+    assert CSWAP_LIGHT.dark is False
+
+
+def _contrast(hex_a: str, hex_b: str) -> float:
+    def lum(h: str) -> float:
+        r, g, b = (int(h[i:i+2], 16) / 255 for i in (1, 3, 5))
+        f = lambda c: c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+        return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
+    la, lb = sorted((lum(hex_a), lum(hex_b)))
+    return (lb + 0.05) / (la + 0.05)
+
+
+def test_light_text_meets_AA_on_all_backgrounds():
+    # Accent and severity colors render as PERCENTAGE TEXT on highlighted
+    # ($surface) and flash ($panel) rows, not just the base background — so
+    # every text color must clear the 4.5:1 text bar against all three.
+    from claude_swap.tui import theme
+    text_colors = (
+        theme.FOREGROUND_LIGHT,
+        theme.MUTED_LIGHT,
+        theme.ACCENT_LIGHT,
+        theme.SEV_OK_LIGHT,
+        theme.SEV_WARN_LIGHT,
+        theme.SEV_CRIT_LIGHT,
+    )
+    backgrounds = (theme.BACKGROUND_LIGHT, theme.SURFACE_LIGHT, theme.PANEL_LIGHT)
+    for color in text_colors:
+        for bg in backgrounds:
+            assert _contrast(color, bg) >= 4.5, f"{color} on {bg}"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -9,6 +9,7 @@ flows) — no scraping, no real credentials, no network.
 from __future__ import annotations
 
 import dataclasses
+import json
 import sys
 import threading
 import time
@@ -282,6 +283,15 @@ class TestFormatting:
             80,
         ).plain
         assert "last seen" not in api_key
+
+    def test_account_card_uses_light_palette_when_passed(self):
+        from claude_swap.tui.theme import ACCENT_LIGHT, CSWAP_LIGHT, Palette
+        from claude_swap.tui.widgets import account_card_text
+
+        acc = make_account(1, active=True, entry=make_entry(pct5=95.0))
+        text = account_card_text(acc, 100, palette=Palette.from_theme(CSWAP_LIGHT))
+        styles = {str(span.style) for span in text.spans}
+        assert any(ACCENT_LIGHT in s for s in styles)  # active marker uses light accent
 
     def test_window_helpers(self):
         entry = make_entry(pct5=47.0)
@@ -655,6 +665,7 @@ class TestDashboard:
                 "add-menu",
                 "disable-menu",
                 "remove-menu",
+                "theme-menu",
                 "quit",
             ]
             # nest into Add (index 3), then back out with escape
@@ -692,6 +703,29 @@ class TestDashboard:
             assert any("dev (user1@example.com)" in label for label in labels)
             assert any("plain@example.com" in label for label in labels)
             assert not any("(plain@example.com)" in label for label in labels)
+
+    async def test_remove_menu_label_renders_bracket_tag_literally(self, tmp_path):
+        # The remove menu labels each account with `[{display_tag}]`, and an
+        # org name of "red" makes that literally "[red]" — a valid Rich
+        # color markup tag. MenuItem must render it as text, not consume it
+        # as styling (which would silently drop the tag from the label).
+        fake = FakeSwitcher(
+            [dataclasses.replace(make_account(1, active=True), org_name="red")],
+            tmp_path,
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 32)) as pilot:
+            await settle(pilot)
+            from textual.widgets import ListView, Static
+
+            from claude_swap.tui.widgets import MenuItem
+
+            await menu_select(pilot, "remove-menu")
+            menu = app.screen.query_one("#menu", ListView)
+            labels = [
+                item.query_one(Static).render().plain for item in menu.query(MenuItem)
+            ]
+            assert any("[red]" in label for label in labels)
 
     async def test_back_menu_entry_pops_submenu(self, tmp_path):
         fake = FakeSwitcher([make_account(1, active=True)], tmp_path)
@@ -1278,6 +1312,18 @@ class TestEventText:
 
         assert event.human() in event_text(event).plain
 
+    def test_event_text_uses_light_accent_for_switch(self):
+        from claude_swap.tui.autoview import event_text
+        from claude_swap.tui.theme import ACCENT_LIGHT, CSWAP_LIGHT, Palette
+
+        event = SwitchEvent(
+            trigger="proactive",
+            from_ref={"number": 1, "email": "a@x.com"},
+            to_ref={"number": 2, "email": "b@x.com"},
+        )
+        text = event_text(event, palette=Palette.from_theme(CSWAP_LIGHT))
+        assert any(ACCENT_LIGHT in str(s.style) for s in text.spans)
+
 
 # ---------------------------------------------------------------------------
 # accounts_snapshot on the real switcher
@@ -1361,3 +1407,75 @@ class TestBareInvocation:
             cli.main()
         assert excinfo.value.code == 0
         assert launched["start"] == "watch"
+
+
+# ---------------------------------------------------------------------------
+# Theme wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestThemeWiring:
+    async def test_mount_selects_light_theme_from_settings(self, tmp_path):
+        (tmp_path / "settings.json").write_text(json.dumps({"ui": {"theme": "light"}}))
+        fake = FakeSwitcher([make_account("1", active=True)], tmp_path)
+        app = make_app(fake)
+        async with app.run_test() as pilot:
+            await settle(pilot)
+            assert app.theme == "cswap-light"
+
+    async def test_auto_setting_uses_detected_light(self, tmp_path):
+        (tmp_path / "settings.json").write_text(json.dumps({"ui": {"theme": "auto"}}))
+        fake = FakeSwitcher([make_account("1", active=True)], tmp_path)
+        from claude_swap.tui.app import CswapApp
+        app = CswapApp(fake, detected="light")
+        async with app.run_test() as pilot:
+            await settle(pilot)
+            assert app.theme == "cswap-light"
+
+    async def test_auto_setting_no_detection_falls_back_to_dark(self, tmp_path):
+        (tmp_path / "settings.json").write_text(json.dumps({"ui": {"theme": "auto"}}))
+        fake = FakeSwitcher([make_account("1", active=True)], tmp_path)
+        from claude_swap.tui.app import CswapApp
+        app = CswapApp(fake, detected=None)
+        async with app.run_test() as pilot:
+            await settle(pilot)
+            assert app.theme == "cswap-dark"
+
+    async def test_toggle_cycles_dark_light_auto(self, tmp_path):
+        (tmp_path / "settings.json").write_text(json.dumps({"ui": {"theme": "dark"}}))
+        fake = FakeSwitcher([make_account("1", active=True)], tmp_path)
+        from claude_swap.tui.app import CswapApp
+        app = CswapApp(fake, detected="light")
+        async with app.run_test() as pilot:
+            await settle(pilot)
+            assert app.theme == "cswap-dark"          # setting dark
+            app.action_toggle_theme(); await pilot.pause()
+            assert app.theme == "cswap-light"          # → light
+            app.action_toggle_theme(); await pilot.pause()
+            assert app.theme == "cswap-light"          # → auto, detected=light
+            assert json.loads((tmp_path / "settings.json").read_text())["ui"]["theme"] == "auto"
+            app.action_toggle_theme(); await pilot.pause()
+            assert app.theme == "cswap-dark"           # → back to dark
+
+    async def test_theme_menu_marks_current_and_applies(self, tmp_path):
+        from textual.widgets import ListView, Static
+
+        from claude_swap.tui.widgets import MenuItem
+
+        fake = FakeSwitcher([make_account("1", active=True)], tmp_path)
+        app = make_app(fake)
+        async with app.run_test(size=(100, 32)) as pilot:
+            await settle(pilot)
+            assert app._theme_name == "auto"  # default
+            await menu_select(pilot, "theme-menu")
+            menu = app.screen.query_one("#menu", ListView)
+            labels = [it.query_one(Static).render().plain for it in menu.query(MenuItem)]
+            assert any("dark" in lbl for lbl in labels)
+            assert any("light" in lbl for lbl in labels)
+            current = next(lbl for lbl in labels if "auto" in lbl)
+            assert "●" in current  # the current theme is marked
+            await menu_select(pilot, "theme:light")
+            assert app._theme_name == "light"
+            assert app.theme == "cswap-light"
+


### PR DESCRIPTION
## Summary

Add a `ui.theme` setting (`dark`, `light`, or `auto`; default `auto`) that themes the Textual TUI and the plain CLI output.

## What's included

- A `cswap-light` Textual theme beside the existing `cswap-dark`. Rich renderables (usage bars, account cards, the auto-view log) read their colours from the active theme through a `Palette` object, so they recolour when the theme changes. The light severity and accent colours clear 4.5:1 contrast on the base background and on the highlighted and flash row backgrounds.
- A light ANSI palette in `printer.py`, selectable with `set_theme()`. The dark output stays the same, byte for byte.
- `auto` reads the terminal background with an OSC 11 query, run before the Textual input driver starts. It falls back to `dark` on a non-tty, a timeout, an unsupported terminal, or tmux, and never blocks or raises. It drains a late reply and does not honour `$TEXTUAL_THEME`.
- `Ctrl+T` cycles `dark`, `light`, `auto` while the app runs and saves the choice.
- The preference lives in a new `ui` section of `settings.json`, with `cswap config get/set/unset ui.theme`.

## Compatibility

`auto` resolves to `dark` when the terminal does not answer the OSC 11 query, so current users see no change unless their terminal reports a light background. The dark theme is the same as before in the TUI and the CLI.

## Testing

Tests cover the setting, palette resolution, the OSC 11 detection and its fall-back paths, the live toggle, and a contrast guard that checks 4.5:1 for six colours against three backgrounds.
