### PR TITLE
feat(session): support --share-history on Windows via junctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP ser
 <details>
 <summary>Sharing details — MCP servers & chat history</summary>
 
-- With `--share-history`, a session started under one account shows up in `--resume` under the others, and nothing already saved is lost.
+- With `--share-history`, a session started under one account shows up in `--resume` under the others, and nothing already saved is lost. On macOS/Linux/WSL this uses symlinks; on **Windows** `projects/` is shared with a directory junction (no admin needed) and `history.jsonl` with a file symlink (which needs Developer Mode or an elevated shell — without it only `history.jsonl` is skipped and a note is printed, while your conversations in `projects/` still share). The first time you enable it on Windows, a one-time safety copy of your existing history is written under the backup directory (`history-backups/`).
 - User-scope MCP servers (`claude mcp add -s user`) are mirrored from your default profile on every launch — manage them there; changes made inside a session don't persist. Definitions are copied as-is (including inline `env`/`headers` values), but MCP OAuth logins are not — HTTP servers may ask you to authenticate once per profile via `/mcp`.
 - `--no-share` turns sharing off and removes the mirrored MCP config (profiles that never mirrored are left alone).
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -158,7 +158,11 @@ Examples:
             "~/.claude into the session profile, so every account sees one "
             "unified history. History the profile already accumulated is "
             "merged into ~/.claude first. --no-share-history restores "
-            "per-account history (the default). Not supported on Windows."
+            "per-account history (the default). On Windows, projects/ is "
+            "shared with a directory junction and history.jsonl with a file "
+            "symlink (the latter needs Developer Mode/admin; without it, only "
+            "history.jsonl is skipped). A one-time safety backup of your "
+            "history is taken under the backup dir first."
         ),
     )
     parser.add_argument(

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -202,10 +202,12 @@ def _create_junction(src: Path, dest: Path) -> None:
 def safe_rmtree(path: Path) -> None:
     """Recursively delete *path*, never traversing a reparse point.
 
-    ``shutil.rmtree`` recurses into Windows junctions (they are not symlinks),
-    so deleting a profile or purging the backup dir could delete the real
-    ``~/.claude`` history a junction points at. This removes any reparse point
-    as a link and only recurses into genuine directories. Best-effort.
+    On some Windows/Python versions ``shutil.rmtree`` recurses *through* a
+    junction (they are not symlinks) and deletes the real ``~/.claude`` history
+    a profile's ``projects/`` junction points at; on others it errors on the
+    junction instead, leaving a partial tree. This removes any reparse point as
+    a link and only recurses into genuine directories, so it is both safe and
+    complete regardless of the platform's rmtree behavior. Best-effort.
     """
     if _is_reparse_link(path):
         _remove_link(path)

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -25,10 +25,19 @@ A manifest records what cswap created so removal never touches user data.
 History sharing (``--share-history``, opt-in): additionally links
 ``projects/`` (conversation transcripts — what ``claude --resume`` lists) and
 ``history.jsonl`` (prompt history) from ``~/.claude``, so all accounts see one
-unified conversation history. POSIX-only: Windows shares by re-synced copy,
-which would fork history rather than share it. If the profile already
-accumulated its own history, it is merged into ``~/.claude`` first so nothing
-disappears from ``--resume``.
+unified conversation history. On POSIX these are symlinks; on Windows — where
+a re-synced copy would *fork* history on first write — ``projects/`` is shared
+with a directory junction (no privilege required) and ``history.jsonl`` with a
+file symlink (needs Developer Mode/admin; if that is unavailable it is skipped
+with a warning while ``projects/`` still shares). Before the first Windows link
+a one-time safety copy of the real history is taken under the backup dir. If
+the profile already accumulated its own history, it is merged into ``~/.claude``
+first so nothing disappears from ``--resume``.
+
+Junctions are reparse points that ``os.path.islink`` does not report, so every
+place that must distinguish a cswap-created link from real user data uses
+:func:`_is_reparse_link`, and profile/backup deletion uses :func:`safe_rmtree`
+to avoid ever recursing through a junction into the shared ``~/.claude``.
 
 This module must not import ``switcher`` (switcher imports us for the
 session-aware guards); it receives a ``ClaudeAccountSwitcher`` instance.
@@ -40,10 +49,12 @@ import hashlib
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
 import unicodedata
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
@@ -78,8 +89,10 @@ SHARED_ITEMS = (
     "agents",
 )
 
-# Conversation-history items linked additionally under --share-history.
-# POSIX symlinks only: Windows copy-mode would fork history, not share it.
+# Conversation-history items shared additionally under --share-history.
+# Always linked, never copied, so history is genuinely shared rather than
+# forked: POSIX symlinks, or on Windows a junction (projects/) + a file
+# symlink (history.jsonl). See _desired_link_kind.
 HISTORY_ITEMS = (
     "projects",
     "history.jsonl",
@@ -106,6 +119,117 @@ MCP_MIRROR_MARKER = ".cswap-mcp-mirror-v1"
 # One-time migration stash: session-local MCP definitions displaced by the
 # first mirror land here (write-once) instead of vanishing.
 MCP_DISPLACED_STASH = ".cswap-mcp-displaced.json"
+
+# One-time safety snapshot of the real ~/.claude history, taken under the
+# backup dir before the first Windows share link, plus the marker recording it
+# so the (potentially large) copy is never repeated.
+HISTORY_BACKUP_DIRNAME = "history-backups"
+HISTORY_BACKUP_MARKER = ".cswap-history-backup.json"
+
+# Reparse tags meaning "this path redirects elsewhere": a Windows symlink or a
+# junction (mount point). Empty off Windows. os.path.islink() reports symlinks
+# but NOT junctions, so any junction-aware check must consult the reparse tag.
+_REPARSE_TAGS = frozenset(
+    tag
+    for tag in (
+        getattr(stat, "IO_REPARSE_TAG_SYMLINK", None),
+        getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", None),
+    )
+    if tag is not None
+)
+
+
+def _fs_timestamp() -> str:
+    """UTC timestamp safe for filenames (no ``:`` — illegal on Windows)."""
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _is_reparse_link(path: Path) -> bool:
+    """True for a POSIX/Windows symlink OR a Windows junction.
+
+    The sharing code must tell a cswap-created link from real user data
+    everywhere it might delete or merge. ``Path.is_symlink()`` alone misses
+    junctions (reparse points, not symlinks), which would let ``rmtree`` or the
+    history merge traverse into the shared ``~/.claude`` target.
+    """
+    try:
+        if path.is_symlink():
+            return True
+    except OSError:
+        # Don't conclude "not a link" yet: fall through to the reparse-tag
+        # probe. safe_rmtree's no-recurse-through-junction guarantee rests on
+        # this never yielding a false negative for a junction.
+        pass
+    if not _REPARSE_TAGS:
+        return False  # non-Windows: a symlink is the only kind of link
+    try:
+        tag = getattr(os.lstat(path), "st_reparse_tag", 0)
+    except OSError:
+        return False
+    return tag in _REPARSE_TAGS
+
+
+def _remove_link(path: Path) -> None:
+    """Remove a symlink or junction without following it. Best-effort.
+
+    ``os.unlink`` handles POSIX symlinks and Windows file symlinks; a Windows
+    junction is a directory reparse point that only ``os.rmdir`` removes. Try
+    unlink first, fall back to rmdir — neither touches the link's target.
+    """
+    try:
+        os.unlink(path)
+        return
+    except OSError:
+        pass
+    try:
+        os.rmdir(path)
+    except OSError:
+        pass
+
+
+def _create_junction(src: Path, dest: Path) -> None:
+    """Create a Windows directory junction at *dest* pointing to *src*.
+
+    Junctions need no privilege (unlike symlinks) and work on NTFS, so they
+    back projects/ sharing. Isolated here so tests can stub it on any host; the
+    ``_winapi`` import is Windows-only and deliberately lazy.
+    """
+    import _winapi
+
+    _winapi.CreateJunction(str(src), str(dest))
+
+
+def safe_rmtree(path: Path) -> None:
+    """Recursively delete *path*, never traversing a reparse point.
+
+    ``shutil.rmtree`` recurses into Windows junctions (they are not symlinks),
+    so deleting a profile or purging the backup dir could delete the real
+    ``~/.claude`` history a junction points at. This removes any reparse point
+    as a link and only recurses into genuine directories. Best-effort.
+    """
+    if _is_reparse_link(path):
+        _remove_link(path)
+        return
+    if not path.is_dir():
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return
+    try:
+        for child in path.iterdir():
+            if _is_reparse_link(child):
+                _remove_link(child)
+            elif child.is_dir():
+                safe_rmtree(child)
+            else:
+                try:
+                    child.unlink()
+                except OSError:
+                    pass
+        path.rmdir()
+    except OSError:
+        pass
 
 
 def mark_session_stale(session_dir: Path) -> None:
@@ -331,12 +455,6 @@ class SessionManager:
         if not claude_bin:
             raise SessionError(
                 "'claude' was not found on PATH. Install Claude Code first."
-            )
-        if share_history and self.switcher.platform == Platform.WINDOWS:
-            raise SessionError(
-                "--share-history is not supported on Windows yet: sharing uses "
-                "re-synced copies there, which would fork the history instead "
-                "of sharing it."
             )
 
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
@@ -574,7 +692,10 @@ class SessionManager:
         # Keychain first: claude may have partially migrated the seed, and the
         # hashed service name can't be recomputed once the dir is gone.
         delete_macos_keychain_entry(session_dir)
-        shutil.rmtree(session_dir, ignore_errors=True)
+        # safe_rmtree, never shutil.rmtree: a share step may already have laid
+        # down a projects/ junction, and a plain rmtree would recurse through
+        # it and delete the real ~/.claude history.
+        safe_rmtree(session_dir)
 
     # -- validation ------------------------------------------------------
 
@@ -645,43 +766,58 @@ class SessionManager:
         if not session_dir.is_dir():
             return
         self._sync_mcp_servers(session_dir, share)
-        # History links are POSIX-only (run() rejects the flag on Windows;
-        # this also drops any links left by a POSIX→Windows profile move).
-        if self.switcher.platform == Platform.WINDOWS:
+
+        source_root = Path.home() / ".claude"
+
+        # History sharing works on every platform now: POSIX via symlinks,
+        # Windows via a junction (projects/) + file symlink (history.jsonl).
+        # Before the first Windows link, take a one-time safety snapshot of
+        # the real history; if that can't be made, decline history sharing for
+        # this launch rather than risk it.
+        if share_history and not self._ensure_history_backup(source_root):
             share_history = False
+
         active_items = (SHARED_ITEMS if share else ()) + (
             HISTORY_ITEMS if share_history else ()
         )
-        source_root = Path.home() / ".claude"
         manifest_path = session_dir / SHARE_MANIFEST
         managed = self._read_manifest(manifest_path)
 
-        # A flag turned off since last launch: remove the links we created
-        # for it (never plain files/dirs the user accumulated themselves).
-        # For history items that holds even when the manifest claims them:
-        # a stale manifest (lock-free launches race) must never be able to
-        # delete real conversation history — only ever unlink symlinks.
+        # A flag turned off since last launch: remove the links/copies we
+        # created for it (never plain files/dirs the user accumulated). For
+        # history items that holds even when the manifest claims them: a stale
+        # manifest (lock-free launches race) must never delete real history —
+        # only ever remove a link we own (symlink OR junction).
         for name in managed:
             if name not in active_items:
                 dest = session_dir / name
-                if name in HISTORY_ITEMS and dest.exists() and not dest.is_symlink():
+                if (
+                    name in HISTORY_ITEMS
+                    and dest.exists()
+                    and not _is_reparse_link(dest)
+                ):
                     continue
                 self._remove_managed(dest)
         if not active_items:
             manifest_path.unlink(missing_ok=True)
             return
 
-        use_symlinks = self.switcher.platform != Platform.WINDOWS
         new_managed: list[str] = []
 
         for name in active_items:
             src = source_root / name
             dest = session_dir / name
 
-            if name in HISTORY_ITEMS and not self._prepare_history_share(
-                src, dest, session_dir
-            ):
-                continue
+            if name in HISTORY_ITEMS:
+                # Gate the destructive merge behind link feasibility: never move
+                # the profile's own history into ~/.claude if the link that
+                # would replace it can't be created (default Windows: no file-
+                # symlink privilege). Otherwise the account loses sight of its
+                # own history to a global file it isn't linked to.
+                if not self._history_link_feasible(name, src, dest, session_dir):
+                    continue
+                if not self._prepare_history_share(src, dest, session_dir):
+                    continue
 
             if not src.exists():
                 # Source vanished (or never existed): prune our own entry.
@@ -689,21 +825,10 @@ class SessionManager:
                     self._remove_managed(dest)
                 continue
 
-            if dest.is_symlink():
-                if name not in managed:
-                    managed = [*managed, name]  # adopt: only cswap links here
-                if use_symlinks:
-                    try:
-                        if dest.readlink() != src:
-                            dest.unlink()
-                            dest.symlink_to(src)
-                    except OSError:
-                        continue
-                    new_managed.append(name)
-                    continue
-                # Platform moved POSIX → Windows: replace link with a copy.
-                dest.unlink()
-            elif dest.exists() and name not in managed:
+            existing_link = _is_reparse_link(dest)
+            if existing_link and name not in managed:
+                managed = [*managed, name]  # adopt: only cswap links here
+            elif not existing_link and dest.exists() and name not in managed:
                 # Pre-existing user data in the profile — never touch it.
                 print(
                     dimmed(
@@ -714,19 +839,25 @@ class SessionManager:
                 continue
 
             try:
-                if use_symlinks:
-                    if dest.exists():
-                        self._remove_managed(dest)
-                    dest.symlink_to(src)
-                else:
-                    if dest.exists():
-                        self._remove_managed(dest)
-                    if src.is_dir():
-                        shutil.copytree(src, dest)
-                    else:
-                        shutil.copy2(src, dest)
+                self._materialize_share(name, src, dest)
             except OSError as e:
-                self._logger.warning(f"Failed to share {name} into session: {e}")
+                if name == "history.jsonl" and (
+                    self.switcher.platform == Platform.WINDOWS
+                ):
+                    # Backstop: _history_link_feasible already gated the common
+                    # no-privilege case, so reaching here means the link failed
+                    # after the probe said it would succeed (a race). projects/
+                    # still shares; never fail the launch over history.jsonl.
+                    warning(
+                        "Not sharing history.jsonl: the file symlink could not "
+                        "be created (see log). Your conversations (projects/) "
+                        "are still shared; your prompt history is preserved in "
+                        "~/.claude/history.jsonl and the safety backup."
+                    )
+                else:
+                    self._logger.warning(
+                        f"Failed to share {name} into session: {e}"
+                    )
                 continue
             new_managed.append(name)
 
@@ -734,6 +865,178 @@ class SessionManager:
         # write the manifest atomically so a concurrent reader never sees a
         # truncated file.
         self._write_manifest(manifest_path, new_managed)
+
+    def _desired_link_kind(self, name: str) -> str:
+        """How a shared item is materialized on this platform.
+
+        POSIX shares everything by symlink. Windows re-syncs customizations as
+        copies (safe — the default profile is the source of truth) but *links*
+        history so it is genuinely shared: a directory junction for
+        ``projects/`` (no privilege) and a file symlink for ``history.jsonl``.
+        """
+        if self.switcher.platform != Platform.WINDOWS:
+            return "symlink"
+        if name in HISTORY_ITEMS:
+            return "junction" if name == "projects" else "file_symlink"
+        return "copy"
+
+    def _materialize_share(self, name: str, src: Path, dest: Path) -> None:
+        """Create/refresh ``dest`` as the platform-appropriate share of ``src``.
+
+        Idempotent: an already-correct link is left in place; a copy is
+        re-synced; a link pointing elsewhere (or a leftover from a
+        cross-platform profile move) is replaced. Raises ``OSError`` on a
+        failed filesystem operation for the caller to handle.
+        """
+        kind = self._desired_link_kind(name)
+        if kind == "copy":
+            if dest.exists() or _is_reparse_link(dest):
+                self._remove_managed(dest)
+            if src.is_dir():
+                shutil.copytree(src, dest)
+            else:
+                shutil.copy2(src, dest)
+            return
+        # Link kinds: symlink | junction | file_symlink.
+        if _is_reparse_link(dest):
+            if self._link_points_to(dest, src, kind):
+                return  # already correct — no-op
+            self._remove_managed(dest)
+        elif dest.exists():
+            # A managed copy left by a Windows→POSIX profile move; replace it.
+            self._remove_managed(dest)
+        self._create_link(src, dest, kind)
+
+    @staticmethod
+    def _link_points_to(dest: Path, src: Path, kind: str) -> bool:
+        """Whether the existing link at ``dest`` already targets ``src``."""
+        if kind == "symlink":
+            try:
+                return dest.readlink() == src
+            except OSError:
+                return False
+        # Junctions/file symlinks: a junction's readlink can carry a \\?\
+        # prefix, so compare resolved targets rather than string-matching.
+        try:
+            return dest.resolve() == src.resolve()
+        except OSError:
+            return False
+
+    def _create_link(self, src: Path, dest: Path, kind: str) -> None:
+        """Create the requested link kind at ``dest`` → ``src``."""
+        if kind == "junction":
+            _create_junction(src, dest)
+        else:  # symlink | file_symlink
+            dest.symlink_to(src)
+
+    def _history_link_feasible(
+        self, name: str, src: Path, dest: Path, session_dir: Path
+    ) -> bool:
+        """Whether it is safe to run the destructive history merge for ``name``.
+
+        Only ``history.jsonl`` on Windows can be blocked: its share is a file
+        symlink, which needs Developer Mode/admin. If we can neither create one
+        nor already have one, return False so the caller skips the item BEFORE
+        merging — the account keeps its own prompt history rather than losing
+        sight of it. ``projects/`` (a junction, no privilege) and every POSIX
+        case are always feasible.
+        """
+        if name != "history.jsonl" or self.switcher.platform != Platform.WINDOWS:
+            return True
+        # An existing symlink keeps working without privilege (privilege is
+        # only needed to *create* one), so a re-sync of an already-shared
+        # profile stays feasible.
+        if _is_reparse_link(dest) and self._link_points_to(
+            dest, src, "file_symlink"
+        ):
+            return True
+        if self._can_create_file_symlink(session_dir):
+            return True
+        warning(
+            "Not sharing history.jsonl: creating a file symlink needs Windows "
+            "Developer Mode or admin. Your conversations (projects/) are still "
+            "shared; this account keeps its own prompt history."
+        )
+        return False
+
+    def _can_create_file_symlink(self, session_dir: Path) -> bool:
+        """Probe whether this process may create a file symlink in the profile.
+
+        Always True off Windows. On Windows, creating a throwaway symlink is the
+        only reliable check for the Developer-Mode/admin privilege; it is cheap
+        and the probe is cleaned up either way.
+        """
+        if self.switcher.platform != Platform.WINDOWS:
+            return True
+        probe = session_dir / ".cswap-symlink-probe"
+        try:
+            if _is_reparse_link(probe) or probe.exists():
+                _remove_link(probe)
+            probe.symlink_to("cswap-probe-target")  # dangling target is fine
+            _remove_link(probe)
+            return True
+        except OSError:
+            _remove_link(probe)  # best-effort cleanup of a partial probe
+            return False
+
+    def _ensure_history_backup(self, source_root: Path) -> bool:
+        """One-time safety snapshot of real history before the first share.
+
+        Returns True when it is safe to proceed with history sharing (backup
+        done, already taken, or not needed), False when a backup was required
+        but failed — the caller then declines history sharing for this launch.
+
+        POSIX linking is non-destructive and matches long-standing behavior, so
+        the gate only binds on Windows, where junctions introduce the delete/
+        merge footguns the snapshot protects against. The marker makes it a
+        one-time cost.
+        """
+        if self.switcher.platform != Platform.WINDOWS:
+            return True
+        marker = self.switcher.backup_dir / HISTORY_BACKUP_MARKER
+        if marker.exists():
+            return True
+        try:
+            stamp = _fs_timestamp()
+            dest_root = (
+                self.switcher.backup_dir / HISTORY_BACKUP_DIRNAME / stamp
+            )
+            backed_up: list[str] = []
+            for name in HISTORY_ITEMS:
+                source = source_root / name
+                if not source.exists() or _is_reparse_link(source):
+                    continue  # nothing real to protect
+                target = dest_root / name
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if source.is_dir():
+                    shutil.copytree(source, target)
+                else:
+                    shutil.copy2(source, target)
+                backed_up.append(name)
+            atomic_write_json(
+                marker,
+                {
+                    "schemaVersion": 1,
+                    "backedUpAt": stamp,
+                    "location": str(dest_root),
+                    "items": backed_up,
+                },
+            )
+            if backed_up:
+                print(
+                    dimmed(
+                        f"Backed up your Claude history to {dest_root} before "
+                        "enabling sharing."
+                    )
+                )
+            return True
+        except OSError as e:
+            self._logger.warning(f"History backup failed: {e}")
+            warning(
+                "Not sharing history: couldn't back up your existing history "
+                "first (see log)."
+            )
+            return False
 
     def _sync_mcp_servers(self, session_dir: Path, share: bool) -> None:
         """Mirror the default profile's user-scope ``mcpServers`` (issue #139).
@@ -938,8 +1241,10 @@ class SessionManager:
         even when the manifest claims the entry is managed: a stale manifest
         (lock-free launches race) must never let the generic loop delete it.
         """
-        if dest.exists() and not dest.is_symlink():
+        if dest.exists() and not _is_reparse_link(dest):
             # Real per-account history accumulated before the flag existed.
+            # (A junction/symlink is already-shared, not real data to merge —
+            # _is_reparse_link catches junctions that is_symlink would miss.)
             # Merging moves files out from under any claude still running in
             # this profile, so only migrate when the profile is quiescent.
             if live_sessions_for(session_dir):
@@ -1055,12 +1360,18 @@ class SessionManager:
 
     @staticmethod
     def _remove_managed(dest: Path) -> None:
-        """Remove a cswap-created share entry (link or copy), never user data
-        beyond it — callers guarantee `dest` is manifest-listed or a symlink."""
+        """Remove a cswap-created share entry (link, junction, or copy), never
+        the data a link points at — callers guarantee `dest` is manifest-listed
+        or a reparse link."""
         try:
-            if dest.is_symlink() or dest.is_file():
+            if _is_reparse_link(dest):
+                # Symlink or junction: drop the link itself, never its target.
+                _remove_link(dest)
+            elif dest.is_file():
                 dest.unlink(missing_ok=True)
             elif dest.is_dir():
+                # A real managed copy (Windows SHARED_ITEMS); no junctions live
+                # inside it, so a plain rmtree is safe here.
                 shutil.rmtree(dest, ignore_errors=True)
         except OSError:
             pass

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1647,13 +1647,15 @@ class ClaudeAccountSwitcher:
         Keychain first: the hashed service name is derived from the dir path
         and can't be recomputed once the dir is gone.
         """
-        from claude_swap.session import delete_macos_keychain_entry
+        from claude_swap.session import delete_macos_keychain_entry, safe_rmtree
 
         session_dir = self._session_dir(account_num, email)
         if not session_dir.exists():
             return
         delete_macos_keychain_entry(session_dir)
-        shutil.rmtree(session_dir, ignore_errors=True)
+        # safe_rmtree, not shutil.rmtree: a shared profile can hold a projects/
+        # junction into ~/.claude, which a plain rmtree would recurse through.
+        safe_rmtree(session_dir)
         self._logger.info(
             f"Removed session profile for account {account_num} at {session_dir}"
         )
@@ -4851,6 +4853,8 @@ class ClaudeAccountSwitcher:
         # Session-profile keychain entries must go BEFORE the backup dir:
         # the hashed service names are derived from the dir paths and can't
         # be recomputed once the directories are deleted.
+        from claude_swap.session import safe_rmtree
+
         if session_dirs:
             from claude_swap.session import delete_macos_keychain_entry
 
@@ -4867,14 +4871,17 @@ class ClaudeAccountSwitcher:
                 handler.close()
                 self._logger.removeHandler(handler)
 
-            shutil.rmtree(self.backup_dir)
+            # safe_rmtree, not shutil.rmtree: the backup dir holds session
+            # profiles whose projects/ may be junctions into ~/.claude — a
+            # plain rmtree would recurse through them and delete real history.
+            safe_rmtree(self.backup_dir)
             removed_items.append(f"Directory: {self.backup_dir}")
 
         # Also clean a stale legacy directory if it somehow still exists
         # (e.g. a partial pre-migration state, or files re-created after init).
         if legacy_distinct and legacy.exists():
             try:
-                shutil.rmtree(legacy)
+                safe_rmtree(legacy)
                 removed_items.append(f"Legacy directory: {legacy}")
             except OSError:
                 pass

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
+import stat
 import sys
 import unicodedata
 from pathlib import Path
@@ -21,6 +23,7 @@ from claude_swap.session import (
     MCP_MIRROR_MARKER,
     SHARE_MANIFEST,
     SessionManager,
+    _is_reparse_link,
     _probe_env,
     keychain_service_name,
     live_sessions_for,
@@ -1375,7 +1378,9 @@ def history_setup(share_setup, temp_home: Path):
     return source, session_dir, mgr
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="history sharing is POSIX-only")
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="exercises POSIX symlink specifics"
+)
 class TestShareHistoryPosix:
     def test_not_shared_by_default(self, history_setup):
         source, session_dir, mgr = history_setup
@@ -1537,25 +1542,444 @@ class TestShareHistoryPosix:
         assert (proj / "bbb.jsonl").read_text() == "profile-b\n"
 
 
+@pytest.fixture
+def fake_junction(monkeypatch):
+    """Make _create_junction build a POSIX symlink so Windows history-share
+    flows are exercisable on any host. _is_reparse_link then detects it as a
+    link exactly as it would a real junction."""
+
+    def as_symlink(src, dest):
+        dest.symlink_to(src)
+
+    monkeypatch.setattr(session_mod, "_create_junction", as_symlink)
+    return as_symlink
+
+
 class TestShareHistoryWindows:
-    def test_sync_never_links_history_in_copy_mode(self, history_setup):
+    """Windows history sharing: junction (projects/) + file symlink
+    (history.jsonl), with a pre-emptive safety backup and graceful degradation.
+    Exercised on any host by stubbing the junction primitive (see fake_junction).
+    """
+
+    @pytest.fixture
+    def win(self, history_setup, fake_junction):
         source, session_dir, mgr = history_setup
         mgr.switcher.platform = Platform.WINDOWS
+        # seeded_switcher persisted creds/config under the macOS backend; the
+        # bootstrap path (test_run_no_longer_rejects) reads via the now-Windows
+        # file backend, so re-persist them there.
+        mgr.switcher._write_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL, CREDS)
+        mgr.switcher._write_account_config(ACCOUNT_NUM, ACCOUNT_EMAIL, CONFIG)
+        return source, session_dir, mgr
+
+    def test_links_projects_and_history(self, win):
+        source, session_dir, mgr = win
         mgr._sync_sharing(session_dir, share=True, share_history=True)
 
+        # projects/ shared via (stubbed) junction, history.jsonl via symlink.
+        assert _is_reparse_link(session_dir / "projects")
+        assert (session_dir / "projects").resolve() == (source / "projects").resolve()
+        assert (session_dir / "history.jsonl").is_symlink()
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert {"projects", "history.jsonl"} <= set(manifest["items"])
+        # Customizations are still copies on Windows, not links.
+        assert (session_dir / "settings.json").is_file()
+        assert not _is_reparse_link(session_dir / "settings.json")
+
+    def test_writes_through_junction_to_shared_source(self, win):
+        """The whole point: a write inside the profile lands in ~/.claude."""
+        source, session_dir, mgr = win
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        (session_dir / "projects" / "-home-user-app" / "new.jsonl").write_text(
+            "written-in-session\n"
+        )
+        assert (
+            source / "projects" / "-home-user-app" / "new.jsonl"
+        ).read_text() == "written-in-session\n"
+
+    def test_backup_taken_before_first_link(self, win):
+        source, session_dir, mgr = win
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        marker = json.loads(
+            (mgr.switcher.backup_dir / session_mod.HISTORY_BACKUP_MARKER).read_text()
+        )
+        assert set(marker["items"]) == {"projects", "history.jsonl"}
+        backup = Path(marker["location"])
+        assert (
+            backup / "projects" / "-home-user-app" / "aaa.jsonl"
+        ).read_text() == "main-a\n"
+        assert (backup / "history.jsonl").read_text() == '{"p": "main"}\n'
+
+    def test_backup_is_one_time(self, win):
+        source, session_dir, mgr = win
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+        backups_root = (
+            mgr.switcher.backup_dir / session_mod.HISTORY_BACKUP_DIRNAME
+        )
+        first = sorted(p.name for p in backups_root.iterdir())
+
+        # Second launch: marker present → no new snapshot dir is created.
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+        assert sorted(p.name for p in backups_root.iterdir()) == first
+
+    def test_backup_failure_declines_history_sharing(self, win, monkeypatch, capsys):
+        source, session_dir, mgr = win
+
+        def boom(*a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(session_mod.shutil, "copytree", boom)
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        # History declined, but customizations still shared and no crash.
         assert not (session_dir / "projects").exists()
+        assert (session_dir / "settings.json").is_file()
+        assert "couldn't back up" in capsys.readouterr().out
         manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
         assert "projects" not in manifest["items"]
 
-    def test_run_rejects_flag(self, history_setup, monkeypatch):
-        source, session_dir, mgr = history_setup
-        mgr.switcher.platform = Platform.WINDOWS
+    def test_no_file_symlink_privilege_keeps_own_history(
+        self, win, monkeypatch, capsys
+    ):
+        """Default Windows (no symlink privilege): history.jsonl is NOT merged
+        away — the account keeps its own prompt history — while projects/ still
+        shares. Regression test for the destructive-merge-before-failed-link
+        bug."""
+        source, session_dir, mgr = win
         monkeypatch.setattr(
-            session_mod.shutil, "which", lambda _name: "/usr/bin/claude"
+            session_mod.SessionManager,
+            "_can_create_file_symlink",
+            lambda self, d: False,
         )
+        # The profile has its own prompt history, predating the flag.
+        (session_dir / "history.jsonl").write_text('{"p": "profile-own"}\n')
+        source_hist_before = (source / "history.jsonl").read_text()
 
-        with pytest.raises(SessionError, match="Windows"):
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        # projects/ still shared...
+        assert _is_reparse_link(session_dir / "projects")
+        # ...but the profile keeps its OWN history.jsonl: not merged, not linked.
+        assert not _is_reparse_link(session_dir / "history.jsonl")
+        assert (session_dir / "history.jsonl").read_text() == '{"p": "profile-own"}\n'
+        # Source history untouched — no destructive merge happened.
+        assert (source / "history.jsonl").read_text() == source_hist_before
+        assert "Developer Mode or admin" in capsys.readouterr().out
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "projects" in manifest["items"]
+        assert "history.jsonl" not in manifest["items"]
+
+    def test_file_symlink_race_failure_degrades(self, win, monkeypatch, capsys):
+        """Probe says capable but the create still fails (race backstop):
+        history.jsonl skipped, projects/ shared, launch not aborted."""
+        source, session_dir, mgr = win
+        monkeypatch.setattr(
+            session_mod.SessionManager,
+            "_can_create_file_symlink",
+            lambda self, d: True,
+        )
+        real_create = session_mod.SessionManager._create_link
+
+        def create(self, src, dest, kind):
+            if kind == "file_symlink":
+                raise OSError(1314, "A required privilege is not held")
+            return real_create(self, src, dest, kind)
+
+        monkeypatch.setattr(session_mod.SessionManager, "_create_link", create)
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert _is_reparse_link(session_dir / "projects")  # conversations shared
+        assert not (session_dir / "history.jsonl").exists()  # gracefully skipped
+        assert "could not be created" in capsys.readouterr().out
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "projects" in manifest["items"]
+        assert "history.jsonl" not in manifest["items"]
+
+    def test_can_create_file_symlink_probes_and_cleans_up(self, win):
+        """The Windows privilege probe creates then removes a throwaway link."""
+        source, session_dir, mgr = win
+        # Linux host allows symlinks, so with platform forced to Windows the
+        # probe succeeds and leaves no trace.
+        assert mgr._can_create_file_symlink(session_dir) is True
+        assert not (session_dir / ".cswap-symlink-probe").exists()
+
+    def test_idempotent(self, win):
+        source, session_dir, mgr = win
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+        target_before = (session_dir / "projects").resolve()
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+        assert (session_dir / "projects").resolve() == target_before
+
+    def test_toggle_off_removes_junction_keeps_real_history(self, win):
+        source, session_dir, mgr = win
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+        mgr._sync_sharing(session_dir, share=True, share_history=False)
+
+        assert not (session_dir / "projects").exists()  # junction gone
+        assert not (session_dir / "history.jsonl").exists()
+        # The shared source history is never touched.
+        assert (
+            source / "projects" / "-home-user-app" / "aaa.jsonl"
+        ).read_text() == "main-a\n"
+
+    def test_run_no_longer_rejects(
+        self, win, capture_exec, auth_status_tracks_seed, refresh_rotates
+    ):
+        source, session_dir, mgr = win
+        with pytest.raises(_ExecCalled) as exc:
             mgr.run(ACCOUNT_NUM, [], share=True, share_history=True)
+        # Reached exec — no Windows rejection — with the session config dir.
+        assert exc.value.env["CLAUDE_CONFIG_DIR"] == str(session_dir)
+
+    def test_bootstrap_validation_failure_preserves_shared_history(
+        self, win, refresh_rotates, monkeypatch
+    ):
+        """The headline safeguard: a share step links projects/ (junction),
+        then validation fails and the profile is torn down — the shared
+        ~/.claude history must survive (cleanup must not recurse the junction)."""
+        source, session_dir, mgr = win
+
+        def always_invalid(cmd, env=None, **kwargs):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"loggedIn": False, "authMethod": "none"}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(session_mod.subprocess, "run", always_invalid)
+
+        with pytest.raises(SessionError, match="failed"):
+            mgr.setup_session(ACCOUNT_NUM, share=True, share_history=True)
+
+        assert not session_dir.exists()  # rolled back
+        # Shared source history is intact — cleanup removed the link, not target.
+        assert (
+            source / "projects" / "-home-user-app" / "aaa.jsonl"
+        ).read_text() == "main-a\n"
+        assert (source / "history.jsonl").read_text() == '{"p": "main"}\n'
+
+
+class TestJunctionSafety:
+    """Reparse-aware helpers: never delete or merge through a link's target.
+
+    POSIX symlinks stand in for Windows junctions here (both are reparse
+    points); the reparse-tag branch of _is_reparse_link is unit-tested with a
+    faked lstat since real junctions need Windows.
+    """
+
+    def test_is_reparse_link_true_for_symlink(self, tmp_path):
+        target = tmp_path / "t"
+        target.mkdir()
+        link = tmp_path / "l"
+        link.symlink_to(target)
+        assert _is_reparse_link(link)
+
+    def test_is_reparse_link_false_for_real(self, tmp_path):
+        (tmp_path / "d").mkdir()
+        (tmp_path / "f").write_text("x")
+        assert not _is_reparse_link(tmp_path / "d")
+        assert not _is_reparse_link(tmp_path / "f")
+        assert not _is_reparse_link(tmp_path / "missing")
+
+    def test_is_reparse_link_detects_junction_via_reparse_tag(
+        self, tmp_path, monkeypatch
+    ):
+        """A junction is not a symlink but carries a mount-point reparse tag."""
+        junction = tmp_path / "j"
+        junction.mkdir()  # a real dir standing in for the junction path
+        tag = 0xA0000003  # IO_REPARSE_TAG_MOUNT_POINT
+        monkeypatch.setattr(session_mod, "_REPARSE_TAGS", frozenset({tag}))
+        real_lstat = os.lstat
+        # st_mode of a directory so is_symlink() (checked first) returns False,
+        # forcing the reparse-tag branch — how a real junction behaves.
+        monkeypatch.setattr(
+            session_mod.os,
+            "lstat",
+            lambda p: SimpleNamespace(st_mode=stat.S_IFDIR, st_reparse_tag=tag)
+            if Path(p) == junction
+            else real_lstat(p),
+        )
+        assert _is_reparse_link(junction)
+
+    def test_safe_rmtree_does_not_follow_link(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "precious.txt").write_text("keep me")
+
+        profile = tmp_path / "profile"
+        profile.mkdir()
+        (profile / "own.txt").write_text("disposable")
+        (profile / "projects").symlink_to(outside)  # stands in for a junction
+
+        session_mod.safe_rmtree(profile)
+
+        assert not profile.exists()  # profile fully removed
+        assert (outside / "precious.txt").read_text() == "keep me"  # target intact
+
+    def test_remove_managed_on_link_keeps_target(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "precious.txt").write_text("keep me")
+        link = tmp_path / "projects"
+        link.symlink_to(outside)
+
+        session_mod.SessionManager._remove_managed(link)
+
+        assert not link.exists()
+        assert (outside / "precious.txt").read_text() == "keep me"
+
+    def test_cleanup_failed_session_does_not_follow_link(
+        self, manager, tmp_path
+    ):
+        outside = tmp_path / "real-history"
+        outside.mkdir()
+        (outside / "aaa.jsonl").write_text("real conversation")
+        session_dir = tmp_path / "profile"
+        session_dir.mkdir()
+        (session_dir / "projects").symlink_to(outside)  # stands in for a junction
+
+        manager._cleanup_failed_session(session_dir)
+
+        assert not session_dir.exists()
+        assert (outside / "aaa.jsonl").read_text() == "real conversation"
+
+    def test_delete_session_profile_does_not_follow_link(
+        self, seeded_switcher, tmp_path
+    ):
+        outside = tmp_path / "real-history"
+        outside.mkdir()
+        (outside / "aaa.jsonl").write_text("real conversation")
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        (session_dir / "projects").symlink_to(outside)
+
+        seeded_switcher._delete_session_profile(ACCOUNT_NUM, ACCOUNT_EMAIL)
+
+        assert not session_dir.exists()
+        assert (outside / "aaa.jsonl").read_text() == "real conversation"
+
+    def test_purge_does_not_follow_link(self, seeded_switcher, tmp_path, monkeypatch):
+        outside = tmp_path / "real-history"
+        outside.mkdir()
+        (outside / "aaa.jsonl").write_text("real conversation")
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        (session_dir / "projects").symlink_to(outside)
+
+        monkeypatch.setattr("builtins.input", lambda *a: "y")
+        seeded_switcher.purge()
+
+        assert not seeded_switcher.backup_dir.exists()
+        assert (outside / "aaa.jsonl").read_text() == "real conversation"
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="real junctions/reparse points require Windows"
+)
+class TestWindowsRealJunctions:
+    """Exercise the REAL _winapi junction syscalls on Windows CI (windows-latest).
+
+    Everything runs under tmp_path — never the real ~/.claude — so this is safe
+    to run automatically. The rest of the Windows suite stubs _create_junction
+    with a symlink; this class is the proof the genuine reparse-point paths work.
+    """
+
+    @pytest.fixture
+    def win_mgr(self, tmp_path):
+        switcher = SimpleNamespace(
+            platform=Platform.WINDOWS,
+            backup_dir=tmp_path / "backup",
+            _logger=logging.getLogger("cswap-win-real-test"),
+        )
+        (tmp_path / "backup").mkdir()
+        return SessionManager(switcher)
+
+    def test_create_detect_and_remove_junction(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "keep.txt").write_text("precious")
+        link = tmp_path / "link"
+
+        session_mod._create_junction(target, link)
+
+        assert _is_reparse_link(link)  # junction detected despite not being a symlink
+        assert not link.is_symlink()  # ...and it genuinely is NOT a symlink
+        assert (link / "keep.txt").read_text() == "precious"  # reads through it
+
+        session_mod._remove_link(link)
+        assert not link.exists()
+        assert (target / "keep.txt").read_text() == "precious"  # target untouched
+
+    def test_write_through_junction_reaches_target(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        link = tmp_path / "link"
+        session_mod._create_junction(target, link)
+
+        (link / "written.txt").write_text("via junction")
+        assert (target / "written.txt").read_text() == "via junction"
+
+    def test_safe_rmtree_spares_real_junction_target(self, tmp_path):
+        outside = tmp_path / "real-history"
+        outside.mkdir()
+        (outside / "aaa.jsonl").write_text("real conversation")
+        profile = tmp_path / "profile"
+        profile.mkdir()
+        (profile / "own.txt").write_text("disposable")
+        session_mod._create_junction(outside, profile / "projects")
+
+        session_mod.safe_rmtree(profile)
+
+        assert not profile.exists()  # profile fully gone
+        assert (outside / "aaa.jsonl").read_text() == "real conversation"  # spared
+
+    def test_stdlib_rmtree_would_follow_junction(self, tmp_path):
+        """Documents WHY safe_rmtree exists: plain shutil.rmtree deletes through
+        a junction. If a future Python fixes this, this test flips and we learn."""
+        import shutil
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "data.txt").write_text("x")
+        profile = tmp_path / "profile"
+        profile.mkdir()
+        session_mod._create_junction(outside, profile / "j")
+
+        try:
+            shutil.rmtree(profile)
+        except OSError:
+            pass
+        # The hazard: the junction's target contents get destroyed by stdlib.
+        assert not (outside / "data.txt").exists()
+
+    def test_materialize_real_junction_and_symlink(self, win_mgr, tmp_path):
+        src_dir = tmp_path / "src-projects"
+        src_dir.mkdir()
+        (src_dir / "a.jsonl").write_text("conv")
+        dest_dir = tmp_path / "profile" / "projects"
+        dest_dir.parent.mkdir()
+
+        win_mgr._materialize_share("projects", src_dir, dest_dir)
+        assert _is_reparse_link(dest_dir)
+        assert (dest_dir / "a.jsonl").read_text() == "conv"
+        # Idempotent: a second call leaves the same junction in place.
+        win_mgr._materialize_share("projects", src_dir, dest_dir)
+        assert _is_reparse_link(dest_dir)
+
+    def test_can_create_file_symlink_probe_real(self, win_mgr, tmp_path):
+        """On the GitHub windows-latest runner (admin) this is True; either way
+        the probe must leave no throwaway file behind."""
+        profile = tmp_path / "profile"
+        profile.mkdir()
+        result = win_mgr._can_create_file_symlink(profile)
+        assert isinstance(result, bool)
+        assert not (profile / ".cswap-symlink-probe").exists()
 
 
 class TestReadSessionCredentials:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -35,6 +35,41 @@ from claude_swap.session import (
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 ACCOUNT_EMAIL = "account2@example.com"
+def _link_dir(link: Path, target: Path) -> None:
+    """Create a reparse-point directory link, using the platform's
+    no-privilege primitive: a real junction on Windows, a symlink elsewhere.
+
+    Junctions need no privilege, but POSIX symlinks on Windows need
+    SeCreateSymbolicLinkPrivilege (Developer Mode/admin). Stubbing a junction
+    with a symlink therefore fails on a default Windows box — so on Windows we
+    stand in for a junction with an actual junction.
+    """
+    if sys.platform == "win32":
+        session_mod._create_junction(target, link)
+    else:
+        link.symlink_to(target)
+
+
+def _symlink_privilege() -> bool:
+    """Whether this host can create file symlinks at all."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        probe = Path(d) / "probe"
+        try:
+            probe.symlink_to(Path(d) / "nonexistent")
+        except (OSError, NotImplementedError):
+            return False
+        return True
+
+
+HAS_SYMLINK_PRIVILEGE = _symlink_privilege()
+requires_symlink = pytest.mark.skipif(
+    not HAS_SYMLINK_PRIVILEGE,
+    reason="needs symlink privilege (Windows Developer Mode/admin)",
+)
+
+
 ACCOUNT_NUM = "2"
 ORG_UUID = "org-uuid-2"
 
@@ -1548,11 +1583,12 @@ def fake_junction(monkeypatch):
     flows are exercisable on any host. _is_reparse_link then detects it as a
     link exactly as it would a real junction."""
 
-    def as_symlink(src, dest):
-        dest.symlink_to(src)
+    def as_link(src, dest):
+        _link_dir(dest, src)
 
-    monkeypatch.setattr(session_mod, "_create_junction", as_symlink)
-    return as_symlink
+    if sys.platform != "win32":
+        monkeypatch.setattr(session_mod, "_create_junction", as_link)
+    return as_link
 
 
 class TestShareHistoryWindows:
@@ -1572,6 +1608,7 @@ class TestShareHistoryWindows:
         mgr.switcher._write_account_config(ACCOUNT_NUM, ACCOUNT_EMAIL, CONFIG)
         return source, session_dir, mgr
 
+    @requires_symlink
     def test_links_projects_and_history(self, win):
         source, session_dir, mgr = win
         mgr._sync_sharing(session_dir, share=True, share_history=True)
@@ -1697,6 +1734,7 @@ class TestShareHistoryWindows:
         assert "projects" in manifest["items"]
         assert "history.jsonl" not in manifest["items"]
 
+    @requires_symlink
     def test_can_create_file_symlink_probes_and_cleans_up(self, win):
         """The Windows privilege probe creates then removes a throwaway link."""
         source, session_dir, mgr = win
@@ -1769,6 +1807,7 @@ class TestJunctionSafety:
     faked lstat since real junctions need Windows.
     """
 
+    @requires_symlink
     def test_is_reparse_link_true_for_symlink(self, tmp_path):
         target = tmp_path / "t"
         target.mkdir()
@@ -1811,7 +1850,7 @@ class TestJunctionSafety:
         profile = tmp_path / "profile"
         profile.mkdir()
         (profile / "own.txt").write_text("disposable")
-        (profile / "projects").symlink_to(outside)  # stands in for a junction
+        _link_dir(profile / "projects", outside)  # stands in for a junction
 
         session_mod.safe_rmtree(profile)
 
@@ -1823,7 +1862,7 @@ class TestJunctionSafety:
         outside.mkdir()
         (outside / "precious.txt").write_text("keep me")
         link = tmp_path / "projects"
-        link.symlink_to(outside)
+        _link_dir(link, outside)
 
         session_mod.SessionManager._remove_managed(link)
 
@@ -1838,7 +1877,7 @@ class TestJunctionSafety:
         (outside / "aaa.jsonl").write_text("real conversation")
         session_dir = tmp_path / "profile"
         session_dir.mkdir()
-        (session_dir / "projects").symlink_to(outside)  # stands in for a junction
+        _link_dir(session_dir / "projects", outside)  # stands in for a junction
 
         manager._cleanup_failed_session(session_dir)
 
@@ -1855,7 +1894,7 @@ class TestJunctionSafety:
             seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
         )
         session_dir.mkdir(parents=True)
-        (session_dir / "projects").symlink_to(outside)
+        _link_dir(session_dir / "projects", outside)
 
         seeded_switcher._delete_session_profile(ACCOUNT_NUM, ACCOUNT_EMAIL)
 
@@ -1870,7 +1909,7 @@ class TestJunctionSafety:
             seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
         )
         session_dir.mkdir(parents=True)
-        (session_dir / "projects").symlink_to(outside)
+        _link_dir(session_dir / "projects", outside)
 
         monkeypatch.setattr("builtins.input", lambda *a: "y")
         seeded_switcher.purge()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1939,9 +1939,20 @@ class TestWindowsRealJunctions:
         assert not profile.exists()  # profile fully gone
         assert (outside / "aaa.jsonl").read_text() == "real conversation"  # spared
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="stdlib shutil.rmtree junction-following is Windows/Python "
+        "version-dependent: observed SAFE on Windows Server 2022 / CPython 3.12 "
+        "(target survives), historically it recursed through junctions. "
+        "safe_rmtree is safe regardless — see "
+        "test_safe_rmtree_spares_real_junction_target.",
+    )
     def test_stdlib_rmtree_would_follow_junction(self, tmp_path):
-        """Documents WHY safe_rmtree exists: plain shutil.rmtree deletes through
-        a junction. If a future Python fixes this, this test flips and we learn."""
+        """Documents the historical hazard that motivates safe_rmtree: on some
+        Windows/Python versions plain shutil.rmtree recurses THROUGH a junction
+        and destroys the target's contents. xfail(strict=False) so it never
+        gates CI — it XFAILs where stdlib is safe and XPASSes where the hazard
+        is live, keeping a live hazard visible either way."""
         import shutil
 
         outside = tmp_path / "outside"
@@ -1955,7 +1966,7 @@ class TestWindowsRealJunctions:
             shutil.rmtree(profile)
         except OSError:
             pass
-        # The hazard: the junction's target contents get destroyed by stdlib.
+        # The historical hazard: stdlib destroys the junction's target contents.
         assert not (outside / "data.txt").exists()
 
     def test_materialize_real_junction_and_symlink(self, win_mgr, tmp_path):


### PR DESCRIPTION
# feat(session): support `--share-history` on Windows via junctions

## Summary

`cswap run --share-history` previously raised on Windows and shared conversation history only on POSIX (via symlinks). This makes it work on Windows too:

- `projects/` (resumable transcripts) → **directory junction** (no privilege needed)
- `history.jsonl` (prompt history) → **file symlink** (needs Developer Mode/admin)

When the file-symlink privilege is absent — the Windows default — `projects/` still shares and `history.jsonl` gracefully degrades: the account keeps its own prompt history and the launch never fails.

This is the deferred Windows follow-up to the `--share-history` work in #80.  @maddada @vcth4nh

## The core hazard this design is built around

A Windows **junction** is a reparse point that `os.path.islink()` reports as `False`. `shutil.rmtree` therefore recurses *through* it and would delete the real `~/.claude/projects` the profile's junction points at. Every deletion path was made reparse-aware, and destructive history operations are gated behind a one-time backup and a capability probe.

Key pieces:

- **`_is_reparse_link()`** — detects symlinks *and* junctions (the latter are invisible to `os.path.islink`). Used everywhere the sharing code distinguishes a cswap link from real user data.
- **`safe_rmtree()`** — never recurses through a reparse point; wired into `_cleanup_failed_session`, `_delete_session_profile`, and `purge`.
- **`_ensure_history_backup()`** — one-time snapshot of real history before the first Windows link; fails closed.
- **`_history_link_feasible()`** — gates the destructive history merge behind actual file-symlink capability, so a no-privilege launch keeps the account's own prompt history rather than merging it away behind a link that can't be created.

### Net improvement to teardown robustness

`safe_rmtree` also makes `purge` more robust on Windows than the current code. Today `purge` calls `shutil.rmtree(self.backup_dir)` with no `ignore_errors`, so a single locked file makes purge raise. `safe_rmtree` is best-effort, so it degrades to leaving a residual file rather than crashing the command.

## Testing

Coverage is platform-conditional by necessity; the union across a normal CI matrix (Linux + macOS + Windows) is complete:

- **`TestShareHistoryWindows` / `TestJunctionSafety`** — no platform gate. They force `platform = WINDOWS` and stub the junction primitive, so they run on **every** host. The symlink-path tests skip only where the host cannot create a symlink at all (default Windows without Developer Mode) — i.e. exactly where the code path under test is physically impossible. The degraded-mode behavior reachable there is covered by tests that don't require the privilege and run everywhere.
- **`TestWindowsRealJunctions`** — `skipif(sys.platform != "win32")`. Exercises the real `_winapi.CreateJunction` syscalls; runs on the Windows CI leg. (Its value depends on CI keeping a Windows runner — noted so a reviewer isn't surprised by a skip on a Linux-only local run.)

Validated end-to-end on real Windows 11 hardware with two real accounts, both Developer Mode states:

- Degraded (no Dev Mode): junction created, one-time backup taken, bidirectional resume, write-through, `history.jsonl` correctly skipped.
- Privileged (Dev Mode on): `history.jsonl` symlinked, the profile's own history merged into `~/.claude` with zero lines lost.
- Teardown: `cswap remove` severed both links with the real `~/.claude` left fully intact (all conversations present).
- Full suite: 1445 passed with Dev Mode off, 1448 with it on (the three privilege-gated tests run and pass), 0 failures.

## Known limitation / proposed follow-up

`safe_rmtree` is best-effort: it swallows `OSError` so teardown never crashes. On Windows, a file transiently locked by antivirus/indexer/git at the moment of deletion can leave a residual profile directory behind (observed once in testing: a plugin-clone git pack file locked during `cswap remove`; it deleted cleanly on retry). This is cosmetic — the account is removed, the reparse links are severed, and no real data is at risk — and it is strictly milder than the current `purge`, which raises on the same condition.

A follow-up can add transient-lock retry to the deletion path, reusing the retry primitive from the companion Windows fix (retry on `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION`). Deferred here to keep this PR focused on the sharing feature.