### PR TITLE
fix: fence long-running usage fetches

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -2858,28 +2858,29 @@ class ClaudeAccountSwitcher:
             for num in info_by_num
             if num not in sentinels and (fetch is None or num in fetch)
         ]
-        to_fetch = store.reserve(
+        claims = store.reserve(
             requested, identities, respect_plans=fetch is None
         )
 
-        if to_fetch:
+        if claims:
             pre = entries
             records = self._run_usage_fetches(
-                [info_by_num[num] for num in to_fetch]
+                [info_by_num[num] for num in claims]
             )
-            store.record(records, identities)
-            for num, record in records.items():
+            plans = self._plans_after_fetch(records, pre, info_by_num)
+            accepted = store.record(records, identities, claims, plans)
+            accepted_records = {
+                num: record for num, record in records.items() if num in accepted
+            }
+            for num, record in accepted_records.items():
                 if record.sentinel is not None:
                     sentinels[num] = record.sentinel
             entries = store.entries(identities, models)
-            self._persist_poll_plans(
-                records, pre, entries, info_by_num, identities
-            )
             # A fetch that just returned invalid_grant advances the strike to the
             # dead threshold. The pre-fetch quarantine scan above couldn't see it,
             # so surface "re-login needed" in *this* pass instead of leaving the
             # slot looking merely refresh-failed until the next refresh notices.
-            for num in to_fetch:
+            for num in accepted:
                 if entries[num].token_dead():
                     sentinels[num] = USAGE_RELOGIN_REQUIRED
 
@@ -2888,40 +2889,36 @@ class ClaudeAccountSwitcher:
             for num in info_by_num
         }
 
-    def _persist_poll_plans(
+    def _plans_after_fetch(
         self,
         records: dict[str, FetchRecord],
         pre: dict[str, UsageEntry],
-        post: dict[str, UsageEntry],
         info_by_num: dict[str, tuple],
-        identities: dict[str, tuple[str, str]],
-    ) -> None:
-        """Adapt and persist the cadence of every slot just fetched
-        successfully, so the next collector — whichever surface it runs in —
-        inherits the plan. Failures are paced by the store's backoff instead
-        and keep their (now past-due) plan for when the backoff lifts."""
+    ) -> dict[str, tuple[float | None, float | None]]:
+        """Build successful-fetch cadence updates for atomic outcome commit.
+
+        Failures are paced by the store's backoff and keep their past-due plan
+        for when the backoff lifts.
+        """
         now = self._usage_store.clock()
         threshold, models = self._poll_policy_inputs()
         plans: dict[str, tuple[float | None, float | None]] = {}
         for num, rec in records.items():
             if rec.sentinel is not None or rec.error is not None:
                 continue
-            before, after = pre.get(num), post.get(num)
-            if after is None or after.fetched_at is None:
-                continue
+            before = pre.get(num)
             recent_429 = before is not None and before.recent_429(now)
             plans[num] = poll_policy.plan_after_fetch(
                 prev_interval_s=before.poll_interval_s if before else None,
                 prev_usage=before.last_good if before else None,
-                new_usage=after.last_good,
+                new_usage=rec.usage,
                 is_active=bool(info_by_num[num][4]),
                 threshold=threshold,
                 models=models,
                 recent_429=recent_429,
                 now=now,
             )
-        if plans:
-            self._usage_store.set_poll_plan(plans, identities)
+        return plans
 
     def _replan_new_active(self, number: str, email: str, org_uuid: str) -> None:
         """Pull the just-activated account's poll plan to the active floor.

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -16,17 +16,19 @@ overlaid on the read model (``UsageEntry.sentinel``) — never written to disk,
 so a stale sentinel can't outlive the condition that produced it.
 
 Locking protocol (never holds the lock across network I/O):
-(a) lock → read, decide/claim the fetch set (stamp ``lastAttemptAt``) → unlock;
+(a) lock → read, decide/claim the fetch set (stamp ``claimUntil``) → unlock;
 (b) fetch with no lock held;
-(c) lock → re-read, merge outcomes, write → unlock.
-The claim stamp lets concurrent collectors skip accounts another process
-started fetching moments ago; a crashed claimer just ages out.
+(c) lock → re-read, merge outcomes, clear the claim, write → unlock.
+The bounded lease lets concurrent collectors skip accounts another process is
+still fetching; a completed fetch releases it immediately and a crashed claimer
+ages out.
 """
 
 from __future__ import annotations
 
 import json
 import time
+import uuid
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -48,7 +50,12 @@ SCHEMA_VERSION = 2
 # without fetching) doubles as the per-token sustained-rate governor: see
 # poll_policy's module docstring for the measured budget it must stay under.
 STALE_OK_S = 300.0  # trusted for switch decisions; older → headroom unknown
-CLAIM_TTL_S = 10.0  # in-flight claim window: skip just-claimed accounts
+# Covers the bounded refresh + usage path, the full inventory's stagger, and
+# executor queueing, so another surface cannot reclaim a request that is still
+# in flight. A crashed collector waiting 90s remains below the provider-safe
+# polling interval.
+CLAIM_TTL_S = 90.0  # in-flight claim window: skip just-claimed accounts
+LEGACY_CLAIM_TTL_S = 10.0  # additive-schema overlap with older collectors
 
 # Deliberate staleness (failure backoff, scheduler-chosen cadence) extends
 # decision trust past STALE_OK_S, but never past this ceiling: a forever-failing
@@ -179,6 +186,9 @@ class UsageEntry:
     # scheduler itself chose the cadence (within nextPollAt). Capped at
     # TRUST_MAX_AGE_S. Computed by UsageStore.entries().
     trust_extended: bool = False
+    # Appended to preserve positional compatibility for the older read-model
+    # fields while exposing whether a fetch lease is currently live.
+    claim_until: float | None = None
 
     def fresh(self, now: float, ttl: float = SERVE_TTL_S) -> bool:
         return self.fetched_at is not None and (now - self.fetched_at) <= ttl
@@ -219,10 +229,13 @@ class UsageEntry:
         return now < anchor + RECENT_429_WINDOW_S
 
     def claimed(self, now: float) -> bool:
-        """A collector stamped this entry moments ago (fetch may be in flight)."""
+        """Whether another collector's bounded fetch lease is still live."""
+        if self.claim_until is not None:
+            return now < self.claim_until
+        # Additive-schema compatibility for rows claimed by an older process.
         return (
             self.last_attempt_at is not None
-            and (now - self.last_attempt_at) < CLAIM_TTL_S
+            and (now - self.last_attempt_at) < LEGACY_CLAIM_TTL_S
         )
 
     def token_dead(self, threshold: int = AUTH_DEAD_STRIKES) -> bool:
@@ -433,6 +446,7 @@ class UsageStore:
             if not self._matches(row, identity):
                 out[num] = UsageEntry()
                 continue
+            assert isinstance(row, dict)
             fetched_at = row.get("fetchedAt")
             if not isinstance(fetched_at, (int, float)):
                 fetched_at = None
@@ -441,6 +455,7 @@ class UsageStore:
             consecutive_failures = int(row.get("consecutiveFailures") or 0)
             next_poll_at = _num_or_none(row.get("nextPollAt"))
             last_attempt_at = _num_or_none(row.get("lastAttemptAt"))
+            claim_until = _num_or_none(row.get("claimUntil"))
             # Strict < mirrors due_candidate: at nextPollAt the entry is due,
             # its staleness no longer scheduler-chosen. A live claim keeps the
             # trust bridge up: when another collector just won the fetch, this
@@ -462,15 +477,20 @@ class UsageStore:
                 )
             else:
                 within_ceiling = age_s is not None and age_s <= TRUST_MAX_AGE_S
+            live_claim = (
+                now < claim_until
+                if claim_until is not None
+                else (
+                    last_attempt_at is not None
+                    and (now - last_attempt_at) < LEGACY_CLAIM_TTL_S
+                )
+            )
             trust_extended = (
                 within_ceiling
                 and (
                     consecutive_failures > 0
                     or (next_poll_at is not None and now < next_poll_at)
-                    or (
-                        last_attempt_at is not None
-                        and (now - last_attempt_at) < CLAIM_TTL_S
-                    )
+                    or live_claim
                 )
             )
             out[num] = UsageEntry(
@@ -486,6 +506,7 @@ class UsageStore:
                 last_429_at=_num_or_none(row.get("last429At")),
                 auth_dead_strikes=int(row.get("authDeadStrikes") or 0),
                 trust_extended=trust_extended,
+                claim_until=claim_until,
             )
         return out
 
@@ -508,13 +529,25 @@ class UsageStore:
                 mutator(num, rows[num])
             self._write_rows(rows)
 
-    def claim(self, nums: Iterable[str], identities: dict[str, Identity]) -> None:
-        """Stamp ``lastAttemptAt`` on the slots about to be fetched."""
+    def claim(
+        self, nums: Iterable[str], identities: dict[str, Identity]
+    ) -> dict[str, str]:
+        """Lease the slots about to be fetched, returning their fencing ids."""
         nums = list(nums)
         if not nums:
-            return
+            return {}
         now = self.clock()
-        self._mutate(identities, nums, lambda _n, row: row.update(lastAttemptAt=now))
+        claims = {num: uuid.uuid4().hex for num in nums}
+        self._mutate(
+            identities,
+            nums,
+            lambda num, row: row.update(
+                lastAttemptAt=now,
+                claimId=claims[num],
+                claimUntil=now + CLAIM_TTL_S,
+            ),
+        )
+        return claims
 
     def reserve(
         self,
@@ -522,9 +555,9 @@ class UsageStore:
         identities: dict[str, Identity],
         *,
         respect_plans: bool,
-    ) -> list[str]:
+    ) -> dict[str, str]:
         """Atomically win the right to fetch: re-check eligibility and stamp
-        ``lastAttemptAt`` in one locked pass, returning only the slots won.
+        a bounded lease in one locked pass, returning slot → fencing id.
 
         Deciding eligibility on a lock-free :meth:`entries` read and then
         claiming separately lets two collectors both pass the check and both
@@ -542,9 +575,9 @@ class UsageStore:
         """
         nums = list(nums)
         if not nums:
-            return []
+            return {}
         now = self.clock()
-        won: list[str] = []
+        won: dict[str, str] = {}
         with self._lock():
             rows = self._read_rows()
             for num in nums:
@@ -552,32 +585,57 @@ class UsageStore:
                 row = rows.get(num)
                 if not self._matches(row, identity):
                     rows[num] = row = self._fresh_row(identity)
-                elif not _row_eligible(row, now, respect_plans):
-                    continue
+                else:
+                    assert isinstance(row, dict)
+                    if not _row_eligible(row, now, respect_plans):
+                        continue
+                claim_id = uuid.uuid4().hex
                 row["lastAttemptAt"] = now
-                won.append(num)
+                row["claimId"] = claim_id
+                row["claimUntil"] = now + CLAIM_TTL_S
+                won[num] = claim_id
             if won:
                 self._write_rows(rows)
         return won
 
     def record(
-        self, outcomes: dict[str, FetchRecord], identities: dict[str, Identity]
-    ) -> None:
-        """Merge fetch outcomes. Success and failure are mutually exclusive
-        writers: success resets the failure fields, failure never touches
-        ``lastGood``/``fetchedAt``. Sentinel records are no-ops (derived state
-        lives only in the collector's overlay)."""
-        effective = {n: r for n, r in outcomes.items() if r.sentinel is None}
-        if not effective:
-            return
+        self,
+        outcomes: dict[str, FetchRecord],
+        identities: dict[str, Identity],
+        claims: dict[str, str] | None = None,
+        plans: dict[str, tuple[float | None, float | None]] | None = None,
+    ) -> set[str]:
+        """Merge outcomes fenced by the leases that produced them.
+
+        A late writer whose lease or slot identity was replaced is ignored
+        without touching the newer row. Success and failure are mutually
+        exclusive writers: success resets the failure fields, failure never
+        touches ``lastGood``/``fetchedAt``. A supplied success plan commits
+        in the same transaction as its measurement. Sentinel records clear
+        only the claim and are otherwise never persisted. Returns the accepted
+        slots.
+        """
+        if not outcomes:
+            return set()
         now = self.clock()
+        accepted: set[str] = set()
 
         def apply(num: str, row: dict) -> None:
-            rec = effective[num]
+            accepted.add(num)
+            rec = outcomes[num]
+            row["claimId"] = None
+            row["claimUntil"] = 0.0
+            if rec.sentinel is not None:
+                return
             row["lastAttemptAt"] = now
             if rec.error is None:
                 row["lastGood"] = rec.usage
                 row["fetchedAt"] = now
+                # Replace the old, possibly due plan in the outcome transaction
+                # so no collector can slip into a record→replan gap.
+                plan = plans.get(num) if plans is not None else None
+                if plan is not None:
+                    row["nextPollAt"], row["pollIntervalS"] = plan
                 row["consecutiveFailures"] = 0
                 row["lastError"] = None
                 row["backoffUntil"] = None
@@ -599,7 +657,30 @@ class UsageStore:
                 if rec.error in PERMANENT_AUTH_ERRORS:
                     row["authDeadStrikes"] = int(row.get("authDeadStrikes") or 0) + 1
 
-        self._mutate(identities, effective.keys(), apply)
+        with self._lock():
+            rows = self._read_rows()
+            for num in outcomes:
+                identity = identities[num]
+                row = rows.get(num)
+                expected: str | None = None
+                if claims is not None:
+                    expected = claims.get(num)
+                    if (
+                        expected is None
+                        or not self._matches(row, identity)
+                        or not isinstance(row, dict)
+                        or row.get("claimId") != expected
+                    ):
+                        continue
+                elif isinstance(row, dict) and row.get("claimId") is not None:
+                    continue
+                elif not self._matches(row, identity):
+                    rows[num] = row = self._fresh_row(identity)
+                assert isinstance(row, dict)
+                apply(num, row)
+            if accepted:
+                self._write_rows(rows)
+        return accepted
 
     def set_poll_plan(
         self,
@@ -632,6 +713,8 @@ class UsageStore:
             return
 
         def apply(_num: str, row: dict) -> None:
+            row["claimId"] = None
+            row["claimUntil"] = 0.0
             row["authDeadStrikes"] = 0
             row["consecutiveFailures"] = 0
             row["lastError"] = None
@@ -652,9 +735,17 @@ def _row_eligible(row: dict, now: float, respect_plans: bool) -> bool:
     backoff_until = _num_or_none(row.get("backoffUntil"))
     if backoff_until is not None and now < backoff_until:
         return False
-    last_attempt = _num_or_none(row.get("lastAttemptAt"))
-    if last_attempt is not None and (now - last_attempt) < CLAIM_TTL_S:
-        return False
+    claim_until = _num_or_none(row.get("claimUntil"))
+    if claim_until is not None:
+        if now < claim_until:
+            return False
+    else:
+        last_attempt = _num_or_none(row.get("lastAttemptAt"))
+        if (
+            last_attempt is not None
+            and (now - last_attempt) < LEGACY_CLAIM_TTL_S
+        ):
+            return False
     fetched_at = _num_or_none(row.get("fetchedAt"))
     stale = fetched_at is None or (now - fetched_at) > SERVE_TTL_S
     next_poll_at = _num_or_none(row.get("nextPollAt"))

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -428,11 +428,27 @@ class TestIdentityGuard:
 
 class TestClaims:
     def test_claim_marks_in_flight(self, store, clock):
-        store.claim(["1"], IDENT)
+        claims = store.claim(["1"], IDENT)
         entry = store.entries(IDENT)["1"]
+        assert set(claims) == {"1"}
         assert entry.claimed(clock.now)
         clock.advance(CLAIM_TTL_S + 1)
         assert not store.entries(IDENT)["1"].claimed(clock.now)
+
+    def test_legacy_last_attempt_claim_is_honored_during_schema_overlap(
+        self, store, clock
+    ):
+        store.claim(["1"], IDENT)
+        raw = json.loads(store.path.read_text())
+        row = raw["accounts"]["1"]
+        row.pop("claimId")
+        row.pop("claimUntil")
+        store.path.write_text(json.dumps(raw))
+
+        assert store.entries(IDENT)["1"].claimed(clock.now)
+        assert store.reserve(["1"], IDENT, respect_plans=True) == {}
+        clock.advance(11)
+        assert set(store.reserve(["1"], IDENT, respect_plans=True)) == {"1"}
 
     def test_claim_does_not_touch_measurement(self, store, clock):
         store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
@@ -441,6 +457,142 @@ class TestClaims:
         entry = store.entries(IDENT)["1"]
         assert entry.last_good == USAGE
         assert entry.age_s == 100.0
+
+    def test_live_claim_outlasts_urgent_poll_interval(self, store, clock):
+        claims = store.reserve(["1"], IDENT, respect_plans=True)
+        assert set(claims) == {"1"}
+        clock.advance(61)
+        assert store.reserve(["1"], IDENT, respect_plans=False) == {}
+
+    def test_record_releases_long_claim_immediately(self, store, clock):
+        claims = store.reserve(["1"], IDENT, respect_plans=True)
+        assert store.entries(IDENT)["1"].claimed(clock.now)
+        assert store.record({"1": FetchRecord(usage=USAGE)}, IDENT, claims) == {"1"}
+        assert not store.entries(IDENT)["1"].claimed(clock.now)
+
+    def test_failure_releases_claim(self, store, clock):
+        claims = store.reserve(["1"], IDENT, respect_plans=True)
+        assert store.record({"1": FetchRecord(error="timeout")}, IDENT, claims) == {
+            "1"
+        }
+        entry = store.entries(IDENT)["1"]
+        assert not entry.claimed(clock.now)
+        assert entry.last_error == "timeout"
+
+    def test_sentinel_releases_claim_without_persisting_state(self, store, clock):
+        claims = store.reserve(["1"], IDENT, respect_plans=True)
+        claimed_at = store.entries(IDENT)["1"].last_attempt_at
+        clock.advance(1)
+        assert store.record(
+            {"1": FetchRecord(sentinel="token expired")}, IDENT, claims
+        ) == {"1"}
+        entry = store.entries(IDENT)["1"]
+        assert not entry.claimed(clock.now)
+        assert entry.last_attempt_at == claimed_at
+        assert entry.sentinel is None
+        assert entry.last_good is None
+
+    def test_expired_writer_cannot_clear_or_overwrite_new_lease(self, store, clock):
+        first = store.reserve(["1"], IDENT, respect_plans=True)
+        clock.advance(CLAIM_TTL_S + 1)
+        second = store.reserve(["1"], IDENT, respect_plans=True)
+        assert first["1"] != second["1"]
+
+        assert store.record(
+            {"1": FetchRecord(error="timeout")}, IDENT, first
+        ) == set()
+        entry = store.entries(IDENT)["1"]
+        assert entry.claimed(clock.now)
+        assert entry.last_error is None
+
+        assert store.record(
+            {"1": FetchRecord(usage=USAGE)}, IDENT, second
+        ) == {"1"}
+        assert store.entries(IDENT)["1"].last_good == USAGE
+
+    def test_stale_writer_cannot_replace_a_rebound_identity(self, store, clock):
+        stale_claim = store.reserve(["1"], IDENT, respect_plans=True)
+        rebound = {"1": ("new@x.com", "org-new")}
+        assert set(store.reserve(["1"], rebound, respect_plans=True)) == {"1"}
+
+        assert store.record(
+            {"1": FetchRecord(usage=USAGE)}, IDENT, stale_claim
+        ) == set()
+        entry = store.entries(rebound)["1"]
+        assert entry.claimed(clock.now)
+        assert entry.last_good is None
+
+    def test_partial_records_can_reuse_their_explicit_claims(self, store):
+        claims = store.reserve(["1", "2"], IDENT, respect_plans=True)
+        assert store.record({"1": FetchRecord(usage=USAGE)}, IDENT, claims) == {
+            "1"
+        }
+        assert store.entries(IDENT)["2"].claimed(store.clock())
+
+        assert store.record({"2": FetchRecord(usage=USAGE)}, IDENT, claims) == {
+            "2"
+        }
+        entries = store.entries(IDENT)
+        assert entries["1"].last_good == USAGE
+        assert entries["2"].last_good == USAGE
+
+    def test_mixed_record_accepts_only_the_current_claim(self, store, clock):
+        first = store.reserve(["1", "2"], IDENT, respect_plans=True)
+        clock.advance(CLAIM_TTL_S + 1)
+        second = store.reserve(["1"], IDENT, respect_plans=True)
+        assert first["1"] != second["1"]
+
+        outcomes = {
+            "1": FetchRecord(error="timeout"),
+            "2": FetchRecord(usage=USAGE),
+        }
+        assert store.record(outcomes, IDENT, first) == {"2"}
+        entries = store.entries(IDENT)
+        assert entries["1"].last_error is None
+        assert entries["1"].claimed(clock.now)
+        assert entries["2"].last_good == USAGE
+
+    def test_unfenced_record_cannot_overwrite_a_live_claim(self, store, clock):
+        claims = store.reserve(["1"], IDENT, respect_plans=True)
+        assert store.record({"1": FetchRecord(error="timeout")}, IDENT) == set()
+        entry = store.entries(IDENT)["1"]
+        assert entry.claimed(clock.now)
+        assert entry.last_error is None
+        assert store.record({"1": FetchRecord(usage=USAGE)}, IDENT, claims) == {
+            "1"
+        }
+
+    def test_credential_refresh_revokes_an_old_fetch_claim(self, store, clock):
+        claims = store.reserve(["1"], IDENT, respect_plans=True)
+        store.clear_dead_token(["1"], IDENT)
+        assert store.record(
+            {"1": FetchRecord(error="invalid_grant")}, IDENT, claims
+        ) == set()
+        entry = store.entries(IDENT)["1"]
+        assert not entry.claimed(clock.now)
+        assert not entry.token_dead()
+        assert set(store.reserve(["1"], IDENT, respect_plans=True)) == {"1"}
+
+    def test_success_commits_its_new_plan_without_a_duplicate_window(
+        self, store, clock
+    ):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        store.set_poll_plan({"1": (clock.now + 60.0, 60.0)}, IDENT)
+        clock.advance(61)
+        claims = store.reserve(["1"], IDENT, respect_plans=False)
+        assert set(claims) == {"1"}
+
+        next_poll = clock.now + 300.0
+        store.record(
+            {"1": FetchRecord(usage=USAGE)},
+            IDENT,
+            claims,
+            {"1": (next_poll, 300.0)},
+        )
+        entry = store.entries(IDENT)["1"]
+        assert entry.next_poll_at == next_poll
+        assert entry.poll_interval_s == 300.0
+        assert store.reserve(["1"], IDENT, respect_plans=False) == {}
 
 
 class TestSentinels:
@@ -593,23 +745,23 @@ class TestReserve:
         clock.advance(SERVE_TTL_S + CLAIM_TTL_S + 1)
 
     def test_reserve_wins_and_stamps(self, store):
-        assert store.reserve(["1"], IDENT, respect_plans=True) == ["1"]
+        assert set(store.reserve(["1"], IDENT, respect_plans=True)) == {"1"}
         # The stamp is the claim: an immediate second reservation loses —
         # this is the double-fetch race the old read-then-claim flow allowed.
-        assert store.reserve(["1"], IDENT, respect_plans=True) == []
-        assert store.reserve(["1"], IDENT, respect_plans=False) == []
+        assert store.reserve(["1"], IDENT, respect_plans=True) == {}
+        assert store.reserve(["1"], IDENT, respect_plans=False) == {}
 
     def test_fresh_entry_not_won(self, store, clock):
         store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
         clock.advance(CLAIM_TTL_S + 1)  # claim expired, entry still fresh
-        assert store.reserve(["1"], IDENT, respect_plans=True) == []
+        assert store.reserve(["1"], IDENT, respect_plans=True) == {}
 
     def test_respect_plans_waits_for_next_poll(self, store, clock):
         self._stale(store, clock)
         store.set_poll_plan({"1": (clock.now + 300.0, 300.0)}, IDENT)
-        assert store.reserve(["1"], IDENT, respect_plans=True) == []
+        assert store.reserve(["1"], IDENT, respect_plans=True) == {}
         clock.advance(301)
-        assert store.reserve(["1"], IDENT, respect_plans=True) == ["1"]
+        assert set(store.reserve(["1"], IDENT, respect_plans=True)) == {"1"}
 
     def test_scheduler_beats_the_ttl_when_due(self, store, clock):
         # Urgent cadence: a due plan wins even inside the serve TTL for the
@@ -617,35 +769,35 @@ class TestReserve:
         store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
         store.set_poll_plan({"1": (clock.now + 60.0, 60.0)}, IDENT)
         clock.advance(61)
-        assert store.reserve(["1"], IDENT, respect_plans=True) == []
-        assert store.reserve(["1"], IDENT, respect_plans=False) == ["1"]
+        assert store.reserve(["1"], IDENT, respect_plans=True) == {}
+        assert set(store.reserve(["1"], IDENT, respect_plans=False)) == {"1"}
 
     def test_scheduler_may_fetch_a_not_due_stale_entry(self, store, clock):
         # Escalation semantics: an explicit set bypasses a future nextPollAt
         # when the entry has gone stale.
         self._stale(store, clock)
         store.set_poll_plan({"1": (clock.now + 600.0, 600.0)}, IDENT)
-        assert store.reserve(["1"], IDENT, respect_plans=False) == ["1"]
+        assert set(store.reserve(["1"], IDENT, respect_plans=False)) == {"1"}
 
     def test_backoff_blocks_both_modes(self, store, clock):
         store.record({"1": FetchRecord(error="timeout")}, IDENT)
-        clock.advance(CLAIM_TTL_S + 1)  # claim gone, 30s backoff still on
-        assert store.reserve(["1"], IDENT, respect_plans=True) == []
-        assert store.reserve(["1"], IDENT, respect_plans=False) == []
+        clock.advance(BACKOFF_BASE_S - 1)  # completed claim gone, backoff still on
+        assert store.reserve(["1"], IDENT, respect_plans=True) == {}
+        assert store.reserve(["1"], IDENT, respect_plans=False) == {}
 
     def test_dead_token_never_won(self, store, clock):
         store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
         clock.advance(TRUST_MAX_AGE_S)  # backoff long gone; quarantine stays
-        assert store.reserve(["1"], IDENT, respect_plans=True) == []
-        assert store.reserve(["1"], IDENT, respect_plans=False) == []
+        assert store.reserve(["1"], IDENT, respect_plans=True) == {}
+        assert store.reserve(["1"], IDENT, respect_plans=False) == {}
 
     def test_unknown_row_and_identity_mismatch_win(self, store, clock):
-        assert store.reserve(["1"], IDENT, respect_plans=True) == ["1"]
+        assert set(store.reserve(["1"], IDENT, respect_plans=True)) == {"1"}
         # Slot reused by a different account: the old row is invisible and
         # replaced, so the new identity is fetch-eligible immediately.
         store.record({"2": FetchRecord(usage=USAGE)}, IDENT)
         other = {"2": ("new@x.com", "org-9")}
-        assert store.reserve(["2"], other, respect_plans=True) == ["2"]
+        assert set(store.reserve(["2"], other, respect_plans=True)) == {"2"}
 
 
 class TestLast429Marker:
@@ -852,7 +1004,7 @@ class TestClaimTrustBridge:
         store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
         store.set_poll_plan({"1": (clock.now + 400.0, 400.0)}, IDENT)
         clock.advance(401)  # poll-due, age > STALE_OK_S
-        assert store.reserve(["1"], IDENT, respect_plans=True) == ["1"]
+        assert set(store.reserve(["1"], IDENT, respect_plans=True)) == {"1"}
         entry = store.entries(IDENT)["1"]
         assert entry.trust_extended
         assert entry.decision_value() == USAGE


### PR DESCRIPTION
## Summary

- replace the 10-second `lastAttemptAt`-derived usage claim with a separate 90-second `claimUntil` lease
- fence each fetch with a random `claimId`, rejecting late results when either the claim or slot identity changed
- commit each accepted successful measurement and its next poll plan in one cache transaction
- release accepted success, failure, and sentinel leases immediately, so the 60-second urgent cadence is not delayed
- revoke an in-flight usage claim when credentials are refreshed
- retain the legacy 10-second interpretation for cache rows written without `claimUntil`

Closes #157.

## Why

The inactive usage path can spend up to 5 seconds on the initial request, 10 seconds refreshing after a 401, and another 5 seconds retrying usage. Inventory staggering and executor queueing add more time before some requests begin.

A second local surface could therefore reserve the same account after the existing 10-second claim expired while the first request was still running. Besides duplicating constrained provider traffic, the two outcomes could race into the shared row.

## Design notes

`UsageStore.reserve()` now returns the fencing IDs it won. The collector carries those IDs through the fetch and `record()` validates the stored identity and claim under the same file lock used for the outcome write.

Successful poll plans are calculated before the write and committed with the accepted measurement. Rejected records cannot install sentinels, poll plans, or dead-token state.

The cache change is additive and keeps `schemaVersion = 2`. Existing rows without the new field retain the original short claim behavior. Long-running processes executing pre-patch code should be restarted when upgrading because running old code cannot interpret additive fields.

## Validation

- `uv run pytest tests/test_usage_store.py tests/test_poll_policy.py tests/test_switcher.py` — **428 passed**
- focused lease, stale-writer, identity-rebind, credential-refresh, mixed-outcome, and atomic-plan regressions are included
- `git diff --check` — passed
- full local suite — **1460 passed, 3 skipped, 6 failed**; the same six credential move/swap tests fail unchanged on clean base `c097d76` on this host because its local keychain backend returns empty values
