### PR TITLE
Add an opt-in vertical-meter watch layout (ui.watch_style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usag
 
 <img src="assets/tui-watch.png" width="760" alt="cswap watch — live 5h/7d usage bars for every account, with reset times and the active account marked">
 
+The watch monitor defaults to the horizontal usage-bar cards above. For a compact, glanceable view — a responsive grid of vertical gradient meters — press **`Ctrl+V`** inside the watch screen to flip between the two live, or set the default up front with `cswap config set ui.watchStyle meters` (classic | meters).
+
+
 ### Refresh expired tokens
 
 If an account's token expires, log back into Claude Code with that account and re-run:
@@ -262,6 +265,7 @@ cswap config                              # list effective settings ("(default)"
 cswap config get autoswitch.threshold
 cswap config set autoswitch.threshold 80  # validated: rejects out-of-range values loudly
 cswap config set autoswitch.model Fable   # per-model switching (see "auto"); Fable,Opus for several
+cswap config set ui.watchStyle meters     # cswap watch layout: classic bars (default) or vertical meters
 cswap config unset autoswitch.threshold   # back to the default
 cswap config path                         # where settings.json lives
 ```

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usag
 
 <img src="assets/tui-watch.png" width="760" alt="cswap watch — live 5h/7d usage bars for every account, with reset times and the active account marked">
 
+The watch monitor defaults to the horizontal usage-bar cards above. For a compact, glanceable view — a responsive grid of vertical gradient meters — press **`Ctrl+V`** inside the watch screen to flip between the two live, or set the default up front with `cswap config set ui.watchStyle meters` (classic | meters).
+
+
 ### Refresh expired tokens
 
 If an account's token expires, log back into Claude Code with that account and re-run:
@@ -255,6 +258,7 @@ cswap config                              # list effective settings ("(default)"
 cswap config get autoswitch.threshold
 cswap config set autoswitch.threshold 80  # validated: rejects out-of-range values loudly
 cswap config set autoswitch.model Fable   # per-model switching (see "auto"); Fable,Opus for several
+cswap config set ui.watchStyle meters     # cswap watch layout: classic bars (default) or vertical meters
 cswap config unset autoswitch.threshold   # back to the default
 cswap config path                         # where settings.json lives
 ```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usag
 
 <img src="assets/tui-watch.png" width="760" alt="cswap watch — live 5h/7d usage bars for every account, with reset times and the active account marked">
 
-The watch monitor defaults to the horizontal usage-bar cards above. For a compact, glanceable view — a responsive grid of vertical gradient meters — press **`Ctrl+V`** inside the watch screen to flip between the two live, or set the default up front with `cswap config set ui.watchStyle meters` (classic | meters).
+The watch monitor defaults to the horizontal usage-bar cards above. For a compact, glanceable view — a responsive grid of vertical gradient meters — press **`Ctrl+V`** inside the watch screen to flip between the two live, or set the default up front with `cswap config set ui.watchStyle meters` (classic | meters). In the meters view, **`a`** runs the auto-switcher in dry-run so the card it would move to next breathes (faster as the threshold nears), and **`L`** arms real switching after a confirmation; the mode and the next target read out at the right end of the footer, and so does a switch that failed.
 
 
 ### Refresh expired tokens

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -314,6 +314,11 @@ class PollEvent(AutoSwitchEvent):
     # (e.g. "89%") hides which window binds — #115 was reported off that
     # ambiguity.
     windows: dict[str, dict[str, float]] = field(default_factory=dict)
+    # The account number the engine would move to if the active account
+    # crossed the threshold on this tick's snapshot; None when nothing
+    # qualifies. A prediction for watch screens, computed every tick —
+    # see `_predict_next_target`. Additive field.
+    next_target: str | None = None
 
     def _fields(self) -> dict:
         fields = {
@@ -325,6 +330,8 @@ class PollEvent(AutoSwitchEvent):
             fields["fetchErrors"] = self.fetch_errors
         if self.windows:
             fields["windowsPct"] = self.windows
+        if self.next_target is not None:
+            fields["nextTarget"] = self.next_target
         return fields
 
     def _describe(self, num: str) -> str:
@@ -665,6 +672,11 @@ class AutoSwitchEngine:
         self.state_path = state_path or (switcher.backup_dir / STATE_FILENAME)
         self.clock = clock
         self._stop = threading.Event()
+        # Held for the whole switch transaction in `_perform`; `stop()` takes
+        # it after signalling, so it cannot return while a switch is under
+        # way on another thread. Re-entrant: a stop() issued from the tick
+        # thread itself (SIGTERM handler) must never wait on its own switch.
+        self._switch_lock = threading.RLock()
         # Cuts the current inter-tick sleep short (a session threshold change
         # from the TUI should show a fresh decision now, not next interval).
         self._wake = threading.Event()
@@ -942,6 +954,9 @@ class AutoSwitchEngine:
                 active=active_ref,
                 headroom=headroom,
                 threshold=settings.threshold,
+                next_target=self._predict_next_target(
+                    state, current, quarantined, usage, headroom, settings
+                ),
                 fetch_errors={
                     num: entry.last_error
                     for num, entry in entries.items()
@@ -1100,81 +1115,10 @@ class AutoSwitchEngine:
 
         consume_first = settings.strategy == "consume-first"
 
-        def _rank(**kw):
-            """Rank with the no-return bar, and WITHOUT it if that empties AND
-            the barred account is a different proposition from the one we left.
-
-            Emptiness alone cannot be the release. On two accounts there is
-            exactly one candidate, so barring it ALWAYS empties the list —
-            measured, sweeping active x barred headroom x both reset shapes,
-            `n=2 barred-rank EMPTY=320 NONEMPTY=0`. An emptiness-only release
-            therefore fires every tick and the bar is inert at the fleet size
-            the flap was reported on: pcts 92/92, resets 500h/400h, 60 ticks
-            gave `[1, 2, 1, 2]` with the bar on and the identical `[1, 2, 1, 2]`
-            with `lastSwitchFrom` popped every tick.
-
-            "BARRING LEAVES NOTHING" AND "WE ARE FLAPPING" ARE DIFFERENT
-            STATES, and at n=2 they are always the same state — which is how
-            one swallowed the other. The ranking cannot separate them: it sees
-            only the present, and both look like an empty list. What separates
-            them is WHY the ranking flipped. Traced at each leg of that walk:
-
-                t8   1->2   left 1 holding 4.0 pts, 500h out
-                t20  2->1   account 1 still 4.0 pts, still 500h out
-                t22  1->2   account 2 still 2.0 pts, still 400h out
-
-            Every return won because the ACTIVE burned down, never because the
-            target recovered. So the release asks the one question the ranking
-            cannot: is the account we left better than when we left it?
-
-            ON BOTH AXES THE RANKING USES, and with the margins it already
-            uses — ``SPENT_HEADROOM_PCT`` of headroom (below that an edge is
-            under two poll intervals of work) or ``RECOVERY_HYSTERESIS_S``
-            sooner. An account's headroom rises only when a window rolls over
-            and its binding reset only moves nearer when a nearer window
-            starts binding, so both are real events rather than the boundary
-            crossings burn manufactures for free.
-
-            Emptiness still decides whether to ASK. Where the bar leaves a
-            real alternative it simply applies, so a fleet with somewhere else
-            to go is untouched by any of this.
-
-            Cheap: the retry runs only when the barred list came back empty,
-            which is the tick that was about to do nothing anyway.
-            """
-            # Recomputed per snapshot, never once per tick: the consume-first
-            # two-phase commit replaces `headroom` and `active_headroom` and
-            # re-ranks, and the ratio release consumes exactly those two
-            # values. Computed once, the bar answered from a snapshot the
-            # ranking had already thrown away — `left=20 active=30` bars,
-            # `left=90 active=10` releases, and phase 2 is where that flips.
-            recovered = self._left_account_recovered(
-                state,
-                kw["usage"],
-                kw["headroom"],
-                kw["active_headroom"],
-                kw["settings"],
-                kw["now"],
-                kw["current"],
-            )
-            no_return = self._no_return_account(
-                trigger,
-                state,
-                kw["headroom"],
-                kw["active_headroom"],
-                recovered,
-                kw["settings"],
-                kw["current"],
-            )
-            ranked = self._rank_candidates(no_return=no_return, **kw)
-            if no_return is not None and not ranked[0] and recovered:
-                unbarred = self._rank_candidates(no_return=None, **kw)
-                if unbarred[0]:
-                    return unbarred
-            return ranked
 
         decided_now = self.clock()
-        ordered, any_known, active_reset_ts = _rank(
+        ordered, any_known, active_reset_ts = self._rank_with_bar(
+            state,
             trigger=trigger,
             consume_first=consume_first,
             oauth_candidates=oauth_candidates,
@@ -1205,7 +1149,8 @@ class AutoSwitchEngine:
             headroom = _headroom_by_account(usage, self._models)
             active_headroom = headroom.get(current)
             decided_now = self.clock()
-            ordered, any_known, active_reset_ts = _rank(
+            ordered, any_known, active_reset_ts = self._rank_with_bar(
+                state,
                 trigger=trigger,
                 consume_first=consume_first,
                 oauth_candidates=oauth_candidates,
@@ -1752,6 +1697,150 @@ class AutoSwitchEngine:
             < was - RECOVERY_HYSTERESIS_S
         )
 
+    def _predict_next_target(
+        self,
+        state: dict,
+        current: str,
+        quarantined: set[str],
+        usage: dict[str, dict | str | None],
+        headroom: dict[str, float | None],
+        settings: AutoSwitchSettings,
+    ) -> str | None:
+        """The account the engine would move to if the active account crossed
+        the threshold on this snapshot, or None when nothing qualifies.
+
+        `best` never ranks while the active account is healthy, so below the
+        threshold the ranking runs as though the active account sat exactly at
+        it — the state a real proactive decision is made in. consume-first and
+        over-threshold ticks are ranked on their real trigger and headroom.
+        Same ranking and no-return bar as a real decision; consume-first's
+        phase-2 refetch can still land elsewhere, which is fine for a
+        prediction. Pure — no emits, no state writes.
+        """
+        if (
+            self.switcher.account_kind_for(current) == "api_key"
+            and not settings.include_api_key_accounts
+        ):
+            return None
+        active_headroom = headroom.get(current)
+        if active_headroom is None:
+            return None
+        candidates = [
+            num
+            for num in self.switcher.switchable_account_numbers()
+            if num != current and num not in quarantined
+        ]
+        oauth_candidates = [
+            n for n in candidates if self.switcher.account_kind_for(n) != "api_key"
+        ]
+        consume_first = settings.strategy == "consume-first"
+        if 100.0 - active_headroom < settings.threshold:
+            if consume_first:
+                trigger, decided_headroom = "consume-first", active_headroom
+            else:
+                trigger, decided_headroom = "proactive", 100.0 - settings.threshold
+        else:
+            trigger = "at-limit" if active_headroom <= 0 else "proactive"
+            decided_headroom = active_headroom
+        if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+            return None  # the decision path holds here too
+        if not oauth_candidates:
+            ordered: list[str] = []
+        else:
+            ordered, _, _ = self._rank_with_bar(
+                state,
+                trigger=trigger,
+                consume_first=consume_first,
+                oauth_candidates=oauth_candidates,
+                usage=usage,
+                headroom=headroom,
+                current=current,
+                active_headroom=decided_headroom,
+                settings=settings,
+                now=self.clock(),
+            )
+        if not ordered and settings.include_api_key_accounts and trigger != "consume-first":
+            # Same last resort as the decision: a metered API-key account.
+            ordered = [
+                n for n in candidates if self.switcher.account_kind_for(n) == "api_key"
+            ]
+        return ordered[0] if ordered else None
+
+    def _rank_with_bar(
+        self, state: dict, **kw
+    ) -> tuple[list[str], bool, float | None]:
+        """Rank with the no-return bar, and WITHOUT it if that empties AND
+        the barred account is a different proposition from the one we left.
+
+        Emptiness alone cannot be the release. On two accounts there is
+        exactly one candidate, so barring it ALWAYS empties the list —
+        measured, sweeping active x barred headroom x both reset shapes,
+        `n=2 barred-rank EMPTY=320 NONEMPTY=0`. An emptiness-only release
+        therefore fires every tick and the bar is inert at the fleet size
+        the flap was reported on: pcts 92/92, resets 500h/400h, 60 ticks
+        gave `[1, 2, 1, 2]` with the bar on and the identical `[1, 2, 1, 2]`
+        with `lastSwitchFrom` popped every tick.
+
+        "BARRING LEAVES NOTHING" AND "WE ARE FLAPPING" ARE DIFFERENT
+        STATES, and at n=2 they are always the same state — which is how
+        one swallowed the other. The ranking cannot separate them: it sees
+        only the present, and both look like an empty list. What separates
+        them is WHY the ranking flipped. Traced at each leg of that walk:
+
+            t8   1->2   left 1 holding 4.0 pts, 500h out
+            t20  2->1   account 1 still 4.0 pts, still 500h out
+            t22  1->2   account 2 still 2.0 pts, still 400h out
+
+        Every return won because the ACTIVE burned down, never because the
+        target recovered. So the release asks the one question the ranking
+        cannot: is the account we left better than when we left it?
+
+        ON BOTH AXES THE RANKING USES, and with the margins it already
+        uses — ``SPENT_HEADROOM_PCT`` of headroom (below that an edge is
+        under two poll intervals of work) or ``RECOVERY_HYSTERESIS_S``
+        sooner. An account's headroom rises only when a window rolls over
+        and its binding reset only moves nearer when a nearer window
+        starts binding, so both are real events rather than the boundary
+        crossings burn manufactures for free.
+
+        Emptiness still decides whether to ASK. Where the bar leaves a
+        real alternative it simply applies, so a fleet with somewhere else
+        to go is untouched by any of this.
+
+        Cheap: the retry runs only when the barred list came back empty,
+        which is the tick that was about to do nothing anyway.
+        """
+        # Recomputed per snapshot, never once per tick: the consume-first
+        # two-phase commit replaces `headroom` and `active_headroom` and
+        # re-ranks, and the ratio release consumes exactly those two
+        # values. Computed once, the bar answered from a snapshot the
+        # ranking had already thrown away — `left=20 active=30` bars,
+        # `left=90 active=10` releases, and phase 2 is where that flips.
+        recovered = self._left_account_recovered(
+            state,
+            kw["usage"],
+            kw["headroom"],
+            kw["active_headroom"],
+            kw["settings"],
+            kw["now"],
+            kw["current"],
+        )
+        no_return = self._no_return_account(
+            kw["trigger"],
+            state,
+            kw["headroom"],
+            kw["active_headroom"],
+            recovered,
+            kw["settings"],
+            kw["current"],
+        )
+        ranked = self._rank_candidates(no_return=no_return, **kw)
+        if no_return is not None and not ranked[0] and recovered:
+            unbarred = self._rank_candidates(no_return=None, **kw)
+            if unbarred[0]:
+                return unbarred
+        return ranked
+
     def _rank_candidates(
         self,
         *,
@@ -2122,44 +2211,35 @@ class AutoSwitchEngine:
         # and backs off instead of double-switching. No deadlock cycle: the
         # switch path (cswap FileLock + Claude Code locks) never takes the
         # state lock.
-        with self._state_lock():
-            state = self._read_state()
-            if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
-                self._emit(NoSwitchEvent(reason="cooldown"))
-                return TickOutcome.NO_ACTION
-
-            result = self.switcher.switch_to(number, json_output=True)
-            if not result or not result.get("switched"):
-                self._emit(
-                    NoSwitchEvent(
-                        reason="already-active",
-                        detail=(result or {}).get("reason", ""),
-                    )
-                )
-                return TickOutcome.NO_ACTION
-
-            state["schemaVersion"] = STATE_SCHEMA_VERSION
-            state["lastSwitchAt"] = self.clock()
-            state["lastSwitchTo"] = number
-            # WHERE we came from, so the next tick can refuse to undo this,
-            # and WHAT IT LOOKED LIKE, so that refusal has a release that burn
-            # cannot fake. See `_left_account_recovered` for why the present
-            # state alone cannot supply one. `inf` is stored as null: it is not
-            # portable JSON, and every other reader of this file would have to
-            # learn about it.
-            state["lastSwitchFrom"] = (result.get("from") or {}).get("number")
-            state["leftHeadroom"], recovery = left
-            state["leftRecoveryAt"] = None if recovery == float("inf") else recovery
-            # A `consume-first` phase-2 refetch can write the SAME (None,
-            # None) shape a `failover` departure writes, whenever the
-            # refetched active row has a `pct` but is otherwise unmeasurable
-            # in the same tick its weekly reset is known --
-            # `account_headroom` needs a numeric `pct`, `_seven_day_reset_ts`
-            # needs only `resets_at`. Inferring the trigger from the two
-            # nulls then runs the wrong legs. Record it directly so the
-            # reader never has to guess.
-            state["leftTrigger"] = trigger
-            atomic_write_json(self.state_path, state)
+        #
+        # Nothing is emitted while `_switch_lock` is held: the TUI delivers
+        # events synchronously onto the thread that calls `stop()`, and
+        # `stop()` waits for this lock — an emit in here would have the two
+        # threads waiting on each other.
+        held: AutoSwitchEvent | None = None
+        with self._switch_lock, self._state_lock():
+            if self._stop.is_set():
+                # stop() landed while this tick was deciding: the caller no
+                # longer wants switches, so the last one must not slip out.
+                held = NoSwitchEvent(reason="stopped")
+            else:
+                state = self._read_state()
+                if trigger in ("proactive", "consume-first") and self._in_cooldown(
+                    state
+                ):
+                    held = NoSwitchEvent(reason="cooldown")
+                else:
+                    result = self.switcher.switch_to(number, json_output=True)
+                    if not result or not result.get("switched"):
+                        held = NoSwitchEvent(
+                            reason="already-active",
+                            detail=(result or {}).get("reason", ""),
+                        )
+                    else:
+                        self._record_switch(state, number, trigger, result, left)
+        if held is not None:
+            self._emit(held)
+            return TickOutcome.NO_ACTION
 
         self._emit(
             SwitchEvent(
@@ -2170,6 +2250,39 @@ class AutoSwitchEngine:
             )
         )
         return TickOutcome.SWITCHED
+
+    def _record_switch(
+        self,
+        state: dict,
+        number: str,
+        trigger: str,
+        result: dict,
+        left: tuple[float | None, float],
+    ) -> None:
+        """Persist a completed switch into the state file (caller holds the
+        state lock)."""
+        state["schemaVersion"] = STATE_SCHEMA_VERSION
+        state["lastSwitchAt"] = self.clock()
+        state["lastSwitchTo"] = number
+        # WHERE we came from, so the next tick can refuse to undo this,
+        # and WHAT IT LOOKED LIKE, so that refusal has a release that burn
+        # cannot fake. See `_left_account_recovered` for why the present
+        # state alone cannot supply one. `inf` is stored as null: it is not
+        # portable JSON, and every other reader of this file would have to
+        # learn about it.
+        state["lastSwitchFrom"] = (result.get("from") or {}).get("number")
+        state["leftHeadroom"], recovery = left
+        state["leftRecoveryAt"] = None if recovery == float("inf") else recovery
+        # A `consume-first` phase-2 refetch can write the SAME (None,
+        # None) shape a `failover` departure writes, whenever the
+        # refetched active row has a `pct` but is otherwise unmeasurable
+        # in the same tick its weekly reset is known --
+        # `account_headroom` needs a numeric `pct`, `_seven_day_reset_ts`
+        # needs only `resets_at`. Inferring the trigger from the two
+        # nulls then runs the wrong legs. Record it directly so the
+        # reader never has to guess.
+        state["leftTrigger"] = trigger
+        atomic_write_json(self.state_path, state)
 
     # -- helpers --------------------------------------------------------------
 
@@ -2267,9 +2380,18 @@ class AutoSwitchEngine:
     def stop(self) -> None:
         """Ask ``run_loop`` to exit; wakes it from any sleep. Safe to call
         before the loop starts — the stop is never cleared, so the loop
-        exits immediately (engines are single-use)."""
+        exits immediately (engines are single-use).
+
+        Called from another thread, returns only once no switch is in
+        flight: a tick that has not yet reached its switch transaction will
+        refuse it, and one already inside it is allowed to finish first, so
+        after this returns the active account no longer changes. Called from
+        the tick thread itself (the SIGTERM handler in ``cswap auto``) it
+        returns at once and the in-flight switch, if any, completes."""
         self._stop.set()
         self._wake.set()
+        with self._switch_lock:
+            pass
 
     def wake(self) -> None:
         """Cut the current inter-tick sleep short and tick now."""

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -62,9 +62,12 @@ class AutoSwitchSettings:
 @dataclass(frozen=True)
 class UiSettings:
     """Appearance preferences (``ui`` section). ``theme`` selects the TUI/CLI
-    color theme; ``auto`` follows terminal-background detection."""
+    color theme (``auto`` follows terminal-background detection); ``watch_style``
+    selects the ``cswap watch`` layout (``classic`` horizontal-bar account list
+    or ``meters`` vertical gradient-meter grid)."""
 
     theme: str = "auto"
+    watch_style: str = "classic"
 
 
 _SECTION_DEFAULT_SOURCES = {"autoswitch": AutoSwitchSettings, "ui": UiSettings}
@@ -81,7 +84,7 @@ class SettingSpec:
 
     section: str  # top-level JSON section ("autoswitch", "ui")
     json_key: str  # camelCase key inside the section
-    field: str  # snake_case AutoSwitchSettings field
+    field: str  # snake_case dataclass field
     kind: str  # "float" | "int" | "bool" | "choice"
     lo: float | None = None
     hi: float | None = None
@@ -138,6 +141,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         SettingSpec(
             "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
             help="Color theme; auto follows the terminal background",
+        ),
+        SettingSpec(
+            "ui", "watchStyle", "watch_style", "choice", choices=("classic", "meters"),
+            help="cswap watch layout: classic bars or vertical meters",
         ),
     )
 }
@@ -232,20 +239,31 @@ def load_settings(backup_root: Path) -> AutoSwitchSettings:
 
 
 def load_ui_settings(backup_root: Path) -> UiSettings:
-    """Load the ui section; missing/corrupt file or unknown theme → default."""
+    """Load the ui section; missing/corrupt file or unknown value → default.
+
+    Each key falls back independently: a bad ``theme`` doesn't discard a good
+    ``watchStyle`` and vice versa.
+    """
     raw = _read_raw(settings_path(backup_root))
     section = raw.get("ui")
     default = UiSettings()
     if not isinstance(section, dict):
         return default
-    theme = section.get("theme", default.theme)
-    if theme not in SETTING_SPECS["ui.theme"].choices:
-        _logger.warning(
-            "settings.json: unsupported ui.theme %r; using %r",
-            theme, default.theme,
-        )
-        return default
-    return UiSettings(theme=theme)
+
+    def _choice(json_key: str, dotted: str, fallback: str) -> str:
+        value = section.get(json_key, fallback)
+        if value not in SETTING_SPECS[dotted].choices:
+            _logger.warning(
+                "settings.json: unsupported %s %r; using %r",
+                dotted, value, fallback,
+            )
+            return fallback
+        return value
+
+    return UiSettings(
+        theme=_choice("theme", "ui.theme", default.theme),
+        watch_style=_choice("watchStyle", "ui.watchStyle", default.watch_style),
+    )
 
 
 def save_settings(backup_root: Path, settings: AutoSwitchSettings) -> None:

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -23,7 +23,12 @@ from claude_swap.snapshot_source import account_identity
 from claude_swap.settings import load_settings, load_ui_settings, set_setting
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui.autoview import AutoScreen
-from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
+from claude_swap.tui.dashboard import (
+    ClassicWatchScreen,
+    DashboardScreen,
+    MeterWatchScreen,
+    watch_screen,
+)
 from claude_swap.tui.data import ActionResult, SnapshotSource, format_duration, run_action
 from claude_swap.tui.modals import AddTokenModal, ConfirmModal, OutputModal, TokenForm
 from claude_swap.tui.theme import CSWAP_DARK, CSWAP_LIGHT
@@ -78,10 +83,14 @@ class CswapApp(App):
             ).threshold
         except Exception:
             self.threshold_pct = None
+        # Appearance settings; a bad/missing value falls back per-field.
         try:
-            self._theme_name = load_ui_settings(switcher.backup_dir).theme
+            ui = load_ui_settings(switcher.backup_dir)
+            self._theme_name = ui.theme
+            self._watch_style = ui.watch_style
         except Exception:
             self._theme_name = "auto"
+            self._watch_style = "classic"
 
     def on_mount(self) -> None:
         self.register_theme(CSWAP_DARK)
@@ -93,7 +102,7 @@ class CswapApp(App):
         self.push_screen(DashboardScreen())
         if self._start == "watch":
             # Stacked over the dashboard so Esc lands there, not on exit.
-            self.push_screen(WatchScreen())
+            self.push_screen(watch_screen(self._watch_style))
         self.set_interval(self.POLL_INTERVAL_S, self._tick)
         self.set_interval(1.0, self._update_refresh_status)
         self._tick()
@@ -400,9 +409,24 @@ class CswapApp(App):
         self.push_screen(AutoScreen())
 
     def action_open_watch(self) -> None:
-        if isinstance(self.screen, WatchScreen):
+        if isinstance(self.screen, (ClassicWatchScreen, MeterWatchScreen)):
             return
-        self.push_screen(WatchScreen())
+        self.push_screen(watch_screen(self._watch_style))
+
+    def action_toggle_watch_style(self) -> None:
+        """Swap the live watch layout (classic ↔ meters) and persist it, so
+        you can preview either from the watch screen without editing config."""
+        if not isinstance(self.screen, (ClassicWatchScreen, MeterWatchScreen)):
+            return
+        new = "classic" if self._watch_style == "meters" else "meters"
+        self._watch_style = new
+        try:
+            set_setting(self.switcher.backup_dir, "ui.watchStyle", new)
+        except Exception as exc:  # persistence is best-effort; never crash the UI
+            self.notify(f"Could not save watch style: {exc}", severity="warning")
+        self.pop_screen()
+        self.push_screen(watch_screen(new))
+        self.notify(f"Watch: {new}")
 
     # -- theme --------------------------------------------------------------
 

--- a/src/claude_swap/tui/cswap.tcss
+++ b/src/claude_swap/tui/cswap.tcss
@@ -76,6 +76,13 @@ MenuItem Static.menu-item-muted { color: $secondary; }
     color: $secondary;
 }
 
+#meters {
+    width: 1fr;
+    height: 1fr;
+    background: $background;
+    padding: 1 2 0 1;
+}
+
 /* -- auto screen ---------------------------------------------------------- */
 
 #auto-top {

--- a/src/claude_swap/tui/cswap.tcss
+++ b/src/claude_swap/tui/cswap.tcss
@@ -101,6 +101,33 @@ MenuItem Static.menu-item-muted { color: $secondary; }
     text-style: bold;
 }
 
+/* Meters watch: the footer shares its row with the auto-switch readout. */
+#footer-row {
+    dock: bottom;
+    height: 1;
+    background: $footer-background;
+}
+
+#footer-row Footer {
+    dock: none;
+    width: 1fr;
+}
+
+#auto-readout {
+    width: auto;
+    padding: 0 1;
+    color: $footer-description-foreground;
+}
+
+#auto-readout.live {
+    color: $primary;
+    text-style: bold;
+}
+
+#auto-readout.error {
+    color: $error;
+}
+
 #mode-badge.dry {
     background: $panel;
     color: $warning;

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -6,10 +6,11 @@ account-targeted opens a context of its own:
 
 - ``s`` / menu "Switch account" → :class:`SwitchScreen` — every account
   full-size, Enter switches, pops back.
-- ``w`` / menu "Watch accounts" / ``cswap watch`` → :class:`WatchScreen` —
-  the same full cards but read-only: a live monitor. ``s`` arms selection
-  (cursor appears on the active account), Enter switches and *stays
-  watching*, Esc disarms.
+- ``w`` / menu "Watch accounts" / ``cswap watch`` → a watch screen chosen by
+  ``ui.watch_style``: :class:`ClassicWatchScreen` (default) shows the same
+  full cards read-only, :class:`MeterWatchScreen` a vertical gradient-meter
+  grid. ``s`` arms selection (cursor appears on the active account), Enter
+  switches and *stays watching*, Esc disarms.
 - "Remove account" nests into a submenu listing the accounts.
 
 No global command palette: actions live where their context is.
@@ -26,7 +27,13 @@ from textual.screen import Screen
 from textual.widgets import Footer, ListView, Static
 
 from claude_swap.models import AccountsSnapshot
-from claude_swap.tui.widgets import AccountItem, AccountsPanel, MenuItem
+from claude_swap.tui.widgets import (
+    AccountItem,
+    AccountsPanel,
+    MenuItem,
+    MetersGrid,
+    _active_index,
+)
 
 if TYPE_CHECKING:
     from claude_swap.tui.app import CswapApp
@@ -215,7 +222,7 @@ class AccountListScreen(Screen):
     """Shared machinery: a live ListView of full account cards.
 
     Subclasses decide what the cursor does — :class:`SwitchScreen` is
-    selection-first, :class:`WatchScreen` is a monitor that can arm
+    selection-first, :class:`ClassicWatchScreen` is a monitor that can arm
     selection on demand.
     """
 
@@ -242,11 +249,20 @@ class AccountListScreen(Screen):
         if numbers != self._numbers:
             first_build = not self._numbers
             previous = listview.index
+            # Follow the highlighted account across reorders/removals: the row
+            # index alone would leave the cursor on whatever account now sits in
+            # that slot, so resolve the selected account's new position first.
+            selected = (
+                self._numbers[previous]
+                if previous is not None and 0 <= previous < len(self._numbers)
+                else None
+            )
             await listview.clear()
             await listview.extend(AccountItem(acc) for acc in snap.accounts)
             self._numbers = numbers
+            followed = numbers.index(selected) if selected in numbers else previous
             listview.index = (
-                self._index_after_build(snap, first_build, previous)
+                self._index_after_build(snap, first_build, followed)
                 if numbers
                 else None
             )
@@ -260,18 +276,8 @@ class AccountListScreen(Screen):
     ) -> int | None:
         """Where the cursor lands after the list is (re)built."""
         if first_build:
-            return self._active_index(snap)
+            return _active_index(snap)
         return min(previous or 0, len(snap.accounts) - 1)
-
-    def _active_index(self, snap: AccountsSnapshot) -> int:
-        return next(
-            (
-                i
-                for i, acc in enumerate(snap.accounts)
-                if acc.number == snap.active_number
-            ),
-            0,
-        )
 
     def _flash_updated(self, snap: AccountsSnapshot, listview: ListView) -> None:
         """Briefly highlight rows whose stored measurement just advanced."""
@@ -329,12 +335,113 @@ class SwitchScreen(AccountListScreen):
         self.app.pop_screen()
 
 
-class WatchScreen(AccountListScreen):
-    """Live monitor of every account, full detail, hands-off by default.
+class MeterWatchScreen(Screen):
+    """Live monitor as a vertical gradient-meter grid, hands-off by default.
 
     ``s`` arms selection (cursor appears on the active account); Enter then
     switches and stays here — you keep watching on the new account. Esc
-    disarms selection first, then leaves the screen.
+    disarms selection first, then leaves the screen. Opt in via
+    ``ui.watch_style = meters``.
+    """
+
+    app: "CswapApp"
+
+    # The grid is self-evident, so monitor mode shows no header; the title row
+    # is reused only for the selection prompt once selection is armed.
+    _WATCH_TITLE = ""
+    _SELECT_TITLE = "switch to which account? · enter confirm · esc cancel"
+
+    BINDINGS = [
+        Binding("s", "toggle_select", "Switch"),
+        Binding("enter", "select_highlighted", "Confirm", priority=True),
+        Binding("f", "app.refresh_full", "Refresh", show=False),
+        Binding("ctrl+v", "app.toggle_watch_style", "Layout"),
+        Binding("escape,q", "back", "Back"),
+        Binding("left,h", "nav_left", show=False),
+        Binding("right,l", "nav_right", show=False),
+        Binding("up,k", "nav_up", show=False),
+        Binding("down,j", "nav_down", show=False),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._selecting = False
+
+    def compose(self) -> ComposeResult:
+        yield Static("", id="list-title")
+        yield MetersGrid(id="meters")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._set_title(self._WATCH_TITLE)
+
+    def _set_title(self, text: str) -> None:
+        """Set the title text and collapse its row when there's none, so the
+        empty header doesn't eat vertical space in monitor mode."""
+        title = self.query_one("#list-title", Static)
+        title.update(text)
+        title.display = bool(text)
+
+    def check_action(self, action: str, parameters: tuple) -> bool | None:
+        if action == "select_highlighted" and not self._selecting:
+            return False  # hidden and inert until selection is armed
+        return True
+
+    def _set_selecting(self, on: bool) -> None:
+        grid = self.query_one("#meters", MetersGrid)
+        if on:
+            snap = self.app.snapshot
+            grid.cursor = _active_index(snap) if snap and snap.accounts else 0
+            self._set_title(self._SELECT_TITLE)
+        else:
+            grid.cursor = None
+            self._set_title(self._WATCH_TITLE)
+        self._selecting = on
+        self.refresh_bindings()
+        grid.refresh(layout=True)
+
+    def action_toggle_select(self) -> None:
+        self._set_selecting(not self._selecting)
+
+    def action_select_highlighted(self) -> None:
+        if not self._selecting:
+            return
+        num = self.query_one("#meters", MetersGrid).selected_number()
+        if num:
+            self.app.do_switch(num)
+        self._set_selecting(False)  # stay here, keep watching
+
+    def action_back(self) -> None:
+        if self._selecting:
+            self._set_selecting(False)
+        else:
+            self.app.pop_screen()
+
+    def action_nav_left(self) -> None:
+        if self._selecting:
+            self.query_one("#meters", MetersGrid).move_cursor(-1, 0)
+
+    def action_nav_right(self) -> None:
+        if self._selecting:
+            self.query_one("#meters", MetersGrid).move_cursor(1, 0)
+
+    def action_nav_up(self) -> None:
+        if self._selecting:
+            self.query_one("#meters", MetersGrid).move_cursor(0, -1)
+
+    def action_nav_down(self) -> None:
+        if self._selecting:
+            self.query_one("#meters", MetersGrid).move_cursor(0, 1)
+
+
+class ClassicWatchScreen(AccountListScreen):
+    """Live monitor of every account as full horizontal-bar cards, hands-off
+    by default.
+
+    ``s`` arms selection (cursor appears on the active account); Enter then
+    switches and stays here — you keep watching on the new account. Esc
+    disarms selection first, then leaves the screen. This is the default
+    ``cswap watch`` layout (``ui.watch_style = classic``).
     """
 
     _WATCH_TITLE = "watching all accounts"
@@ -344,6 +451,7 @@ class WatchScreen(AccountListScreen):
         Binding("s", "toggle_select", "Switch"),
         Binding("enter", "select_highlighted", "Confirm", priority=True),
         Binding("f", "app.refresh_full", "Refresh", show=False),
+        Binding("ctrl+v", "app.toggle_watch_style", "Layout"),
         Binding("escape,q", "back", "Back"),
         Binding("down,j", "nav_down", show=False),
         Binding("up,k", "nav_up", show=False),
@@ -387,7 +495,7 @@ class WatchScreen(AccountListScreen):
         if on:
             snap = self.app.snapshot
             if snap is not None and snap.accounts:
-                listview.index = self._active_index(snap)
+                listview.index = _active_index(snap)
             listview.focus()
             title.update(self._SELECT_TITLE)
         else:
@@ -430,3 +538,14 @@ class WatchScreen(AccountListScreen):
             listview.action_cursor_up()
         else:
             listview.scroll_up(animate=False)
+
+
+def watch_screen(watch_style: str) -> Screen:
+    """The ``cswap watch`` screen for a ``ui.watch_style`` value.
+
+    ``meters`` opts into the vertical gradient-meter grid; anything else
+    (the default ``classic``) gets the horizontal-bar account list.
+    """
+    if watch_style == "meters":
+        return MeterWatchScreen()
+    return ClassicWatchScreen()

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -23,10 +23,20 @@ from typing import TYPE_CHECKING, Callable
 
 from textual.app import ComposeResult
 from textual.binding import Binding
+from textual.containers import Horizontal
 from textual.screen import Screen
 from textual.widgets import Footer, ListView, Static
 
+from claude_swap.autoswitch import (
+    AutoSwitchEngine,
+    AutoSwitchEvent,
+    ErrorEvent,
+    PollEvent,
+    SwitchEvent,
+)
 from claude_swap.models import AccountsSnapshot
+from claude_swap.settings import load_settings
+from claude_swap.tui.modals import ConfirmModal
 from claude_swap.tui.widgets import (
     AccountItem,
     AccountsPanel,
@@ -335,6 +345,10 @@ class SwitchScreen(AccountListScreen):
         self.app.pop_screen()
 
 
+def _clip(text: str, limit: int) -> str:
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
 class MeterWatchScreen(Screen):
     """Live monitor as a vertical gradient-meter grid, hands-off by default.
 
@@ -354,6 +368,8 @@ class MeterWatchScreen(Screen):
     BINDINGS = [
         Binding("s", "toggle_select", "Switch"),
         Binding("enter", "select_highlighted", "Confirm", priority=True),
+        Binding("a", "toggle_auto", "Auto"),
+        Binding("L", "toggle_live", "Live", key_display="L"),
         Binding("f", "app.refresh_full", "Refresh", show=False),
         Binding("ctrl+v", "app.toggle_watch_style", "Layout"),
         Binding("escape,q", "back", "Back"),
@@ -363,17 +379,168 @@ class MeterWatchScreen(Screen):
         Binding("down,j", "nav_down", show=False),
     ]
 
+    # Headroom margin (percentage points above the threshold) at which the
+    # predicted target's breathing reaches full tempo… and where it is at rest.
+    _URGENT_MARGIN_PCT = 0.0
+    _CALM_MARGIN_PCT = 20.0
+
     def __init__(self) -> None:
         super().__init__()
         self._selecting = False
+        self._engine: AutoSwitchEngine | None = None
+        self._next_target: str | None = None
+        self._engine_error = ""  # last engine error, shown until the next poll
 
     def compose(self) -> ComposeResult:
         yield Static("", id="list-title")
         yield MetersGrid(id="meters")
-        yield Footer()
+        # The auto-switch readout shares the footer's row, at the right edge,
+        # so the meters keep every row while an engine runs. It is a sibling
+        # of the Footer, not a child: Footer recomposes on every binding
+        # change and drops anything composed into it.
+        with Horizontal(id="footer-row"):
+            yield Footer()
+            yield Static("", id="auto-readout")
 
     def on_mount(self) -> None:
         self._set_title(self._WATCH_TITLE)
+        self._refresh_readout()
+
+    def on_unmount(self) -> None:
+        # Leaving the screen (Esc, or a Ctrl+V layout swap) must not leave an
+        # engine running behind it. The widgets are already gone by now, so
+        # only the engine and the poller mode are reset.
+        self._halt_engine()
+
+    # -- auto-switch engine ---------------------------------------------------
+    # Mirrors AutoScreen: a dry-run engine runs the real decision loop and
+    # reports what it WOULD do, which is what the grid highlights; only a
+    # confirmed live engine ever switches.
+
+    def _start_engine(self, *, dry_run: bool) -> None:
+        # The callback names its engine, so a replaced engine finishing its
+        # last tick cannot drive the grid.
+        engine = AutoSwitchEngine(
+            self.app.switcher,
+            load_settings(self.app.switcher.backup_dir),
+            lambda event: self._emit_from_thread(engine, event),
+            dry_run=dry_run,
+        )
+        self._engine = engine
+        self.run_worker(
+            engine.run_loop,
+            thread=True,
+            group="engine",
+            exit_on_error=False,
+            name=f"meters-engine-{'dry' if dry_run else 'live'}",
+        )
+        # The engine fetches usage; the app poller only reads the store.
+        self.app.set_store_only(True)
+
+    def _halt_engine(self) -> None:
+        if self._engine is None:
+            return
+        self._engine.stop()
+        self._engine = None
+        self._next_target = None
+        self._engine_error = ""
+        # The engine pinned the poll planner to its settings; unpin so
+        # ordinary refreshes follow the settings file again.
+        self.app.switcher.clear_poll_policy_inputs()
+        self.app.set_store_only(False)
+
+    def _stop_engine(self) -> None:
+        self._halt_engine()
+        self.query_one("#meters", MetersGrid).set_predicted(None, 0.0)
+        self._refresh_title()
+
+    def _emit_from_thread(
+        self, engine: AutoSwitchEngine, event: AutoSwitchEvent
+    ) -> None:
+        """Engine ``on_event`` callback — runs on the worker thread."""
+        try:
+            self.app.call_from_thread(self._on_engine_event, engine, event)
+        except Exception:
+            # App/screen tearing down mid-tick; the event has nowhere to go.
+            pass
+
+    def _on_engine_event(
+        self, engine: AutoSwitchEngine, event: AutoSwitchEvent
+    ) -> None:
+        if not self.is_attached or engine is not self._engine:
+            return
+        if isinstance(event, PollEvent):
+            self._engine_error = ""
+            self._next_target = event.next_target
+            self.query_one("#meters", MetersGrid).set_predicted(
+                event.next_target, self._urgency(event)
+            )
+            self._refresh_title()
+        elif isinstance(event, ErrorEvent):
+            # A switch that failed is not "next": show the failure where the
+            # user is looking and drop the promise until the engine re-polls.
+            self._engine_error = event.human()
+            self._next_target = None
+            self.query_one("#meters", MetersGrid).set_predicted(None, 0.0)
+            self._refresh_title()
+        elif isinstance(event, SwitchEvent) and not event.dry_run:
+            # The landed account is active now, not "next": drop the stale
+            # prediction until the engine re-ranks from its new vantage point.
+            grid = self.query_one("#meters", MetersGrid)
+            grid.set_predicted(None, 0.0)
+            grid.start_sweep(
+                str(event.from_ref["number"]) if event.from_ref else None,
+                str(event.to_ref["number"]),
+            )
+            self._next_target = None
+            self._refresh_title()
+            self.app.request_refresh()
+
+    def _urgency(self, event: PollEvent) -> float:
+        """0 while the active account has ≥20 points of headroom margin above
+        the threshold, rising to 1 as that margin closes."""
+        active = event.active or {}
+        headroom = event.headroom.get(str(active.get("number", "")))
+        if headroom is None:
+            return 0.0
+        margin = headroom - (100.0 - event.threshold)
+        span = self._CALM_MARGIN_PCT - self._URGENT_MARGIN_PCT
+        calm = max(0.0, min(1.0, (margin - self._URGENT_MARGIN_PCT) / span))
+        return 1.0 - calm
+
+    def action_toggle_auto(self) -> None:
+        if self._engine is None:
+            self._start_engine(dry_run=True)
+            self._refresh_title()
+        else:
+            self._stop_engine()
+        self.refresh_bindings()  # the footer's "L Live" hint follows the engine
+
+    def action_toggle_live(self) -> None:
+        if self._engine is None:
+            return
+        if self._engine.dry_run:
+            self.app.push_screen(
+                ConfirmModal(
+                    "Go live? claude-swap will switch your active account "
+                    "automatically when the threshold is reached.\n\n"
+                    "(Same behavior as running `cswap auto` in a terminal.)",
+                    title="Go live",
+                    yes_label="Go live",
+                ),
+                self._on_live_confirm,
+            )
+        else:
+            self._restart_engine(dry_run=True)
+
+    def _on_live_confirm(self, confirmed: bool | None) -> None:
+        if confirmed:
+            self._restart_engine(dry_run=False)
+
+    def _restart_engine(self, *, dry_run: bool) -> None:
+        self._halt_engine()
+        self._start_engine(dry_run=dry_run)
+        self._refresh_title()
 
     def _set_title(self, text: str) -> None:
         """Set the title text and collapse its row when there's none, so the
@@ -382,9 +549,43 @@ class MeterWatchScreen(Screen):
         title.update(text)
         title.display = bool(text)
 
+    def _refresh_title(self) -> None:
+        """The selection prompt while armed; otherwise nothing (row collapsed).
+        The auto-switch readout has its own place in the footer."""
+        self._set_title(self._SELECT_TITLE if self._selecting else self._WATCH_TITLE)
+        self._refresh_readout()
+
+    def _refresh_readout(self) -> None:
+        """Footer readout: ``dry-run · next → <alias>`` or ``LIVE · next → …``
+        while an engine runs; hidden otherwise."""
+        readout = self.query_one("#auto-readout", Static)
+        if self._engine is None:
+            readout.update("")
+            readout.display = False
+            return
+        mode = "dry-run" if self._engine.dry_run else "LIVE"
+        if self._engine_error:
+            readout.update(f"{mode} · {_clip(self._engine_error, 60)}")
+        else:
+            readout.update(f"{mode} · next → {self._next_target_label()}")
+        readout.set_class(bool(self._engine_error), "error")
+        readout.set_class(not self._engine.dry_run, "live")
+        readout.display = True
+
+    def _next_target_label(self) -> str:
+        if self._next_target is None:
+            return "none"
+        snap = self.app.snapshot
+        for acc in snap.accounts if snap else ():
+            if acc.number == self._next_target:
+                return acc.alias or acc.email.split("@", 1)[0]
+        return self._next_target
+
     def check_action(self, action: str, parameters: tuple) -> bool | None:
         if action == "select_highlighted" and not self._selecting:
             return False  # hidden and inert until selection is armed
+        if action == "toggle_live" and self._engine is None:
+            return False  # live only arms on top of a running prediction
         return True
 
     def _set_selecting(self, on: bool) -> None:
@@ -392,11 +593,10 @@ class MeterWatchScreen(Screen):
         if on:
             snap = self.app.snapshot
             grid.cursor = _active_index(snap) if snap and snap.accounts else 0
-            self._set_title(self._SELECT_TITLE)
         else:
             grid.cursor = None
-            self._set_title(self._WATCH_TITLE)
         self._selecting = on
+        self._refresh_title()
         self.refresh_bindings()
         grid.refresh(layout=True)
 

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -8,7 +8,9 @@ auto-switch trigger line), and stale-measurement dimming.
 
 from __future__ import annotations
 
+import textwrap
 import time
+from functools import partial
 from typing import TYPE_CHECKING
 
 from rich.text import Text
@@ -16,7 +18,7 @@ from textual.widgets import ListItem, Static
 
 from claude_swap import pace
 from claude_swap.json_output import USAGE_API_KEY
-from claude_swap.models import AccountSnapshot
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
 from claude_swap.usage_store import STALE_OK_S
 from claude_swap.tui import data
 from claude_swap.tui.theme import Palette
@@ -28,6 +30,22 @@ _BAR_FILLED = "━"
 _BAR_HALF = "╸"
 _BAR_EMPTY = "─"
 _BAR_TICK = "┃"
+
+_FLASH_S = 1.5  # how long a just-refreshed card's border stays highlighted
+
+_ACTIVE_GREEN = "#3fb950"  # bright green frame/title for the active account's card
+
+# Frame glyph sets keyed by whether the card belongs to the active account:
+# active cards get a bold double-line box, inactive cards the thin rounded one.
+_FRAME_GLYPHS = {
+    True: {"tl": "╔", "tr": "╗", "bl": "╚", "br": "╝", "h": "═", "v": "║"},
+    False: {"tl": "╭", "tr": "╮", "bl": "╰", "br": "╯", "h": "─", "v": "│"},
+}
+
+# meter_card's non-bar rows: top+bottom borders (2), baseline (1), window
+# labels (1), a blank margin row (1), big-digit percent (5), a blank margin
+# row (1), reset (1).
+CARD_CHROME = 12
 
 
 def bar_cells(
@@ -62,6 +80,63 @@ def bar_cells(
         else:
             text.append(_BAR_EMPTY, style=palette.track)
     return text
+
+
+# A maxed window's bar stays entirely in reds — dark at the base, hot at the
+# ceiling — so a limit that's been hit never reads as calm green at the bottom.
+# Theme-independent by design: a hit limit is red in light and dark alike.
+_RED_STOPS = ((0.0, "#7a2e2e"), (1.0, "#ff6b6b"))
+
+
+def _hex_rgb(h: str) -> tuple[int, int, int]:
+    return int(h[1:3], 16), int(h[3:5], 16), int(h[5:7], 16)
+
+
+def _interp(stops: tuple, t: float) -> str:
+    """Interpolate a hex colour along ``stops`` at fraction ``t`` (clamped)."""
+    t = 0.0 if t < 0.0 else 1.0 if t > 1.0 else t
+    for (t0, c0), (t1, c1) in zip(stops, stops[1:]):
+        if t <= t1:
+            f = 0.0 if t1 == t0 else (t - t0) / (t1 - t0)
+            r0, g0, b0 = _hex_rgb(c0)
+            r1, g1, b1 = _hex_rgb(c1)
+            return "#%02x%02x%02x" % (
+                round(r0 + (r1 - r0) * f),
+                round(g0 + (g1 - g0) * f),
+                round(b0 + (b1 - b0) * f),
+            )
+    return stops[-1][1]
+
+
+def gradient_color(t: float, palette: Palette = Palette.DARK) -> str:
+    """Colour for a bar cell at height fraction ``t`` (0 bottom .. 1 top):
+    interpolates the palette's ok → warn → crit severity ramp."""
+    stops = (
+        (0.0, palette.sev_ok),
+        (0.5, palette.sev_warn),
+        (1.0, palette.sev_crit),
+    )
+    return _interp(stops, t)
+
+
+def _bar_color(pct: float, t: float, palette: Palette = Palette.DARK) -> str:
+    """Bar-cell colour: shades of red once the window is maxed (>=100%),
+    otherwise the green → amber → red climb."""
+    return _interp(_RED_STOPS, t) if pct >= 100 else gradient_color(t, palette)
+
+
+_V_EIGHTHS = " ▁▂▃▄▅▆▇█"  # index 0..8, empty → full
+
+
+def bar_v(pct: float, height: int) -> list[str]:
+    """A vertical bar ``height`` cells tall, glyphs top-row-first, filled from
+    the bottom via eighth blocks."""
+    eighths = max(0.0, min(100.0, pct)) / 100.0 * height * 8
+    rows = []
+    for r in range(height - 1, -1, -1):  # r = whole cells below this one
+        cell = max(0, min(8, round(eighths - r * 8)))
+        rows.append(_V_EIGHTHS[cell])
+    return rows
 
 
 def usage_bar(
@@ -157,6 +232,495 @@ def usage_rows(
                 suffix_full = f"{suffix_full}  {marker}" if suffix_full else marker
         rows.append((window["name"], pct, suffix, suffix_full))
     return rows
+
+
+def _short_reset(window: dict, now: float) -> str | None:
+    """Largest-unit reset, e.g. 'resets 2h 13m' -> '2h'."""
+    full = data.reset_text(window, now)
+    if not full:
+        return None
+    body = full.replace("resets ", "").strip()
+    return body.split()[0] if body else None
+
+
+def meter_windows(
+    last_good: dict | None, now: float
+) -> list[tuple[str, float, str | None, bool]]:
+    """(label, pct, short_reset, maxed) per window — spend, 5h, 7d, scoped."""
+    out: list[tuple[str, float, str | None, bool]] = []
+    if not isinstance(last_good, dict):
+        return out
+    spend = last_good.get("spend")
+    if spend:
+        pct = float(spend["pct"])
+        out.append(("$$", pct, _short_reset(spend, now), pct >= 100))
+    for key, label in (("five_hour", "5h"), ("seven_day", "7d")):
+        w = last_good.get(key)
+        if w:
+            pct = float(w["pct"])
+            out.append((label, pct, _short_reset(w, now), pct >= 100))
+    for w in last_good.get("scoped") or []:
+        pct = float(w["pct"])
+        out.append((w["name"], pct, _short_reset(w, now), pct >= 100))
+    return out
+
+
+def meter_grid_dims(
+    width: int,
+    height: int,
+    n_accounts: int,
+    *,
+    min_card_w: int = 20,
+    bar_min: int = 1,
+    card_chrome: int = CARD_CHROME,
+    gutter: int = 1,
+) -> tuple[int, int, int]:
+    """(ncols, card_width, bar_height) for the meter grid at this terminal size.
+
+    Columns account for the inter-card gutter so a card never falls below
+    ``min_card_w`` by ignoring it. Bars fill the available height — growing to
+    consume every spare row and shrinking (down to ``bar_min``) rather than
+    overflow, since the grid is not scrollable.
+    """
+    n = max(1, n_accounts)
+    ncols = max(1, min((width + 1) // (min_card_w + gutter), n))
+    card_width = (width - gutter * (ncols - 1)) // ncols
+    rows_of_cards = -(-n // ncols)  # ceil
+    seps = rows_of_cards - 1
+    avail = height - rows_of_cards * card_chrome - seps
+    bar_height = max(bar_min, avail // rows_of_cards)
+    return ncols, card_width, bar_height
+
+
+def _cell_widths(interior_width: int, n_windows: int) -> list[int]:
+    """Split ``interior_width`` into ``n_windows`` cells, remainder spread
+    across the leftmost cells so the widths sum to ``interior_width``."""
+    base, remainder = divmod(interior_width, n_windows)
+    return [base + (1 if i < remainder else 0) for i in range(n_windows)]
+
+
+def _meter_bar_width(cell_width: int) -> int:
+    """Bar fills its cell, leaving a one-column gutter on each side."""
+    return max(1, cell_width - 2)
+
+
+def _fit_center(s: str, width: int) -> str:
+    """Center ``s`` in ``width`` columns, truncating first so the result is
+    always exactly ``width`` wide even when ``s`` is longer than the cell."""
+    return s[:width].center(width)
+
+
+def _fit_label(label: str, width: int) -> str:
+    """Center ``label`` in ``width`` columns; a label longer than the cell
+    truncates to an ellipsis (``label[:1]`` when ``width`` is 1) rather than
+    silently dropping its tail via ``_fit_center``'s plain slice."""
+    if len(label) > width:
+        label = label[:1] if width == 1 else label[: width - 1] + "…"
+    return _fit_center(label, width)
+
+
+_PIXEL_DIGITS = {
+    "0": ("███", "█ █", "█ █", "█ █", "███"),
+    "1": (" █ ", "██ ", " █ ", " █ ", "███"),
+    "2": ("███", "  █", "███", "█  ", "███"),
+    "3": ("███", "  █", "███", "  █", "███"),
+    "4": ("█ █", "█ █", "███", "  █", "  █"),
+    "5": ("███", "█  ", "███", "  █", "███"),
+    "6": ("███", "█  ", "███", "█ █", "███"),
+    "7": ("███", "  █", "  █", "  █", "  █"),
+    "8": ("███", "█ █", "███", "█ █", "███"),
+    "9": ("███", "█ █", "███", "  █", "███"),
+}
+
+
+def big_number(s: str) -> list[str]:
+    """Render a digit string as 5 rows of bold block glyphs. Each digit is 3
+    cols wide and digits are joined by a one-column gap, so ``"100"`` is
+    3+1+3+1+3 = 11 wide."""
+    rows = ["", "", "", "", ""]
+    for pos, ch in enumerate(s):
+        g = _PIXEL_DIGITS.get(ch, ("   ", "   ", "   ", "   ", "   "))
+        for i in range(5):
+            if pos:
+                rows[i] += " "
+            rows[i] += g[i]
+    return rows
+
+
+def _meter_header(
+    acc: AccountSnapshot,
+    card_width: int,
+    frame: str,
+    *,
+    active: bool = False,
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """``╭─┤ {number} {name} {● if active}├────╮`` (the active account's card
+    uses the double-line ``╔═┤ … ├────╗`` variant instead).
+
+    Degrades under a tight ``card_width``: the name is hard-truncated first,
+    then dropped along with the active dot, and if even the bare number
+    can't be framed, this falls back to a plain corner-to-corner border.
+    Always exactly ``card_width`` columns.
+    """
+    glyphs = _FRAME_GLYPHS[active]
+    number = str(acc.number)
+    name = acc.alias or acc.email.split("@", 1)[0]
+    active_suffix = " ●" if acc.is_active else ""
+    prefix = f"{glyphs['tl']}{glyphs['h']}┤ "
+    number_style = frame if active else palette.accent
+    name_style = frame if active else palette.foreground
+    dot_style = frame if active else palette.accent
+
+    # Minimal frame: prefix + number + "├" + tr, no name, no active dot,
+    # no fill. If even this doesn't fit, there's no room for a framed title.
+    base_len = len(prefix) + len(number) + 1 + 1
+    if base_len > card_width:
+        return Text(
+            glyphs["tl"] + glyphs["h"] * max(0, card_width - 2) + glyphs["tr"],
+            style=frame,
+        )
+
+    available = card_width - base_len
+    active_part = active_suffix if len(active_suffix) <= available else ""
+    name_budget = max(0, available - len(active_part) - (1 if name else 0))
+    name = name[:name_budget]
+
+    text = Text()
+    text.append(prefix, style=frame)
+    text.append(number, style=number_style)
+    if name:
+        text.append(" ", style=frame)
+        text.append(name, style=name_style)
+    if active_part:
+        text.append(" ", style=frame)
+        text.append("●", style=dot_style)
+    text.append("├", style=frame)
+    fill_len = max(0, card_width - len(text.plain) - 1)
+    text.append(glyphs["h"] * fill_len, style=frame)
+    text.append(glyphs["tr"], style=frame)
+
+    # Final safety net: guarantee exact width regardless of the arithmetic
+    # above, since callers rely on every meter_card line being card_width.
+    plain_len = len(text.plain)
+    if plain_len < card_width:
+        text.append(glyphs["h"] * (card_width - plain_len), style=frame)
+    elif plain_len > card_width:
+        text = text[:card_width]
+    return text
+
+
+def _to_exact_width(card: Text, card_width: int) -> Text:
+    """Force every line of ``card`` to exactly ``card_width`` columns, keeping
+    per-character styles — truncating overlong lines and padding short ones.
+    Callers rely on this invariant; at tiny widths (1–2 cols) the framed
+    layout can't hold it on its own, so this is the final guarantee."""
+    lines = card.plain.split("\n")
+    if all(len(line) == card_width for line in lines):
+        return card
+    out = Text()
+    offset = 0
+    for i, line in enumerate(lines):
+        if i:
+            out.append("\n")
+        take = min(len(line), card_width)
+        out.append(card[offset : offset + take])
+        if take < card_width:
+            out.append(" " * (card_width - take))
+        offset += len(line) + 1
+    return out
+
+
+def meter_card(
+    acc: AccountSnapshot,
+    card_width: int,
+    bar_height: int,
+    *,
+    now: float,
+    flash: bool = False,
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """A framed vertical-meter card: header, one bar column per window, and
+    baseline/label/percent/reset rows beneath. Always ``bar_height +
+    CARD_CHROME`` lines of exactly ``card_width`` columns — used by the
+    watch screen's meter grid. ``flash`` highlights the top border to signal
+    a just-refreshed measurement."""
+    interior_width = card_width - 2
+    # An active account's card wears a bold bright-green double-line frame;
+    # the rest wear the thin muted single-line one.
+    active = acc.is_active
+    frame_glyphs = _FRAME_GLYPHS[active]
+    frame = f"{_ACTIVE_GREEN} bold" if active else palette.muted
+    side = frame_glyphs["v"]
+    bottom_border = (
+        frame_glyphs["bl"] + frame_glyphs["h"] * (card_width - 2) + frame_glyphs["br"]
+    )
+    stale = acc.usage.age_s is not None and acc.usage.age_s > STALE_OK_S
+    text = Text()
+    header = _meter_header(acc, card_width, frame, active=active, palette=palette)
+    if flash:
+        header = Text(header.plain, style=f"bold {palette.accent}")
+    text.append(header)
+
+    if acc.usage.sentinel is not None:
+        windows = []
+    else:
+        windows = meter_windows(acc.usage.last_good, now)
+    if not windows:
+        n_blank = bar_height + CARD_CHROME - 2
+        label = (
+            data.sentinel_label(acc.usage.sentinel)
+            if acc.usage.sentinel is not None
+            else "usage unavailable"
+        )
+        # Wrap the message across the interior rows rather than truncate it to
+        # one line — nothing should be clipped when it can fit. Centered
+        # vertically within the available rows.
+        wrapped = textwrap.wrap(label, width=max(1, interior_width))[:n_blank] or [""]
+        start_row = (n_blank - len(wrapped)) // 2
+        for i in range(n_blank):
+            text.append("\n")
+            text.append(side, style=frame)
+            idx = i - start_row
+            if 0 <= idx < len(wrapped):
+                text.append(_fit_center(wrapped[idx], interior_width), style=palette.muted)
+            else:
+                text.append(" " * interior_width)
+            text.append(side, style=frame)
+        text.append("\n")
+        text.append(bottom_border, style=frame)
+        return _to_exact_width(text, card_width)
+
+    widths = _cell_widths(interior_width, len(windows))
+    # Each window's full bar column, its bar glyph width (for centring within
+    # the cell), and its pct (for the per-window colour ramp).
+    bars = []
+    for w, (_label, pct, _reset, _maxed) in zip(widths, windows):
+        bar_w = _meter_bar_width(w)
+        bars.append((bar_v(pct, bar_height), bar_w, pct, w))
+
+    for r in range(bar_height):
+        frac = (bar_height - 1 - r) / (bar_height - 1) if bar_height > 1 else 0.0
+        text.append("\n")
+        text.append(side, style=frame)
+        for glyphs, bar_w, pct, w in bars:
+            glyph = glyphs[r]
+            fill_style = None
+            if glyph != " ":
+                color = _bar_color(pct, frac, palette)
+                fill_style = f"{color} dim" if stale else color
+            # Left/right pads centre the ``bar_w`` run within the cell, exactly
+            # as ``_fit_center`` would (extra column on the right).
+            left_pad = (w - bar_w) // 2
+            right_pad = w - bar_w - left_pad
+            text.append(" " * left_pad)
+            text.append(glyph * bar_w, style=fill_style)
+            text.append(" " * right_pad)
+        text.append(side, style=frame)
+
+    text.append("\n")
+    text.append(side, style=frame)
+    for glyphs, bar_w, _pct, w in bars:
+        text.append(_fit_center("─" * bar_w, w), style=palette.track)
+    text.append(side, style=frame)
+
+    # Plain bold label row: each window's name, centred in its cell.
+    text.append("\n")
+    text.append(side, style=frame)
+    for w, (label, _pct, _reset, _maxed) in zip(widths, windows):
+        text.append(_fit_label(label, w), style=f"bold {palette.foreground}")
+    text.append(side, style=frame)
+
+    # Blank margin row above the percent block.
+    text.append("\n")
+    text.append(side, style=frame)
+    text.append(" " * interior_width)
+    text.append(side, style=frame)
+
+    # Percent as large 5-row block digits, glanceable at a distance. A window
+    # whose cell can't hold the big digits falls back to a small "NN%" token
+    # on the middle row, keeping every card exactly 5 percent rows tall.
+    percent_cells = []
+    for w, (_label, pct, _reset, _maxed) in zip(widths, windows):
+        sev = palette.severity(pct)
+        pct_style = f"{sev} dim" if stale else sev
+        rows = big_number(str(round(pct)))
+        if len(rows[0]) <= w:
+            cell_rows = [_fit_center(row, w) for row in rows]
+        else:
+            blank = " " * w
+            cell_rows = [blank, blank, _fit_center(f"{round(pct)}%", w), blank, blank]
+        percent_cells.append((cell_rows, pct_style))
+
+    for r in range(5):
+        text.append("\n")
+        text.append(side, style=frame)
+        for cell_rows, pct_style in percent_cells:
+            text.append(cell_rows[r], style=pct_style)
+        text.append(side, style=frame)
+
+    # Blank margin row below the percent block.
+    text.append("\n")
+    text.append(side, style=frame)
+    text.append(" " * interior_width)
+    text.append(side, style=frame)
+
+    # Plain reset countdown row, one cell per window.
+    text.append("\n")
+    text.append(side, style=frame)
+    for w, (_label, _pct, reset, maxed) in zip(widths, windows):
+        reset_style = palette.sev_crit if maxed else palette.muted
+        text.append(_fit_center(reset or "", w), style=reset_style)
+    text.append(side, style=frame)
+
+    text.append("\n")
+    text.append(bottom_border, style=frame)
+    return _to_exact_width(text, card_width)
+
+
+def grid_move(cursor: int, dx: int, dy: int, ncols: int, n: int) -> int:
+    """New row-major index after moving ``(dx, dy)`` across an ``ncols``-wide
+    grid of ``n`` items, clamped to the grid's bounds — never wraps, and a
+    short last row clamps to its own last column rather than the grid's."""
+    ncols = max(1, ncols)
+    n = max(0, n)
+    if n == 0:
+        return cursor
+    cursor = max(0, min(n - 1, cursor))
+    row, col = divmod(cursor, ncols)
+    nrows = -(-n // ncols)
+    new_row = max(0, min(nrows - 1, row + dy))
+    row_start = new_row * ncols
+    row_len = min(ncols, n - row_start)
+    new_col = max(0, min(row_len - 1, col + dx))
+    return row_start + new_col
+
+
+def _line_spans(card: Text) -> list[tuple[int, int]]:
+    """``[(start, end), ...]`` character offsets of each line in ``card``,
+    excluding the ``\\n`` separators — for slicing a line back out of the
+    multi-line :class:`Text` while keeping its per-character styles."""
+    spans = []
+    start = 0
+    for line in card.plain.split("\n"):
+        end = start + len(line)
+        spans.append((start, end))
+        start = end + 1
+    return spans
+
+
+_SELECT_BG = "#2b3648"  # highlight fill behind the account being selected
+
+
+def _mark_cursor(card: Text, card_width: int, palette: Palette = Palette.DARK) -> Text:
+    """Highlight a card as the selection cursor: tint its whole background and
+    give its left/right border edges a bold accent, so it clearly stands out."""
+    marked = card.copy()
+    marked.stylize(f"on {_SELECT_BG}", 0, len(card.plain))
+    offset = 0
+    for line in card.plain.split("\n"):
+        marked.stylize(f"{palette.accent} bold", offset, offset + 1)
+        marked.stylize(
+            f"{palette.accent} bold", offset + card_width - 1, offset + card_width
+        )
+        offset += len(line) + 1
+    return marked
+
+
+def _cards_fit(ncols: int, bar_height: int, height: int, n_accounts: int) -> bool:
+    """Whether the framed card grid — at the given column count and bar
+    height, one row separator between rows — fits within ``height`` lines.
+    ``meter_grid_dims`` already shrinks ``bar_height`` down to its floor, so
+    when this is false, no card size can make the grid fit; the caller must
+    fall back to a one-line-per-account view instead of clipping."""
+    rows_of_cards = -(-n_accounts // ncols)  # ceil
+    needed = rows_of_cards * (bar_height + CARD_CHROME) + (rows_of_cards - 1)
+    return needed <= height
+
+
+def _compact_fallback_text(
+    accounts: list[AccountSnapshot],
+    width: int,
+    *,
+    cursor: int | None,
+    now: float,
+    flashed: set[str],
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """One :func:`mini_account_text` line per account — the watch screen's
+    fallback when even minimum-height cards can't fit the viewport. Fits any
+    number of accounts without scrolling by trading the card layout for a
+    dense list. ``cursor`` and ``flashed`` accent a line's number prefix
+    instead of a card border."""
+    text = Text()
+    for i, acc in enumerate(accounts):
+        if i:
+            text.append("\n")
+        line = mini_account_text(acc, now, palette=palette)
+        if len(line.plain) > width:
+            line = line[:width]
+        if i == cursor or acc.number in flashed:
+            line = line.copy()
+            prefix_len = len(f"{acc.number:>2}") + 2
+            line.stylize(palette.accent, 0, prefix_len)
+        text.append(line)
+    return text
+
+
+def meters_grid_text(
+    accounts: list[AccountSnapshot],
+    width: int,
+    height: int,
+    *,
+    cursor: int | None = None,
+    now: float,
+    flashed: set[str] | None = None,
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """The watch screen's tiled meter grid: every account as a
+    :func:`meter_card`, ``ncols`` per row with a one-space gutter, rows
+    separated by a blank line. ``cursor`` marks that account's card as
+    selected; ``flashed`` account numbers get their card's top border
+    highlighted.
+
+    When even minimum-height cards can't fit ``height`` (tiny terminals or
+    many accounts), falls back to a compact one-line-per-account view — see
+    :func:`_compact_fallback_text` — rather than clipping cards silently.
+    """
+    if not accounts:
+        return Text("no accounts", style=palette.muted)
+
+    flashed = flashed or set()
+    ncols, card_width, bar_height = meter_grid_dims(width, height, len(accounts))
+    if not _cards_fit(ncols, bar_height, height, len(accounts)):
+        return _compact_fallback_text(
+            accounts, width, cursor=cursor, now=now, flashed=flashed, palette=palette
+        )
+    cards = [
+        meter_card(
+            acc, card_width, bar_height, now=now,
+            flash=acc.number in flashed, palette=palette,
+        )
+        for acc in accounts
+    ]
+    if cursor is not None and 0 <= cursor < len(cards):
+        cards[cursor] = _mark_cursor(cards[cursor], card_width, palette)
+
+    text = Text()
+    for row_start in range(0, len(cards), ncols):
+        row_cards = cards[row_start : row_start + ncols]
+        if row_start:
+            text.append("\n\n")
+        row_line_spans = [_line_spans(card) for card in row_cards]
+        for line_idx in range(len(row_line_spans[0])):
+            if line_idx:
+                text.append("\n")
+            for col_idx, card in enumerate(row_cards):
+                if col_idx:
+                    text.append(" ")
+                start, end = row_line_spans[col_idx][line_idx]
+                text.append(card[start:end])
+    return text
 
 
 def account_card_text(
@@ -352,6 +916,141 @@ class AccountsPanel(Static):
             text.append(block)
             previous_multiline = multiline
         return text
+
+
+def _active_index(snap: AccountsSnapshot) -> int:
+    return next(
+        (i for i, acc in enumerate(snap.accounts) if acc.number == snap.active_number),
+        0,
+    )
+
+
+class MetersGrid(Static):
+    """The watch screen's tiled vertical-meter grid, with a keyboard-navigable
+    cursor over the accounts."""
+
+    def __init__(self, *, id: str | None = None) -> None:
+        super().__init__(id=id)
+        self.cursor: int | None = None
+        self._numbers: list[str] = []
+        self._stamps: dict[str, float | None] = {}
+        self._flash: set[str] = set()
+        self._flash_gen: dict[str, int] = {}
+
+    def on_mount(self) -> None:
+        self.watch(self.app, "snapshot", self._on_snapshot)
+        self.watch(self.app, "theme", lambda _t: self.refresh(layout=True))
+
+    def _on_snapshot(self, snap: AccountsSnapshot | None) -> None:
+        if snap is not None:
+            self._anchor_cursor(snap)
+            self._flash_updated(snap)
+        self.refresh(layout=True)
+
+    def _anchor_cursor(self, snap: AccountsSnapshot) -> None:
+        """Keep an armed cursor pointed at a real account.
+
+        Selection can be armed (``MeterWatchScreen._set_selecting``) before the
+        first snapshot ever lands, when there's no account list yet to
+        anchor against — it defaults the cursor to slot 0. The first
+        snapshot that arrives afterward re-anchors it to the active
+        account. Later, if the accounts reorder (an external move/swap) while
+        armed, the cursor follows the *selected account* to its new slot, so
+        Enter never switches to a different target than the one highlighted;
+        if that account is gone, the cursor clamps back into range.
+        """
+        numbers = [acc.number for acc in snap.accounts]
+        if self.cursor is not None:
+            if not self._numbers:
+                self.cursor = _active_index(snap) if numbers else None
+            elif numbers != self._numbers:
+                selected = (
+                    self._numbers[self.cursor]
+                    if 0 <= self.cursor < len(self._numbers)
+                    else None
+                )
+                if selected in numbers:
+                    self.cursor = numbers.index(selected)
+                elif numbers:
+                    self.cursor = min(self.cursor, len(numbers) - 1)
+                else:
+                    self.cursor = None
+        self._numbers = numbers
+
+    def _flash_updated(self, snap: AccountsSnapshot) -> None:
+        """Briefly highlight cards whose stored measurement just advanced.
+
+        A card already flashing that changes again extends its flash: each
+        change bumps the card's generation and schedules a clear tagged with
+        that generation, so an earlier timer can't cut a re-flash short."""
+        new_stamps = {acc.number: acc.usage.fetched_at for acc in snap.accounts}
+        if self._stamps:
+            changed = {
+                num
+                for num, ts in new_stamps.items()
+                if ts is not None and ts != self._stamps.get(num)
+            }
+            for num in changed:
+                gen = self._flash_gen.get(num, 0) + 1
+                self._flash_gen[num] = gen
+                self._flash.add(num)
+                self.set_timer(_FLASH_S, partial(self._clear_flash, num, gen))
+        self._stamps = new_stamps
+
+    def _clear_flash(self, number: str, generation: int) -> None:
+        if self._flash_gen.get(number) != generation:
+            return  # a newer re-flash owns this card now; leave it lit
+        self._flash.discard(number)
+        self.refresh(layout=True)
+
+    def render(self) -> Text:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        palette = Palette.from_theme(app.current_theme)
+        snap = app.snapshot
+        if snap is None:
+            return Text("loading…", style=palette.muted)
+        if not snap.accounts:
+            return Text("No managed accounts yet.", style=palette.muted)
+        return meters_grid_text(
+            snap.accounts,
+            self.size.width,
+            self.size.height,
+            cursor=self.cursor,
+            now=time.time(),
+            flashed=self._flash,
+            palette=palette,
+        )
+
+    def _ncols(self) -> int:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        snap = app.snapshot
+        n = len(snap.accounts) if snap else 0
+        if n == 0:
+            return 1
+        ncols, _card_width, bar_height = meter_grid_dims(
+            self.size.width, self.size.height, n
+        )
+        if not _cards_fit(ncols, bar_height, self.size.height, n):
+            return 1  # compact fallback renders as a single vertical column
+        return ncols
+
+    def move_cursor(self, dx: int, dy: int) -> None:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        snap = app.snapshot
+        n = len(snap.accounts) if snap else 0
+        if n == 0:
+            return
+        self.cursor = grid_move(self.cursor or 0, dx, dy, self._ncols(), n)
+        self.refresh(layout=True)
+
+    def selected_number(self) -> str | None:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        snap = app.snapshot
+        if snap is None or self.cursor is None:
+            return None
+        if not 0 <= self.cursor < len(snap.accounts):
+            return None
+        return snap.accounts[self.cursor].number
 
 
 class AccountCard(Static):

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -8,7 +8,9 @@ auto-switch trigger line), and stale-measurement dimming.
 
 from __future__ import annotations
 
+import textwrap
 import time
+from functools import partial
 from typing import TYPE_CHECKING
 
 from rich.text import Text
@@ -16,7 +18,7 @@ from textual.widgets import ListItem, Static
 
 from claude_swap import pace
 from claude_swap.json_output import USAGE_API_KEY
-from claude_swap.models import AccountSnapshot
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
 from claude_swap.switcher import ERROR_NOTES
 from claude_swap.usage_store import STALE_OK_S
 from claude_swap.tui import data
@@ -29,6 +31,22 @@ _BAR_FILLED = "━"
 _BAR_HALF = "╸"
 _BAR_EMPTY = "─"
 _BAR_TICK = "┃"
+
+_FLASH_S = 1.5  # how long a just-refreshed card's border stays highlighted
+
+_ACTIVE_GREEN = "#3fb950"  # bright green frame/title for the active account's card
+
+# Frame glyph sets keyed by whether the card belongs to the active account:
+# active cards get a bold double-line box, inactive cards the thin rounded one.
+_FRAME_GLYPHS = {
+    True: {"tl": "╔", "tr": "╗", "bl": "╚", "br": "╝", "h": "═", "v": "║"},
+    False: {"tl": "╭", "tr": "╮", "bl": "╰", "br": "╯", "h": "─", "v": "│"},
+}
+
+# meter_card's non-bar rows: top+bottom borders (2), baseline (1), window
+# labels (1), a blank margin row (1), big-digit percent (5), a blank margin
+# row (1), reset (1).
+CARD_CHROME = 12
 
 
 def bar_cells(
@@ -63,6 +81,63 @@ def bar_cells(
         else:
             text.append(_BAR_EMPTY, style=palette.track)
     return text
+
+
+# A maxed window's bar stays entirely in reds — dark at the base, hot at the
+# ceiling — so a limit that's been hit never reads as calm green at the bottom.
+# Theme-independent by design: a hit limit is red in light and dark alike.
+_RED_STOPS = ((0.0, "#7a2e2e"), (1.0, "#ff6b6b"))
+
+
+def _hex_rgb(h: str) -> tuple[int, int, int]:
+    return int(h[1:3], 16), int(h[3:5], 16), int(h[5:7], 16)
+
+
+def _interp(stops: tuple, t: float) -> str:
+    """Interpolate a hex colour along ``stops`` at fraction ``t`` (clamped)."""
+    t = 0.0 if t < 0.0 else 1.0 if t > 1.0 else t
+    for (t0, c0), (t1, c1) in zip(stops, stops[1:]):
+        if t <= t1:
+            f = 0.0 if t1 == t0 else (t - t0) / (t1 - t0)
+            r0, g0, b0 = _hex_rgb(c0)
+            r1, g1, b1 = _hex_rgb(c1)
+            return "#%02x%02x%02x" % (
+                round(r0 + (r1 - r0) * f),
+                round(g0 + (g1 - g0) * f),
+                round(b0 + (b1 - b0) * f),
+            )
+    return stops[-1][1]
+
+
+def gradient_color(t: float, palette: Palette = Palette.DARK) -> str:
+    """Colour for a bar cell at height fraction ``t`` (0 bottom .. 1 top):
+    interpolates the palette's ok → warn → crit severity ramp."""
+    stops = (
+        (0.0, palette.sev_ok),
+        (0.5, palette.sev_warn),
+        (1.0, palette.sev_crit),
+    )
+    return _interp(stops, t)
+
+
+def _bar_color(pct: float, t: float, palette: Palette = Palette.DARK) -> str:
+    """Bar-cell colour: shades of red once the window is maxed (>=100%),
+    otherwise the green → amber → red climb."""
+    return _interp(_RED_STOPS, t) if pct >= 100 else gradient_color(t, palette)
+
+
+_V_EIGHTHS = " ▁▂▃▄▅▆▇█"  # index 0..8, empty → full
+
+
+def bar_v(pct: float, height: int) -> list[str]:
+    """A vertical bar ``height`` cells tall, glyphs top-row-first, filled from
+    the bottom via eighth blocks."""
+    eighths = max(0.0, min(100.0, pct)) / 100.0 * height * 8
+    rows = []
+    for r in range(height - 1, -1, -1):  # r = whole cells below this one
+        cell = max(0, min(8, round(eighths - r * 8)))
+        rows.append(_V_EIGHTHS[cell])
+    return rows
 
 
 def usage_bar(
@@ -158,6 +233,495 @@ def usage_rows(
                 suffix_full = f"{suffix_full}  {marker}" if suffix_full else marker
         rows.append((window["name"], pct, suffix, suffix_full))
     return rows
+
+
+def _short_reset(window: dict, now: float) -> str | None:
+    """Largest-unit reset, e.g. 'resets 2h 13m' -> '2h'."""
+    full = data.reset_text(window, now)
+    if not full:
+        return None
+    body = full.replace("resets ", "").strip()
+    return body.split()[0] if body else None
+
+
+def meter_windows(
+    last_good: dict | None, now: float
+) -> list[tuple[str, float, str | None, bool]]:
+    """(label, pct, short_reset, maxed) per window — spend, 5h, 7d, scoped."""
+    out: list[tuple[str, float, str | None, bool]] = []
+    if not isinstance(last_good, dict):
+        return out
+    spend = last_good.get("spend")
+    if spend:
+        pct = float(spend["pct"])
+        out.append(("$$", pct, _short_reset(spend, now), pct >= 100))
+    for key, label in (("five_hour", "5h"), ("seven_day", "7d")):
+        w = last_good.get(key)
+        if w:
+            pct = float(w["pct"])
+            out.append((label, pct, _short_reset(w, now), pct >= 100))
+    for w in last_good.get("scoped") or []:
+        pct = float(w["pct"])
+        out.append((w["name"], pct, _short_reset(w, now), pct >= 100))
+    return out
+
+
+def meter_grid_dims(
+    width: int,
+    height: int,
+    n_accounts: int,
+    *,
+    min_card_w: int = 20,
+    bar_min: int = 1,
+    card_chrome: int = CARD_CHROME,
+    gutter: int = 1,
+) -> tuple[int, int, int]:
+    """(ncols, card_width, bar_height) for the meter grid at this terminal size.
+
+    Columns account for the inter-card gutter so a card never falls below
+    ``min_card_w`` by ignoring it. Bars fill the available height — growing to
+    consume every spare row and shrinking (down to ``bar_min``) rather than
+    overflow, since the grid is not scrollable.
+    """
+    n = max(1, n_accounts)
+    ncols = max(1, min((width + 1) // (min_card_w + gutter), n))
+    card_width = (width - gutter * (ncols - 1)) // ncols
+    rows_of_cards = -(-n // ncols)  # ceil
+    seps = rows_of_cards - 1
+    avail = height - rows_of_cards * card_chrome - seps
+    bar_height = max(bar_min, avail // rows_of_cards)
+    return ncols, card_width, bar_height
+
+
+def _cell_widths(interior_width: int, n_windows: int) -> list[int]:
+    """Split ``interior_width`` into ``n_windows`` cells, remainder spread
+    across the leftmost cells so the widths sum to ``interior_width``."""
+    base, remainder = divmod(interior_width, n_windows)
+    return [base + (1 if i < remainder else 0) for i in range(n_windows)]
+
+
+def _meter_bar_width(cell_width: int) -> int:
+    """Bar fills its cell, leaving a one-column gutter on each side."""
+    return max(1, cell_width - 2)
+
+
+def _fit_center(s: str, width: int) -> str:
+    """Center ``s`` in ``width`` columns, truncating first so the result is
+    always exactly ``width`` wide even when ``s`` is longer than the cell."""
+    return s[:width].center(width)
+
+
+def _fit_label(label: str, width: int) -> str:
+    """Center ``label`` in ``width`` columns; a label longer than the cell
+    truncates to an ellipsis (``label[:1]`` when ``width`` is 1) rather than
+    silently dropping its tail via ``_fit_center``'s plain slice."""
+    if len(label) > width:
+        label = label[:1] if width == 1 else label[: width - 1] + "…"
+    return _fit_center(label, width)
+
+
+_PIXEL_DIGITS = {
+    "0": ("███", "█ █", "█ █", "█ █", "███"),
+    "1": (" █ ", "██ ", " █ ", " █ ", "███"),
+    "2": ("███", "  █", "███", "█  ", "███"),
+    "3": ("███", "  █", "███", "  █", "███"),
+    "4": ("█ █", "█ █", "███", "  █", "  █"),
+    "5": ("███", "█  ", "███", "  █", "███"),
+    "6": ("███", "█  ", "███", "█ █", "███"),
+    "7": ("███", "  █", "  █", "  █", "  █"),
+    "8": ("███", "█ █", "███", "█ █", "███"),
+    "9": ("███", "█ █", "███", "  █", "███"),
+}
+
+
+def big_number(s: str) -> list[str]:
+    """Render a digit string as 5 rows of bold block glyphs. Each digit is 3
+    cols wide and digits are joined by a one-column gap, so ``"100"`` is
+    3+1+3+1+3 = 11 wide."""
+    rows = ["", "", "", "", ""]
+    for pos, ch in enumerate(s):
+        g = _PIXEL_DIGITS.get(ch, ("   ", "   ", "   ", "   ", "   "))
+        for i in range(5):
+            if pos:
+                rows[i] += " "
+            rows[i] += g[i]
+    return rows
+
+
+def _meter_header(
+    acc: AccountSnapshot,
+    card_width: int,
+    frame: str,
+    *,
+    active: bool = False,
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """``╭─┤ {number} {name} {● if active}├────╮`` (the active account's card
+    uses the double-line ``╔═┤ … ├────╗`` variant instead).
+
+    Degrades under a tight ``card_width``: the name is hard-truncated first,
+    then dropped along with the active dot, and if even the bare number
+    can't be framed, this falls back to a plain corner-to-corner border.
+    Always exactly ``card_width`` columns.
+    """
+    glyphs = _FRAME_GLYPHS[active]
+    number = str(acc.number)
+    name = acc.alias or acc.email.split("@", 1)[0]
+    active_suffix = " ●" if acc.is_active else ""
+    prefix = f"{glyphs['tl']}{glyphs['h']}┤ "
+    number_style = frame if active else palette.accent
+    name_style = frame if active else palette.foreground
+    dot_style = frame if active else palette.accent
+
+    # Minimal frame: prefix + number + "├" + tr, no name, no active dot,
+    # no fill. If even this doesn't fit, there's no room for a framed title.
+    base_len = len(prefix) + len(number) + 1 + 1
+    if base_len > card_width:
+        return Text(
+            glyphs["tl"] + glyphs["h"] * max(0, card_width - 2) + glyphs["tr"],
+            style=frame,
+        )
+
+    available = card_width - base_len
+    active_part = active_suffix if len(active_suffix) <= available else ""
+    name_budget = max(0, available - len(active_part) - (1 if name else 0))
+    name = name[:name_budget]
+
+    text = Text()
+    text.append(prefix, style=frame)
+    text.append(number, style=number_style)
+    if name:
+        text.append(" ", style=frame)
+        text.append(name, style=name_style)
+    if active_part:
+        text.append(" ", style=frame)
+        text.append("●", style=dot_style)
+    text.append("├", style=frame)
+    fill_len = max(0, card_width - len(text.plain) - 1)
+    text.append(glyphs["h"] * fill_len, style=frame)
+    text.append(glyphs["tr"], style=frame)
+
+    # Final safety net: guarantee exact width regardless of the arithmetic
+    # above, since callers rely on every meter_card line being card_width.
+    plain_len = len(text.plain)
+    if plain_len < card_width:
+        text.append(glyphs["h"] * (card_width - plain_len), style=frame)
+    elif plain_len > card_width:
+        text = text[:card_width]
+    return text
+
+
+def _to_exact_width(card: Text, card_width: int) -> Text:
+    """Force every line of ``card`` to exactly ``card_width`` columns, keeping
+    per-character styles — truncating overlong lines and padding short ones.
+    Callers rely on this invariant; at tiny widths (1–2 cols) the framed
+    layout can't hold it on its own, so this is the final guarantee."""
+    lines = card.plain.split("\n")
+    if all(len(line) == card_width for line in lines):
+        return card
+    out = Text()
+    offset = 0
+    for i, line in enumerate(lines):
+        if i:
+            out.append("\n")
+        take = min(len(line), card_width)
+        out.append(card[offset : offset + take])
+        if take < card_width:
+            out.append(" " * (card_width - take))
+        offset += len(line) + 1
+    return out
+
+
+def meter_card(
+    acc: AccountSnapshot,
+    card_width: int,
+    bar_height: int,
+    *,
+    now: float,
+    flash: bool = False,
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """A framed vertical-meter card: header, one bar column per window, and
+    baseline/label/percent/reset rows beneath. Always ``bar_height +
+    CARD_CHROME`` lines of exactly ``card_width`` columns — used by the
+    watch screen's meter grid. ``flash`` highlights the top border to signal
+    a just-refreshed measurement."""
+    interior_width = card_width - 2
+    # An active account's card wears a bold bright-green double-line frame;
+    # the rest wear the thin muted single-line one.
+    active = acc.is_active
+    frame_glyphs = _FRAME_GLYPHS[active]
+    frame = f"{_ACTIVE_GREEN} bold" if active else palette.muted
+    side = frame_glyphs["v"]
+    bottom_border = (
+        frame_glyphs["bl"] + frame_glyphs["h"] * (card_width - 2) + frame_glyphs["br"]
+    )
+    stale = acc.usage.age_s is not None and acc.usage.age_s > STALE_OK_S
+    text = Text()
+    header = _meter_header(acc, card_width, frame, active=active, palette=palette)
+    if flash:
+        header = Text(header.plain, style=f"bold {palette.accent}")
+    text.append(header)
+
+    if acc.usage.sentinel is not None:
+        windows = []
+    else:
+        windows = meter_windows(acc.usage.last_good, now)
+    if not windows:
+        n_blank = bar_height + CARD_CHROME - 2
+        label = (
+            data.sentinel_label(acc.usage.sentinel)
+            if acc.usage.sentinel is not None
+            else "usage unavailable"
+        )
+        # Wrap the message across the interior rows rather than truncate it to
+        # one line — nothing should be clipped when it can fit. Centered
+        # vertically within the available rows.
+        wrapped = textwrap.wrap(label, width=max(1, interior_width))[:n_blank] or [""]
+        start_row = (n_blank - len(wrapped)) // 2
+        for i in range(n_blank):
+            text.append("\n")
+            text.append(side, style=frame)
+            idx = i - start_row
+            if 0 <= idx < len(wrapped):
+                text.append(_fit_center(wrapped[idx], interior_width), style=palette.muted)
+            else:
+                text.append(" " * interior_width)
+            text.append(side, style=frame)
+        text.append("\n")
+        text.append(bottom_border, style=frame)
+        return _to_exact_width(text, card_width)
+
+    widths = _cell_widths(interior_width, len(windows))
+    # Each window's full bar column, its bar glyph width (for centring within
+    # the cell), and its pct (for the per-window colour ramp).
+    bars = []
+    for w, (_label, pct, _reset, _maxed) in zip(widths, windows):
+        bar_w = _meter_bar_width(w)
+        bars.append((bar_v(pct, bar_height), bar_w, pct, w))
+
+    for r in range(bar_height):
+        frac = (bar_height - 1 - r) / (bar_height - 1) if bar_height > 1 else 0.0
+        text.append("\n")
+        text.append(side, style=frame)
+        for glyphs, bar_w, pct, w in bars:
+            glyph = glyphs[r]
+            fill_style = None
+            if glyph != " ":
+                color = _bar_color(pct, frac, palette)
+                fill_style = f"{color} dim" if stale else color
+            # Left/right pads centre the ``bar_w`` run within the cell, exactly
+            # as ``_fit_center`` would (extra column on the right).
+            left_pad = (w - bar_w) // 2
+            right_pad = w - bar_w - left_pad
+            text.append(" " * left_pad)
+            text.append(glyph * bar_w, style=fill_style)
+            text.append(" " * right_pad)
+        text.append(side, style=frame)
+
+    text.append("\n")
+    text.append(side, style=frame)
+    for glyphs, bar_w, _pct, w in bars:
+        text.append(_fit_center("─" * bar_w, w), style=palette.track)
+    text.append(side, style=frame)
+
+    # Plain bold label row: each window's name, centred in its cell.
+    text.append("\n")
+    text.append(side, style=frame)
+    for w, (label, _pct, _reset, _maxed) in zip(widths, windows):
+        text.append(_fit_label(label, w), style=f"bold {palette.foreground}")
+    text.append(side, style=frame)
+
+    # Blank margin row above the percent block.
+    text.append("\n")
+    text.append(side, style=frame)
+    text.append(" " * interior_width)
+    text.append(side, style=frame)
+
+    # Percent as large 5-row block digits, glanceable at a distance. A window
+    # whose cell can't hold the big digits falls back to a small "NN%" token
+    # on the middle row, keeping every card exactly 5 percent rows tall.
+    percent_cells = []
+    for w, (_label, pct, _reset, _maxed) in zip(widths, windows):
+        sev = palette.severity(pct)
+        pct_style = f"{sev} dim" if stale else sev
+        rows = big_number(str(round(pct)))
+        if len(rows[0]) <= w:
+            cell_rows = [_fit_center(row, w) for row in rows]
+        else:
+            blank = " " * w
+            cell_rows = [blank, blank, _fit_center(f"{round(pct)}%", w), blank, blank]
+        percent_cells.append((cell_rows, pct_style))
+
+    for r in range(5):
+        text.append("\n")
+        text.append(side, style=frame)
+        for cell_rows, pct_style in percent_cells:
+            text.append(cell_rows[r], style=pct_style)
+        text.append(side, style=frame)
+
+    # Blank margin row below the percent block.
+    text.append("\n")
+    text.append(side, style=frame)
+    text.append(" " * interior_width)
+    text.append(side, style=frame)
+
+    # Plain reset countdown row, one cell per window.
+    text.append("\n")
+    text.append(side, style=frame)
+    for w, (_label, _pct, reset, maxed) in zip(widths, windows):
+        reset_style = palette.sev_crit if maxed else palette.muted
+        text.append(_fit_center(reset or "", w), style=reset_style)
+    text.append(side, style=frame)
+
+    text.append("\n")
+    text.append(bottom_border, style=frame)
+    return _to_exact_width(text, card_width)
+
+
+def grid_move(cursor: int, dx: int, dy: int, ncols: int, n: int) -> int:
+    """New row-major index after moving ``(dx, dy)`` across an ``ncols``-wide
+    grid of ``n`` items, clamped to the grid's bounds — never wraps, and a
+    short last row clamps to its own last column rather than the grid's."""
+    ncols = max(1, ncols)
+    n = max(0, n)
+    if n == 0:
+        return cursor
+    cursor = max(0, min(n - 1, cursor))
+    row, col = divmod(cursor, ncols)
+    nrows = -(-n // ncols)
+    new_row = max(0, min(nrows - 1, row + dy))
+    row_start = new_row * ncols
+    row_len = min(ncols, n - row_start)
+    new_col = max(0, min(row_len - 1, col + dx))
+    return row_start + new_col
+
+
+def _line_spans(card: Text) -> list[tuple[int, int]]:
+    """``[(start, end), ...]`` character offsets of each line in ``card``,
+    excluding the ``\\n`` separators — for slicing a line back out of the
+    multi-line :class:`Text` while keeping its per-character styles."""
+    spans = []
+    start = 0
+    for line in card.plain.split("\n"):
+        end = start + len(line)
+        spans.append((start, end))
+        start = end + 1
+    return spans
+
+
+_SELECT_BG = "#2b3648"  # highlight fill behind the account being selected
+
+
+def _mark_cursor(card: Text, card_width: int, palette: Palette = Palette.DARK) -> Text:
+    """Highlight a card as the selection cursor: tint its whole background and
+    give its left/right border edges a bold accent, so it clearly stands out."""
+    marked = card.copy()
+    marked.stylize(f"on {_SELECT_BG}", 0, len(card.plain))
+    offset = 0
+    for line in card.plain.split("\n"):
+        marked.stylize(f"{palette.accent} bold", offset, offset + 1)
+        marked.stylize(
+            f"{palette.accent} bold", offset + card_width - 1, offset + card_width
+        )
+        offset += len(line) + 1
+    return marked
+
+
+def _cards_fit(ncols: int, bar_height: int, height: int, n_accounts: int) -> bool:
+    """Whether the framed card grid — at the given column count and bar
+    height, one row separator between rows — fits within ``height`` lines.
+    ``meter_grid_dims`` already shrinks ``bar_height`` down to its floor, so
+    when this is false, no card size can make the grid fit; the caller must
+    fall back to a one-line-per-account view instead of clipping."""
+    rows_of_cards = -(-n_accounts // ncols)  # ceil
+    needed = rows_of_cards * (bar_height + CARD_CHROME) + (rows_of_cards - 1)
+    return needed <= height
+
+
+def _compact_fallback_text(
+    accounts: list[AccountSnapshot],
+    width: int,
+    *,
+    cursor: int | None,
+    now: float,
+    flashed: set[str],
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """One :func:`mini_account_text` line per account — the watch screen's
+    fallback when even minimum-height cards can't fit the viewport. Fits any
+    number of accounts without scrolling by trading the card layout for a
+    dense list. ``cursor`` and ``flashed`` accent a line's number prefix
+    instead of a card border."""
+    text = Text()
+    for i, acc in enumerate(accounts):
+        if i:
+            text.append("\n")
+        line = mini_account_text(acc, now, palette=palette)
+        if len(line.plain) > width:
+            line = line[:width]
+        if i == cursor or acc.number in flashed:
+            line = line.copy()
+            prefix_len = len(f"{acc.number:>2}") + 2
+            line.stylize(palette.accent, 0, prefix_len)
+        text.append(line)
+    return text
+
+
+def meters_grid_text(
+    accounts: list[AccountSnapshot],
+    width: int,
+    height: int,
+    *,
+    cursor: int | None = None,
+    now: float,
+    flashed: set[str] | None = None,
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """The watch screen's tiled meter grid: every account as a
+    :func:`meter_card`, ``ncols`` per row with a one-space gutter, rows
+    separated by a blank line. ``cursor`` marks that account's card as
+    selected; ``flashed`` account numbers get their card's top border
+    highlighted.
+
+    When even minimum-height cards can't fit ``height`` (tiny terminals or
+    many accounts), falls back to a compact one-line-per-account view — see
+    :func:`_compact_fallback_text` — rather than clipping cards silently.
+    """
+    if not accounts:
+        return Text("no accounts", style=palette.muted)
+
+    flashed = flashed or set()
+    ncols, card_width, bar_height = meter_grid_dims(width, height, len(accounts))
+    if not _cards_fit(ncols, bar_height, height, len(accounts)):
+        return _compact_fallback_text(
+            accounts, width, cursor=cursor, now=now, flashed=flashed, palette=palette
+        )
+    cards = [
+        meter_card(
+            acc, card_width, bar_height, now=now,
+            flash=acc.number in flashed, palette=palette,
+        )
+        for acc in accounts
+    ]
+    if cursor is not None and 0 <= cursor < len(cards):
+        cards[cursor] = _mark_cursor(cards[cursor], card_width, palette)
+
+    text = Text()
+    for row_start in range(0, len(cards), ncols):
+        row_cards = cards[row_start : row_start + ncols]
+        if row_start:
+            text.append("\n\n")
+        row_line_spans = [_line_spans(card) for card in row_cards]
+        for line_idx in range(len(row_line_spans[0])):
+            if line_idx:
+                text.append("\n")
+            for col_idx, card in enumerate(row_cards):
+                if col_idx:
+                    text.append(" ")
+                start, end = row_line_spans[col_idx][line_idx]
+                text.append(card[start:end])
+    return text
 
 
 def account_card_text(
@@ -357,6 +921,141 @@ class AccountsPanel(Static):
             text.append(block)
             previous_multiline = multiline
         return text
+
+
+def _active_index(snap: AccountsSnapshot) -> int:
+    return next(
+        (i for i, acc in enumerate(snap.accounts) if acc.number == snap.active_number),
+        0,
+    )
+
+
+class MetersGrid(Static):
+    """The watch screen's tiled vertical-meter grid, with a keyboard-navigable
+    cursor over the accounts."""
+
+    def __init__(self, *, id: str | None = None) -> None:
+        super().__init__(id=id)
+        self.cursor: int | None = None
+        self._numbers: list[str] = []
+        self._stamps: dict[str, float | None] = {}
+        self._flash: set[str] = set()
+        self._flash_gen: dict[str, int] = {}
+
+    def on_mount(self) -> None:
+        self.watch(self.app, "snapshot", self._on_snapshot)
+        self.watch(self.app, "theme", lambda _t: self.refresh(layout=True))
+
+    def _on_snapshot(self, snap: AccountsSnapshot | None) -> None:
+        if snap is not None:
+            self._anchor_cursor(snap)
+            self._flash_updated(snap)
+        self.refresh(layout=True)
+
+    def _anchor_cursor(self, snap: AccountsSnapshot) -> None:
+        """Keep an armed cursor pointed at a real account.
+
+        Selection can be armed (``MeterWatchScreen._set_selecting``) before the
+        first snapshot ever lands, when there's no account list yet to
+        anchor against — it defaults the cursor to slot 0. The first
+        snapshot that arrives afterward re-anchors it to the active
+        account. Later, if the accounts reorder (an external move/swap) while
+        armed, the cursor follows the *selected account* to its new slot, so
+        Enter never switches to a different target than the one highlighted;
+        if that account is gone, the cursor clamps back into range.
+        """
+        numbers = [acc.number for acc in snap.accounts]
+        if self.cursor is not None:
+            if not self._numbers:
+                self.cursor = _active_index(snap) if numbers else None
+            elif numbers != self._numbers:
+                selected = (
+                    self._numbers[self.cursor]
+                    if 0 <= self.cursor < len(self._numbers)
+                    else None
+                )
+                if selected in numbers:
+                    self.cursor = numbers.index(selected)
+                elif numbers:
+                    self.cursor = min(self.cursor, len(numbers) - 1)
+                else:
+                    self.cursor = None
+        self._numbers = numbers
+
+    def _flash_updated(self, snap: AccountsSnapshot) -> None:
+        """Briefly highlight cards whose stored measurement just advanced.
+
+        A card already flashing that changes again extends its flash: each
+        change bumps the card's generation and schedules a clear tagged with
+        that generation, so an earlier timer can't cut a re-flash short."""
+        new_stamps = {acc.number: acc.usage.fetched_at for acc in snap.accounts}
+        if self._stamps:
+            changed = {
+                num
+                for num, ts in new_stamps.items()
+                if ts is not None and ts != self._stamps.get(num)
+            }
+            for num in changed:
+                gen = self._flash_gen.get(num, 0) + 1
+                self._flash_gen[num] = gen
+                self._flash.add(num)
+                self.set_timer(_FLASH_S, partial(self._clear_flash, num, gen))
+        self._stamps = new_stamps
+
+    def _clear_flash(self, number: str, generation: int) -> None:
+        if self._flash_gen.get(number) != generation:
+            return  # a newer re-flash owns this card now; leave it lit
+        self._flash.discard(number)
+        self.refresh(layout=True)
+
+    def render(self) -> Text:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        palette = Palette.from_theme(app.current_theme)
+        snap = app.snapshot
+        if snap is None:
+            return Text("loading…", style=palette.muted)
+        if not snap.accounts:
+            return Text("No managed accounts yet.", style=palette.muted)
+        return meters_grid_text(
+            snap.accounts,
+            self.size.width,
+            self.size.height,
+            cursor=self.cursor,
+            now=time.time(),
+            flashed=self._flash,
+            palette=palette,
+        )
+
+    def _ncols(self) -> int:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        snap = app.snapshot
+        n = len(snap.accounts) if snap else 0
+        if n == 0:
+            return 1
+        ncols, _card_width, bar_height = meter_grid_dims(
+            self.size.width, self.size.height, n
+        )
+        if not _cards_fit(ncols, bar_height, self.size.height, n):
+            return 1  # compact fallback renders as a single vertical column
+        return ncols
+
+    def move_cursor(self, dx: int, dy: int) -> None:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        snap = app.snapshot
+        n = len(snap.accounts) if snap else 0
+        if n == 0:
+            return
+        self.cursor = grid_move(self.cursor or 0, dx, dy, self._ncols(), n)
+        self.refresh(layout=True)
+
+    def selected_number(self) -> str | None:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        snap = app.snapshot
+        if snap is None or self.cursor is None:
+            return None
+        if not 0 <= self.cursor < len(snap.accounts):
+            return None
+        return snap.accounts[self.cursor].number
 
 
 class AccountCard(Static):

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -15,7 +15,9 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 from rich.text import Text
+from textual.app import ComposeResult
 from textual.timer import Timer
+from textual.widget import Widget
 from textual.widgets import ListItem, Static
 
 from claude_swap import pace
@@ -661,15 +663,30 @@ def _compact_fallback_text(
     for i, acc in enumerate(window, start=top):
         if i > top:
             text.append("\n")
-        line = mini_account_text(acc, now, palette=palette)
-        if len(line.plain) > width:
-            line = line[:width]
-        if i == cursor or acc.number in flashed:
-            line = line.copy()
-            prefix_len = len(f"{acc.number:>2}") + 2
-            line.stylize(palette.accent, 0, prefix_len)
-        text.append(line)
+        text.append(
+            compact_account_line(
+                acc, width, now=now,
+                accent=i == cursor or acc.number in flashed, palette=palette,
+            )
+        )
     return text
+
+
+def compact_account_line(
+    acc: AccountSnapshot, width: int, *, now: float, accent: bool,
+    palette: Palette = Palette.DARK,
+) -> Text:
+    """One account's row in the compact fallback: :func:`mini_account_text`
+    clipped to ``width``; ``accent`` colours its number prefix, standing in
+    for the card border the cursor or a flash would otherwise highlight."""
+    line = mini_account_text(acc, now, palette=palette)
+    if len(line.plain) > width:
+        line = line[:width]
+    if accent:
+        line = line.copy()
+        prefix_len = len(f"{acc.number:>2}") + 2
+        line.stylize(palette.accent, 0, prefix_len)
+    return line
 
 
 def meters_grid_text(
@@ -943,14 +960,69 @@ def _active_index(snap: AccountsSnapshot) -> int:
     )
 
 
-class MetersGrid(Static):
+class MeterCard(Static):
+    """One account's framed meter card. Owns nothing but its own props, so
+    the grid can repaint a single card (cursor, flash, breathing frame)
+    without re-rendering the whole screen."""
+
+    DEFAULT_CSS = """
+    MeterCard { width: auto; height: auto; }
+    """
+
+    def __init__(self, acc: AccountSnapshot, *, palette: Palette) -> None:
+        super().__init__()
+        self.acc = acc
+        self.palette = palette
+        self.card_width = 0
+        self.bar_height = 0
+        self.compact = False  # render as one compact-fallback line instead
+        self.flash = False
+        self.marked = False
+        self.frame_style: str | None = None
+
+    def render(self) -> Text:
+        if self.compact:
+            return compact_account_line(
+                self.acc, self.card_width, now=time.time(),
+                accent=self.marked or self.flash, palette=self.palette,
+            )
+        card = meter_card(
+            self.acc,
+            self.card_width,
+            self.bar_height,
+            now=time.time(),
+            flash=self.flash,
+            palette=self.palette,
+            frame_style=self.frame_style,
+        )
+        if self.marked:
+            card = _mark_cursor(card, self.card_width, self.palette)
+        return card
+
+
+class MetersGrid(Widget):
     """The watch screen's tiled vertical-meter grid, with a keyboard-navigable
-    cursor over the accounts."""
+    cursor over the accounts.
+
+    A container of one :class:`MeterCard` per account rather than a single
+    renderable: every state change (cursor, flash, breathing frame, handoff
+    sweep) repaints only the cards it touches, so a 10 Hz animation frame
+    costs one card, not the whole screen."""
+
+    DEFAULT_CSS = """
+    MetersGrid {
+        layout: grid;
+        grid-rows: auto;
+        grid-columns: auto;
+    }
+    MetersGrid > #meters-note { width: 1fr; height: auto; }
+    """
 
     def __init__(self, *, id: str | None = None) -> None:
         super().__init__(id=id)
-        self.cursor: int | None = None
+        self._cursor: int | None = None
         self._numbers: list[str] = []
+        self._cards: list[MeterCard] = []  # one per account, in grid order
         self._stamps: dict[str, float | None] = {}
         self._flash: set[str] = set()
         self._flash_gen: dict[str, int] = {}
@@ -965,6 +1037,27 @@ class MetersGrid(Static):
         # is being swept across the cards; a newer switch simply replaces it.
         self._sweep: tuple[str | None, str, float] | None = None
 
+    def compose(self) -> ComposeResult:
+        yield Static("", id="meters-note")
+
+    @property
+    def cursor(self) -> int | None:
+        return self._cursor
+
+    @cursor.setter
+    def cursor(self, value: int | None) -> None:
+        self._cursor = value
+        self._sync_marks()
+        if self._compact:
+            self._apply_window()
+
+    def _sync_marks(self) -> None:
+        for i, card in enumerate(self._cards):
+            marked = i == self._cursor
+            if card.marked != marked:
+                card.marked = marked
+                card.refresh()
+
     def set_predicted(self, number: str | None, urgency: float) -> None:
         """Highlight ``number`` as the predicted next-switch target (``None``
         clears it); ``urgency`` in 0..1 sets the breathing tempo."""
@@ -975,7 +1068,7 @@ class MetersGrid(Static):
             self._phase = 0.0
         self._sync_animation()
         if changed:
-            self.refresh(layout=True)
+            self._paint_frames()
 
     def start_sweep(
         self, from_number: str | None, to_number: str, *, now: float | None = None
@@ -984,7 +1077,7 @@ class MetersGrid(Static):
         to muted while the new active card's frame rises to green."""
         self._sweep = (from_number, to_number, time.time() if now is None else now)
         self._sync_animation()
-        self.refresh(layout=True)
+        self._paint_frames(now)
 
     def _compact_window(self) -> int:
         """First account to show in the compact list: the window moves only
@@ -1020,7 +1113,7 @@ class MetersGrid(Static):
         if self._sweep is not None and now - self._sweep[2] >= _SWEEP_S:
             self._sweep = None
             self._sync_animation()
-        self.refresh()
+        self._paint_frames(now)
 
     def frame_styles(self, palette: Palette, now: float) -> dict[str, str]:
         """Per-account frame colours for this frame: the predicted target
@@ -1042,15 +1135,113 @@ class MetersGrid(Static):
             )
         return styles
 
+    def _paint_frames(self, now: float | None = None) -> None:
+        """Push this frame's colours to the cards, repainting only those
+        whose frame actually changed."""
+        if not self._cards:
+            return
+        now = time.time() if now is None else now
+        styles = self.frame_styles(self._palette(), now)
+        for card in self._cards:
+            style = styles.get(card.acc.number)
+            if card.frame_style != style:
+                card.frame_style = style
+                card.refresh()
+
+    def _palette(self) -> Palette:
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        return Palette.from_theme(app.current_theme)
+
     def on_mount(self) -> None:
         self.watch(self.app, "snapshot", self._on_snapshot)
-        self.watch(self.app, "theme", lambda _t: self.refresh(layout=True))
+        self.watch(self.app, "theme", self._on_theme)
+
+    def on_resize(self) -> None:
+        self._apply_layout()
+
+    def _on_theme(self, _theme: str) -> None:
+        palette = self._palette()
+        for card in self._cards:
+            card.palette = palette
+        self._apply_layout()  # repaints every card in the new palette
 
     def _on_snapshot(self, snap: AccountsSnapshot | None) -> None:
         if snap is not None:
             self._anchor_cursor(snap)
             self._flash_updated(snap)
-        self.refresh(layout=True)
+        self._reconcile_cards(snap)
+        self._apply_layout()
+
+    def _reconcile_cards(self, snap: AccountsSnapshot | None) -> None:
+        """Keep one card per account, in snapshot order. Same membership and
+        order (every routine poll) updates the cards in place; anything else
+        rebuilds them, which is rare enough not to need a smarter diff."""
+        accounts = list(snap.accounts) if snap is not None else []
+        numbers = [acc.number for acc in accounts]
+        if numbers == [card.acc.number for card in self._cards]:
+            for card, acc in zip(self._cards, accounts):
+                card.acc = acc
+                card.flash = acc.number in self._flash
+                card.refresh()
+            self._sync_marks()
+            return
+        palette = self._palette()
+        self.remove_children(MeterCard)
+        self._cards = [MeterCard(acc, palette=palette) for acc in accounts]
+        for i, card in enumerate(self._cards):
+            card.flash = card.acc.number in self._flash
+            card.marked = i == self._cursor
+        self.mount_all(self._cards)
+
+    def _dims(self) -> tuple[int, int, int, bool]:
+        """(columns, card width, bar height, compact) for the current size."""
+        n = len(self._cards)
+        ncols, card_width, bar_height = meter_grid_dims(
+            self.size.width, self.size.height, n
+        )
+        compact = not _cards_fit(ncols, bar_height, self.size.height, n)
+        return ncols, card_width, bar_height, compact
+
+    def _apply_layout(self) -> None:
+        """Size the cards and the grid for the current viewport; called on
+        resize and whenever the account list changes."""
+        note = self.query_one("#meters-note", Static)
+        app: "CswapApp" = self.app  # type: ignore[assignment]
+        if app.snapshot is None:
+            note.update(Text("loading…", style=self._palette().muted))
+        elif not self._cards:
+            note.update(Text("No managed accounts yet.", style=self._palette().muted))
+        note.display = not self._cards
+        if not self._cards or self.size.width == 0:
+            return
+        ncols, card_width, bar_height, compact = self._dims()
+        self.set_compact(compact)
+        self._compact_rows = self.size.height
+        if compact:
+            ncols, card_width, bar_height = 1, self.size.width, 0
+        self.styles.grid_size_columns = ncols
+        self.styles.grid_gutter_horizontal = 0 if compact else 1
+        self.styles.grid_gutter_vertical = 0 if compact else 1
+        for card in self._cards:
+            card.compact = compact
+            card.card_width, card.bar_height = card_width, bar_height
+            if compact:
+                card.frame_style = None  # no frame to animate on a line
+            card.refresh(layout=True)
+        self._apply_window()
+        if not compact:
+            self._paint_frames()  # rebuilt or re-themed cards get this frame now
+
+    def _apply_window(self) -> None:
+        """Show only the compact window's cards; every card when framed."""
+        if self._compact:
+            top = self._compact_window()
+            rows = max(1, self._compact_rows)
+            for i, card in enumerate(self._cards):
+                card.display = top <= i < top + rows
+        else:
+            for card in self._cards:
+                card.display = True
 
     def _anchor_cursor(self, snap: AccountsSnapshot) -> None:
         """Keep an armed cursor pointed at a real account.
@@ -1065,21 +1256,21 @@ class MetersGrid(Static):
         if that account is gone, the cursor clamps back into range.
         """
         numbers = [acc.number for acc in snap.accounts]
-        if self.cursor is not None:
+        if self._cursor is not None:
             if not self._numbers:
-                self.cursor = _active_index(snap) if numbers else None
+                self._cursor = _active_index(snap) if numbers else None
             elif numbers != self._numbers:
                 selected = (
-                    self._numbers[self.cursor]
-                    if 0 <= self.cursor < len(self._numbers)
+                    self._numbers[self._cursor]
+                    if 0 <= self._cursor < len(self._numbers)
                     else None
                 )
                 if selected in numbers:
-                    self.cursor = numbers.index(selected)
+                    self._cursor = numbers.index(selected)
                 elif numbers:
-                    self.cursor = min(self.cursor, len(numbers) - 1)
+                    self._cursor = min(self._cursor, len(numbers) - 1)
                 else:
-                    self.cursor = None
+                    self._cursor = None
         self._numbers = numbers
 
     def _flash_updated(self, snap: AccountsSnapshot) -> None:
@@ -1106,66 +1297,29 @@ class MetersGrid(Static):
         if self._flash_gen.get(number) != generation:
             return  # a newer re-flash owns this card now; leave it lit
         self._flash.discard(number)
-        self.refresh(layout=True)
-
-    def render(self) -> Text:
-        app: "CswapApp" = self.app  # type: ignore[assignment]
-        palette = Palette.from_theme(app.current_theme)
-        snap = app.snapshot
-        if snap is None:
-            return Text("loading…", style=palette.muted)
-        if not snap.accounts:
-            return Text("No managed accounts yet.", style=palette.muted)
-        now = time.time()
-        ncols, _card_width, bar_height = meter_grid_dims(
-            self.size.width, self.size.height, len(snap.accounts)
-        )
-        self.set_compact(
-            not _cards_fit(ncols, bar_height, self.size.height, len(snap.accounts))
-        )
-        self._compact_rows = self.size.height
-        return meters_grid_text(
-            snap.accounts,
-            self.size.width,
-            self.size.height,
-            cursor=self.cursor,
-            now=now,
-            flashed=self._flash,
-            palette=palette,
-            frame_styles=self.frame_styles(palette, now),
-            compact_top=self._compact_window(),
-        )
+        for card in self._cards:
+            if card.acc.number == number and card.flash:
+                card.flash = False
+                card.refresh()
 
     def _ncols(self) -> int:
-        app: "CswapApp" = self.app  # type: ignore[assignment]
-        snap = app.snapshot
-        n = len(snap.accounts) if snap else 0
-        if n == 0:
+        if not self._cards:
             return 1
-        ncols, _card_width, bar_height = meter_grid_dims(
-            self.size.width, self.size.height, n
-        )
-        if not _cards_fit(ncols, bar_height, self.size.height, n):
+        ncols, _card_width, _bar_height, compact = self._dims()
+        if compact:
             return 1  # compact fallback renders as a single vertical column
         return ncols
 
     def move_cursor(self, dx: int, dy: int) -> None:
-        app: "CswapApp" = self.app  # type: ignore[assignment]
-        snap = app.snapshot
-        n = len(snap.accounts) if snap else 0
+        n = len(self._cards)
         if n == 0:
             return
         self.cursor = grid_move(self.cursor or 0, dx, dy, self._ncols(), n)
-        self.refresh(layout=True)
 
     def selected_number(self) -> str | None:
-        app: "CswapApp" = self.app  # type: ignore[assignment]
-        snap = app.snapshot
-        if snap is None or self.cursor is None:
+        if self.cursor is None or not 0 <= self.cursor < len(self._cards):
             return None
-        if not 0 <= self.cursor < len(snap.accounts):
-            return None
-        return snap.accounts[self.cursor].number
+        return self._cards[self.cursor].acc.number
 
 
 class AccountCard(Static):

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -42,7 +42,9 @@ _FLASH_S = 1.5  # how long a just-refreshed card's border stays highlighted
 # something to animate. The predicted next-switch target's frame "breathes"
 # between muted and accent; the period shrinks as the active account nears
 # the threshold.
-_ANIM_DT = 0.1  # seconds between animation frames
+_ANIM_DT = 0.1  # seconds between animation frames while something moves fast
+_ANIM_DT_REST = 0.2  # ... while the predicted card only breathes slowly
+_URGENT = 0.5  # urgency from which breathing runs at the full frame rate
 _BREATHE_SLOW_S = 2.0  # breathing period when a switch is far off
 _BREATHE_FAST_S = 0.6  # breathing period when a switch is imminent
 _SWEEP_S = 1.0  # handoff sweep: old active fades to muted, new one to green
@@ -1030,6 +1032,7 @@ class MetersGrid(Widget):
         self.urgency: float = 0.0  # 0 = far from the threshold … 1 = imminent
         self._phase: float = 0.0  # breathing phase, radians
         self._anim: Timer | None = None
+        self._anim_dt = _ANIM_DT  # period of the running interval
         self._compact = False  # compact fallback in use: no frames to animate
         self._compact_rows = 0  # viewport rows available to the compact list
         self._compact_top = 0  # first account the compact list shows
@@ -1100,16 +1103,27 @@ class MetersGrid(Widget):
         want = not self._compact and (
             self.predicted is not None or self._sweep is not None
         )
-        if want and self._anim is None:
-            self._anim = self.set_interval(_ANIM_DT, self._advance_frame)
+        dt = self._frame_dt()
+        if want and (self._anim is None or dt != self._anim_dt):
+            if self._anim is not None:
+                self._anim.stop()
+            self._anim = self.set_interval(dt, self._advance_frame)
+            self._anim_dt = dt
         elif not want and self._anim is not None:
             self._anim.stop()
             self._anim = None
 
+    def _frame_dt(self) -> float:
+        """Half the frames while the card breathes slowly; the full rate once
+        the switch is near or a handoff sweep is running."""
+        if self._sweep is not None or self.urgency >= _URGENT:
+            return _ANIM_DT
+        return _ANIM_DT_REST
+
     def _advance_frame(self, now: float | None = None) -> None:
         now = time.time() if now is None else now
         period = _BREATHE_SLOW_S - (_BREATHE_SLOW_S - _BREATHE_FAST_S) * self.urgency
-        self._phase = (self._phase + math.tau * _ANIM_DT / period) % math.tau
+        self._phase = (self._phase + math.tau * self._anim_dt / period) % math.tau
         if self._sweep is not None and now - self._sweep[2] >= _SWEEP_S:
             self._sweep = None
             self._sync_animation()

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -8,12 +8,14 @@ auto-switch trigger line), and stale-measurement dimming.
 
 from __future__ import annotations
 
+import math
 import textwrap
 import time
 from functools import partial
 from typing import TYPE_CHECKING
 
 from rich.text import Text
+from textual.timer import Timer
 from textual.widgets import ListItem, Static
 
 from claude_swap import pace
@@ -33,6 +35,15 @@ _BAR_EMPTY = "─"
 _BAR_TICK = "┃"
 
 _FLASH_S = 1.5  # how long a just-refreshed card's border stays highlighted
+
+# Meter-grid animation, driven by one interval that runs only while there is
+# something to animate. The predicted next-switch target's frame "breathes"
+# between muted and accent; the period shrinks as the active account nears
+# the threshold.
+_ANIM_DT = 0.1  # seconds between animation frames
+_BREATHE_SLOW_S = 2.0  # breathing period when a switch is far off
+_BREATHE_FAST_S = 0.6  # breathing period when a switch is imminent
+_SWEEP_S = 1.0  # handoff sweep: old active fades to muted, new one to green
 
 _ACTIVE_GREEN = "#3fb950"  # bright green frame/title for the active account's card
 
@@ -440,18 +451,20 @@ def meter_card(
     now: float,
     flash: bool = False,
     palette: Palette = Palette.DARK,
+    frame_style: str | None = None,
 ) -> Text:
     """A framed vertical-meter card: header, one bar column per window, and
     baseline/label/percent/reset rows beneath. Always ``bar_height +
     CARD_CHROME`` lines of exactly ``card_width`` columns — used by the
     watch screen's meter grid. ``flash`` highlights the top border to signal
-    a just-refreshed measurement."""
+    a just-refreshed measurement; ``frame_style`` replaces the frame's
+    colour (animations: the predicted next target, a switch handoff)."""
     interior_width = card_width - 2
     # An active account's card wears a bold bright-green double-line frame;
     # the rest wear the thin muted single-line one.
     active = acc.is_active
     frame_glyphs = _FRAME_GLYPHS[active]
-    frame = f"{_ACTIVE_GREEN} bold" if active else palette.muted
+    frame = frame_style or (f"{_ACTIVE_GREEN} bold" if active else palette.muted)
     side = frame_glyphs["v"]
     bottom_border = (
         frame_glyphs["bl"] + frame_glyphs["h"] * (card_width - 2) + frame_glyphs["br"]
@@ -597,19 +610,6 @@ def grid_move(cursor: int, dx: int, dy: int, ncols: int, n: int) -> int:
     return row_start + new_col
 
 
-def _line_spans(card: Text) -> list[tuple[int, int]]:
-    """``[(start, end), ...]`` character offsets of each line in ``card``,
-    excluding the ``\\n`` separators — for slicing a line back out of the
-    multi-line :class:`Text` while keeping its per-character styles."""
-    spans = []
-    start = 0
-    for line in card.plain.split("\n"):
-        end = start + len(line)
-        spans.append((start, end))
-        start = end + 1
-    return spans
-
-
 _SELECT_BG = "#2b3648"  # highlight fill behind the account being selected
 
 
@@ -642,20 +642,24 @@ def _cards_fit(ncols: int, bar_height: int, height: int, n_accounts: int) -> boo
 def _compact_fallback_text(
     accounts: list[AccountSnapshot],
     width: int,
+    height: int,
     *,
     cursor: int | None,
     now: float,
     flashed: set[str],
     palette: Palette = Palette.DARK,
+    top: int = 0,
 ) -> Text:
     """One :func:`mini_account_text` line per account — the watch screen's
-    fallback when even minimum-height cards can't fit the viewport. Fits any
-    number of accounts without scrolling by trading the card layout for a
-    dense list. ``cursor`` and ``flashed`` accent a line's number prefix
-    instead of a card border."""
+    fallback when even minimum-height cards can't fit the viewport. Renders
+    the ``height`` accounts from ``top`` down, so the caller can keep the
+    selected account inside the viewport (see ``MetersGrid._compact_window``).
+    ``cursor`` and ``flashed`` accent a line's number prefix instead of a
+    card border."""
     text = Text()
-    for i, acc in enumerate(accounts):
-        if i:
+    window = accounts[top : top + max(1, height)]
+    for i, acc in enumerate(window, start=top):
+        if i > top:
             text.append("\n")
         line = mini_account_text(acc, now, palette=palette)
         if len(line.plain) > width:
@@ -677,12 +681,16 @@ def meters_grid_text(
     now: float,
     flashed: set[str] | None = None,
     palette: Palette = Palette.DARK,
+    frame_styles: dict[str, str] | None = None,
+    compact_top: int = 0,
 ) -> Text:
     """The watch screen's tiled meter grid: every account as a
     :func:`meter_card`, ``ncols`` per row with a one-space gutter, rows
     separated by a blank line. ``cursor`` marks that account's card as
     selected; ``flashed`` account numbers get their card's top border
-    highlighted.
+    highlighted; ``frame_styles`` (account number → style) recolours those
+    cards' frames — cards only, the compact fallback ignores it, and
+    ``compact_top`` is the first account the compact fallback shows.
 
     When even minimum-height cards can't fit ``height`` (tiny terminals or
     many accounts), falls back to a compact one-line-per-account view — see
@@ -692,15 +700,18 @@ def meters_grid_text(
         return Text("no accounts", style=palette.muted)
 
     flashed = flashed or set()
+    frame_styles = frame_styles or {}
     ncols, card_width, bar_height = meter_grid_dims(width, height, len(accounts))
     if not _cards_fit(ncols, bar_height, height, len(accounts)):
         return _compact_fallback_text(
-            accounts, width, cursor=cursor, now=now, flashed=flashed, palette=palette
+            accounts, width, height, cursor=cursor, now=now, flashed=flashed,
+            palette=palette, top=compact_top,
         )
     cards = [
         meter_card(
             acc, card_width, bar_height, now=now,
             flash=acc.number in flashed, palette=palette,
+            frame_style=frame_styles.get(acc.number),
         )
         for acc in accounts
     ]
@@ -712,15 +723,17 @@ def meters_grid_text(
         row_cards = cards[row_start : row_start + ncols]
         if row_start:
             text.append("\n\n")
-        row_line_spans = [_line_spans(card) for card in row_cards]
-        for line_idx in range(len(row_line_spans[0])):
+        # One split per card: slicing a line out of the multi-line Text per
+        # row runs Rich's divide (and its whole-text control-code scrub) once
+        # per line, which is quadratic in card size and pinned a core at 10 Hz.
+        row_lines = [card.split("\n", allow_blank=True) for card in row_cards]
+        for line_idx in range(len(row_lines[0])):
             if line_idx:
                 text.append("\n")
-            for col_idx, card in enumerate(row_cards):
+            for col_idx, lines in enumerate(row_lines):
                 if col_idx:
                     text.append(" ")
-                start, end = row_line_spans[col_idx][line_idx]
-                text.append(card[start:end])
+                text.append(lines[line_idx])
     return text
 
 
@@ -941,6 +954,93 @@ class MetersGrid(Static):
         self._stamps: dict[str, float | None] = {}
         self._flash: set[str] = set()
         self._flash_gen: dict[str, int] = {}
+        self.predicted: str | None = None  # account number the engine would move to
+        self.urgency: float = 0.0  # 0 = far from the threshold … 1 = imminent
+        self._phase: float = 0.0  # breathing phase, radians
+        self._anim: Timer | None = None
+        self._compact = False  # compact fallback in use: no frames to animate
+        self._compact_rows = 0  # viewport rows available to the compact list
+        self._compact_top = 0  # first account the compact list shows
+        # (account left, account switched to, started at) while a real switch
+        # is being swept across the cards; a newer switch simply replaces it.
+        self._sweep: tuple[str | None, str, float] | None = None
+
+    def set_predicted(self, number: str | None, urgency: float) -> None:
+        """Highlight ``number`` as the predicted next-switch target (``None``
+        clears it); ``urgency`` in 0..1 sets the breathing tempo."""
+        changed = number != self.predicted
+        self.predicted = number
+        self.urgency = max(0.0, min(1.0, urgency))
+        if changed:
+            self._phase = 0.0
+        self._sync_animation()
+        if changed:
+            self.refresh(layout=True)
+
+    def start_sweep(
+        self, from_number: str | None, to_number: str, *, now: float | None = None
+    ) -> None:
+        """Animate a real switch: the old active card's frame fades from green
+        to muted while the new active card's frame rises to green."""
+        self._sweep = (from_number, to_number, time.time() if now is None else now)
+        self._sync_animation()
+        self.refresh(layout=True)
+
+    def _compact_window(self) -> int:
+        """First account to show in the compact list: the window moves only
+        as far as it must to keep the cursor's line inside the viewport."""
+        rows = max(1, self._compact_rows)
+        if self.cursor is None:
+            self._compact_top = 0
+        else:
+            top = min(self._compact_top, self.cursor)
+            self._compact_top = max(0, top, self.cursor - rows + 1)
+        return self._compact_top
+
+    def set_compact(self, compact: bool) -> None:
+        if compact != self._compact:
+            self._compact = compact
+            self._sync_animation()
+
+    def _sync_animation(self) -> None:
+        """Run the frame interval only while something is animating."""
+        want = not self._compact and (
+            self.predicted is not None or self._sweep is not None
+        )
+        if want and self._anim is None:
+            self._anim = self.set_interval(_ANIM_DT, self._advance_frame)
+        elif not want and self._anim is not None:
+            self._anim.stop()
+            self._anim = None
+
+    def _advance_frame(self, now: float | None = None) -> None:
+        now = time.time() if now is None else now
+        period = _BREATHE_SLOW_S - (_BREATHE_SLOW_S - _BREATHE_FAST_S) * self.urgency
+        self._phase = (self._phase + math.tau * _ANIM_DT / period) % math.tau
+        if self._sweep is not None and now - self._sweep[2] >= _SWEEP_S:
+            self._sweep = None
+            self._sync_animation()
+        self.refresh()
+
+    def frame_styles(self, palette: Palette, now: float) -> dict[str, str]:
+        """Per-account frame colours for this frame: the predicted target
+        breathes from the resting muted frame up to the accent and back; a
+        handoff sweep in flight overrides the two cards it moves between."""
+        styles: dict[str, str] = {}
+        if self.predicted is not None:
+            lit = 0.5 - 0.5 * math.cos(self._phase)
+            styles[self.predicted] = _interp(
+                ((0.0, palette.muted), (1.0, palette.accent)), lit
+            )
+        if self._sweep is not None:
+            left, landed, started = self._sweep
+            t = (now - started) / _SWEEP_S
+            if left is not None:
+                styles[left] = _interp(((0.0, _ACTIVE_GREEN), (1.0, palette.muted)), t)
+            styles[landed] = (
+                _interp(((0.0, palette.muted), (1.0, _ACTIVE_GREEN)), t) + " bold"
+            )
+        return styles
 
     def on_mount(self) -> None:
         self.watch(self.app, "snapshot", self._on_snapshot)
@@ -1016,14 +1116,24 @@ class MetersGrid(Static):
             return Text("loading…", style=palette.muted)
         if not snap.accounts:
             return Text("No managed accounts yet.", style=palette.muted)
+        now = time.time()
+        ncols, _card_width, bar_height = meter_grid_dims(
+            self.size.width, self.size.height, len(snap.accounts)
+        )
+        self.set_compact(
+            not _cards_fit(ncols, bar_height, self.size.height, len(snap.accounts))
+        )
+        self._compact_rows = self.size.height
         return meters_grid_text(
             snap.accounts,
             self.size.width,
             self.size.height,
             cursor=self.cursor,
-            now=time.time(),
+            now=now,
             flashed=self._flash,
             palette=palette,
+            frame_styles=self.frame_styles(palette, now),
+            compact_top=self._compact_window(),
         )
 
     def _ncols(self) -> int:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -5925,12 +5925,12 @@ class TestHorizonAxisDoesNotFlap:
         reset_at = self._iso_at(ranking_now + 100.0)   # future at ranking_now
         stale_reread = ranking_now + 200.0             # past reset_at
 
-        # Enough values for the OLD code's clock() call order (pre-tick
-        # check, ranking now, left_snapshot re-read, freshen expiry check,
-        # _perform's lastSwitchAt) with a couple of spares so neither code
-        # path can exhaust the sequence.
+        # Enough values for the clock() call order (pre-tick check, the
+        # next-target prediction, ranking now, a left_snapshot re-read,
+        # freshen expiry check, _perform's lastSwitchAt) with a couple of
+        # spares so neither code path can exhaust the sequence.
         clock_values = iter([
-            ranking_now, ranking_now, stale_reread,
+            ranking_now, ranking_now, ranking_now, stale_reread,
             stale_reread, stale_reread, stale_reread,
         ])
         with patch.object(h.engine, "clock", side_effect=lambda: next(clock_values)):
@@ -6894,3 +6894,242 @@ class TestFreshenRoutesThroughGate:
         assert gate_calls["args"][0] == "2"
         assert "called" not in direct, "freshen must not POST outside the gate"
 
+
+
+# --- next-target prediction ---------------------------------------------------
+
+
+class TestNextTargetPrediction:
+    """`PollEvent.next_target` names the account the engine would move to if
+    the active account crossed the threshold on this tick's snapshot. It is
+    computed on EVERY tick, including below-threshold ticks where `best`
+    never reaches candidate ranking, so a watch screen can highlight "who is
+    next" before a switch is imminent."""
+
+    def _poll(self, h: EngineHarness) -> PollEvent:
+        return next(e for e in h.events if isinstance(e, PollEvent))
+
+    def test_best_below_threshold_predicts_most_headroom(self, harness):
+        outcome = harness.tick_with_usage({
+            "1": _usage(20),   # active, healthy -> below-threshold hold
+            "2": _usage(10),   # most headroom -> would be next
+            "3": _usage(50),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert self._poll(harness).next_target == "2"
+
+    def test_consume_first_predicts_soonest_reset_not_most_headroom(
+        self, temp_home
+    ):
+        h = EngineHarness(temp_home, strategy="consume-first")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATER),    # active, resets later
+            "2": _usage7(50, 50, _R_SOON),     # less headroom, resets soonest
+            "3": _usage7(10, 10, _R_LATEST),   # most headroom, resets last
+        })
+        assert self._poll(h).next_target == "2"
+
+    def test_none_when_every_candidate_is_at_its_limit(self, harness):
+        harness.tick_with_usage({
+            "1": _usage(20),
+            "2": _usage(100),
+            "3": _usage(100),
+        })
+        assert self._poll(harness).next_target is None
+
+    def test_the_account_just_left_is_not_predicted_while_barred(
+        self, temp_home
+    ):
+        """Mirrors `test_the_bar_reaches_the_ranking_through_tick`: on the
+        recovery axis the barred account would win the ranking, so the
+        prediction must exclude it exactly as the decision does."""
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        assert h.tick_with_usage({
+            "1": _usage(92, _iso_at(h.clock.now + 500 * 86400)),
+            "2": _usage(10, _iso_at(h.clock.now + 400 * 86400)),
+            "3": _usage(50, _iso_at(h.clock.now + 300 * 86400)),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(301.0)
+        h.events.clear()
+        second = {
+            "1": _usage(99, _iso_at(h.clock.now + 1800)),   # left; back soonest
+            "2": _usage(99, _iso_at(h.clock.now + 7200)),   # active, spent
+            "3": _usage(99, _iso_at(h.clock.now + 3600)),
+        }
+        assert h.tick_with_usage(second) is TickOutcome.SWITCHED
+        assert h.active_number() == 3, "premise: the decision honours the bar"
+        assert self._poll(h).next_target == "3"
+
+    def test_none_while_the_post_switch_cooldown_holds(self, harness):
+        """The decision path holds during cooldown, so the prediction must
+        not name a target the engine cannot take this tick."""
+        assert harness.tick_with_usage({
+            "1": _usage(95), "2": _usage(10), "3": _usage(50),
+        }) is TickOutcome.SWITCHED
+        harness.events.clear()
+        harness.tick_with_usage({"1": _usage(10), "2": _usage(95), "3": _usage(50)})
+        reasons = [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["cooldown"], "premise: this tick is a cooldown hold"
+        assert self._poll(harness).next_target is None
+
+    def test_api_key_last_resort_is_predicted_when_included(self, temp_home):
+        h = EngineHarness(temp_home, include_api_key_accounts=True)
+        h.seed(1, "a@example.com")
+        h.seed(2, "key@token.local")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        data = h.switcher._get_sequence_data()
+        data["accounts"]["2"]["kind"] = "api_key"
+        h.switcher._write_json(h.switcher.sequence_file, data)
+        h.tick_with_usage({"1": _usage(100), "2": "api key", "3": _usage(100)})
+        assert h.active_number() == 2, "premise: the decision lands on the key"
+        assert self._poll(h).next_target == "2"
+
+    def test_json_carries_next_target_only_when_known(self):
+        base = dict(active=None, headroom={}, threshold=90.0)
+        assert PollEvent(**base, next_target="2").to_json()["nextTarget"] == "2"
+        assert "nextTarget" not in PollEvent(**base).to_json()
+
+
+class TestStopRefusesAnInFlightSwitch:
+    """`stop()` only interrupts the inter-tick sleep. A tick that has already
+    ranked and is about to switch must notice the stop under the state lock
+    and hold — otherwise leaving the TUI's live mode (or SIGTERM to `cswap
+    auto`) can be followed by one more unrequested switch."""
+
+    def test_a_stopped_engine_holds_instead_of_switching(self, harness):
+        harness.engine.stop()
+        outcome = harness.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert harness.active_number() == 1
+        assert not any(isinstance(e, SwitchEvent) for e in harness.events)
+        reasons = [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["stopped"]
+
+    def test_dry_run_still_reports_the_would_switch_after_stop(self, temp_home):
+        """Dry-run never mutates anything, so there is nothing to refuse."""
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        h.engine = h._make_engine(dry_run=True)
+        h.engine.stop()
+        outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 1
+
+    def test_stop_from_another_thread_waits_for_an_in_flight_switch(
+        self, harness
+    ):
+        """After `stop()` returns to the TUI, the account must not change:
+        a switch transaction already under way is allowed to finish, and
+        `stop()` does not return until it has."""
+        import threading
+
+        entered = threading.Event()
+        release = threading.Event()
+        real_switch_to = harness.switcher.switch_to
+
+        def slow_switch_to(*args, **kwargs):
+            entered.set()
+            assert release.wait(5), "test harness never released the switch"
+            return real_switch_to(*args, **kwargs)
+
+        with patch.object(harness.switcher, "switch_to", side_effect=slow_switch_to):
+            tick = threading.Thread(
+                target=harness.tick_with_usage,
+                args=({"1": _usage(95), "2": _usage(10)},),
+            )
+            tick.start()
+            assert entered.wait(5), "premise: the tick reached switch_to"
+
+            stopped = threading.Event()
+            stopper = threading.Thread(
+                target=lambda: (harness.engine.stop(), stopped.set())
+            )
+            stopper.start()
+            assert not stopped.wait(0.3), "stop() returned mid-transaction"
+
+            release.set()
+            tick.join(5)
+            assert stopped.wait(5), "stop() never returned after the switch"
+        assert harness.active_number() == 2  # the in-flight switch completed
+
+    def test_stop_from_the_tick_thread_never_deadlocks(self, harness):
+        """`cswap auto` stops from a SIGTERM handler on the loop thread; a
+        stop() issued mid-switch on that same thread must return at once."""
+        real_switch_to = harness.switcher.switch_to
+
+        def stopping_switch_to(*args, **kwargs):
+            harness.engine.stop()
+            return real_switch_to(*args, **kwargs)
+
+        with patch.object(harness.switcher, "switch_to", side_effect=stopping_switch_to):
+            outcome = harness.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.SWITCHED
+
+    def test_events_are_never_delivered_while_the_switch_lock_is_held(
+        self, harness
+    ):
+        """The TUI delivers events synchronously onto its main thread, and
+        that same thread is what calls `stop()`. If an event were emitted
+        while `_switch_lock` is held, a main thread blocked in `stop()` and a
+        worker blocked delivering to it would wait on each other forever.
+        Modelled here with a UI thread that calls `stop()` and only accepts
+        events once `stop()` has returned."""
+        import threading
+
+        in_lock = threading.Event()
+        stop_pending = threading.Event()
+        ui_free = threading.Event()
+        delivered: list = []
+        starved: list = []
+
+        class GateEvent(threading.Event):
+            # The first thing `_perform` does under the lock is read this
+            # flag; park there until the UI thread is about to call stop().
+            def is_set(self):
+                in_lock.set()
+                stop_pending.wait(5)
+                return super().is_set()
+
+        gate = GateEvent()
+        harness.engine._stop = gate
+
+        def ui_delivery(event):
+            # The UI thread is unavailable only while it sits inside stop().
+            if stop_pending.is_set() and not ui_free.wait(3):
+                starved.append(event)
+            delivered.append(event)
+
+        harness.engine.on_event = ui_delivery
+        tick = threading.Thread(
+            target=harness.tick_with_usage,
+            args=({"1": _usage(95), "2": _usage(10)},),
+        )
+        tick.start()
+        assert in_lock.wait(5), "premise: the tick reached the locked block"
+
+        def ui_thread():
+            stop_pending.set()
+            harness.engine.stop()
+            ui_free.set()
+
+        ui = threading.Thread(target=ui_thread)
+        ui.start()
+        ui.join(8)
+        tick.join(8)
+        assert not ui.is_alive() and not tick.is_alive(), "deadlocked"
+        assert starved == [], "an event was delivered while stop() was blocked"
+        reasons = [e.reason for e in delivered if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["stopped"]
+        assert harness.active_number() == 1

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -49,9 +49,10 @@ class TestConfigList:
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
             "ui.theme",
+            "ui.watchStyle",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,10 +79,14 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False
+        assert by_key["ui.theme"]["value"] == "auto"
+        assert by_key["ui.theme"]["isSet"] is False
+        assert by_key["ui.watchStyle"]["value"] == "classic"
+        assert by_key["ui.watchStyle"]["isSet"] is False
 
 
 class TestConfigSetGet:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -125,8 +125,10 @@ class TestSaveSettings:
 
 
 class TestUiSettings:
-    def test_missing_file_defaults_to_auto(self, tmp_path: Path):
-        assert load_ui_settings(tmp_path) == UiSettings(theme="auto")
+    def test_missing_file_defaults(self, tmp_path: Path):
+        assert load_ui_settings(tmp_path) == UiSettings(
+            theme="auto", watch_style="classic"
+        )
 
     def test_reads_auto(self, tmp_path: Path):
         settings_path(tmp_path).write_text(json.dumps({"ui": {"theme": "auto"}}))
@@ -140,6 +142,34 @@ class TestUiSettings:
         settings_path(tmp_path).write_text(json.dumps({"ui": {"theme": "purple"}}))
         assert load_ui_settings(tmp_path).theme == "auto"
 
+    def test_reads_classic(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"ui": {"watchStyle": "classic"}})
+        )
+        assert load_ui_settings(tmp_path).watch_style == "classic"
+
+    def test_reads_meters(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"ui": {"watchStyle": "meters"}})
+        )
+        assert load_ui_settings(tmp_path).watch_style == "meters"
+
+    def test_unknown_style_clamps_to_default(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"ui": {"watchStyle": "hologram"}})
+        )
+        assert load_ui_settings(tmp_path).watch_style == "classic"
+
+    def test_bad_theme_keeps_good_watch_style(self, tmp_path: Path):
+        # Each ui key falls back independently: garbage theme must not
+        # discard a valid watchStyle.
+        settings_path(tmp_path).write_text(
+            json.dumps({"ui": {"theme": "purple", "watchStyle": "meters"}})
+        )
+        loaded = load_ui_settings(tmp_path)
+        assert loaded.theme == "auto"
+        assert loaded.watch_style == "meters"
+
     def test_set_and_unset_ui_theme(self, tmp_path: Path):
         assert set_setting(tmp_path, "ui.theme", "light") == "light"
         raw = json.loads(settings_path(tmp_path).read_text())
@@ -147,9 +177,20 @@ class TestUiSettings:
         assert unset_setting(tmp_path, "ui.theme") is True
         assert "ui" not in json.loads(settings_path(tmp_path).read_text())
 
-    def test_set_rejects_bad_choice(self, tmp_path: Path):
+    def test_set_and_unset_ui_watch_style(self, tmp_path: Path):
+        assert set_setting(tmp_path, "ui.watchStyle", "meters") == "meters"
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert raw == {"schemaVersion": 1, "ui": {"watchStyle": "meters"}}
+        assert unset_setting(tmp_path, "ui.watchStyle") is True
+        assert "ui" not in json.loads(settings_path(tmp_path).read_text())
+
+    def test_set_rejects_bad_theme(self, tmp_path: Path):
         with pytest.raises(ConfigError, match="dark, light"):
             set_setting(tmp_path, "ui.theme", "purple")
+
+    def test_set_rejects_bad_watch_style(self, tmp_path: Path):
+        with pytest.raises(ConfigError, match="classic, meters"):
+            set_setting(tmp_path, "ui.watchStyle", "hologram")
 
 
 class TestSettingSpecs:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -24,6 +24,7 @@ from claude_swap.json_output import USAGE_API_KEY, USAGE_TOKEN_EXPIRED
 from claude_swap.models import AccountSnapshot, AccountsSnapshot
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui import data as tui_data
+from claude_swap.tui.widgets import bar_v, gradient_color, meter_grid_dims, meter_windows
 from claude_swap.usage_store import UsageEntry
 
 
@@ -238,9 +239,18 @@ class BlockingSnapshotSwitcher(FakeSwitcher):
         )
 
 
-def make_app(fake: FakeSwitcher):
+def set_watch_style(backup_dir: Path, style: str) -> None:
+    """Persist ui.watch_style so the app picks that watch layout at launch."""
+    from claude_swap.settings import set_setting
+
+    set_setting(backup_dir, "ui.watchStyle", style)
+
+
+def make_app(fake: FakeSwitcher, *, watch_style: str | None = None):
     from claude_swap.tui.app import CswapApp
 
+    if watch_style is not None:
+        set_watch_style(fake.backup_dir, watch_style)
     return CswapApp(fake)
 
 
@@ -1095,13 +1105,271 @@ class TestDashboard:
 
 
 @pytest.mark.asyncio
-class TestWatchScreen:
+class TestMeterWatchScreen:
+    """The opt-in ``ui.watch_style = meters`` vertical-meter grid layout."""
+
     def _fake(self, tmp_path):
         return FakeSwitcher(
             [make_account(1, active=True), make_account(2)], tmp_path
         )
 
     async def test_w_opens_monitor_without_cursor(self, tmp_path):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from claude_swap.tui.dashboard import MeterWatchScreen
+            from claude_swap.tui.widgets import MetersGrid
+
+            assert isinstance(app.screen, MeterWatchScreen)
+            grid = app.screen.query_one("#meters", MetersGrid)
+            assert grid.cursor is None  # monitor mode: no cursor
+            await pilot.press("enter")  # inert while just watching
+            await settle(pilot)
+            assert not any(call[0] == "switch_to" for call in fake_calls(app))
+
+    async def test_no_monitor_title_but_prompt_when_armed(self, tmp_path):
+        # The meters view drops the "watching all accounts" header (the grid is
+        # self-evident) but still shows the selection prompt once armed.
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from textual.widgets import Static
+
+            title = app.screen.query_one("#list-title", Static)
+            assert "watching all accounts" not in str(title.render())
+            assert str(title.render()) == ""  # blank while just watching
+            assert title.display is False  # row collapsed — no wasted space
+            await pilot.press("s")  # arm selection
+            await pilot.pause()
+            assert "switch to which account?" in str(title.render())
+            assert title.display is True  # prompt row appears while selecting
+
+    async def test_s_arms_selection_at_active_index(self, tmp_path):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            from claude_swap.tui.widgets import MetersGrid
+
+            grid = app.screen.query_one("#meters", MetersGrid)
+            assert grid.cursor == 0  # armed on the active account
+
+    async def test_nav_right_moves_cursor_one(self, tmp_path):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            from claude_swap.tui.widgets import MetersGrid
+
+            grid = app.screen.query_one("#meters", MetersGrid)
+            assert grid.cursor == 0
+            await pilot.press("l")  # two accounts side by side at this width
+            await pilot.pause()
+            assert grid.cursor == 1
+
+    async def test_grid_content_fits_small_terminal_without_clipping(self, tmp_path):
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2), make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(44, 38)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from claude_swap.tui.widgets import MetersGrid
+
+            grid = app.screen.query_one("#meters", MetersGrid)
+            assert grid._ncols() == 2
+            rendered_lines = grid.render().plain.count("\n") + 1
+            assert rendered_lines <= grid.size.height
+
+    async def test_grid_fallback_cursor_moves_through_compact_list(self, tmp_path):
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2), make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(30, 12)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            from claude_swap.tui.widgets import MetersGrid
+
+            grid = app.screen.query_one("#meters", MetersGrid)
+            assert grid._ncols() == 1  # fallback list is effectively one column
+            assert grid.cursor == 0
+            rendered_lines = grid.render().plain.count("\n") + 1
+            assert rendered_lines <= grid.size.height
+            await pilot.press("j")  # down moves to the next account in the list
+            await pilot.pause()
+            assert grid.cursor == 1
+            assert grid.selected_number() == "2"
+
+    async def test_selection_anchors_to_active_after_pre_snapshot_arm(self, tmp_path):
+        """``s`` pressed before the initial snapshot lands must still end up
+        selecting the active account once data arrives, not slot 1."""
+
+        class BlockingFakeSwitcher(FakeSwitcher):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.release = threading.Event()
+
+            def accounts_snapshot(self, fetch=None):
+                self.release.wait(5)
+                return super().accounts_snapshot(fetch)
+
+        fake = BlockingFakeSwitcher(
+            [make_account(1), make_account(2, active=True), make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            assert app.snapshot is None  # initial refresh hasn't landed yet
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            from claude_swap.tui.widgets import MetersGrid
+
+            grid = app.screen.query_one("#meters", MetersGrid)
+            assert grid.cursor == 0  # arms at the fallback default, snapshot unknown
+
+            fake.release.set()
+            await settle(pilot)
+
+            assert grid.selected_number() == "2"  # anchored to the active account
+
+            # Membership changing later must keep the cursor in range too.
+            shrunk = dataclasses.replace(
+                app.snapshot, accounts=app.snapshot.accounts[:1]
+            )
+            app.snapshot = shrunk
+            await pilot.pause()
+            assert grid.cursor is not None
+            assert grid.cursor < len(shrunk.accounts)
+
+    async def test_armed_cursor_follows_account_across_reorder(self, tmp_path):
+        """An external move/swap that reorders accounts while selection is
+        armed must keep the cursor on the *same account*, not the same slot —
+        otherwise Enter would switch to the wrong target."""
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2), make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            await pilot.press("l")  # move selection off the active account
+            await pilot.pause()
+            from claude_swap.tui.widgets import MetersGrid
+
+            grid = app.screen.query_one("#meters", MetersGrid)
+            selected = grid.selected_number()
+            assert selected == "2"
+
+            # Reorder so account "2" moves to a different index.
+            accts = app.snapshot.accounts
+            reordered = dataclasses.replace(
+                app.snapshot, accounts=(accts[2], accts[0], accts[1])
+            )
+            app.snapshot = reordered
+            await pilot.pause()
+            assert grid.selected_number() == selected  # still on account "2"
+
+    async def test_s_arms_selection_switch_stays_watching(self, tmp_path):
+        fake = self._fake(tmp_path)
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            from claude_swap.tui.dashboard import MeterWatchScreen
+            from claude_swap.tui.widgets import MetersGrid
+
+            await pilot.press("l", "enter")
+            await settle(pilot)
+            assert ("switch_to", "2") in fake.calls
+            assert isinstance(app.screen, MeterWatchScreen)  # stayed watching
+            grid = app.screen.query_one("#meters", MetersGrid)
+            assert grid.cursor is None  # disarmed after switch
+            assert app.snapshot.active_number == "2"
+
+    async def test_escape_disarms_then_leaves(self, tmp_path):
+        fake = self._fake(tmp_path)
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            await pilot.press("escape")  # disarm selection only
+            await pilot.pause()
+            from claude_swap.tui.dashboard import DashboardScreen, MeterWatchScreen
+            from claude_swap.tui.widgets import MetersGrid
+
+            assert isinstance(app.screen, MeterWatchScreen)
+            assert app.screen.query_one("#meters", MetersGrid).cursor is None
+            await pilot.press("escape")  # now leave
+            await pilot.pause()
+            assert isinstance(app.screen, DashboardScreen)
+            assert not any(call[0] == "switch_to" for call in fake.calls)
+
+    async def test_menu_watch_entry_opens_it(self, tmp_path):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await menu_select(pilot, "watch")
+            from claude_swap.tui.dashboard import MeterWatchScreen
+
+            assert isinstance(app.screen, MeterWatchScreen)
+
+    async def test_app_start_watch_stacks_over_dashboard(self, tmp_path):
+        from claude_swap.tui.app import CswapApp
+
+        fake = self._fake(tmp_path)
+        set_watch_style(fake.backup_dir, "meters")
+        app = CswapApp(fake, start="watch")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            from claude_swap.tui.dashboard import DashboardScreen, MeterWatchScreen
+
+            assert isinstance(app.screen, MeterWatchScreen)
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, DashboardScreen)
+
+
+@pytest.mark.asyncio
+class TestClassicWatchScreen:
+    """The default horizontal-bar account-list watch layout (``classic``)."""
+
+    def _fake(self, tmp_path):
+        return FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+
+    async def test_w_opens_monitor_without_cursor(self, tmp_path):
+        # No ui.watch_style set → default classic.
         app = make_app(self._fake(tmp_path))
         async with app.run_test(size=(100, 40)) as pilot:
             await settle(pilot)
@@ -1109,16 +1377,68 @@ class TestWatchScreen:
             await pilot.pause()
             from textual.widgets import ListView
 
-            from claude_swap.tui.dashboard import WatchScreen
-            from claude_swap.tui.widgets import AccountItem
+            from claude_swap.tui.dashboard import ClassicWatchScreen
 
-            assert isinstance(app.screen, WatchScreen)
+            assert isinstance(app.screen, ClassicWatchScreen)
             listview = app.screen.query_one("#accounts", ListView)
-            assert len(list(listview.query(AccountItem))) == 2  # full cards
             assert listview.index is None  # monitor mode: no cursor
             await pilot.press("enter")  # inert while just watching
             await settle(pilot)
             assert not any(call[0] == "switch_to" for call in fake_calls(app))
+
+    async def test_monitor_title_preserved(self, tmp_path):
+        # The classic screen is the author's default view — keep its
+        # "watching all accounts" header (only the meters view drops it).
+        app = make_app(self._fake(tmp_path))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from textual.widgets import Static
+
+            title = app.screen.query_one("#list-title", Static)
+            assert "watching all accounts" in str(title.render())
+
+    async def test_s_arms_selection_at_active_index(self, tmp_path):
+        app = make_app(self._fake(tmp_path))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            from textual.widgets import ListView
+
+            listview = app.screen.query_one("#accounts", ListView)
+            assert listview.index == 0  # armed on the active account
+
+    async def test_armed_cursor_follows_account_across_reorder(self, tmp_path):
+        """A reorder while selection is armed keeps the cursor on the same
+        account, not the same row — so Enter can't switch to the wrong one."""
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2), make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            await pilot.press("down")  # highlight account 2
+            await pilot.pause()
+            from textual.widgets import ListView
+
+            listview = app.screen.query_one("#accounts", ListView)
+            assert app.snapshot.accounts[listview.index].number == "2"
+
+            accts = app.snapshot.accounts
+            app.snapshot = dataclasses.replace(
+                app.snapshot, accounts=(accts[2], accts[0], accts[1])
+            )
+            await pilot.pause()
+            assert app.snapshot.accounts[listview.index].number == "2"
 
     async def test_s_arms_selection_switch_stays_watching(self, tmp_path):
         fake = self._fake(tmp_path)
@@ -1129,17 +1449,16 @@ class TestWatchScreen:
             await pilot.pause()
             await pilot.press("s")
             await pilot.pause()
+            await pilot.press("down", "enter")  # move to account 2, confirm
+            await settle(pilot)
             from textual.widgets import ListView
 
-            from claude_swap.tui.dashboard import WatchScreen
+            from claude_swap.tui.dashboard import ClassicWatchScreen
 
-            listview = app.screen.query_one("#accounts", ListView)
-            assert listview.index == 0  # cursor armed, on the active account
-            await pilot.press("down", "enter")
-            await settle(pilot)
             assert ("switch_to", "2") in fake.calls
-            assert isinstance(app.screen, WatchScreen)  # stayed watching
-            assert app.screen.query_one("#accounts", ListView).index is None
+            assert isinstance(app.screen, ClassicWatchScreen)  # stayed watching
+            listview = app.screen.query_one("#accounts", ListView)
+            assert listview.index is None  # disarmed after switch
             assert app.snapshot.active_number == "2"
 
     async def test_escape_disarms_then_leaves(self, tmp_path):
@@ -1155,9 +1474,9 @@ class TestWatchScreen:
             await pilot.pause()
             from textual.widgets import ListView
 
-            from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
+            from claude_swap.tui.dashboard import ClassicWatchScreen, DashboardScreen
 
-            assert isinstance(app.screen, WatchScreen)
+            assert isinstance(app.screen, ClassicWatchScreen)
             assert app.screen.query_one("#accounts", ListView).index is None
             await pilot.press("escape")  # now leave
             await pilot.pause()
@@ -1169,9 +1488,9 @@ class TestWatchScreen:
         async with app.run_test(size=(100, 40)) as pilot:
             await settle(pilot)
             await menu_select(pilot, "watch")
-            from claude_swap.tui.dashboard import WatchScreen
+            from claude_swap.tui.dashboard import ClassicWatchScreen
 
-            assert isinstance(app.screen, WatchScreen)
+            assert isinstance(app.screen, ClassicWatchScreen)
 
     async def test_app_start_watch_stacks_over_dashboard(self, tmp_path):
         from claude_swap.tui.app import CswapApp
@@ -1179,9 +1498,83 @@ class TestWatchScreen:
         app = CswapApp(self._fake(tmp_path), start="watch")
         async with app.run_test(size=(100, 40)) as pilot:
             await settle(pilot)
-            from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
+            from claude_swap.tui.dashboard import ClassicWatchScreen, DashboardScreen
 
-            assert isinstance(app.screen, WatchScreen)
+            assert isinstance(app.screen, ClassicWatchScreen)
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, DashboardScreen)
+
+
+def test_watch_screen_factory_maps_styles():
+    from claude_swap.tui.dashboard import (
+        ClassicWatchScreen,
+        MeterWatchScreen,
+        watch_screen,
+    )
+
+    assert isinstance(watch_screen("classic"), ClassicWatchScreen)
+    assert isinstance(watch_screen("meters"), MeterWatchScreen)
+    # An unexpected value falls back to the classic default.
+    assert isinstance(watch_screen("hologram"), ClassicWatchScreen)
+
+
+@pytest.mark.asyncio
+class TestWatchStyle:
+    """ui.watch_style selects which watch layout the launcher opens."""
+
+    def _fake(self, tmp_path):
+        return FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+
+    async def test_unset_setting_opens_classic(self, tmp_path):
+        app = make_app(self._fake(tmp_path))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from claude_swap.tui.dashboard import ClassicWatchScreen
+
+            assert isinstance(app.screen, ClassicWatchScreen)
+
+    async def test_meters_setting_opens_meters(self, tmp_path):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from claude_swap.tui.dashboard import MeterWatchScreen
+
+            assert isinstance(app.screen, MeterWatchScreen)
+
+    async def test_ctrl_v_toggles_layout_live_and_persists(self, tmp_path):
+        fake = self._fake(tmp_path)
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from claude_swap.tui.dashboard import (
+                ClassicWatchScreen,
+                DashboardScreen,
+                MeterWatchScreen,
+            )
+            from claude_swap.settings import load_ui_settings
+
+            assert isinstance(app.screen, MeterWatchScreen)
+            await pilot.press("ctrl+v")  # swap to the classic view live
+            await pilot.pause()
+            assert isinstance(app.screen, ClassicWatchScreen)
+            assert app._watch_style == "classic"
+            assert load_ui_settings(fake.backup_dir).watch_style == "classic"
+
+            await pilot.press("ctrl+v")  # and back to meters
+            await pilot.pause()
+            assert isinstance(app.screen, MeterWatchScreen)
+            assert load_ui_settings(fake.backup_dir).watch_style == "meters"
+
+            # Esc still lands on the dashboard, not app-exit (stack intact).
             await pilot.press("escape")
             await pilot.pause()
             assert isinstance(app.screen, DashboardScreen)
@@ -1710,3 +2103,748 @@ class TestThemeWiring:
             assert app._theme_name == "light"
             assert app.theme == "cswap-light"
 
+
+def test_bar_color_maxed_is_all_red_else_green_climb():
+    from claude_swap.tui.widgets import _bar_color, gradient_color
+    from claude_swap.tui.theme import SEV_OK
+
+    # A maxed window's whole bar is red-dominant (no calm green at the base)
+    for t in (0.0, 0.5, 1.0):
+        c = _bar_color(100.0, t)
+        r, g, b = int(c[1:3], 16), int(c[3:5], 16), int(c[5:7], 16)
+        assert r > g and r > b, (t, c)
+    assert _bar_color(100.0, 0.0) != gradient_color(0.0)  # maxed base != green
+
+    # Below 100%, the bar keeps the green→amber→red climb (green at the base)
+    assert _bar_color(50.0, 0.0) == SEV_OK
+    assert _bar_color(50.0, 1.0) == gradient_color(1.0)
+
+
+def test_gradient_color_hits_stops_and_interpolates():
+    assert gradient_color(0.0) == "#87af87"   # SEV_OK
+    assert gradient_color(0.5) == "#d7af5f"   # SEV_WARN
+    assert gradient_color(1.0) == "#d75f5f"   # SEV_CRIT
+    # quarter point = midpoint of SEV_OK(135,175,135) and SEV_WARN(215,175,95)
+    assert gradient_color(0.25) == "#afaf73"  # (175,175,115)
+    assert gradient_color(-1.0) == "#87af87"  # clamp low
+    assert gradient_color(2.0) == "#d75f5f"   # clamp high
+
+
+def test_bar_v_fill_from_bottom():
+    from claude_swap.tui.widgets import bar_v
+    assert bar_v(100.0, 4) == ["█", "█", "█", "█"]
+    assert bar_v(0.0, 4)   == [" ", " ", " ", " "]
+    assert bar_v(50.0, 4)  == [" ", " ", "█", "█"]   # 2 full at bottom
+    assert bar_v(75.0, 4)  == [" ", "█", "█", "█"]
+    assert bar_v(62.5, 4)  == [" ", "▄", "█", "█"]   # partial top cell
+    assert bar_v(150.0, 2) == ["█", "█"]             # clamps to 100
+
+
+def test_meter_windows_order_and_fields():
+    now = 1_000_000.0
+
+    def _iso(offset: float) -> str:
+        return datetime.fromtimestamp(now + offset, tz=timezone.utc).isoformat()
+
+    last_good = {
+        "five_hour": {"pct": 78.0, "resets_at": _iso(3 * 3600)},
+        "seven_day": {"pct": 34.0, "resets_at": _iso(4 * 86400)},
+        "scoped": [{"name": "Fable", "pct": 100.0, "resets_at": _iso(3600)}],
+    }
+    rows = meter_windows(last_good, now)
+    assert [r[0] for r in rows] == ["5h", "7d", "Fable"]
+    assert [r[1] for r in rows] == [78.0, 34.0, 100.0]
+    assert [r[3] for r in rows] == [False, False, True]
+    assert meter_windows(None, now) == []
+
+
+def test_meter_grid_dims_fluid():
+    from claude_swap.tui.widgets import meter_grid_dims
+    # 44x16, 3 accounts -> 2 columns, card_width (44-1)//2
+    ncols, cw, bh = meter_grid_dims(44, 16, 3)
+    assert ncols == 2
+    assert cw == 21
+    # 96x34, 3 accounts -> 3 columns, card_width (96-2)//3
+    ncols, cw, bh = meter_grid_dims(96, 34, 3)
+    assert ncols == 3
+    assert cw == 31
+    # narrow: single column; bars shrink to fit (floor is 1, not 3)
+    ncols, cw, bh = meter_grid_dims(30, 12, 3)
+    assert ncols == 1
+    assert bh >= 1
+
+
+def test_meter_grid_dims_fits_height():
+    from claude_swap.tui.widgets import CARD_CHROME, meter_grid_dims
+
+    # (44, 16, 3) is deliberately excluded: at that size the bar floors at
+    # bar_min before the chrome fits, which is exactly the case
+    # meters_grid_text's _cards_fit check catches to fall back to the
+    # compact view instead of overflowing.
+    for w, h, n in ((44, 31, 3), (96, 34, 3), (21, 16, 1)):
+        ncols, _cw, bh = meter_grid_dims(w, h, n)
+        rows = -(-n // ncols)  # ceil
+        assert rows * (bh + CARD_CHROME) + (rows - 1) <= h, (w, h, n, ncols, bh)
+
+
+def test_meter_grid_dims_honors_gutter_min_card_width():
+    from claude_swap.tui.widgets import meter_grid_dims
+
+    # 40 wide, 3 accounts: gutters must not push cards below min_card_w (20)
+    ncols, cw, _bh = meter_grid_dims(40, 16, 3)
+    assert cw >= 20
+
+
+def test_meter_grid_dims_bars_fill_tall_terminal():
+    from claude_swap.tui.widgets import meter_grid_dims
+
+    # one account on a tall terminal: the bar consumes the spare rows
+    # (no fixed height cap), leaving only the 12-line card chrome.
+    _ncols, _cw, bh = meter_grid_dims(40, 40, 1)
+    assert bh == 40 - 12
+
+
+def test_meter_bar_width_fills_cell():
+    from claude_swap.tui.widgets import _meter_bar_width
+
+    # bar spans its cell minus a one-column gutter each side (no width cap)
+    assert _meter_bar_width(15) == 13
+    assert _meter_bar_width(30) == 28
+    assert _meter_bar_width(4) == 2
+
+
+def test_big_number_pixel_5_rows():
+    from claude_swap.tui.widgets import big_number
+
+    rows = big_number("100")
+    assert len(rows) == 5
+    # three digits, each 3 cols, joined by a one-space gap: 3+1+3+1+3 = 11
+    assert all(len(r) == 11 for r in rows)
+
+    rows7 = big_number("7")
+    assert len(rows7) == 5
+    assert all(len(r) == 3 for r in rows7)
+
+    # the pixel font uses only the full block and spaces
+    for r in rows + rows7:
+        assert set(r) <= {"█", " "}
+
+
+def test_meter_card_has_plain_label_row():
+    from claude_swap.tui.widgets import meter_card
+
+    acc = make_account(
+        1,
+        active=True,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=34.0, scoped=[("Fable", 100.0)]),
+    )
+    now = time.time()
+    bar_height = 10
+    card = meter_card(acc, 34, bar_height, now=now)
+    lines = card.plain.split("\n")
+    # header + bar rows + baseline + label + 5 percent + reset + bottom
+    assert len(lines) == bar_height + 12
+    assert all(len(ln) == 34 for ln in lines)
+
+    label_row = lines[bar_height + 2]  # header(1) + bars(bar_height) + baseline(1)
+    assert "5h" in label_row
+    assert "7d" in label_row
+    assert "Fable" in label_row
+
+    # not carved into the bars: no bar row contains the label text
+    bar_rows = lines[1 : 1 + bar_height]
+    assert not any("5h" in row or "7d" in row or "Fable" in row for row in bar_rows)
+
+    # a label longer than its cell truncates with an ellipsis rather than
+    # overflowing or wrapping
+    narrow_acc = make_account(
+        2,
+        active=True,
+        email="work@acme.dev",
+        entry=make_entry(pct5=None, pct7=None, scoped=[("AnthropicMaxPlan", 50.0)]),
+    )
+    narrow_bar_height = 3
+    narrow_card = meter_card(narrow_acc, 8, narrow_bar_height, now=now)
+    narrow_lines = narrow_card.plain.split("\n")
+    narrow_label_row = narrow_lines[narrow_bar_height + 2]
+    assert "…" in narrow_label_row
+    assert "AnthropicMaxPlan" not in narrow_card.plain
+
+
+def test_meter_card_line_count_chrome_12():
+    from claude_swap.tui.widgets import meter_card
+
+    acc = make_account(
+        1,
+        active=True,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=34.0, scoped=[("Fable", 100.0)]),
+    )
+    card = meter_card(acc, 40, 12, now=time.time())
+    lines = card.plain.split("\n")
+    # bar_height (12) + chrome (12): 2 borders + baseline + label + blank +
+    # 5 percent + blank + reset
+    assert len(lines) == 12 + 12
+    assert all(len(ln) == 40 for ln in lines)
+
+
+def test_meter_card_reset_is_plain_single_row():
+    from claude_swap.tui.widgets import meter_card
+    from claude_swap.usage_store import UsageEntry
+
+    now = 1_000_000.0
+
+    def _iso(offset: float) -> str:
+        return datetime.fromtimestamp(now + offset, tz=timezone.utc).isoformat()
+
+    last_good = {
+        "five_hour": {"pct": 78.0, "resets_at": _iso(3 * 3600)},
+        "seven_day": {"pct": 34.0, "resets_at": _iso(3 * 86400)},
+    }
+    entry = UsageEntry(last_good=last_good, fetched_at=now - 5.0, age_s=5.0)
+    # inactive account: keeps the single-line frame this test's glyph checks
+    # rely on — the active card's border is covered separately.
+    acc = make_account(1, email="work@acme.dev", entry=entry)
+    bar_height = 10
+    card = meter_card(acc, 34, bar_height, now=now)
+    lines = card.plain.split("\n")
+    assert len(lines) == bar_height + 12
+    assert all(len(ln) == 34 for ln in lines)
+
+    def is_blank_interior(line: str) -> bool:
+        return line[0] == "│" and line[-1] == "│" and line[1:-1].strip() == ""
+
+    # header(1) + bars(bar_height) + baseline(1) + label(1) -> percent block
+    # starts right after a blank margin row; below it, another blank margin
+    # row precedes a SINGLE plain reset row, then the bottom border.
+    label_row = bar_height + 2
+    percent_start = label_row + 2
+    assert is_blank_interior(lines[percent_start - 1])
+    percent_end = percent_start + 5
+    assert is_blank_interior(lines[percent_end])  # blank margin below percent
+
+    reset_row = lines[percent_end + 1]
+    assert "3d" in reset_row  # seven_day resets in 3 days
+    assert not is_blank_interior(reset_row)
+    # the reset row is a single row: the very next line is the bottom border
+    assert lines[percent_end + 2] == lines[-1]
+    assert lines[-1].startswith("╰") and lines[-1].endswith("╯")
+
+    # not a half-block pixel font: the reset row itself has no block glyphs
+    # (the bar rows above legitimately use them for the meter fill)
+    assert not (set(reset_row) & set("█▀▄"))
+
+
+def test_meter_card_percent_has_margin_rows():
+    from claude_swap.tui.widgets import meter_card
+
+    # inactive account: keeps the single-line frame this test's glyph checks
+    # rely on — the active card's border is covered separately.
+    acc = make_account(
+        1,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=34.0, scoped=[("Fable", 100.0)]),
+    )
+    bar_height = 10
+    card = meter_card(acc, 34, bar_height, now=time.time())
+    lines = card.plain.split("\n")
+    assert len(lines) == bar_height + 12
+    assert all(len(ln) == 34 for ln in lines)
+
+    def is_blank_interior(line: str) -> bool:
+        return line[0] == "│" and line[-1] == "│" and line[1:-1].strip() == ""
+
+    # header(1) + bars(bar_height) + baseline(1) + label(1) -> percent block
+    # starts right after a blank margin row.
+    label_row = bar_height + 2
+    percent_start = label_row + 2
+    assert is_blank_interior(lines[percent_start - 1])
+    assert not is_blank_interior(lines[percent_start])  # first percent row has content
+
+    # the percent block is exactly 5 rows, followed by a blank margin row
+    # before the reset row.
+    percent_end = percent_start + 5
+    assert not is_blank_interior(lines[percent_end - 1])  # last percent row has content
+    assert is_blank_interior(lines[percent_end])
+
+
+def test_meter_card_active_double_green_border():
+    from claude_swap.tui.widgets import _ACTIVE_GREEN, meter_card
+    from claude_swap.tui.theme import MUTED
+
+    entry = make_entry(pct5=78.0, pct7=34.0)
+    active = make_account(1, active=True, email="work@acme.dev", entry=entry)
+    inactive = make_account(2, active=False, email="work@acme.dev", entry=entry)
+    now = time.time()
+    acard = meter_card(active, 21, 5, now=now)
+    icard = meter_card(inactive, 21, 5, now=now)
+    active_style = f"{_ACTIVE_GREEN} bold"
+
+    def frame_styles(card, glyphs):
+        return {
+            sp.style
+            for sp in card.spans
+            if set(card.plain[sp.start : sp.end]) & set(glyphs)
+        }
+
+    # active: double-line box glyphs, bold bright-green frame, no single-line
+    # glyphs anywhere in the card
+    assert "║" in acard.plain
+    assert all(g in acard.plain for g in "╔╗╚╝")
+    assert "│" not in acard.plain
+    assert not (set(acard.plain) & set("╭╮╰╯"))
+    assert active_style in frame_styles(acard, "║")
+    assert active_style in frame_styles(acard, "╔╗╚╝")
+
+    # active: the header number, name, and active dot render in the same
+    # bold bright-green style as the frame, not ACCENT/FOREGROUND
+    def texts_with_style(card, style):
+        return [card.plain[sp.start : sp.end] for sp in card.spans if sp.style == style]
+
+    assert "1" in texts_with_style(acard, active_style)
+    assert "work" in texts_with_style(acard, active_style)
+    assert "●" in texts_with_style(acard, active_style)
+
+    # inactive: unchanged thin rounded single-line frame, muted, never green
+    assert "│" in icard.plain
+    assert all(g in icard.plain for g in "╭╮╰╯")
+    assert "║" not in icard.plain
+    assert not (set(icard.plain) & set("╔╗╚╝"))
+    assert MUTED in frame_styles(icard, "│")
+    assert active_style not in frame_styles(icard, "│")
+    assert active_style not in frame_styles(icard, "╭╮╰╯")
+
+
+def test_meter_card_percent_is_five_big_rows():
+    from claude_swap.tui.widgets import meter_card
+
+    acc = make_account(
+        1,
+        active=True,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=None),
+    )
+    now = time.time()
+    card = meter_card(acc, 30, 5, now=now)
+    lines = card.plain.split("\n")
+    # top border + 5 bar rows + baseline + 5 percent rows + reset + bottom
+    assert len(lines) == 5 + 12
+    assert all(len(ln) == 30 for ln in lines)
+    # the single window's cell is wide enough for the pixel digits, so the
+    # small "78%" token never appears — the percent is drawn as block glyphs
+    # spanning five rows instead.
+    assert "78%" not in card.plain
+    assert "█" in card.plain  # the pixel-block digit font
+
+
+def test_meter_card_structure():
+    from claude_swap.tui.widgets import meter_card
+    from claude_swap.tui.theme import SEV_OK
+
+    # inactive account: keeps the single-line frame this test's glyph checks
+    # rely on — the active card's border is covered separately.
+    acc = make_account(
+        1,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=34.0, scoped=[("Fable", 100.0)]),
+    )
+    now = time.time()
+    card = meter_card(acc, 21, 5, now=now)
+    lines = card.plain.split("\n")
+    assert len(lines) == 5 + 12
+    assert all(len(ln) == 21 for ln in lines)
+    assert lines[0].startswith("╭") and lines[0].endswith("╮")
+    assert lines[-1].startswith("╰") and lines[-1].endswith("╯")
+    # window labels render as plain text in the label row beneath the bars.
+    assert "5h" in card.plain and "7d" in card.plain
+    assert "Fable" in card.plain
+    # Fable's cell is too narrow for the pixel digits ("100" needs 11 cols),
+    # so it degrades to the small "100%" token.
+    assert "100%" in card.plain
+    # bottom cell of a filled bar is the green (SEV_OK) end of the gradient
+    assert any(SEV_OK in str(span.style) for span in card.spans)
+
+
+def test_meter_card_handles_no_windows():
+    from claude_swap.tui.widgets import meter_card
+
+    acc = make_account(1, active=True, entry=make_entry(pct5=None, pct7=None))
+    card = meter_card(acc, 21, 5, now=time.time())
+    lines = card.plain.split("\n")
+    assert len(lines) == 5 + 12
+    assert all(len(ln) == 21 for ln in lines)
+    # the placeholder message is actually rendered, not just blank rows
+    assert "usage unavailable" in card.plain
+
+
+def test_meter_card_sentinel_message_wraps_full():
+    from claude_swap.tui.widgets import meter_card
+
+    acc = make_account(1, active=True, entry=UsageEntry(sentinel=USAGE_TOKEN_EXPIRED))
+    now = time.time()
+    card = meter_card(acc, 21, 5, now=now)
+    lines = card.plain.split("\n")
+    assert len(lines) == 5 + 12
+    assert all(len(ln) == 21 for ln in lines)
+    # the full sentinel label wraps across rows rather than truncating to one
+    # line — its last word must survive.
+    label = tui_data.sentinel_label(USAGE_TOKEN_EXPIRED)
+    assert label.split()[-1] in card.plain
+
+
+def test_meter_card_exact_width_at_narrow_widths():
+    from claude_swap.tui.widgets import meter_card
+
+    acc = make_account(
+        1,
+        active=True,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=34.0, scoped=[("Fable", 100.0)]),
+    )
+    now = time.time()
+    for w in (1, 2, 3, 6, 8, 12, 21):
+        card = meter_card(acc, w, 3, now=now)
+        assert all(len(ln) == w for ln in card.plain.split("\n")), (
+            w,
+            card.plain.split("\n"),
+        )
+
+
+def test_meter_card_header_and_row_styling():
+    from claude_swap.tui.widgets import meter_card
+    from claude_swap.tui.theme import ACCENT, FOREGROUND, SEV_CRIT, Palette
+    from claude_swap.usage_store import UsageEntry
+
+    severity_color = Palette.DARK.severity  # meter_card() defaults to Palette.DARK
+
+    now = 1_000_000.0
+
+    def _iso(offset: float) -> str:
+        return datetime.fromtimestamp(now + offset, tz=timezone.utc).isoformat()
+
+    last_good = {
+        "five_hour": {"pct": 78.0, "resets_at": _iso(3 * 3600)},
+        "seven_day": {"pct": 34.0, "resets_at": _iso(4 * 86400)},
+        "scoped": [{"name": "Fable", "pct": 100.0, "resets_at": _iso(2 * 86400)}],
+    }
+    entry = UsageEntry(last_good=last_good, fetched_at=now - 5.0, age_s=5.0)
+    # inactive account: the active card's header renders in the bright-green
+    # frame style instead of ACCENT/FOREGROUND — covered separately.
+    acc = make_account(1, email="work@acme.dev", entry=entry)
+
+    card = meter_card(acc, 21, 5, now=now)
+
+    def texts_with_style(style: str) -> list[str]:
+        return [card.plain[sp.start : sp.end] for sp in card.spans if sp.style == style]
+
+    # header: number in ACCENT, name in FOREGROUND
+    assert "1" in texts_with_style(ACCENT)
+    assert "work" in texts_with_style(FOREGROUND)
+
+    # percent rows: 5h and 7d's cells fit big digits (no "%" glyph rendered),
+    # each styled by severity_color(pct); Fable's cell is too narrow for its
+    # 3-digit "100" and degrades to the small "100%" token.
+    for pct in (78.0, 34.0):
+        assert any(
+            any(ch != " " for ch in t) for t in texts_with_style(severity_color(pct))
+        )
+    assert any("100%" in t for t in texts_with_style(severity_color(100.0)))
+
+    # MAXED window's reset (Fable, exactly 2 days out -> "2d") renders as
+    # plain text styled SEV_CRIT.
+    assert any("2d" in t for t in texts_with_style(SEV_CRIT))
+
+
+def test_meter_card_renders_in_light_palette():
+    # The meters follow ui.theme: a light-palette render paints its text in the
+    # light theme's colours, never the dark constants.
+    from claude_swap.tui.widgets import meter_card
+    from claude_swap.tui.theme import (
+        ACCENT,
+        ACCENT_LIGHT,
+        FOREGROUND,
+        FOREGROUND_LIGHT,
+        CSWAP_LIGHT,
+        Palette,
+    )
+    from claude_swap.usage_store import UsageEntry
+
+    now = 1_000_000.0
+    entry = UsageEntry(
+        last_good={"five_hour": {"pct": 50.0}}, fetched_at=now - 5.0, age_s=5.0
+    )
+    acc = make_account(1, email="work@acme.dev", entry=entry)
+
+    light = Palette.from_theme(CSWAP_LIGHT)
+    card = meter_card(acc, 21, 5, now=now, palette=light)
+    styles = {str(sp.style) for sp in card.spans}
+
+    # Header number/name pick up the light accent/foreground, not the dark ones.
+    assert any(ACCENT_LIGHT in s for s in styles)
+    assert any(FOREGROUND_LIGHT in s for s in styles)
+    assert not any(ACCENT in s and ACCENT_LIGHT not in s for s in styles)
+    assert not any(FOREGROUND in s and FOREGROUND_LIGHT not in s for s in styles)
+
+
+def test_meter_card_header_honors_alias():
+    from claude_swap.tui.widgets import meter_card
+
+    now = time.time()
+    aliased = make_account(
+        1,
+        active=True,
+        email="work@acme.dev",
+        alias="acme",
+        entry=make_entry(pct5=78.0, pct7=34.0),
+    )
+    unaliased = make_account(
+        2,
+        active=True,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=34.0),
+    )
+
+    aliased_card = meter_card(aliased, 21, 5, now=now)
+    unaliased_card = meter_card(unaliased, 21, 5, now=now)
+
+    assert "acme" in aliased_card.plain
+    assert "work" not in aliased_card.plain
+    assert "work" in unaliased_card.plain
+
+    for card in (aliased_card, unaliased_card):
+        lines = card.plain.split("\n")
+        assert len(lines) == 5 + 12
+        assert all(len(ln) == 21 for ln in lines)
+
+
+def test_meter_card_stale_dims_bars_and_percent():
+    from claude_swap.tui.widgets import meter_card
+    from claude_swap.usage_store import STALE_OK_S
+
+    now = time.time()
+    stale = make_account(
+        1,
+        active=True,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=34.0, age_s=STALE_OK_S + 60),
+    )
+    fresh = make_account(
+        2,
+        active=True,
+        email="work@acme.dev",
+        entry=make_entry(pct5=78.0, pct7=34.0, age_s=5.0),
+    )
+    stale_card = meter_card(stale, 21, 5, now=now)
+    fresh_card = meter_card(fresh, 21, 5, now=now)
+
+    assert any("dim" in str(sp.style) for sp in stale_card.spans)
+    assert not any("dim" in str(sp.style) for sp in fresh_card.spans)
+
+
+def test_meter_card_flash_highlights_top_border():
+    from claude_swap.tui.widgets import meter_card
+    from claude_swap.tui.theme import ACCENT
+
+    acc = make_account(
+        1, active=True, email="work@acme.dev", entry=make_entry(pct5=78.0, pct7=34.0)
+    )
+    now = time.time()
+    plain = meter_card(acc, 21, 5, now=now)
+    flashed = meter_card(acc, 21, 5, now=now, flash=True)
+
+    # flash never changes layout or text, only the top border's style
+    assert plain.plain == flashed.plain
+    lines = flashed.plain.split("\n")
+    assert len(lines) == 5 + 12
+    assert all(len(ln) == 21 for ln in lines)
+
+    header_end = len(lines[0])
+    flash_style = f"bold {ACCENT}"
+    assert any(
+        sp.start == 0 and sp.end == header_end and sp.style == flash_style
+        for sp in flashed.spans
+    )
+    assert not any(
+        sp.start == 0 and sp.end == header_end and sp.style == flash_style
+        for sp in plain.spans
+    )
+
+
+def test_meters_grid_text_flash_marks_only_flashed_account():
+    from claude_swap.tui.theme import ACCENT
+    from claude_swap.tui.widgets import meters_grid_text
+
+    accounts = _make_three_meter_accounts()
+    flash_style = f"bold {ACCENT}"
+
+    plain_out = meters_grid_text(accounts, 44, 31, now=time.time())
+    assert not [sp for sp in plain_out.spans if sp.style == flash_style]
+
+    flashed_out = meters_grid_text(
+        accounts, 44, 31, now=time.time(), flashed={accounts[1].number}
+    )
+    assert flashed_out.plain == plain_out.plain  # flash never changes layout/text
+    assert len([sp for sp in flashed_out.spans if sp.style == flash_style]) == 1
+
+
+def test_fit_center_truncates_oversized_content():
+    from claude_swap.tui.widgets import _fit_center
+
+    long_label = "Anthropic-Claude-Max-Plan"
+    for w in (1, 3, 4, 5):
+        result = _fit_center(long_label, w)
+        assert len(result) == w
+    assert _fit_center(long_label, 4) == "Anth"
+
+
+def test_grid_move_clamps_and_no_wrap():
+    from claude_swap.tui.widgets import grid_move
+
+    # 3 items, 2 cols -> layout [0,1 / 2]
+    assert grid_move(0, 1, 0, 2, 3) == 1  # right
+    assert grid_move(1, 1, 0, 2, 3) == 1  # right at edge: clamp (no wrap)
+    assert grid_move(0, 0, 1, 2, 3) == 2  # down
+    assert grid_move(0, -1, 0, 2, 3) == 0  # left at edge: clamp
+    assert grid_move(2, 0, -1, 2, 3) == 0  # up
+    # short last row: moving down from col 1 lands on the only item in row 1
+    assert grid_move(1, 0, 1, 2, 3) == 2
+
+
+def _make_three_meter_accounts() -> list[AccountSnapshot]:
+    return [
+        make_account(1, active=True, email="a@example.com", entry=make_entry(pct5=78.0, pct7=34.0)),
+        make_account(2, email="b@example.com", entry=make_entry(pct5=50.0, pct7=10.0)),
+        make_account(3, email="c@example.com", entry=make_entry(pct5=20.0, pct7=5.0)),
+    ]
+
+
+def test_meters_grid_text_two_columns():
+    from claude_swap.tui.widgets import meters_grid_text
+
+    accounts = _make_three_meter_accounts()
+    out = meters_grid_text(accounts, 44, 31, now=time.time())
+    lines = out.plain.split("\n")
+    # two cards side by side on row 1: account 1 is active (double-line ╔),
+    # account 2 is not (single-line rounded ╭).
+    assert lines[0].count("╭") + lines[0].count("╔") == 2
+    assert len(lines) <= 31  # the whole grid fits the device height
+
+
+def test_meters_grid_text_rows_separated_by_blank_line():
+    from claude_swap.tui.widgets import meter_grid_dims, meters_grid_text
+
+    accounts = _make_three_meter_accounts()
+    out = meters_grid_text(accounts, 44, 31, now=time.time())
+    lines = out.plain.split("\n")
+    _ncols, _cw, bar_height = meter_grid_dims(44, 31, len(accounts))
+    card_lines = bar_height + 12
+    assert lines[card_lines] == ""  # blank separator between card rows
+    assert lines[card_lines + 1].count("╭") == 1  # lone third card on row 2
+
+
+def _accent_cols_by_line(text) -> dict[int, set[int]]:
+    """Per-line column offsets styled ACCENT, for pinpointing which card's
+    border the cursor marked."""
+    from claude_swap.tui.theme import ACCENT
+
+    accent_offsets: set[int] = set()
+    for sp in text.spans:
+        if sp.style == ACCENT:
+            accent_offsets.update(range(sp.start, sp.end))
+    result: dict[int, set[int]] = {}
+    offset = 0
+    for i, line in enumerate(text.plain.split("\n")):
+        cols = {o - offset for o in accent_offsets if offset <= o < offset + len(line)}
+        if cols:
+            result[i] = cols
+        offset += len(line) + 1
+    return result
+
+
+def test_meters_grid_text_cursor_marks_selected_card():
+    from claude_swap.tui.theme import ACCENT
+    from claude_swap.tui.widgets import meters_grid_text, _SELECT_BG
+
+    accounts = _make_three_meter_accounts()
+    now = time.time()
+
+    plain_out = meters_grid_text(accounts, 44, 31, now=now)
+    marked0 = meters_grid_text(accounts, 44, 31, cursor=0, now=now)
+    assert plain_out.plain == marked0.plain  # marking never changes layout/text
+
+    # the selection highlight fills the selected card's background...
+    assert any(_SELECT_BG in str(s.style) for s in marked0.spans)
+    assert not any(_SELECT_BG in str(s.style) for s in plain_out.spans)
+    # ...and gives its border a bold accent
+    assert any("bold" in str(s.style) and ACCENT in str(s.style) for s in marked0.spans)
+
+
+def test_meters_grid_text_empty_accounts():
+    from claude_swap.tui.widgets import meters_grid_text
+
+    out = meters_grid_text([], 44, 16, now=time.time())
+    assert out.plain == "no accounts"
+
+
+def test_meters_grid_text_falls_back_to_compact_when_cards_cannot_fit():
+    from claude_swap.tui.widgets import meters_grid_text
+
+    accounts = _make_three_meter_accounts()
+    out = meters_grid_text(accounts, 30, 12, now=time.time())
+    lines = out.plain.split("\n")
+    assert len(lines) <= 12  # fits the viewport instead of clipping
+    assert "╭" not in out.plain  # compact form, not framed cards
+    for acc, line in zip(accounts, lines):
+        assert line.lstrip().startswith(str(acc.number))
+
+
+def test_meters_grid_text_fallback_cursor_marks_selected_line():
+    from claude_swap.tui.widgets import meters_grid_text
+
+    accounts = _make_three_meter_accounts()
+    now = time.time()
+    marked0 = meters_grid_text(accounts, 30, 12, cursor=0, now=now)
+    marked1 = meters_grid_text(accounts, 30, 12, cursor=1, now=now)
+
+    cols0 = _accent_cols_by_line(marked0)
+    cols1 = _accent_cols_by_line(marked1)
+    assert 0 in cols0 and 1 not in cols0  # cursor=0 accents only line 0
+    assert 1 in cols1 and 0 not in cols1  # cursor=1 accents only line 1
+
+
+def _snap_with_fetched_at(fetched_at: float) -> AccountsSnapshot:
+    entry = dataclasses.replace(make_entry(pct5=50.0), fetched_at=fetched_at)
+    return AccountsSnapshot(
+        active_number="1",
+        accounts=(make_account(1, active=True, entry=entry),),
+        taken_at=time.time(),
+    )
+
+
+def test_meters_grid_flash_extends_on_reflash():
+    # A re-flash of an already-flashing account must not be cleared early by
+    # the earlier timer: the generation guard keeps the account flashed until
+    # the LATEST timer fires.
+    from claude_swap.tui.widgets import MetersGrid
+
+    grid = MetersGrid()
+    grid.set_timer = lambda *a, **k: None  # no live scheduling in a unit test
+    grid.refresh = lambda *a, **k: None
+
+    grid._flash_updated(_snap_with_fetched_at(1000.0))  # baseline, no flash
+    assert grid._flash == set()
+
+    grid._flash_updated(_snap_with_fetched_at(1001.0))  # first change -> gen 1
+    assert "1" in grid._flash
+
+    grid._flash_updated(_snap_with_fetched_at(1002.0))  # re-flash -> gen 2
+    assert "1" in grid._flash
+
+    # The FIRST timer fires with its stale generation: must NOT clear.
+    grid._clear_flash("1", 1)
+    assert "1" in grid._flash
+
+    # The LATEST timer fires with the current generation: clears.
+    grid._clear_flash("1", 2)
+    assert "1" not in grid._flash

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import json
+import math
 import sys
 import threading
 import time
@@ -3558,7 +3559,7 @@ def test_meters_grid_animates_only_while_a_target_is_predicted():
     assert grid.predicted == "2"
     assert len(grid.intervals) == 1 and not grid.intervals[0][1].stopped
 
-    grid.set_predicted("3", 0.5)  # retarget reuses the running interval
+    grid.set_predicted("3", 0.2)  # retarget at the same tempo reuses the interval
     assert len(grid.intervals) == 1
 
     grid.set_predicted(None, 0.0)
@@ -3579,7 +3580,7 @@ def test_predicted_card_frame_breathes_between_muted_and_accent():
     assert set(at_rest) == {"2"}
     assert at_rest["2"] == palette.muted  # phase 0: starts from the resting frame
 
-    for _ in range(10):  # half a slow period (2.0s at 0.1s frames)
+    for _ in range(5):  # half a slow period (2.0s at 0.2s rest frames)
         grid._advance_frame()
     at_peak = grid.frame_styles(palette, now=0.0)["2"]
     assert at_peak == palette.accent  # phase pi: fully lit
@@ -3587,7 +3588,7 @@ def test_predicted_card_frame_breathes_between_muted_and_accent():
         palette.muted, palette.accent
     )  # the ramp really passes through intermediate colours
 
-    for _ in range(10):
+    for _ in range(5):
         grid._advance_frame()
     assert grid.frame_styles(palette, now=0.0)["2"] == palette.muted  # back down
 
@@ -3619,12 +3620,36 @@ def test_urgency_speeds_up_the_breathing():
     grid = _animatable_grid()
     grid.set_predicted("2", 0.0)
     grid._advance_frame()
-    slow_step = grid._phase
+    slow_rate = grid._phase / grid._anim_dt  # radians per second
 
     grid.set_predicted("3", 1.0)  # retarget resets the phase
     assert grid._phase == 0.0
     grid._advance_frame()
-    assert grid._phase > slow_step * 3  # 0.6s period vs 2.0s: >3x faster
+    fast_rate = grid._phase / grid._anim_dt
+    assert fast_rate > slow_rate * 3  # 0.6s period vs 2.0s: >3x faster
+
+
+def test_breathing_rests_at_five_hz_and_speeds_up_when_urgent():
+    """Far from the threshold the card breathes slowly, so half the frames
+    are enough; urgency and a handoff sweep run at the full 10 Hz."""
+    from claude_swap.tui.widgets import _ANIM_DT, _ANIM_DT_REST
+
+    grid = _animatable_grid()
+    grid.set_predicted("2", 0.0)
+    assert grid.intervals[-1][0] == _ANIM_DT_REST == 0.2
+    grid._advance_frame()
+    assert grid._phase == pytest.approx(math.tau * 0.2 / 2.0)  # a real 0.2s step
+
+    grid.set_predicted("2", 0.9)  # urgent: retime the interval
+    assert grid.intervals[0][1].stopped
+    assert grid.intervals[-1][0] == _ANIM_DT == 0.1
+
+    grid.set_predicted("2", 0.1)  # calm again: back to the rest tempo
+    assert grid.intervals[-1][0] == _ANIM_DT_REST
+
+    grid.start_sweep("1", "2", now=0.0)  # a sweep always runs at 10 Hz
+    assert grid.intervals[-1][0] == _ANIM_DT
+    assert sum(not t.stopped for _p, t in grid.intervals) == 1  # one live timer
 
 
 def test_compact_fallback_does_not_animate():

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from claude_swap.autoswitch import NoSwitchEvent, SwitchEvent
+from claude_swap.autoswitch import ErrorEvent, NoSwitchEvent, PollEvent, SwitchEvent
 from claude_swap.json_output import USAGE_API_KEY, USAGE_TOKEN_EXPIRED
 from claude_swap.models import AccountSnapshot, AccountsSnapshot
 from claude_swap.switcher import ClaudeAccountSwitcher
@@ -1360,6 +1360,295 @@ class TestMeterWatchScreen:
 
 
 @pytest.mark.asyncio
+class TestMeterWatchAutoSwitch:
+    """``a`` runs a dry-run auto-switch engine from the meters view so the
+    grid can highlight the predicted next target; ``L`` arms real switching."""
+
+    def _fake(self, tmp_path):
+        return FakeSwitcher(
+            [make_account(1, active=True), make_account(2, alias="peer")], tmp_path
+        )
+
+    async def _open(self, app, pilot):
+        await settle(pilot)
+        await pilot.press("w")
+        await pilot.pause()
+        from claude_swap.tui.widgets import MetersGrid
+
+        return app.screen.query_one("#meters", MetersGrid)
+
+    async def _emit(self, pilot, engine, event) -> None:
+        """Deliver ``event`` the way the real engine does: from a worker
+        thread, so ``call_from_thread`` hands it to the app loop."""
+        await asyncio.to_thread(engine.on_event, event)
+        await pilot.pause()
+
+    async def test_a_toggles_a_dry_run_engine_and_store_only(
+        self, tmp_path, fake_engine
+    ):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(app, pilot)
+            assert fake_engine.instances == []  # off until asked
+            assert app._store_only is False
+
+            await pilot.press("a")
+            await pilot.pause()
+            assert len(fake_engine.instances) == 1
+            assert fake_engine.instances[0].dry_run is True
+            assert app._store_only is True
+
+            await pilot.press("a")
+            await pilot.pause()
+            assert fake_engine.instances[0].stopped is True
+            assert len(fake_engine.instances) == 1
+            assert app._store_only is False
+
+
+    async def test_poll_events_drive_the_predicted_highlight_and_title(
+        self, tmp_path, fake_engine
+    ):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            grid = await self._open(app, pilot)
+            from textual.widgets import Static
+
+            title = app.screen.query_one("#list-title", Static)
+            readout = app.screen.query_one("#auto-readout", Static)
+            assert readout.display is False  # nothing to say while auto is off
+            await pilot.press("a")
+            await pilot.pause()
+            engine = fake_engine.instances[0]
+
+            await self._emit(pilot, engine, PollEvent(
+                active={"number": 1, "email": "a@example.com"},
+                headroom={"1": 40.0, "2": 90.0},
+                threshold=90.0,
+                next_target="2",
+            ))
+            assert grid.predicted == "2"
+            assert grid.urgency == pytest.approx(0.0)  # 30 points of margin
+            # The readout lives in the footer, so the meters keep every row.
+            assert title.display is False
+            assert readout.display is True
+            assert str(readout.render()) == "dry-run · next → peer"
+
+            await self._emit(pilot, engine, PollEvent(
+                active={"number": 1, "email": "a@example.com"},
+                headroom={"1": 12.0, "2": 90.0},
+                threshold=90.0,
+                next_target="2",
+            ))
+            assert grid.urgency == pytest.approx(0.9)  # 2 points of margin
+
+            await self._emit(pilot, engine, PollEvent(
+                active={"number": 1, "email": "a@example.com"},
+                headroom={"1": 12.0, "2": 0.0},
+                threshold=90.0,
+            ))
+            assert grid.predicted is None
+            assert str(readout.render()) == "dry-run · next → none"
+
+            await pilot.press("a")  # off: highlight and readout both go
+            await pilot.pause()
+            assert grid.predicted is None
+            assert readout.display is False
+            assert title.display is False
+
+
+    async def test_L_confirms_before_going_live_and_returns_to_dry_run(
+        self, tmp_path, fake_engine
+    ):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(app, pilot)
+            from textual.widgets import Static
+            from claude_swap.tui.modals import ConfirmModal
+
+            readout = app.screen.query_one("#auto-readout", Static)
+            await pilot.press("L")  # inert while auto is off
+            await pilot.pause()
+            assert fake_engine.instances == []
+            assert not isinstance(app.screen, ConfirmModal)
+
+            await pilot.press("a")
+            await pilot.pause()
+            await pilot.press("L")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+            await pilot.press("n")  # declined: still dry-run
+            await pilot.pause()
+            assert len(fake_engine.instances) == 1
+            assert fake_engine.instances[0].stopped is False
+
+            await pilot.press("L")
+            await pilot.pause()
+            await pilot.press("y")
+            await pilot.pause()
+            assert fake_engine.instances[0].stopped is True
+            assert len(fake_engine.instances) == 2
+            assert fake_engine.instances[1].dry_run is False
+            assert app._store_only is True
+            assert str(readout.render()).startswith("LIVE")
+
+            await pilot.press("L")  # back to dry-run needs no confirmation
+            await pilot.pause()
+            assert fake_engine.instances[1].stopped is True
+            assert fake_engine.instances[2].dry_run is True
+            assert str(readout.render()).startswith("dry-run")
+
+    async def test_a_live_switch_sweeps_the_frames_and_refreshes(
+        self, tmp_path, fake_engine
+    ):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            grid = await self._open(app, pilot)
+            await pilot.press("a")
+            await pilot.pause()
+            engine = fake_engine.instances[0]
+            await settle(pilot)
+            snapshots_before = len(app.switcher.fetch_sets)
+
+            def switch(dry_run):
+                return SwitchEvent(
+                    trigger="proactive",
+                    from_ref={"number": 1, "email": "a@example.com"},
+                    to_ref={"number": 2, "email": "b@example.com"},
+                    dry_run=dry_run,
+                )
+
+            await self._emit(pilot, engine, PollEvent(
+                active={"number": 1, "email": "a@example.com"},
+                headroom={"1": 5.0, "2": 80.0},
+                threshold=90.0,
+                next_target="2",
+            ))
+            assert grid.predicted == "2"
+
+            await self._emit(pilot, engine, switch(dry_run=True))
+            assert grid._sweep is None  # a would-switch is not a handoff
+            assert grid.predicted == "2"
+
+            await self._emit(pilot, engine, switch(dry_run=False))
+            assert grid._sweep is not None
+            assert grid._sweep[:2] == ("1", "2")
+            # The landed account is active now, not "next": the prediction is
+            # dropped until the engine re-ranks from the new vantage point.
+            assert grid.predicted is None
+            assert grid._anim is not None  # the sweep alone keeps frames coming
+            await settle(pilot)
+            assert len(app.switcher.fetch_sets) > snapshots_before  # cards re-read the store
+
+    async def test_footer_offers_live_only_while_auto_runs(
+        self, tmp_path, fake_engine
+    ):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(app, pilot)
+            assert "L" not in app.screen.active_bindings
+            await pilot.press("a")
+            await pilot.pause()
+            assert "L" in app.screen.active_bindings
+            await pilot.press("a")
+            await pilot.pause()
+            assert "L" not in app.screen.active_bindings
+
+    async def test_stopping_auto_unpins_the_poll_policy(self, tmp_path, fake_engine):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(app, pilot)
+            app.switcher._poll_inputs_override = (90.0, ())  # as the engine pins it
+            await pilot.press("a")
+            await pilot.pause()
+            await pilot.press("a")
+            await pilot.pause()
+            assert app.switcher._poll_inputs_override is None
+
+    async def test_events_from_a_replaced_engine_are_ignored(
+        self, tmp_path, fake_engine
+    ):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            grid = await self._open(app, pilot)
+            await pilot.press("a")
+            await pilot.pause()
+            old = fake_engine.instances[0]
+            await pilot.press("L")
+            await pilot.pause()
+            await pilot.press("y")
+            await pilot.pause()
+            assert old.stopped
+            # The old worker may still finish a tick after being replaced.
+            await self._emit(pilot, old, PollEvent(
+                active={"number": 1, "email": "a@example.com"},
+                headroom={"1": 40.0, "2": 90.0},
+                threshold=90.0,
+                next_target="2",
+            ))
+            assert grid.predicted is None
+
+    async def test_a_failed_live_switch_shows_in_the_readout(
+        self, tmp_path, fake_engine
+    ):
+        """A live engine that cannot switch must say so where the user is
+        looking; a readout still promising ``next → …`` over a failed switch
+        leaves them believing they are protected."""
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            grid = await self._open(app, pilot)
+            from textual.widgets import Static
+
+            readout = app.screen.query_one("#auto-readout", Static)
+            await pilot.press("a")
+            await pilot.pause()
+            await pilot.press("L")
+            await pilot.pause()
+            await pilot.press("y")
+            await pilot.pause()
+            engine = fake_engine.instances[-1]
+            await self._emit(pilot, engine, PollEvent(
+                active={"number": 1, "email": "a@example.com"},
+                headroom={"1": 5.0, "2": 80.0},
+                threshold=90.0,
+                next_target="2",
+            ))
+            assert grid.predicted == "2"
+
+            await self._emit(pilot, engine, ErrorEvent(
+                message="could not freshen: the credential store is locked",
+                transient=True,
+            ))
+            text = str(readout.render())
+            assert text.startswith("LIVE · error: could not freshen")
+            assert "next →" not in text
+            assert grid.predicted is None  # no promise while switching fails
+            assert readout.has_class("error")
+
+            await self._emit(pilot, engine, PollEvent(
+                active={"number": 1, "email": "a@example.com"},
+                headroom={"1": 5.0, "2": 80.0},
+                threshold=90.0,
+                next_target="2",
+            ))
+            assert str(readout.render()) == "LIVE · next → peer"
+            assert not readout.has_class("error")
+
+    async def test_layout_swap_stops_the_engine(self, tmp_path, fake_engine):
+        app = make_app(self._fake(tmp_path), watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(app, pilot)
+            await pilot.press("a")
+            await pilot.pause()
+            await pilot.press("ctrl+v")
+            await pilot.pause()
+            from claude_swap.tui.dashboard import ClassicWatchScreen
+
+            assert isinstance(app.screen, ClassicWatchScreen)
+            assert fake_engine.instances[0].stopped is True
+            assert app._store_only is False
+
+
+@pytest.mark.asyncio
 class TestClassicWatchScreen:
     """The default horizontal-bar account-list watch layout (``classic``)."""
 
@@ -1713,6 +2002,9 @@ def fake_engine(monkeypatch):
     _FakeEngine.instances = []
     monkeypatch.setattr(
         "claude_swap.tui.autoview.AutoSwitchEngine", _FakeEngine
+    )
+    monkeypatch.setattr(
+        "claude_swap.tui.dashboard.AutoSwitchEngine", _FakeEngine
     )
     return _FakeEngine
 
@@ -2671,6 +2963,31 @@ def test_meter_card_flash_highlights_top_border():
     )
 
 
+def test_meter_card_frame_style_overrides_the_border_only():
+    from claude_swap.tui.widgets import meter_card
+    from claude_swap.tui.theme import Palette
+
+    acc = make_account(2, email="peer@example.com", entry=make_entry(pct5=40.0))
+    now = time.time()
+    plain = meter_card(acc, 21, 5, now=now)
+    styled = meter_card(acc, 21, 5, now=now, frame_style="#ff00ff")
+
+    assert styled.plain == plain.plain  # never changes layout or text
+    lines = styled.plain.split("\n")
+    # Every line's left and right border cell carries the override; the
+    # muted default is gone from the frame entirely.
+    from rich.console import Console
+
+    console = Console()
+    offset = 0
+    for ln in lines:
+        for pos in (offset, offset + len(ln) - 1):
+            assert styled.get_style_at_offset(console, pos).color.triplet.hex == "#ff00ff"
+        offset += len(ln) + 1
+    muted = Palette.DARK.muted.lstrip("#")
+    assert plain.get_style_at_offset(console, 0).color.triplet.hex == f"#{muted}"
+
+
 def test_meters_grid_text_flash_marks_only_flashed_account():
     from claude_swap.tui.theme import ACCENT
     from claude_swap.tui.widgets import meters_grid_text
@@ -2686,6 +3003,57 @@ def test_meters_grid_text_flash_marks_only_flashed_account():
     )
     assert flashed_out.plain == plain_out.plain  # flash never changes layout/text
     assert len([sp for sp in flashed_out.spans if sp.style == flash_style]) == 1
+
+
+def test_meters_grid_text_splits_each_card_once(monkeypatch):
+    """Assembling rows by slicing a card once per line runs Rich's
+    ``Text.divide`` (and its per-Text control-code scrub) once per line per
+    card, which at 10 Hz on a large terminal pinned a core. One split per
+    card is the budget."""
+    from rich.text import Text
+    from claude_swap.tui.widgets import meters_grid_text
+
+    calls = []
+    real_divide = Text.divide
+
+    def counting_divide(self, offsets):
+        calls.append(1)
+        return real_divide(self, offsets)
+
+    monkeypatch.setattr(Text, "divide", counting_divide)
+    accounts = _make_three_meter_accounts()
+    meters_grid_text(accounts, 120, 40, now=time.time())
+    assert len(calls) <= len(accounts), f"{len(calls)} divides for {len(accounts)} cards"
+
+
+def test_meters_grid_text_frame_styles_mark_only_named_accounts():
+    from rich.console import Console
+    from claude_swap.tui.widgets import meters_grid_text
+
+    accounts = _make_three_meter_accounts()
+    console = Console()
+    plain_out = meters_grid_text(accounts, 44, 31, now=time.time())
+    styled_out = meters_grid_text(
+        accounts, 44, 31, now=time.time(),
+        frame_styles={accounts[1].number: "#ff00ff"},
+    )
+    assert styled_out.plain == plain_out.plain
+
+    def border_colours(text, line_idx, card_idx):
+        # Cards are 21 wide with a one-space gutter: left border at col 0/22,
+        # right border at col 20/42.
+        line_start = sum(len(ln) + 1 for ln in text.plain.split("\n")[:line_idx])
+        left = line_start + card_idx * 22
+        right = left + 20
+        return {
+            text.get_style_at_offset(console, pos).color.triplet.hex
+            for pos in (left, right)
+        }
+
+    for line_idx in range(3):
+        assert border_colours(styled_out, line_idx, 1) == {"#ff00ff"}
+        assert border_colours(styled_out, line_idx, 0) == border_colours(plain_out, line_idx, 0)
+    assert "#ff00ff" not in {sp.style for sp in plain_out.spans}
 
 
 def test_fit_center_truncates_oversized_content():
@@ -2799,6 +3167,54 @@ def test_meters_grid_text_falls_back_to_compact_when_cards_cannot_fit():
         assert line.lstrip().startswith(str(acc.number))
 
 
+def _many_meter_accounts(n: int) -> list[AccountSnapshot]:
+    return [
+        make_account(i, active=(i == 1), email=f"user{i}@example.com",
+                     entry=make_entry(pct5=float(i * 5 % 100), pct7=10.0))
+        for i in range(1, n + 1)
+    ]
+
+
+def test_compact_fallback_keeps_the_selected_account_in_view():
+    """Fifteen accounts in ten rows: the compact list must window itself so
+    the cursor's line is always among the rendered rows, else Enter switches
+    to an account the user cannot see."""
+    from claude_swap.tui.widgets import meters_grid_text
+
+    accounts = _many_meter_accounts(15)
+    now = time.time()
+
+    top = meters_grid_text(accounts, 80, 10, cursor=0, now=now, compact_top=0)
+    assert top.plain.count("\n") + 1 <= 10
+    assert top.plain.lstrip().startswith("1")
+
+    last = meters_grid_text(accounts, 80, 10, cursor=14, now=now, compact_top=5)
+    lines = last.plain.split("\n")
+    assert len(lines) <= 10
+    assert lines[-1].lstrip().startswith("15")
+    assert not any(ln.lstrip().startswith("1 ") for ln in lines)  # scrolled past
+
+
+def test_meters_grid_compact_window_follows_the_cursor():
+    """The window moves only as far as needed: down past the bottom edge
+    shifts it by one, up past the top edge snaps to the cursor."""
+    grid = _animatable_grid()
+    grid._compact_rows = 10  # viewport rows the compact list can use
+
+    grid.cursor = 0
+    assert grid._compact_window() == 0
+    grid.cursor = 9
+    assert grid._compact_window() == 0  # still inside the first page
+    grid.cursor = 10
+    assert grid._compact_window() == 1  # one past the bottom: shift by one
+    grid.cursor = 14
+    assert grid._compact_window() == 5
+    grid.cursor = 3
+    assert grid._compact_window() == 3  # above the top: snap to the cursor
+    grid.cursor = None
+    assert grid._compact_window() == 0  # monitor mode: from the top
+
+
 def test_meters_grid_text_fallback_cursor_marks_selected_line():
     from claude_swap.tui.widgets import meters_grid_text
 
@@ -2820,6 +3236,123 @@ def _snap_with_fetched_at(fetched_at: float) -> AccountsSnapshot:
         accounts=(make_account(1, active=True, entry=entry),),
         taken_at=time.time(),
     )
+
+
+class _FakeTimer:
+    def __init__(self):
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+
+def _animatable_grid():
+    """A MetersGrid outside an app, with scheduling and repaint stubbed."""
+    from claude_swap.tui.widgets import MetersGrid
+
+    grid = MetersGrid()
+    grid.set_timer = lambda *a, **k: None
+    grid.refresh = lambda *a, **k: None
+    grid.intervals: list[tuple[float, object]] = []
+
+    def set_interval(period, callback, **_k):
+        timer = _FakeTimer()
+        grid.intervals.append((period, timer))
+        return timer
+
+    grid.set_interval = set_interval
+    return grid
+
+
+def test_meters_grid_animates_only_while_a_target_is_predicted():
+    grid = _animatable_grid()
+    assert grid.intervals == []  # idle: nothing scheduled, flat CPU
+
+    grid.set_predicted("2", 0.0)
+    assert grid.predicted == "2"
+    assert len(grid.intervals) == 1 and not grid.intervals[0][1].stopped
+
+    grid.set_predicted("3", 0.5)  # retarget reuses the running interval
+    assert len(grid.intervals) == 1
+
+    grid.set_predicted(None, 0.0)
+    assert grid.predicted is None
+    assert grid.intervals[0][1].stopped
+
+
+def test_predicted_card_frame_breathes_between_muted_and_accent():
+    from claude_swap.tui.theme import Palette
+    from claude_swap.tui.widgets import _interp
+
+    palette = Palette.DARK
+    grid = _animatable_grid()
+    assert grid.frame_styles(palette, now=0.0) == {}  # nothing predicted
+
+    grid.set_predicted("2", 0.0)
+    at_rest = grid.frame_styles(palette, now=0.0)
+    assert set(at_rest) == {"2"}
+    assert at_rest["2"] == palette.muted  # phase 0: starts from the resting frame
+
+    for _ in range(10):  # half a slow period (2.0s at 0.1s frames)
+        grid._advance_frame()
+    at_peak = grid.frame_styles(palette, now=0.0)["2"]
+    assert at_peak == palette.accent  # phase pi: fully lit
+    assert _interp(((0.0, palette.muted), (1.0, palette.accent)), 0.5) not in (
+        palette.muted, palette.accent
+    )  # the ramp really passes through intermediate colours
+
+    for _ in range(10):
+        grid._advance_frame()
+    assert grid.frame_styles(palette, now=0.0)["2"] == palette.muted  # back down
+
+
+def test_handoff_sweep_fades_old_active_out_and_new_active_in():
+    from claude_swap.tui.theme import Palette
+    from claude_swap.tui.widgets import _ACTIVE_GREEN, _SWEEP_S
+
+    palette = Palette.DARK
+    grid = _animatable_grid()
+    grid.start_sweep("1", "2", now=100.0)
+    assert len(grid.intervals) == 1  # the sweep alone keeps frames coming
+
+    # Weight follows the active role at once; only the colour crosses over.
+    start = grid.frame_styles(palette, now=100.0)
+    assert start["1"] == _ACTIVE_GREEN  # old active: still green, no longer bold
+    assert start["2"] == f"{palette.muted} bold"  # new active: bold, still muted
+
+    end = grid.frame_styles(palette, now=100.0 + _SWEEP_S)
+    assert end["1"] == palette.muted
+    assert end["2"] == f"{_ACTIVE_GREEN} bold"
+
+    grid._advance_frame(now=100.0 + _SWEEP_S + 0.1)  # sweep over: back to idle
+    assert grid.frame_styles(palette, now=200.0) == {}
+    assert grid.intervals[0][1].stopped
+
+
+def test_urgency_speeds_up_the_breathing():
+    grid = _animatable_grid()
+    grid.set_predicted("2", 0.0)
+    grid._advance_frame()
+    slow_step = grid._phase
+
+    grid.set_predicted("3", 1.0)  # retarget resets the phase
+    assert grid._phase == 0.0
+    grid._advance_frame()
+    assert grid._phase > slow_step * 3  # 0.6s period vs 2.0s: >3x faster
+
+
+def test_compact_fallback_does_not_animate():
+    """The compact one-line-per-account view has no frames to breathe, so a
+    prediction must not keep the 10 Hz interval running there."""
+    grid = _animatable_grid()
+    grid.set_predicted("2", 0.0)
+    assert len(grid.intervals) == 1 and not grid.intervals[0][1].stopped
+
+    grid.set_compact(True)
+    assert grid.intervals[0][1].stopped  # nothing to paint: interval off
+
+    grid.set_compact(False)
+    assert len(grid.intervals) == 2 and not grid.intervals[1][1].stopped
 
 
 def test_meters_grid_flash_extends_on_reflash():

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1177,6 +1177,99 @@ class TestMeterWatchScreen:
             await pilot.pause()
             assert grid.cursor == 1
 
+    async def test_grid_mounts_one_card_per_account_at_the_reference_cells(
+        self, tmp_path, monkeypatch
+    ):
+        """The grid is a container of MeterCard widgets, one per account, laid
+        out exactly where ``meters_grid_text`` paints each card, so a frame
+        can repaint one card without touching the rest."""
+        from claude_swap.tui import widgets
+        from claude_swap.tui.theme import Palette
+        from claude_swap.tui.widgets import (
+            MeterCard, MetersGrid, meter_grid_dims, meters_grid_text,
+        )
+
+        monkeypatch.setattr(widgets.time, "time", lambda: 1_000.0)
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2), make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            grid = app.screen.query_one("#meters", MetersGrid)
+            cards = list(grid.query(MeterCard))
+            accounts = app.snapshot.accounts
+            assert [c.acc.number for c in cards] == [a.number for a in accounts]
+
+            width, height = grid.size.width, grid.size.height
+            ncols, card_width, bar_height = meter_grid_dims(width, height, 3)
+            reference = meters_grid_text(
+                accounts, width, height, cursor=None, now=1_000.0,
+                flashed=set(), palette=Palette.from_theme(app.current_theme),
+            ).plain.split("\n")
+            origin = grid.content_region
+            for i, card in enumerate(cards):
+                x = card.region.x - origin.x
+                y = card.region.y - origin.y
+                assert (x, y) == (
+                    (i % ncols) * (card_width + 1),
+                    (i // ncols) * (bar_height + widgets.CARD_CHROME + 1),
+                )
+                lines = card.render().plain.split("\n")
+                assert lines == [
+                    reference[y + j][x : x + card_width] for j in range(len(lines))
+                ]
+
+    async def test_animation_and_cursor_repaint_only_the_cards_they_touch(
+        self, tmp_path, monkeypatch
+    ):
+        """One breathing frame repaints one card, a handoff sweep two, a cursor
+        move the old and the new card, and none of them asks for a relayout,
+        which would re-run the grid for every card on every frame."""
+        from claude_swap.tui.widgets import MeterCard, MetersGrid
+
+        repaints: list[tuple[str, bool]] = []
+        orig = MeterCard.refresh
+
+        def spy(self, *args, **kwargs):
+            repaints.append((self.acc.number, bool(kwargs.get("layout"))))
+            return orig(self, *args, **kwargs)
+
+        monkeypatch.setattr(MeterCard, "refresh", spy)
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2), make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            grid = app.screen.query_one("#meters", MetersGrid)
+
+            repaints.clear()
+            grid.set_predicted("2", 0.5)
+            grid._advance_frame(now=1_000.0)
+            grid._advance_frame(now=1_000.1)
+            assert repaints == [("2", False)] * 3  # arm + two frames
+
+            repaints.clear()
+            grid.set_predicted(None, 0.0)
+            assert repaints == [("2", False)]  # back to the resting frame
+
+            repaints.clear()
+            grid.start_sweep("1", "3", now=2_000.0)
+            grid._advance_frame(now=2_000.1)
+            assert sorted(repaints) == [("1", False)] * 2 + [("3", False)] * 2
+
+            repaints.clear()
+            grid.cursor = 1
+            grid.cursor = 2
+            assert repaints == [("2", False), ("2", False), ("3", False)]
+
     async def test_grid_content_fits_small_terminal_without_clipping(self, tmp_path):
         fake = FakeSwitcher(
             [make_account(1, active=True), make_account(2), make_account(3)],
@@ -1189,12 +1282,27 @@ class TestMeterWatchScreen:
             await pilot.pause()
             from claude_swap.tui.widgets import MetersGrid
 
+            from claude_swap.tui.widgets import MeterCard
+
             grid = app.screen.query_one("#meters", MetersGrid)
             assert grid._ncols() == 2
-            rendered_lines = grid.render().plain.count("\n") + 1
-            assert rendered_lines <= grid.size.height
+            cards = list(grid.query(MeterCard))
+            assert len(cards) == 3
+            for card in cards:
+                assert card.region in grid.content_region  # nothing clipped
 
-    async def test_grid_fallback_cursor_moves_through_compact_list(self, tmp_path):
+    async def test_grid_fallback_cursor_moves_through_compact_list(
+        self, tmp_path, monkeypatch
+    ):
+        """Too small for cards: each card renders as the one-line row of the
+        compact fallback, stacked in one column with no gutter."""
+        from claude_swap.tui import widgets
+        from claude_swap.tui.theme import Palette
+        from claude_swap.tui.widgets import (
+            MeterCard, MetersGrid, _compact_fallback_text,
+        )
+
+        monkeypatch.setattr(widgets.time, "time", lambda: 1_000.0)
         fake = FakeSwitcher(
             [make_account(1, active=True), make_account(2), make_account(3)],
             tmp_path,
@@ -1206,17 +1314,54 @@ class TestMeterWatchScreen:
             await pilot.pause()
             await pilot.press("s")
             await pilot.pause()
-            from claude_swap.tui.widgets import MetersGrid
 
             grid = app.screen.query_one("#meters", MetersGrid)
             assert grid._ncols() == 1  # fallback list is effectively one column
             assert grid.cursor == 0
-            rendered_lines = grid.render().plain.count("\n") + 1
-            assert rendered_lines <= grid.size.height
+            cards = list(grid.query(MeterCard))
+            origin = grid.content_region
+            reference = _compact_fallback_text(
+                app.snapshot.accounts, grid.size.width, grid.size.height,
+                cursor=0, now=1_000.0, flashed=set(),
+                palette=Palette.from_theme(app.current_theme),
+            )
+            assert [c.region.y - origin.y for c in cards] == [0, 1, 2]
+            assert [c.render().plain for c in cards] == reference.plain.split("\n")
+            assert cards[0].render().spans == reference.split("\n")[0].spans
+
             await pilot.press("j")  # down moves to the next account in the list
             await pilot.pause()
             assert grid.cursor == 1
             assert grid.selected_number() == "2"
+
+    async def test_compact_grid_windows_the_cards_around_the_cursor(self, tmp_path):
+        """Fifteen accounts in a ten-row viewport: only a window of cards is
+        shown, and it follows the cursor so Enter never targets a hidden one."""
+        from claude_swap.tui.widgets import MeterCard, MetersGrid
+
+        fake = FakeSwitcher(_many_meter_accounts(15), tmp_path)
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(80, 11)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            grid = app.screen.query_one("#meters", MetersGrid)
+            rows = grid.size.height
+            assert rows < 15
+
+            def visible():
+                return [c.acc.number for c in grid.query(MeterCard) if c.display]
+
+            assert visible() == [str(i) for i in range(1, rows + 1)]
+            for _ in range(14):
+                await pilot.press("j")
+            await pilot.pause()
+            assert grid.selected_number() == "15"
+            assert visible() == [str(i) for i in range(16 - rows, 16)]
+            assert all(c.region in grid.content_region
+                       for c in grid.query(MeterCard) if c.display)
 
     async def test_selection_anchors_to_active_after_pre_snapshot_arm(self, tmp_path):
         """``s`` pressed before the initial snapshot lands must still end up
@@ -1261,6 +1406,104 @@ class TestMeterWatchScreen:
             assert grid.cursor is not None
             assert grid.cursor < len(shrunk.accounts)
 
+    async def test_grid_shows_a_note_while_loading_and_with_no_accounts(
+        self, tmp_path
+    ):
+        import threading
+
+        class BlockingFakeSwitcher(FakeSwitcher):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.release = threading.Event()
+
+            def accounts_snapshot(self, fetch=None):
+                self.release.wait(5)
+                return super().accounts_snapshot(fetch)
+
+        from textual.widgets import Static
+        from claude_swap.tui.widgets import MeterCard, MetersGrid
+
+        fake = BlockingFakeSwitcher([make_account(1, active=True)], tmp_path)
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.press("w")
+            await pilot.pause()
+            grid = app.screen.query_one("#meters", MetersGrid)
+            note = grid.query_one("#meters-note", Static)
+            assert app.snapshot is None
+            assert note.display is True
+            assert note.region.width > 0 and note.region in grid.content_region
+            assert str(note.render()) == "loading…"
+
+            fake.release.set()
+            await settle(pilot)
+            assert note.display is False
+            assert len(grid.query(MeterCard)) == 1
+
+            app.snapshot = dataclasses.replace(app.snapshot, accounts=())
+            await pilot.pause()
+            assert note.display is True
+            assert note.region.width > 0
+            assert str(note.render()) == "No managed accounts yet."
+            assert not any(c.display for c in grid.query(MeterCard))
+
+    async def test_compact_line_grows_with_its_content_on_a_snapshot(self, tmp_path):
+        """A compact card is auto-width; an in-place snapshot update that
+        lengthens the line must relayout, or the new text gets ellipsised."""
+        from claude_swap.tui.widgets import MeterCard, MetersGrid
+
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2, email="a@example.com"),
+             make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(60, 12)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            grid = app.screen.query_one("#meters", MetersGrid)
+            assert grid._compact
+            card = list(grid.query(MeterCard))[1]
+            before = card.region.width
+            longer = dataclasses.replace(
+                app.snapshot.accounts[1], email="a-much-longer-name@example.com"
+            )
+            app.snapshot = dataclasses.replace(
+                app.snapshot,
+                accounts=(app.snapshot.accounts[0], longer, app.snapshot.accounts[2]),
+            )
+            await pilot.pause()
+            assert card.acc is longer
+            assert card.region.width == len(card.render().plain) > before
+
+    async def test_rebuilt_cards_never_share_the_grid_with_the_old_ones(self, tmp_path):
+        """Old cards are hidden the moment a rebuild starts, so a layout that
+        runs before the prune completes shows only the new order."""
+        from claude_swap.tui.widgets import MeterCard, MetersGrid
+
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2), make_account(3)],
+            tmp_path,
+        )
+        app = make_app(fake, watch_style="meters")
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            grid = app.screen.query_one("#meters", MetersGrid)
+            grid.set_predicted("2", 0.5)
+            grid._advance_frame(now=1_000.0)  # a visibly lit frame on card 2
+            accts = app.snapshot.accounts
+            app.snapshot = dataclasses.replace(
+                app.snapshot, accounts=(accts[2], accts[0], accts[1])
+            )
+            # No pause: the old cards may still be pruning.
+            shown = [c for c in grid.query(MeterCard) if c.display]
+            assert [c.acc.number for c in shown] == ["3", "1", "2"]
+            # The rebuilt predicted card already wears this frame's colour.
+            assert shown[2].frame_style is not None
+
     async def test_armed_cursor_follows_account_across_reorder(self, tmp_path):
         """An external move/swap that reorders accounts while selection is
         armed must keep the cursor on the *same account*, not the same slot —
@@ -1292,6 +1535,23 @@ class TestMeterWatchScreen:
             app.snapshot = reordered
             await pilot.pause()
             assert grid.selected_number() == selected  # still on account "2"
+
+            # The rebuilt cards sit in the DOM (and so on screen) in the new
+            # order, in the same cells the reference layout would use.
+            from claude_swap.tui.widgets import CARD_CHROME, MeterCard, meter_grid_dims
+
+            cards = list(grid.query(MeterCard))
+            assert [c.acc.number for c in cards] == ["3", "1", "2"]
+            assert [c.marked for c in cards] == [False, False, True]
+            ncols, card_width, bar_height = meter_grid_dims(
+                grid.size.width, grid.size.height, 3
+            )
+            origin = grid.content_region
+            for i, card in enumerate(cards):
+                assert (card.region.x - origin.x, card.region.y - origin.y) == (
+                    (i % ncols) * (card_width + 1),
+                    (i // ncols) * (bar_height + CARD_CHROME + 1),
+                )
 
     async def test_s_arms_selection_switch_stays_watching(self, tmp_path):
         fake = self._fake(tmp_path)
@@ -2932,6 +3192,32 @@ def test_meter_card_stale_dims_bars_and_percent():
 
     assert any("dim" in str(sp.style) for sp in stale_card.spans)
     assert not any("dim" in str(sp.style) for sp in fresh_card.spans)
+
+
+def test_meter_card_widget_renders_the_meter_card_reference(monkeypatch):
+    """One MeterCard widget per account paints exactly what ``meter_card``
+    paints for it, cursor mark included, so only that widget has to repaint
+    when its frame changes."""
+    from claude_swap.tui import widgets
+    from claude_swap.tui.theme import Palette
+    from claude_swap.tui.widgets import MeterCard, _mark_cursor, meter_card
+
+    monkeypatch.setattr(widgets.time, "time", lambda: 1_000.0)
+    acc = make_account(2, email="peer@example.com", entry=make_entry(pct5=40.0, pct7=20.0))
+    card = MeterCard(acc, palette=Palette.DARK)
+    card.card_width, card.bar_height = 21, 5
+
+    reference = meter_card(acc, 21, 5, now=1_000.0)
+    assert card.render().plain == reference.plain
+    assert card.render().spans == reference.spans
+
+    card.frame_style = "#ff00ff"
+    card.flash = True
+    styled = meter_card(acc, 21, 5, now=1_000.0, flash=True, frame_style="#ff00ff")
+    assert card.render().spans == styled.spans
+
+    card.marked = True
+    assert card.render().spans == _mark_cursor(styled, 21).spans
 
 
 def test_meter_card_flash_highlights_top_border():


### PR DESCRIPTION
<img width="960" height="640" alt="cswap-meters-watch" src="https://github.com/user-attachments/assets/32b22456-5b8a-46fc-aa29-e27f4845557f" />
## Summary

Add a `ui.watch_style` setting (`classic` or `meters`; default `classic`) that chooses the `cswap watch` layout. `classic` is the current horizontal-bar account list. `meters` is a compact grid of vertical gradient meters, one column per usage window. The default is unchanged, so existing users see the same watch screen unless they opt in.

## What's included

- A `MeterWatchScreen` beside the existing list view. Every account is a framed card of vertical 5h/7d (and per-model) meters, with the percentage in large digits and the reset time beneath. `s` arms selection, the arrows move a 2-D cursor over the grid, and Enter switches and keeps watching. A `watch_screen()` factory picks the screen from the setting.
- The meters read their colours from the active theme's `Palette`, so they follow `ui.theme` in dark and light. The maxed-window reds and the active-account green frame are fixed on purpose.
- `Ctrl+V` swaps the layout live from either watch screen and saves the choice.
- The grid is responsive. It fits the column count and bar height to the terminal, and falls back to a one-line-per-account view when even minimum-height cards will not fit.
- The preference lives in the `ui` section of `settings.json`, with `cswap config get/set/unset ui.watchStyle`.

## Auto-switch from the meters view

The second commit adds the auto-switcher to this screen, so I can arm it without leaving the display.

- `a` runs the engine in dry-run. The card it would move to next gets a breathing frame, and the cycle speeds up as the active account nears the threshold. `L` asks for the same confirmation the auto screen uses, then goes live. A real switch sweeps the green frame from the old card to the new one. The mode and the next target read out at the right end of the footer, so the grid keeps every row.
- The "next" comes from the engine, not the UI. `PollEvent` gains a `next_target` field (JSON `nextTarget`, only when set) that every tick fills from the same ranking and no-return bar the decision uses, so it stays right under `consume-first`, cooldown, quarantine and the API-key last resort. Existing event consumers are unaffected.
- Two engine changes that also apply to `cswap auto`: `stop()` now waits for a switch already under way to finish and refuses one that has not started yet, so a SIGTERM (or leaving live mode in the TUI) is never followed by one more switch. Events are no longer emitted while that lock is held.

## CPU while the card breathes

Two more commits, both perf. The first version of the animation pinned a core at 80% on a 257x90 terminal, and the fix for that lives in the auto-switch commit. What was left was Textual repainting the whole grid ten times a second because the grid was one Static.

- 854695f: `MetersGrid` is a grid container of one `MeterCard` per account. A breathing frame repaints one card, a handoff sweep two, a cursor move the old and the new card, none of them with a relayout. Compact mode is the same cards as one-line rows in a single column, hidden outside the cursor window instead of clipped. `meters_grid_text` no longer runs in production; the pilot tests keep it as the reference they compare the mounted cards against.
- 428ec21: the interval runs at 0.2 s while urgency is under 0.5 and at 0.1 s from there and during a sweep, with the phase step following the running period.

Headless with a predicted target, 257x90: 15% before the container, 6.7% after it at the full rate, 4.0% at rest. 120x40: 6.9% to 2.2% at rest. Idle stays under 1%.

## Compatibility

The default is `classic`, the existing watch view, so nothing changes for current users unless they set `ui.watchStyle` to `meters` or press `Ctrl+V`. The classic screen is untouched. The auto-switch keys exist only on the meters screen and do nothing until pressed.

## Testing

Tests cover the setting and its round-trip, both watch screens, the meter rendering in the dark and light palettes, the selection cursor following its account across a reorder, the live toggle, the next-target prediction under both strategies, the stop-mid-switch and deadlock cases, and the animation timer running only while there is something to animate. Full suite passes on Linux, macOS and Windows.

## Notes

This started as personal styling. I run `cswap watch` fullscreen on a small dedicated display and wanted a more glanceable, at-a-distance view, so I built the meter grid for that and have been using it this way. It is opt-in and leaves the default untouched, so I am opening it in case it is useful to anyone else, with no pressure to take it.

One open question: the active-account frame green and the maxed-bar reds are the same in both themes right now; I can add light-mode variants if you would prefer.

