### PR TITLE
feat(session): `cswap env` for shell hooks + `--share-all` session profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,47 @@ Subfolders inherit the nearest mapped ancestor. In an unmapped directory, `cswap
 
 </details>
 
+### Pin a whole shell to an account (`cswap env`)
+
+`cswap env` does everything `cswap run` does *except* launch claude: it
+bootstraps (or reuses) the account's session profile and prints a single
+`export CLAUDE_CONFIG_DIR=...` line on stdout — everything else goes to
+stderr, so the output is safe to `eval`. After that, every `claude` in the
+shell (including your own wrappers and scripts) runs as that account; no
+launcher wrapper needed.
+
+```bash
+eval "$(cswap env 2)"           # this shell is now account 2
+eval "$(cswap env)"             # resolve from the directory mapping (cswap map)
+```
+
+`env` defaults to `--share-all`: the profile symlinks **everything** in
+`~/.claude` — skills, plugins, hooks, settings, `projects/` (transcripts /
+`--resume`) and `history.jsonl` — except credentials and per-profile state
+(`.claude.json` is seeded once from the account's stored config snapshot, so
+project trust and MCP approvals carry over). The profile is effectively
+auth-only; there is one set of files for all accounts. `--share-all` is also
+available on `cswap run`. POSIX only.
+
+If the target account already **is** your default login, `env` prints
+nothing and exits 0 (no override needed — and bootstrapping would fork the
+live login's refresh-token family, logging running claudes out).
+
+Hook it to a directory (re-evaluated on every `cd`, this shell only) — e.g.
+in `.zshrc`/`.bashrc`:
+
+```sh
+__claude_account_eval() {
+    case "$PWD/" in
+    "$HOME/work/"*) [ -n "${CLAUDE_CONFIG_DIR:-}" ] || eval "$(cswap env 2)" ;;
+    *) unset CLAUDE_CONFIG_DIR ;;
+    esac
+}
+# zsh:  autoload -Uz add-zsh-hook && add-zsh-hook chpwd __claude_account_eval
+# bash: PROMPT_COMMAND="__claude_account_eval${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+__claude_account_eval
+```
+
 ### Interactive dashboard (TUI)
 
 Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usage for every account, switching, and the auto-switcher, all keyboard-driven. `cswap watch` opens it straight to the live monitor. Works on macOS, Linux, and Windows.

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
+import shlex
 import sys
 
 from claude_swap import __version__, paths, printer
@@ -163,6 +165,17 @@ Examples:
         ),
     )
     parser.add_argument(
+        "--share-all",
+        action="store_true",
+        help=(
+            "Symlink EVERYTHING from ~/.claude into the session profile — "
+            "plugins, hooks, todos, history, the lot — except credentials "
+            "and per-profile state (.claude.json, sessions/, ide/, statsig/, "
+            "backups/). The profile becomes auth-only. Implies "
+            "--share-history; POSIX only."
+        ),
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -183,6 +196,7 @@ Examples:
                 tail,
                 share=not args.no_share,
                 share_history=args.share_history,
+                share_all=args.share_all,
             )
             return  # only reachable in tests where exec/exit is mocked
 
@@ -194,6 +208,7 @@ Examples:
                 tail,
                 share=not args.no_share,
                 share_history=args.share_history,
+                share_all=args.share_all,
             )
             return  # only reachable in tests
         if email is not None:
@@ -215,6 +230,134 @@ Examples:
     except KeyboardInterrupt:
         print(f"\n{dimmed('Operation cancelled')}")
         sys.exit(130)
+
+
+def _env_command(argv: list[str]) -> None:
+    """Handle `cswap env [NUM|EMAIL]` — print a shell `export` line.
+
+    Bootstraps (or reuses) the account's session profile exactly like
+    `cswap run`, but instead of launching claude it prints
+    ``export CLAUDE_CONFIG_DIR=<profile>`` on stdout, so shell hooks can pin
+    a whole terminal — or a directory, via a chpwd/PROMPT_COMMAND hook — to
+    an account without wrapping the claude launch:
+
+        eval "$(cswap env 2)"
+
+    Sharing defaults to --share-all: the profile is auth-only and everything
+    else stays one set of files in ~/.claude. Everything except the final
+    export line is routed to stderr so `eval "$(...)"` never executes
+    bootstrap chatter.
+    """
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} env",
+        description=(
+            "Bootstrap an account's session profile and print the "
+            "`export CLAUDE_CONFIG_DIR=...` line for shell hooks "
+            "(per-shell / per-directory account selection)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  eval "$(cswap env 2)"
+  eval "$(cswap env user@example.com)"
+  eval "$(cswap env)"        # resolve from the current directory's mapping
+        """,
+    )
+    parser.add_argument(
+        "account",
+        nargs="?",
+        metavar="NUM|EMAIL",
+        help="Account (number or email). Omit to use the current "
+        "directory's mapping (see `cswap map`).",
+    )
+    parser.add_argument(
+        "--share-all",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Symlink everything from ~/.claude except credentials and "
+            "per-profile state into the profile (default: on). "
+            "--no-share-all falls back to the standard shared set."
+        ),
+    )
+    parser.add_argument(
+        "--share-history",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="With --no-share-all: also share projects/ and history.jsonl.",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    if sys.platform == "win32":
+        error("Error: `env` prints POSIX shell syntax; not supported on Windows.")
+        sys.exit(1)
+
+    session_dir = None
+    # The caller evals stdout: nothing but the export line may reach it.
+    with contextlib.redirect_stdout(sys.stderr):
+        try:
+            switcher = ClaudeAccountSwitcher(debug=args.debug)
+            _guard_root(switcher)
+
+            from claude_swap.session import AUTH_OVERRIDE_ENV_VARS, SessionManager
+
+            manager = SessionManager(switcher)
+
+            identifier = args.account
+            if identifier is None:
+                slot, email = switcher.slot_for_directory(os.getcwd())
+                if slot is None:
+                    if email is not None:
+                        warning(
+                            f"Mapped account {email} no longer exists — "
+                            "not printing an export line."
+                        )
+                    else:
+                        print(dimmed(f"No account mapped for {os.getcwd()}."))
+                    sys.exit(3)
+                identifier = slot
+
+            # Same-account guard, mirroring `run`'s fast path: if the target
+            # account IS the active default login, bootstrapping a profile
+            # would seed a second copy of its live refresh-token family, and
+            # the next rotation (either side) can invalidate the other —
+            # logging running claudes out. No override is needed anyway:
+            # print nothing and exit 0 so eval'ing hooks fall through to the
+            # default login, which already is the requested account.
+            account_num, email, org_uuid = switcher.resolve_account(identifier)
+            current = switcher._get_current_account()
+            if current is not None and current == (email, org_uuid):
+                print(
+                    dimmed(
+                        f"Account-{account_num} ({email}) is already the "
+                        "active default login — no export needed."
+                    )
+                )
+                sys.exit(0)
+
+            overrides = [v for v in AUTH_OVERRIDE_ENV_VARS if os.environ.get(v)]
+            if overrides:
+                warning(
+                    f"{', '.join(overrides)} is set in this shell and will "
+                    "override the profile's account inside Claude Code."
+                )
+
+            session_dir, account_num, email = manager.setup_session(
+                identifier,
+                share=True,
+                share_history=args.share_history,
+                share_all=args.share_all,
+            )
+            print(dimmed(f"Account-{account_num} ({email}) session profile ready."))
+        except ClaudeSwitchError as e:
+            error(f"Error: {e}")
+            sys.exit(1)
+        except KeyboardInterrupt:
+            print(f"\n{dimmed('Operation cancelled')}")
+            sys.exit(130)
+
+    print(f"export CLAUDE_CONFIG_DIR={shlex.quote(str(session_dir))}")
 
 
 def _guard_root(switcher: ClaudeAccountSwitcher) -> None:
@@ -869,6 +1012,9 @@ def main() -> None:
     if argv and argv[0] == "run":
         _run_command(argv[1:])
         return  # only reachable in tests where exec/exit is mocked
+    if argv and argv[0] == "env":
+        _env_command(argv[1:])
+        return
     if argv and argv[0] == "auto":
         _auto_command(argv[1:])
         return  # only reachable in tests where sys.exit is mocked
@@ -920,6 +1066,7 @@ Commands:
   %(prog)s enable <num|email>         return a disabled account to rotation
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s run                        run the current dir's mapped account
+  %(prog)s env [num|email]            print `export CLAUDE_CONFIG_DIR=...` for shell hooks
   %(prog)s map <num|email> [path]     map a directory to an account
   %(prog)s map                        list directory mappings
   %(prog)s unmap [path]               remove a directory mapping

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -85,6 +85,54 @@ HISTORY_ITEMS = (
     "history.jsonl",
 )
 
+# share-all mode (`run --share-all`, and the default for `cswap env`): instead
+# of the SHARED_ITEMS allowlist, symlink EVERYTHING found in ~/.claude except
+# what must stay per-profile. Only correctness exclusions live here:
+#   .credentials.json — per-account credentials are the whole point of a
+#     session profile (on macOS the profile's hashed keychain entry pairs it);
+#   .claude.json — claude rewrites it atomically (temp+rename), which would
+#     sever a symlink and silently fork the file; share-all bootstrap seeds a
+#     real copy from the account's stored config snapshot instead;
+#   sessions/, ide/ — per-instance PID/lock files; cswap's own live-session
+#     detection reads them *per profile*, so sharing would cross-wire it;
+#   statsig/ — account-scoped telemetry/feature-flag caches;
+#   backups/ — claude's own .claude.json backups, per-profile by nature;
+#   .cswap-* — this profile's own cswap markers and manifest.
+NEVER_SHARED_NAMES = frozenset(
+    {
+        ".credentials.json",
+        ".claude.json",
+        "sessions",
+        "ide",
+        "statsig",
+        "backups",
+        ".DS_Store",
+    }
+)
+NEVER_SHARED_PREFIXES = (".cswap-",)
+
+
+def share_all_eligible(name: str) -> bool:
+    """Whether share-all mode may symlink this ~/.claude entry."""
+    if name in NEVER_SHARED_NAMES:
+        return False
+    return not name.startswith(NEVER_SHARED_PREFIXES)
+
+
+def share_all_items(source_root: Path) -> tuple[str, ...]:
+    """Dynamic share list: everything in ~/.claude that isn't NEVER_SHARED.
+
+    Unioned with the static lists so history items keep their seed-if-missing
+    treatment (and the SHARED_ITEMS set stays covered) even when the source
+    entry doesn't exist yet.
+    """
+    try:
+        entries = sorted(os.listdir(source_root))
+    except OSError:
+        entries = []
+    dynamic = [name for name in entries if share_all_eligible(name)]
+    return tuple(dict.fromkeys((*dynamic, *SHARED_ITEMS, *HISTORY_ITEMS)))
+
 # Records which entries in a session profile cswap created (so --no-share and
 # re-syncs only ever remove cswap-managed links/copies, never user data).
 SHARE_MANIFEST = ".cswap-shared.json"
@@ -325,6 +373,7 @@ class SessionManager:
         claude_args: list[str],
         share: bool = True,
         share_history: bool = False,
+        share_all: bool = False,
     ) -> NoReturn:
         """Launch Claude Code as the given account in the current terminal."""
         claude_bin = shutil.which("claude")
@@ -337,6 +386,10 @@ class SessionManager:
                 "--share-history is not supported on Windows yet: sharing uses "
                 "re-synced copies there, which would fork the history instead "
                 "of sharing it."
+            )
+        if share_all and self.switcher.platform == Platform.WINDOWS:
+            raise SessionError(
+                "--share-all is not supported on Windows: it is symlink-based."
             )
 
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
@@ -376,7 +429,7 @@ class SessionManager:
             )
 
         session_dir, account_num, email = self.setup_session(
-            identifier, share, share_history
+            identifier, share, share_history, share_all
         )
 
         print(
@@ -440,7 +493,11 @@ class SessionManager:
     # -- bootstrap -------------------------------------------------------
 
     def setup_session(
-        self, identifier: str, share: bool, share_history: bool = False
+        self,
+        identifier: str,
+        share: bool,
+        share_history: bool = False,
+        share_all: bool = False,
     ) -> tuple[Path, str, str]:
         """Ensure a valid session profile exists; returns (dir, num, email)."""
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
@@ -459,7 +516,7 @@ class SessionManager:
 
         # Cheap reuse check without the lock: most launches hit this.
         if not stale and self._is_session_valid(session_dir, email, org_uuid):
-            self._sync_sharing(session_dir, share, share_history)
+            self._sync_sharing(session_dir, share, share_history, share_all)
             return session_dir, account_num, email
 
         with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
@@ -471,11 +528,14 @@ class SessionManager:
                 self.switcher._invalidate_session_credentials(account_num, email)
                 (session_dir / STALE_MARKER).unlink(missing_ok=True)
             if self._is_session_valid(session_dir, email, org_uuid):
-                self._sync_sharing(session_dir, share, share_history)
+                self._sync_sharing(session_dir, share, share_history, share_all)
                 return session_dir, account_num, email
 
-            self._bootstrap(session_dir, account_num, email, org_uuid)
-            self._sync_sharing(session_dir, share, share_history)
+            self._bootstrap(
+                session_dir, account_num, email, org_uuid,
+                seed_full_config=share_all,
+            )
+            self._sync_sharing(session_dir, share, share_history, share_all)
 
             if not self._is_session_valid(session_dir, email, org_uuid):
                 self._cleanup_failed_session(session_dir)
@@ -489,7 +549,12 @@ class SessionManager:
         return session_dir, account_num, email
 
     def _bootstrap(
-        self, session_dir: Path, account_num: str, email: str, org_uuid: str
+        self,
+        session_dir: Path,
+        account_num: str,
+        email: str,
+        org_uuid: str,
+        seed_full_config: bool = False,
     ) -> None:
         """Seed the session profile from backup storage. Caller holds the lock."""
         # Claude reads the keychain before the plaintext file — a stale hashed
@@ -552,6 +617,12 @@ class SessionManager:
                 existing = json.loads(config_path.read_text(encoding="utf-8")) or {}
             except (json.JSONDecodeError, OSError):
                 existing = {}
+        if seed_full_config:
+            # share-all bootstrap: start from the account's full stored
+            # .claude.json snapshot (its project-trust map, MCP approvals,
+            # onboarding state) so the profile doesn't re-prompt for all of
+            # it; anything the profile accumulated itself still wins.
+            existing = {**config_data, **existing}
         existing["oauthAccount"] = oauth_account
         existing["hasCompletedOnboarding"] = True
         existing.setdefault("theme", config_data.get("theme") or "dark")
@@ -625,7 +696,11 @@ class SessionManager:
     # -- sharing ---------------------------------------------------------
 
     def _sync_sharing(
-        self, session_dir: Path, share: bool, share_history: bool = False
+        self,
+        session_dir: Path,
+        share: bool,
+        share_history: bool = False,
+        share_all: bool = False,
     ) -> None:
         """Mirror shared items from ~/.claude into the profile (or undo it).
 
@@ -634,6 +709,8 @@ class SessionManager:
         on the adoption marker); ``share_history`` governs HISTORY_ITEMS
         (conversation history) — independent concerns, so ``--no-share
         --share-history`` gives a bare profile with unified history.
+        ``share_all`` supersedes both with the dynamic everything-except-
+        NEVER_SHARED list (POSIX only).
         Idempotent; runs on every launch. Deliberately sources from the
         default ``~/.claude`` (not ``get_claude_config_home()``): sharing
         always mirrors the default profile, even when ``CLAUDE_CONFIG_DIR``
@@ -644,27 +721,36 @@ class SessionManager:
         """
         if not session_dir.is_dir():
             return
-        self._sync_mcp_servers(session_dir, share)
-        # History links are POSIX-only (run() rejects the flag on Windows;
-        # this also drops any links left by a POSIX→Windows profile move).
+        # History and share-all links are POSIX-only (run() rejects the flags
+        # on Windows; this also drops any links left by a POSIX→Windows
+        # profile move).
         if self.switcher.platform == Platform.WINDOWS:
             share_history = False
-        active_items = (SHARED_ITEMS if share else ()) + (
-            HISTORY_ITEMS if share_history else ()
-        )
+            share_all = False
+        self._sync_mcp_servers(session_dir, share or share_all)
         source_root = Path.home() / ".claude"
+        if share_all:
+            active_items = share_all_items(source_root)
+        else:
+            active_items = (SHARED_ITEMS if share else ()) + (
+                HISTORY_ITEMS if share_history else ()
+            )
         manifest_path = session_dir / SHARE_MANIFEST
         managed = self._read_manifest(manifest_path)
 
         # A flag turned off since last launch: remove the links we created
         # for it (never plain files/dirs the user accumulated themselves).
-        # For history items that holds even when the manifest claims them:
-        # a stale manifest (lock-free launches race) must never be able to
-        # delete real conversation history — only ever unlink symlinks.
+        # For history and share-all items that holds even when the manifest
+        # claims them: a stale manifest (lock-free launches race) must never
+        # be able to delete real user data — only ever unlink symlinks.
         for name in managed:
             if name not in active_items:
                 dest = session_dir / name
-                if name in HISTORY_ITEMS and dest.exists() and not dest.is_symlink():
+                if (
+                    name not in SHARED_ITEMS
+                    and dest.exists()
+                    and not dest.is_symlink()
+                ):
                     continue
                 self._remove_managed(dest)
         if not active_items:
@@ -1032,8 +1118,13 @@ class SessionManager:
         try:
             data = json.loads(manifest_path.read_text(encoding="utf-8"))
             items = data.get("items", [])
-            # Only ever act on names we could have created.
-            return [i for i in items if i in SHARED_ITEMS + HISTORY_ITEMS]
+            # Only ever act on names we could have created (the static lists,
+            # or anything share-all mode is allowed to link).
+            return [
+                i
+                for i in items
+                if i in SHARED_ITEMS + HISTORY_ITEMS or share_all_eligible(i)
+            ]
         except (OSError, json.JSONDecodeError, AttributeError):
             return []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -572,8 +572,17 @@ class TestRunCommand:
             def __init__(self, switcher):
                 calls.append(("init", switcher))
 
-            def run(self, identifier, claude_args, share=True, share_history=False):
-                calls.append(("run", identifier, claude_args, share, share_history))
+            def run(
+                self,
+                identifier,
+                claude_args,
+                share=True,
+                share_history=False,
+                share_all=False,
+            ):
+                calls.append(
+                    ("run", identifier, claude_args, share, share_history, share_all)
+                )
 
         with patch("claude_swap.session.SessionManager", FakeSessionManager), \
              patch("claude_swap.cli.ClaudeAccountSwitcher"), \
@@ -584,32 +593,36 @@ class TestRunCommand:
 
     def test_run_dispatches_with_defaults(self):
         calls = self._dispatch(["run", "2"])
-        assert ("run", "2", [], True, False) in calls
+        assert ("run", "2", [], True, False, False) in calls
 
     def test_run_by_email(self):
         calls = self._dispatch(["run", "user@example.com"])
-        assert ("run", "user@example.com", [], True, False) in calls
+        assert ("run", "user@example.com", [], True, False, False) in calls
 
     def test_no_share_flag(self):
         calls = self._dispatch(["run", "2", "--no-share"])
-        assert ("run", "2", [], False, False) in calls
+        assert ("run", "2", [], False, False, False) in calls
 
     def test_share_history_flag(self):
         calls = self._dispatch(["run", "2", "--share-history"])
-        assert ("run", "2", [], True, True) in calls
+        assert ("run", "2", [], True, True, False) in calls
 
     def test_no_share_history_flag(self):
         calls = self._dispatch(["run", "2", "--no-share-history"])
-        assert ("run", "2", [], True, False) in calls
+        assert ("run", "2", [], True, False, False) in calls
+
+    def test_share_all_flag(self):
+        calls = self._dispatch(["run", "2", "--share-all"])
+        assert ("run", "2", [], True, False, True) in calls
 
     def test_tail_forwarded_verbatim(self):
         calls = self._dispatch(["run", "2", "--", "--resume", "--model", "x"])
-        assert ("run", "2", ["--resume", "--model", "x"], True, False) in calls
+        assert ("run", "2", ["--resume", "--model", "x"], True, False, False) in calls
 
     def test_tail_may_contain_run_flags(self):
         """Args after `--` are NOT parsed by cswap, even if they look like ours."""
         calls = self._dispatch(["run", "2", "--", "--no-share"])
-        assert ("run", "2", ["--no-share"], True, False) in calls
+        assert ("run", "2", ["--no-share"], True, False, False) in calls
 
     def test_run_unknown_flag_errors(self, capsys):
         with patch.object(sys, "argv", ["claude-swap", "run", "2", "--bogus"]):
@@ -649,7 +662,7 @@ class TestRunCommand:
             def __init__(self, switcher):
                 pass
 
-            def run(self, identifier, claude_args, share=True, share_history=False):
+            def run(self, identifier, claude_args, share=True, share_history=False, share_all=False):
                 from claude_swap.exceptions import SessionError
 
                 raise SessionError("boom")
@@ -663,6 +676,120 @@ class TestRunCommand:
 
         assert excinfo.value.code == 1
         assert "boom" in capsys.readouterr().err
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="`env` is POSIX-only")
+class TestEnvCommand:
+    """`cswap env` pre-dispatch: eval-safe stdout, share-all defaults, guards."""
+
+    RESOLVED = ("2", "user@example.com", "org-2")
+
+    def _dispatch(
+        self,
+        argv: list[str],
+        session_dir="/tmp/profile",
+        current=None,
+        mapping=None,
+    ):
+        calls = []
+
+        class FakeSessionManager:
+            def __init__(self, switcher):
+                pass
+
+            def setup_session(
+                self, identifier, share, share_history=False, share_all=False
+            ):
+                calls.append(("setup", identifier, share, share_history, share_all))
+                return Path(session_dir), "2", "user@example.com"
+
+        with patch("claude_swap.session.SessionManager", FakeSessionManager), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "env", *argv]):
+            switcher = switcher_cls.return_value
+            switcher.resolve_account.return_value = self.RESOLVED
+            switcher._get_current_account.return_value = current
+            if mapping is not None:
+                switcher.slot_for_directory.return_value = mapping
+            cli.main()
+        return calls
+
+    def test_env_defaults_to_share_all(self, capsys):
+        calls = self._dispatch(["2"])
+        assert ("setup", "2", True, False, True) in calls
+        assert capsys.readouterr().out == "export CLAUDE_CONFIG_DIR=/tmp/profile\n"
+
+    def test_env_stdout_is_eval_safe(self, capsys):
+        """Bootstrap chatter (printer writes to stdout) must land on stderr."""
+        self._dispatch(["2"])
+        captured = capsys.readouterr()
+        assert captured.out == "export CLAUDE_CONFIG_DIR=/tmp/profile\n"
+        assert "session profile ready" in captured.err
+
+    def test_env_quotes_awkward_paths(self, capsys):
+        self._dispatch(["2"], session_dir="/tmp/pro file")
+        assert capsys.readouterr().out == "export CLAUDE_CONFIG_DIR='/tmp/pro file'\n"
+
+    def test_env_no_share_all_falls_back(self):
+        calls = self._dispatch(["2", "--no-share-all", "--share-history"])
+        assert ("setup", "2", True, True, False) in calls
+
+    def test_env_same_account_prints_nothing_and_skips_bootstrap(self, capsys):
+        """Target == active default login: bootstrapping would fork the live
+        refresh-token family (rotation then logs the other copy out), and no
+        override is needed anyway — exit 0 with empty stdout."""
+        with pytest.raises(SystemExit) as excinfo:
+            self._dispatch(["2"], current=("user@example.com", "org-2"))
+        captured = capsys.readouterr()
+        assert excinfo.value.code == 0
+        assert captured.out == ""
+        assert "already the active default login" in captured.err
+
+    def test_env_resolves_directory_mapping(self, capsys):
+        calls = self._dispatch([], mapping=("3", "user@example.com"))
+        assert [c[1] for c in calls] == ["3"]
+        assert capsys.readouterr().out == "export CLAUDE_CONFIG_DIR=/tmp/profile\n"
+
+    def test_env_unmapped_directory_exits_3_with_empty_stdout(self, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            self._dispatch([], mapping=(None, None))
+        assert excinfo.value.code == 3
+        assert capsys.readouterr().out == ""
+
+    def test_env_error_exits_1_with_empty_stdout(self, capsys):
+        class FailingSessionManager:
+            def __init__(self, switcher):
+                pass
+
+            def setup_session(
+                self, identifier, share, share_history=False, share_all=False
+            ):
+                from claude_swap.exceptions import SessionError
+
+                raise SessionError("boom")
+
+        with patch("claude_swap.session.SessionManager", FailingSessionManager), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "env", "2"]):
+            switcher_cls.return_value.resolve_account.return_value = self.RESOLVED
+            switcher_cls.return_value._get_current_account.return_value = None
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        captured = capsys.readouterr()
+        assert excinfo.value.code == 1
+        assert captured.out == ""
+        assert "boom" in captured.err
+
+    def test_main_help_mentions_env(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "env [num|email]" in result.stdout
 
 
 class TestSubcommandAliases:
@@ -751,7 +878,7 @@ class TestSubcommandAliases:
             def __init__(self, switcher):
                 pass
 
-            def run(self, identifier, claude_args, share=True, share_history=False):
+            def run(self, identifier, claude_args, share=True, share_history=False, share_all=False):
                 calls.append((identifier, claude_args, share))
 
         with patch("claude_swap.session.SessionManager", FakeSessionManager), \
@@ -1290,7 +1417,7 @@ class TestRunAutoResolve:
             def __init__(self, switcher):
                 pass
 
-            def run(self, identifier, claude_args, share=True, share_history=False):
+            def run(self, identifier, claude_args, share=True, share_history=False, share_all=False):
                 calls.append(("run", identifier, claude_args, share, share_history))
 
             def exec_default(self, claude_args):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -61,6 +61,8 @@ CONFIG = json.dumps(
             "organizationUuid": ORG_UUID,
         },
         "theme": "light",
+        # Only share-all bootstrap (seed_full_config) may carry this over.
+        "projects": {"/some/repo": {"hasTrustDialogAccepted": True}},
     }
 )
 
@@ -642,6 +644,90 @@ class TestSharingPosix:
         mgr._sync_sharing(session_dir, share=True)
 
         assert (session_dir / "settings.json").readlink() == source / "settings.json"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="share-all is POSIX-only")
+class TestShareAll:
+    """share-all mode: everything in ~/.claude symlinks except NEVER_SHARED."""
+
+    def test_links_everything_except_denylist(self, share_setup):
+        source, session_dir, mgr = share_setup
+        for extra_dir in ("plugins", "hooks", "todos", "file-history"):
+            (source / extra_dir).mkdir()
+        (source / "chrome-profiles.json").write_text("{}")
+        (source / ".credentials.json").write_text("secret")
+        (source / ".claude.json").write_text("{}")
+        for private_dir in ("sessions", "ide", "statsig", "backups"):
+            (source / private_dir).mkdir()
+
+        mgr._sync_sharing(session_dir, share=True, share_all=True)
+
+        for shared in (
+            "settings.json",
+            "CLAUDE.md",
+            "skills",
+            "plugins",
+            "hooks",
+            "todos",
+            "file-history",
+            "chrome-profiles.json",
+            "projects",       # HISTORY_ITEMS: seeded empty in source, linked
+            "history.jsonl",
+        ):
+            assert (session_dir / shared).is_symlink(), shared
+        for private in (
+            ".credentials.json",
+            ".claude.json",
+            "sessions",
+            "ide",
+            "statsig",
+            "backups",
+        ):
+            assert not (session_dir / private).exists(), private
+
+    def test_share_all_manifest_survives_reload(self, share_setup):
+        """Dynamic names must round-trip the manifest (its read filter)."""
+        source, session_dir, mgr = share_setup
+        (source / "todos").mkdir()
+        mgr._sync_sharing(session_dir, share=True, share_all=True)
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "todos" in manifest["items"]
+
+        # Back to the standard set: dynamic links are pruned, allowlist stays.
+        mgr._sync_sharing(session_dir, share=True, share_all=False)
+        assert not (session_dir / "todos").exists()
+        assert (session_dir / "settings.json").is_symlink()
+
+    def test_share_all_never_touches_real_profile_data(self, share_setup):
+        source, session_dir, mgr = share_setup
+        (source / "todos").mkdir()
+        (session_dir / "todos").mkdir()
+        (session_dir / "todos" / "t.json").write_text("profile-own data")
+
+        mgr._sync_sharing(session_dir, share=True, share_all=True)
+        assert not (session_dir / "todos").is_symlink()
+
+        mgr._sync_sharing(session_dir, share=True, share_all=False)
+        assert (session_dir / "todos" / "t.json").read_text() == "profile-own data"
+
+    def test_share_all_bootstrap_seeds_full_config(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        session_dir, num, email = manager.setup_session(
+            ACCOUNT_NUM, share=True, share_all=True
+        )
+        config = json.loads((session_dir / ".claude.json").read_text())
+        assert config["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
+        assert config["hasCompletedOnboarding"] is True
+        # Full snapshot carried over (project trust survives).
+        assert config["projects"] == {"/some/repo": {"hasTrustDialogAccepted": True}}
+
+    def test_standard_bootstrap_stays_minimal(
+        self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
+    ):
+        session_dir, num, email = manager.setup_session(ACCOUNT_NUM, share=False)
+        config = json.loads((session_dir / ".claude.json").read_text())
+        assert "projects" not in config  # only share-all seeds the full snapshot
 
 
 class TestSharingWindowsMode:


### PR DESCRIPTION
## What

Two additions to session mode, aimed at people who drive account selection from their shell rather than through a launcher:

### `cswap env [NUM|EMAIL]`

Everything `cswap run` does *except* the exec: bootstraps (or reuses) the account's session profile and prints a single eval-safe line on stdout:

```bash
eval "$(cswap env 2)"        # this shell is now account 2
eval "$(cswap env)"          # resolve from the directory mapping (cswap map)
```

After that, every `claude` invocation in the shell — including the user's own aliases/wrappers/scripts — runs as that account, and hooks (`chpwd` / `PROMPT_COMMAND`) can re-evaluate per directory. Contract:

- stdout is **exactly** `export CLAUDE_CONFIG_DIR=<quoted path>` (or empty); all bootstrap chatter goes to stderr via `redirect_stdout`, so `eval "$(...)"` is always safe.
- Directory mappings are honored when the account is omitted; an unmapped directory exits 3 with empty stdout.
- **Same-account guard**, mirroring `run`'s fast path: if the target account already *is* the active default login, `env` prints nothing and exits 0. Bootstrapping there would seed a second copy of the live refresh-token family, and the next rotation on either side logs the other one out (found this the hard way — my running sessions got de-authed).
- POSIX only (it prints POSIX shell syntax).

### `--share-all` (flag on `run`, default for `env`)

Session profiles currently share the SHARED_ITEMS allowlist; `--share-all` flips the model: symlink **everything** in `~/.claude` except what must stay per-profile (`NEVER_SHARED_NAMES`: `.credentials.json`, `.claude.json`, `sessions/`, `ide/`, `statsig/`, `backups/`, `.cswap-*`). The profile becomes auth-only — plugins, hooks, todos, file-history, projects/ and history.jsonl are one set of files across accounts, so nothing diverges.

Because `.claude.json` can't be a symlink (claude rewrites it atomically via temp+rename, which would sever the link and fork the file silently), share-all bootstrap seeds it from the account's **full stored config snapshot** instead of the minimal identity seed — project trust and MCP approvals carry over instead of re-prompting.

Safety details:

- The manifest read filter now also accepts share-all-eligible names, so dynamic entries round-trip and get pruned when the flag turns off.
- The removal loop only ever unlinks **symlinks** for non-SHARED_ITEMS names (generalizing the existing history guard), so a stale manifest can never delete real profile data. Windows behavior for the existing allowlist (copies) is unchanged; `--share-all` is rejected on Windows.

## Tests

- `tests/test_session.py`: new `TestShareAll` — denylist enforcement, manifest round-trip + prune, never-touch-real-data, full-config seeding vs minimal seeding.
- `tests/test_cli.py`: new `TestEnvCommand` — eval-safe stdout, quoting, share-all default, `--no-share-all` fallback, mapping resolution, unmapped exit 3, same-account guard, error exit 1 with empty stdout; `run` dispatch tests extended for `--share-all`.
- Full suite: 1537 passed locally; the 6 failures in `test_swap_accounts`/`test_move_accounts` are pre-existing on upstream HEAD in my environment (verified with my changes stashed).

README gets a "Pin a whole shell to an account" section with a copy-pasteable hook example.

Happy to adjust naming/flag defaults (e.g. `env` defaulting to share-all vs. the standard set) to your taste.
