### PR TITLE
fix(windows): retry atomic file replace past transient sharing failures

### DIFF
--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -29,6 +29,7 @@ from typing import NamedTuple, Protocol
 
 from claude_swap import macos_keychain
 from claude_swap.exceptions import CredentialError, CredentialWriteError
+from claude_swap.fsutil import replace_with_retry
 from claude_swap.models import Platform
 from claude_swap.paths import (
     get_claude_config_home,
@@ -445,7 +446,7 @@ class CredentialStore:
             os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
             os.close(fd)
             fd = -1
-            os.replace(tmp_path, str(path))
+            replace_with_retry(tmp_path, str(path))
             if sys.platform != "win32":
                 os.chmod(str(path), 0o600)
         except BaseException:
@@ -468,7 +469,7 @@ class CredentialStore:
             os.write(fd, credentials.encode("utf-8"))
             os.close(fd)
             fd = -1
-            os.replace(tmp_path, str(cred_file))
+            replace_with_retry(tmp_path, str(cred_file))
             if sys.platform != "win32":
                 os.chmod(str(cred_file), 0o600)
         except BaseException:
@@ -803,7 +804,7 @@ class CredentialStore:
             os.write(fd, encoded.encode("utf-8"))
             os.close(fd)
             fd = -1
-            os.replace(tmp_path, str(enc_file))
+            replace_with_retry(tmp_path, str(enc_file))
             if sys.platform != "win32":
                 os.chmod(str(enc_file), 0o600)
         except BaseException:

--- a/src/claude_swap/fsutil.py
+++ b/src/claude_swap/fsutil.py
@@ -1,0 +1,52 @@
+"""Filesystem primitives with no claude_swap dependencies.
+
+Deliberately a leaf module: the atomic-write helpers here are needed by
+settings, credentials, mappings and session, which sit on both sides of
+the paths/models/usage_store import cycle.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+# Windows error codes that mean "someone else has the file open right now",
+# not "this operation is invalid": ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION
+# and ERROR_LOCK_VIOLATION. All three clear on their own within milliseconds.
+_TRANSIENT_WIN_ERRORS = frozenset({5, 32, 33})
+
+
+def replace_with_retry(
+    src: os.PathLike | str,
+    dst: os.PathLike | str,
+    *,
+    attempts: int = 10,
+    initial_delay: float = 0.002,
+) -> None:
+    """``os.replace``, retried past transient Windows sharing failures.
+
+    POSIX ``rename`` is genuinely atomic and never fails this way, but on
+    Windows antivirus (Defender) and the search indexer open freshly-created
+    files opportunistically. A replace onto a just-written target then fails
+    with ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION for a few milliseconds
+    — measured at ~44% of replaces into a scanned temp directory, which made
+    credential and usage-store writes fail intermittently for real users.
+
+    Only the transient codes are retried; a genuine error (missing source,
+    cross-device link) surfaces on the first attempt.
+    """
+    delay = initial_delay
+    for attempt in range(attempts):
+        try:
+            os.replace(src, dst)
+            return
+        except OSError as e:
+            transient = (
+                sys.platform == "win32"
+                and getattr(e, "winerror", None) in _TRANSIENT_WIN_ERRORS
+            )
+            if not transient or attempt == attempts - 1:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, 0.25)

--- a/src/claude_swap/mappings.py
+++ b/src/claude_swap/mappings.py
@@ -21,6 +21,7 @@ import tempfile
 from pathlib import Path
 
 from claude_swap.models import get_timestamp
+from claude_swap.fsutil import replace_with_retry
 
 SCHEMA_VERSION = 1
 
@@ -132,7 +133,7 @@ class MappingStore:
                 os.fchmod(fd, 0o600)
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(payload)
-            os.replace(tmp, self.path)
+            replace_with_retry(tmp, self.path)
         except OSError:
             try:
                 os.unlink(tmp)

--- a/src/claude_swap/migrations.py
+++ b/src/claude_swap/migrations.py
@@ -35,6 +35,7 @@ from claude_swap import macos_keychain
 from claude_swap.exceptions import MigrationIncomplete
 from claude_swap.models import Platform, get_timestamp
 from claude_swap.switcher import KEYRING_SERVICE, SECURITY_SERVICE
+from claude_swap.fsutil import replace_with_retry
 
 if TYPE_CHECKING:
     from claude_swap.switcher import ClaudeAccountSwitcher
@@ -87,7 +88,7 @@ def _mark_applied(switcher: "ClaudeAccountSwitcher", migration_id: str) -> None:
         os.write(fd, content.encode("utf-8"))
         os.close(fd)
         fd = -1
-        os.replace(tmp_path, str(path))
+        replace_with_retry(tmp_path, str(path))
         if sys.platform != "win32":
             os.chmod(str(path), 0o600)
     except BaseException:

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -58,6 +58,7 @@ from claude_swap.paths import get_default_global_config_path
 from claude_swap.printer import accent, dimmed, muted, warning
 from claude_swap.process_detection import ClaudeSession, list_sessions
 from claude_swap.settings import atomic_write_json
+from claude_swap.fsutil import replace_with_retry
 
 if TYPE_CHECKING:
     from claude_swap.switcher import ClaudeAccountSwitcher
@@ -1046,7 +1047,7 @@ class SessionManager:
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(payload)
-            os.replace(tmp, manifest_path)
+            replace_with_retry(tmp, manifest_path)
         except OSError:
             try:
                 os.unlink(tmp)

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from claude_swap.exceptions import ConfigError
+from claude_swap.fsutil import replace_with_retry
 
 SETTINGS_SCHEMA_VERSION = 1
 SETTINGS_FILENAME = "settings.json"
@@ -412,7 +413,7 @@ def atomic_write_json(path: Path, data: dict) -> None:
         os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
         os.close(fd)
         fd = -1
-        os.replace(tmp_path, str(path))
+        replace_with_retry(tmp_path, str(path))
         if sys.platform != "win32":
             os.chmod(str(path), 0o600)
     except BaseException:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import pytest
 
 from claude_swap.exceptions import MigrationError
+from claude_swap.fsutil import replace_with_retry
 from claude_swap.models import Platform
 from claude_swap.paths import (
     LEGACY_BACKUP_DIRNAME,
@@ -314,3 +315,76 @@ class TestMigrateLegacyBackupDir:
         moved = target / "credentials" / ".creds-1-user@example.com.enc"
         assert moved.stat().st_mode & 0o777 == 0o600
         assert (target / "credentials").stat().st_mode & 0o777 == 0o700
+
+
+class TestReplaceWithRetry:
+    """os.replace is not reliably available on Windows: antivirus and the
+    search indexer open freshly-written files opportunistically, so a replace
+    onto a just-created target fails with ERROR_ACCESS_DENIED/SHARING_VIOLATION
+    for a few milliseconds. Measured at ~44% of replaces on a Defender-scanned
+    temp dir, which silently broke credential and usage-store writes.
+    """
+
+    def _win_oserror(self, winerror: int) -> OSError:
+        e = OSError(13, "Access is denied")
+        e.winerror = winerror
+        return e
+
+    @pytest.mark.parametrize("winerror", [5, 32, 33])
+    def test_retries_transient_windows_errors(self, tmp_path, monkeypatch, winerror):
+        monkeypatch.setattr("claude_swap.fsutil.sys.platform", "win32")
+        calls = []
+        real_replace = os.replace
+
+        def flaky(src, dst):
+            calls.append(1)
+            if len(calls) < 4:
+                raise self._win_oserror(winerror)
+            return real_replace(src, dst)
+
+        monkeypatch.setattr("claude_swap.fsutil.os.replace", flaky)
+        src = tmp_path / "tmp.tmp"
+        src.write_text("payload")
+        dst = tmp_path / "target.json"
+
+        replace_with_retry(src, dst)
+
+        assert len(calls) == 4
+        assert dst.read_text() == "payload"
+
+    def test_gives_up_and_raises_after_attempts(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("claude_swap.fsutil.sys.platform", "win32")
+
+        def always_fail(src, dst):
+            raise self._win_oserror(5)
+
+        monkeypatch.setattr("claude_swap.fsutil.os.replace", always_fail)
+        with pytest.raises(OSError):
+            replace_with_retry(tmp_path / "a", tmp_path / "b", attempts=3)
+
+    def test_does_not_retry_real_errors(self, tmp_path, monkeypatch):
+        """A genuine failure (e.g. missing source) must surface immediately."""
+        monkeypatch.setattr("claude_swap.fsutil.sys.platform", "win32")
+        calls = []
+
+        def missing(src, dst):
+            calls.append(1)
+            raise self._win_oserror(2)  # ERROR_FILE_NOT_FOUND
+
+        monkeypatch.setattr("claude_swap.fsutil.os.replace", missing)
+        with pytest.raises(OSError):
+            replace_with_retry(tmp_path / "a", tmp_path / "b")
+        assert len(calls) == 1
+
+    def test_posix_never_retries(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("claude_swap.fsutil.sys.platform", "linux")
+        calls = []
+
+        def fail(src, dst):
+            calls.append(1)
+            raise self._win_oserror(5)
+
+        monkeypatch.setattr("claude_swap.fsutil.os.replace", fail)
+        with pytest.raises(OSError):
+            replace_with_retry(tmp_path / "a", tmp_path / "b")
+        assert len(calls) == 1


### PR DESCRIPTION
# fix(windows): retry atomic file replace past transient sharing failures

## The error

On Windows, cswap intermittently fails a switch with:

```
WARNING  credentials.py Failed to write credentials file: [WinError 5] Access is denied:
  '...\credentials\tmpXXXX.tmp' -> '...\credentials\.creds-1-<email>.enc'
ERROR    switcher.py Switch failed: [WinError 5] Access is denied, attempting rollback
```

The same failure also hits the usage store, where it is swallowed rather than surfaced — writes are silently dropped, which makes the adaptive autoswitch scheduler behave erratically (poll intervals not backing off, escalations not refreshing candidates). The failures are load-correlated: the busier the machine, the more often they occur.

## Suspected cause

Every atomic write in cswap ends in `os.replace(tmp, target)`. On POSIX, `rename(2)` is genuinely atomic and cannot fail this way. On Windows it can: antivirus (Defender) and the search indexer open freshly-created files opportunistically to scan them, and a replace onto a file another process holds open fails with `ERROR_ACCESS_DENIED` (5) or `ERROR_SHARING_VIOLATION` (32). The handle is released within milliseconds, so the failure is transient — but unretried, it propagates as a hard write failure.

Measured directly on an affected Windows 11 machine — 4000 sequential tmpfile-then-replace cycles into a Defender-scanned directory:

```
1779/4000 os.replace failures (~44%); worst-case replace latency 33ms
```

This is invisible to Linux and macOS CI, which is why it has not surfaced before.

## The fix

`fsutil.replace_with_retry()` — `os.replace` retried with exponential backoff (2 ms doubling to a 250 ms cap, 10 attempts) on the three Windows error codes that mean "someone has this file open right now" rather than "this operation is invalid": `ERROR_ACCESS_DENIED` (5), `ERROR_SHARING_VIOLATION` (32), `ERROR_LOCK_VIOLATION` (33).

Deliberate constraints:

- **win32 only.** On POSIX the retry branch is unreachable, so behavior there is byte-for-byte unchanged.
- **Genuine errors are not retried.** A missing source or cross-device link raises on the first attempt rather than being retried into a delay. Covered by a test.
- **`fsutil` is a new dependency-free leaf module.** `settings`, `credentials`, `mappings` and `session` all need the helper, and they sit on both sides of the existing `paths → models → usage_store → settings` import cycle; putting it in `paths` triggers a circular import.

Applied to the seven single-file atomic writes: `credentials.py` (3), `settings.py`, `mappings.py`, `migrations.py`, `session.py`.

## Deliberately out of scope

The `os.replace` **directory** renames in `switcher.py` are untouched. They are plausibly vulnerable to the same locking, but no failures were observed there and a directory rename may warrant different handling — worth a follow-up rather than a speculative change here.

## Testing

Six new tests in `tests/test_paths.py` covering: retry-then-succeed for each of the three transient codes, give-up-and-raise after the attempt budget, no-retry-on-genuine-error, and no-retry-on-POSIX. Written failing first, then implemented. Because they monkeypatch `os.replace` and `sys.platform`, they run and assert on every platform, including a Linux/macOS CI.

Full suite on the affected Windows 11 machine (Python 3.14): **1428 passed, 34 skipped, 0 failed.**

Causal evidence the fix addresses the observed symptom: before the change, the autoswitch suite failed a varying 3-test subset on slower runs (e.g. 3 failures in a 74 s run). After, three consecutive runs at 54 s / 101 s / 111 s all passed 105/105 — including runs substantially slower, and therefore under more antivirus contention, than the ones that previously failed.