### PR TITLE
fix: reject directory destinations in export's atomic write (fixes #154)

### DIFF
--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -96,6 +96,10 @@ def _validate_imported_account(switcher: ClaudeAccountSwitcher, account: dict) -
 
 def _atomic_write_file(path: Path, content: str) -> None:
     """Write text atomically with 0600 perms — same pattern as switcher._write_json."""
+    if path.is_dir():
+        raise TransferError(
+            f"export destination must be a file path, not a directory: {path}"
+        )
     temp_path = path.with_suffix(f".{os.getpid()}.tmp")
     temp_path.write_text(content, encoding="utf-8")
     if sys.platform != "win32":


### PR DESCRIPTION
Fixes #154.

`_atomic_write_file()` in `src/claude_swap/transfer.py` assumed its `path` argument is always a file. When `cswap --export` is given an existing directory as the destination instead:

1. `path.with_suffix(f".{pid}.tmp")` builds a sibling temp path next to the directory.
2. `shutil.move(temp_path, path)` — since `path` is an existing directory, `shutil.move` drops the temp file *into* it rather than renaming, so the write appears to "succeed."
3. `os.chmod(path, 0o600)` then runs against the original `path` — the directory itself — stripping its execute bit (`0600` = `drw-------`). Every file inside becomes unreadable via `stat`/`access` until the directory is manually `chmod`'d back.

This reproduced twice on a real machine (`~/Desktop` and a subfolder), corrupting real user data directories, and also broke VMware guest→host file copy ("Cannot get attributes of file on virtual machine") since the copy tooling stats every file recursively.

**Fix:** `_atomic_write_file` now raises `TransferError` immediately if `path.is_dir()`, before any write or chmod happens — turning silent, destructive permission corruption into an immediate, actionable error that points the user at the real fix (pass a file path, e.g. `cswap --export ~/Desktop/Career/export.json`).

No behavior changes for the normal case (file path destination).
