### PR TITLE
feat(auth): recover owner-held expired tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,15 +163,21 @@ Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usag
 
 <img src="assets/tui-watch.png" width="760" alt="cswap watch — live 5h/7d usage bars for every account, with reset times and the active account marked">
 
-### Refresh expired tokens
+### Recover an expired token
 
-If an account's token expires, log back into Claude Code with that account and re-run:
+Recovery is explicit and automation-friendly:
 
 ```bash
-cswap add
+cswap recover 2 --json
 ```
 
-This will update the stored credentials without creating a duplicate.
+For an ordinary expired OAuth token, this asks the **live Claude Code profile that already owns the credential** to refresh it, then verifies that same profile still has the matching identity and a non-expired OAuth credential. It makes one minimal Haiku request, which may be billable. Recovery serializes commands for a slot and rereads the owner immediately before launch, but a manual `/login` or other external profile change after that final read can still race the canary; the mandatory post-run identity check detects the resulting drift. Recovery never runs implicitly from `list`, `status`, `watch`, `auto`, or the TUI, never restores a stale backup, and never starts browser login. `cswap list --json` performs the later usage observation through its normal collector protocol.
+
+The JSON `recoveryStatus` is one of `recovered`, `not_needed`, `retry_later`, or `human_required`. `human_required` is the safe limit for a missing or ambiguous owner, profile drift, setup tokens/API keys, missing or dead refresh tokens, and identity mismatches. In that case, log into Claude Code as the account yourself and re-run:
+
+```bash
+cswap add --slot 2
+```
 
 ### Other commands
 
@@ -182,6 +188,7 @@ cswap config                    # Show or edit settings (see Configuration below
 cswap list                      # Show all accounts with 5h/7d usage and reset times
 cswap list --token-status       # Add source-labelled OAuth token diagnostics
 cswap status                    # Show current account
+cswap recover 2 --json          # Explicitly recover an owner-held expired OAuth token
 cswap add --slot 3              # Add account to a specific slot (prompts before overwrite)
 cswap add --alias dev           # Add account and give it a short alias
 cswap remove 2                  # Remove an account
@@ -285,13 +292,14 @@ If an imported account is the one you're currently logged in as, activate the im
 
 ### JSON output for scripting
 
-Add `--json` to `list`, `status`, or `switch` to emit a single machine-readable JSON object on stdout (human-readable notices go to stderr). Useful for scripting auto-swap and quota tracking.
+Add `--json` to `list`, `status`, or `switch` to emit a single machine-readable JSON object on stdout (human-readable notices go to stderr). Explicit recovery is JSON-only. Useful for scripting auto-swap and quota tracking.
 
 ```bash
 cswap list --json                   # all accounts with usage/quota
 cswap status --json                 # current active account
 cswap switch --strategy best --json # switch, then report the result
 cswap switch 2 --json
+cswap recover 2 --json              # one PII-free recovery result
 ```
 
 <details>
@@ -309,7 +317,7 @@ cswap switch 2 --json
 }
 ```
 
-Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
+Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`. Recovery reports `{"schemaVersion":1,"operation":"recover","accountNumber":2,"recoveryStatus":"recovered"}` without email, paths, process IDs, or provider output.
 
 Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -218,11 +218,72 @@ Examples:
 
 
 def _guard_root(switcher: ClaudeAccountSwitcher) -> None:
-    """Refuse to run as root outside a container (shared by run/map/unmap)."""
+    """Refuse to run as root outside a container (shared by pre-dispatch commands)."""
     if sys.platform != "win32":
         if os.geteuid() == 0 and not switcher._is_running_in_container():
             error("Error: Do not run this script as root (unless running in a container)")
             sys.exit(1)
+
+
+def _recovery_failure_payload() -> dict:
+    """Sanitized existing-style error envelope for pre-operation failures."""
+    return {
+        "schemaVersion": 1,
+        "error": {
+            "type": "RecoveryError",
+            "message": "Recovery could not be started.",
+        },
+    }
+
+
+def _recover_command(argv: list[str]) -> None:
+    """Handle the explicit, JSON-only ``cswap recover NUM|EMAIL --json``."""
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} recover",
+        description=(
+            "Ask the live Claude Code profile that owns an expired OAuth token "
+            "to refresh it with one minimal noninteractive request."
+        ),
+    )
+    parser.add_argument("account", metavar="NUM|EMAIL", help="Account to recover")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        required=True,
+        help="Emit one stable, machine-readable recovery result",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        # Keep stdout machine-readable when a caller did request JSON, even if
+        # the rest of the invocation is malformed. argparse diagnostics remain
+        # on stderr and retain their normal exit code.
+        if exc.code and "--json" in argv:
+            print(json.dumps(_recovery_failure_payload(), indent=2))
+        raise
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        if (
+            sys.platform != "win32"
+            and os.geteuid() == 0
+            and not switcher._is_running_in_container()
+        ):
+            print(json.dumps(_recovery_failure_payload(), indent=2))
+            sys.exit(1)
+        payload = switcher.recover(args.account)
+    except KeyboardInterrupt:
+        print("Operation cancelled", file=sys.stderr)
+        sys.exit(130)
+    except Exception:
+        # The target may itself be an email address. Never echo it (or an
+        # exception that could contain it) into automation output.
+        payload = _recovery_failure_payload()
+        print(json.dumps(payload, indent=2))
+        sys.exit(1)
+
+    print(json.dumps(payload, indent=2))
 
 
 def _map_command(argv: list[str]) -> None:
@@ -926,6 +987,9 @@ def main() -> None:
     if argv and argv[0] == "auto":
         _auto_command(argv[1:])
         return  # only reachable in tests where sys.exit is mocked
+    if argv and argv[0] == "recover":
+        _recover_command(argv[1:])
+        return
     if len(sys.argv) > 1 and sys.argv[1] == "config":
         _config_command(sys.argv[2:])
         return
@@ -970,6 +1034,7 @@ Commands:
   %(prog)s status                     show current account
   %(prog)s switch                     rotate to the next account
   %(prog)s switch <num|email>         switch to a specific account
+  %(prog)s recover <num|email> --json recover an owner-held expired token
   %(prog)s add                        add the current account
   %(prog)s add-token [TOKEN|-]        register a setup-token or API key
   %(prog)s remove <num|email>         remove an account
@@ -1002,7 +1067,8 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s switch --strategy best           # pick the account with most quota left
   %(prog)s switch --strategy next-available # rotate, skipping rate-limited accounts
   %(prog)s switch user@example.com
-  %(prog)s list --token-status
+  %(prog)s recover 2 --json                 # explicit one-request token recovery
+  %(prog)s list --token-status              # credential-source token diagnostics
   %(prog)s list --json
   %(prog)s add --slot 3                      # add to a specific slot
   %(prog)s add-token sk-ant-oat01-... --email me@example.com

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -39,6 +39,8 @@ from claude_swap.paths import (
     get_claude_config_home,
     get_credentials_path,
     get_default_claude_config_home,
+    get_default_credentials_path,
+    get_default_global_config_path,
     get_global_config_path,
 )
 
@@ -647,6 +649,78 @@ class CredentialStore:
         # Nothing anywhere. Flag a failed-and-uncovered OAuth Keychain read so the
         # UI distinguishes it from a real empty slot.
         return ActiveCredentials("", keychain_failed, keychain_failed)
+
+    def _read_default_profile_credentials(self) -> ActiveCredentials:
+        """Read the default profile even when ``CLAUDE_CONFIG_DIR`` is inherited.
+
+        Recovery launches Claude with that override absent, so its ownership
+        checks must inspect the same default file paths.
+
+        The Keychain half names ``CLAUDE_CODE_KEYCHAIN_SERVICE`` explicitly
+        rather than going through :meth:`_read_active_oauth_keychain`, which
+        resolves a *per-profile* service from the environment. The unsuffixed
+        item is by definition the default profile's — claude only writes there
+        with no ``CLAUDE_CONFIG_DIR``/``CLAUDE_SECURESTORAGE_CONFIG_DIR`` in
+        play — so it is the one item that answers for the profile recovery is
+        about, whatever this process inherited.
+        """
+        keychain_failed = False
+        if self._use_keychain():
+            val, keychain_failed = self._read_one_oauth_keychain(
+                CLAUDE_CODE_KEYCHAIN_SERVICE
+            )
+            if val:
+                return ActiveCredentials(val, False)
+        elif self._host.platform == Platform.MACOS:
+            keychain_failed = True
+
+        # The default profile can be the live owner of an explicit recovery.
+        # A failed OAuth Keychain read may hide a newer credential than its
+        # plaintext seed, so unlike the ordinary display path it must not fall
+        # through to that seed (or to a managed key) on failure. A missing
+        # Keychain item is safe to fall through: there is no hidden generation.
+        if keychain_failed:
+            return ActiveCredentials(None, True)
+
+        cred_file = get_default_credentials_path()
+        if cred_file.exists():
+            try:
+                text = cred_file.read_text(encoding="utf-8")
+            except Exception as e:
+                self._host._logger.error(f"Failed to read credentials file: {e}")
+                return ActiveCredentials(None, False)
+            if text.strip():
+                return ActiveCredentials(text, False)
+
+        key = self._read_default_managed_key()
+        if key:
+            return ActiveCredentials(key, False)
+        return ActiveCredentials("", keychain_failed)
+
+    def _read_default_managed_key(self) -> str:
+        """Read the managed key from the default profile only."""
+        if self._use_keychain():
+            try:
+                val = self._kc_call(
+                    macos_keychain.get_password,
+                    CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
+                    macos_keychain.keychain_account_name(),
+                )
+            except macos_keychain.KEYCHAIN_ERRORS as e:
+                self._host._logger.warning(f"Managed-key Keychain read failed: {e}")
+                val = None
+            if val:
+                return val
+        path = get_default_global_config_path()
+        if not path.exists():
+            return ""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            self._host._logger.warning(f"Failed to read global config: {e}")
+            return ""
+        key = data.get("primaryApiKey") if isinstance(data, dict) else None
+        return key if isinstance(key, str) and key else ""
 
     def _read_managed_key(self) -> str:
         """Read the active managed API key, or "" when absent. Non-mutating.

--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -82,6 +82,11 @@ def get_credentials_path() -> Path:
     return get_claude_config_home() / ".credentials.json"
 
 
+def get_default_credentials_path() -> Path:
+    """Return the default profile credential path, ignoring config overrides."""
+    return get_default_claude_config_home() / ".credentials.json"
+
+
 def get_legacy_backup_root() -> Path:
     """Return the legacy (pre-XDG) backup root: ``~/.claude-swap-backup``."""
     return Path.home() / LEGACY_BACKUP_DIRNAME

--- a/src/claude_swap/recovery.py
+++ b/src/claude_swap/recovery.py
@@ -53,14 +53,17 @@ CANARY_TIMEOUT_S = 60.0
 CANARY_TERMINATE_GRACE_S = 2.0
 
 # Only process-launch essentials cross the boundary. In particular, proxy,
-# provider, model, and auth variables do not reach the canary.
+# provider, model, and auth variables do not reach the canary. USER and LOGNAME
+# are load-bearing inputs to Claude's macOS Keychain account lookup.
 _POSIX_ENV_ALLOWLIST = frozenset({
     "HOME",
     "PATH",
     "LANG",
     "LC_ALL",
     "LC_CTYPE",
+    "LOGNAME",
     "TMPDIR",
+    "USER",
 })
 _WINDOWS_ENV_ALLOWLIST = frozenset({
     "APPDATA",

--- a/src/claude_swap/recovery.py
+++ b/src/claude_swap/recovery.py
@@ -1,0 +1,600 @@
+"""Explicit recovery for an expired credential owned by a live Claude profile.
+
+Recovery never rotates OAuth credentials itself. It asks Claude Code to make one
+small noninteractive request in the profile that already owns the token, then
+re-reads that profile. ``recovered`` means that same identity-matched owner now
+has a non-expired OAuth credential; normal list/status collection observes
+usage through its own claim protocol. Backups are intentionally absent from this
+module: a session profile may hold a newer refresh-token generation than its
+slot backup.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal, Protocol
+
+from claude_swap import oauth
+from claude_swap.credentials import ActiveCredentials, looks_like_api_key
+from claude_swap.json_output import SCHEMA_VERSION
+from claude_swap.locking import FileLock
+from claude_swap.paths import (
+    get_default_claude_config_home,
+    get_default_global_config_path,
+)
+from claude_swap.process_detection import get_running_instances
+from claude_swap.session import (
+    AUTH_OVERRIDE_ENV_VARS,
+    profile_is_quiescent,
+    read_session_identity,
+    read_session_owner_credentials,
+)
+
+RecoveryStatus = Literal[
+    "recovered",
+    "not_needed",
+    "retry_later",
+    "human_required",
+]
+
+CANARY_PROMPT = "Reply with exactly OK."
+CANARY_TIMEOUT_S = 60.0
+CANARY_TERMINATE_GRACE_S = 2.0
+
+# Only process-launch essentials cross the boundary. In particular, proxy,
+# provider, model, and auth variables do not reach the canary.
+_POSIX_ENV_ALLOWLIST = frozenset({
+    "HOME",
+    "PATH",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TMPDIR",
+})
+_WINDOWS_ENV_ALLOWLIST = frozenset({
+    "APPDATA",
+    "COMSPEC",
+    "HOME",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "LOCALAPPDATA",
+    "PATH",
+    "PATHEXT",
+    "PROGRAMDATA",
+    "SYSTEMDRIVE",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "WINDIR",
+})
+
+
+class _UsageStore(Protocol):
+    def entries(self, identities: dict[str, tuple[str, str]], models=()): ...
+
+
+class _Switcher(Protocol):
+    backup_dir: Path
+    _usage_store: _UsageStore
+
+    def _account_kind(self, account_num: str | None) -> str: ...
+
+    def _get_sequence_data(self) -> dict | None: ...
+
+    def _read_default_profile_credentials(self) -> ActiveCredentials: ...
+
+
+@dataclass(frozen=True)
+class _Owner:
+    kind: Literal["default", "session"]
+    config_dir: Path | None
+
+
+@dataclass(frozen=True)
+class _OwnerSnapshot:
+    owner: _Owner
+    credential_fingerprint: str
+    credential_state: CredentialState
+
+
+CanaryStatus = Literal["exited", "timed_out", "start_failed"]
+CredentialState = Literal["expired", "not_needed", "human_required"]
+
+
+def _envelope(account_num: str, status: RecoveryStatus) -> dict:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "operation": "recover",
+        "accountNumber": int(account_num),
+        "recoveryStatus": status,
+    }
+
+
+def _read_default_identity() -> tuple[str, str] | None:
+    """Read the default profile identity without honoring config-dir overrides."""
+    try:
+        data = json.loads(get_default_global_config_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    account = data.get("oauthAccount")
+    if not isinstance(account, dict):
+        return None
+    email = account.get("emailAddress")
+    if not isinstance(email, str) or not email:
+        return None
+    org_uuid = account.get("organizationUuid") or ""
+    if not isinstance(org_uuid, str):
+        return None
+    return email, org_uuid
+
+
+def _same_identity(
+    actual: tuple[str, str] | None, email: str, org_uuid: str
+) -> bool:
+    return actual == (email, org_uuid or "")
+
+
+def _find_owner(
+    switcher: _Switcher,
+    account_num: str,
+    email: str,
+    org_uuid: str,
+) -> tuple[_Owner | None, RecoveryStatus | None]:
+    """Return the one live profile allowed to own recovery, failing closed."""
+    try:
+        default_sessions, default_ides = get_running_instances(
+            get_default_claude_config_home()
+        )
+        default_live = bool(default_sessions or default_ides)
+        default_identity = _read_default_identity()
+
+        # Keep path construction centralized with session mode, including its
+        # platform-safe email slug.
+        from claude_swap.session import session_dir_for
+
+        session_dir = session_dir_for(switcher.backup_dir, account_num, email)
+        # Not-quiescent, not "has live sessions": an unreadable session record
+        # is not evidence that nothing is running, and every branch below
+        # spends this answer on whether a canary may launch against the
+        # profile. Unknown has to read as occupied.
+        session_live = not profile_is_quiescent(session_dir)
+        session_identity = read_session_identity(session_dir) if session_live else None
+    except Exception:
+        return None, "retry_later"
+
+    # A live profile with unreadable identity cannot be safely attributed.
+    if default_live and default_identity is None:
+        return None, "human_required"
+    if session_live and not _same_identity(session_identity, email, org_uuid):
+        return None, "human_required"
+
+    candidates: list[_Owner] = []
+    if default_live and _same_identity(default_identity, email, org_uuid):
+        candidates.append(_Owner("default", None))
+    if session_live:
+        candidates.append(_Owner("session", session_dir))
+
+    if len(candidates) != 1:
+        return None, "human_required"
+
+    owner = candidates[0]
+    if owner.kind == "default":
+        # A default owner is valid only for the account currently named by the
+        # default profile; the equality above is deliberately strict on org.
+        return owner, None
+
+    # Session recovery is only for an inactive slot. If default identity is
+    # unreadable, inactivity cannot be proven; if it names the target, this is
+    # an active slot with the wrong owner shape.
+    if default_identity is None or _same_identity(default_identity, email, org_uuid):
+        return None, "human_required"
+    return owner, None
+
+
+def _read_owner_credentials(
+    switcher: _Switcher, owner: _Owner
+) -> ActiveCredentials:
+    if owner.kind == "default":
+        return switcher._read_default_profile_credentials()
+    assert owner.config_dir is not None
+    return read_session_owner_credentials(owner.config_dir)
+
+
+def _credential_state(
+    switcher: _Switcher, account_num: str, credentials: str
+) -> CredentialState:
+    """Classify local bytes without calling OAuth endpoints."""
+    if switcher._account_kind(account_num) == "api_key" or looks_like_api_key(
+        credentials
+    ):
+        return "human_required"
+    data = oauth.extract_oauth_data(credentials)
+    if not data:
+        return "human_required"
+    scopes = data.get("scopes")
+    if (
+        isinstance(scopes, list)
+        and {scope for scope in scopes if isinstance(scope, str)} == {"user:inference"}
+        and len(scopes) == 1
+    ):
+        return "human_required"
+    if not isinstance(data.get("refreshToken"), str) or not data.get("refreshToken"):
+        return "human_required"
+    if not isinstance(data.get("accessToken"), str) or not data.get("accessToken"):
+        return "human_required"
+    expires_at = data.get("expiresAt")
+    if isinstance(expires_at, bool) or not isinstance(expires_at, (int, float)):
+        return "human_required"
+    if not oauth.is_oauth_token_expired(expires_at):
+        return "not_needed"
+    return "expired"
+
+
+def _canary_environment(config_dir: Path | None) -> dict[str, str]:
+    allowlist = _WINDOWS_ENV_ALLOWLIST if sys.platform == "win32" else _POSIX_ENV_ALLOWLIST
+    env = {key: value for key, value in os.environ.items() if key in allowlist}
+    for key in AUTH_OVERRIDE_ENV_VARS:
+        env.pop(key, None)
+    # Absence selects the default profile. A session owner gets exactly its
+    # canonical cswap profile path.
+    if config_dir is None:
+        env.pop("CLAUDE_CONFIG_DIR", None)
+    else:
+        env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+    return env
+
+
+def _canary_argv(claude_bin: str) -> list[str]:
+    return [
+        claude_bin,
+        "-p",
+        CANARY_PROMPT,
+        "--safe-mode",
+        "--no-session-persistence",
+        "--output-format",
+        "json",
+        "--max-turns",
+        "1",
+        "--tools",
+        "",
+        "--permission-mode",
+        "bypassPermissions",
+        "--model",
+        "haiku",
+        "--effort",
+        "low",
+    ]
+
+
+def _wait_quietly(process: subprocess.Popen, timeout: float) -> bool:
+    try:
+        process.wait(timeout=timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        return False
+    except Exception:
+        try:
+            return process.poll() is not None
+        except Exception:
+            return False
+
+
+def _terminate_posix_tree(process: subprocess.Popen) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (OSError, ValueError):
+        try:
+            process.terminate()
+        except OSError:
+            pass
+    if _wait_quietly(process, CANARY_TERMINATE_GRACE_S):
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (OSError, ValueError):
+        try:
+            process.kill()
+        except OSError:
+            pass
+    _wait_quietly(process, CANARY_TERMINATE_GRACE_S)
+
+
+def _taskkill_tree(pid: int, *, force: bool) -> None:
+    argv = ["taskkill", "/PID", str(pid), "/T"]
+    if force:
+        argv.append("/F")
+    try:
+        subprocess.run(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=CANARY_TERMINATE_GRACE_S,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+def _terminate_windows_tree(process: subprocess.Popen) -> None:
+    try:
+        process.send_signal(signal.CTRL_BREAK_EVENT)
+    except (AttributeError, OSError, ValueError):
+        _taskkill_tree(process.pid, force=False)
+    if _wait_quietly(process, CANARY_TERMINATE_GRACE_S):
+        return
+    _taskkill_tree(process.pid, force=True)
+    if not _wait_quietly(process, CANARY_TERMINATE_GRACE_S):
+        try:
+            process.kill()
+        except OSError:
+            pass
+        _wait_quietly(process, CANARY_TERMINATE_GRACE_S)
+
+
+def _terminate_process_tree(process: subprocess.Popen) -> None:
+    if sys.platform == "win32":
+        _terminate_windows_tree(process)
+    else:
+        _terminate_posix_tree(process)
+
+
+class _CanarySignal(BaseException):
+    def __init__(self, signum: int):
+        self.signum = signum
+
+
+def _can_install_canary_signal_guard() -> bool:
+    return (
+        sys.platform != "win32"
+        and hasattr(signal, "SIGTERM")
+        and threading.current_thread() is threading.main_thread()
+    )
+
+
+@contextmanager
+def _canary_signal_guard(cleanup: Callable[[], None]):
+    if not _can_install_canary_signal_guard():
+        yield
+        return
+
+    installed: dict[int, object] = {}
+    watched = [signal.SIGTERM]
+    if hasattr(signal, "SIGINT"):
+        watched.append(signal.SIGINT)
+
+    def handler(signum, _frame):
+        cleanup()
+        raise _CanarySignal(signum)
+
+    try:
+        for signum in watched:
+            installed[signum] = signal.getsignal(signum)
+            signal.signal(signum, handler)
+    except (AttributeError, OSError, RuntimeError, ValueError):
+        for signum, previous in installed.items():
+            signal.signal(signum, previous)
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        for signum, previous in installed.items():
+            signal.signal(signum, previous)
+
+
+def _propagate_canary_signal(exc: _CanarySignal) -> None:
+    if exc.signum == getattr(signal, "SIGINT", None):
+        raise KeyboardInterrupt
+    raise SystemExit(128 + exc.signum)
+
+
+def run_canary(config_dir: Path | None) -> CanaryStatus:
+    """Run the fixed Claude canary with no terminal and bounded tree cleanup."""
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        return "start_failed"
+
+    kwargs: dict = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+        "env": _canary_environment(config_dir),
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
+        )
+    else:
+        kwargs["start_new_session"] = True
+
+    process: subprocess.Popen | None = None
+    terminated = False
+
+    def cleanup_process() -> None:
+        nonlocal terminated
+        if terminated or process is None:
+            return
+        terminated = True
+        try:
+            if process.poll() is not None:
+                return
+        except Exception:
+            pass
+        _terminate_process_tree(process)
+
+    with tempfile.TemporaryDirectory(prefix="cswap-recover-") as cwd:
+        kwargs["cwd"] = cwd
+        try:
+            process = subprocess.Popen(_canary_argv(claude_bin), **kwargs)
+            with _canary_signal_guard(cleanup_process):
+                process.wait(timeout=CANARY_TIMEOUT_S)
+            return "exited"
+        except subprocess.TimeoutExpired:
+            cleanup_process()
+            return "timed_out"
+        except _CanarySignal as exc:
+            _propagate_canary_signal(exc)
+        except KeyboardInterrupt:
+            cleanup_process()
+            raise
+        except Exception:
+            cleanup_process()
+            return "start_failed"
+
+
+def _slot_still_matches(
+    switcher: _Switcher, account_num: str, email: str, org_uuid: str
+) -> bool:
+    data = switcher._get_sequence_data() or {}
+    account = data.get("accounts", {}).get(account_num)
+    return bool(
+        isinstance(account, dict)
+        and account.get("email") == email
+        and (account.get("organizationUuid") or "") == (org_uuid or "")
+    )
+
+
+def _owner_identity(owner: _Owner) -> tuple[str, str] | None:
+    if owner.kind == "default":
+        return _read_default_identity()
+    assert owner.config_dir is not None
+    return read_session_identity(owner.config_dir)
+
+
+def _credential_fingerprint(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _recovery_lock(switcher: _Switcher, account_num: str) -> FileLock:
+    """A nonblocking, per-slot command lock distinct from the state lock.
+
+    The lock file intentionally remains after release: deleting a flock path can
+    create a second inode for a waiter and break exclusion. It contains no
+    credential data and lives in claude-swap's private state directory.
+    """
+    lock_dir = switcher.backup_dir / "recovery-locks"
+    lock_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if sys.platform != "win32":
+        os.chmod(lock_dir, 0o700)
+    return FileLock(lock_dir / f"{account_num}.lock", timeout=0.0)
+
+
+def _snapshot_owner(
+    switcher: _Switcher,
+    account_num: str,
+    email: str,
+    org_uuid: str,
+) -> tuple[_OwnerSnapshot | None, RecoveryStatus | None]:
+    """Read exactly the owner state that must remain stable through launch."""
+    if not _slot_still_matches(switcher, account_num, email, org_uuid):
+        return None, "human_required"
+    owner, owner_status = _find_owner(switcher, account_num, email, org_uuid)
+    if owner is None:
+        return None, owner_status or "human_required"
+    if not _same_identity(_owner_identity(owner), email, org_uuid):
+        return None, "human_required"
+    credentials = _read_owner_credentials(switcher, owner)
+    if credentials.keychain_unavailable or credentials.value is None:
+        return None, "retry_later"
+    state = _credential_state(switcher, account_num, credentials.value)
+    return _OwnerSnapshot(owner, _credential_fingerprint(credentials.value), state), None
+
+
+def _recover(
+    switcher: _Switcher,
+    account_num: str,
+    email: str,
+    org_uuid: str,
+) -> RecoveryStatus:
+    identity = {account_num: (email, org_uuid or "")}
+    # Keep a known-dead credential out of Claude Code even if it is still in a
+    # live owner profile. This is a cache read only; recovery never observes or
+    # writes usage because that bypasses the collector's claim/fencing protocol.
+    if switcher._usage_store.entries(identity)[account_num].token_dead():
+        return "human_required"
+
+    before, status = _snapshot_owner(switcher, account_num, email, org_uuid)
+    if before is None:
+        return status or "human_required"
+    if before.credential_state != "expired":
+        return before.credential_state
+
+    # Re-read immediately before Popen. The command lock serializes recoveries
+    # for this stable slot, but it cannot lock Claude Code's /login or another
+    # external profile change. One after this final read is the narrow residual
+    # race; post-canary identity verification below remains mandatory.
+    launch, status = _snapshot_owner(switcher, account_num, email, org_uuid)
+    if launch is None:
+        return status or "human_required"
+    if launch.owner != before.owner:
+        return "human_required"
+    if (
+        launch.credential_fingerprint != before.credential_fingerprint
+        or launch.credential_state != before.credential_state
+    ):
+        return (
+            "human_required"
+            if launch.credential_state == "human_required"
+            else "retry_later"
+        )
+
+    canary_status = run_canary(launch.owner.config_dir)
+    if canary_status == "start_failed":
+        return "retry_later"
+
+    # A canary may refresh before later timing out, so inspect after every
+    # launched process. ``recovered`` is credential/identity proof only; list
+    # and status perform the subsequent usage observation under their claims.
+    after, status = _snapshot_owner(switcher, account_num, email, org_uuid)
+    if after is None:
+        return status or "human_required"
+    if after.owner != launch.owner:
+        return "human_required"
+    if after.credential_state != "not_needed":
+        return "retry_later"
+    return "recovered"
+
+
+def recover_account(
+    switcher: _Switcher,
+    account_num: str,
+    email: str,
+    org_uuid: str,
+) -> dict:
+    """Recover one resolved slot and return the stable, PII-free envelope."""
+    if not account_num.isdigit() or int(account_num) <= 0:
+        raise ValueError("account number must be positive")
+    lock: FileLock | None = None
+    try:
+        lock = _recovery_lock(switcher, account_num)
+        if not lock.acquire():
+            status = "retry_later"
+        else:
+            if sys.platform != "win32":
+                os.chmod(lock.lock_path, 0o600)
+            status = _recover(switcher, account_num, email, org_uuid)
+    except KeyboardInterrupt:
+        raise
+    except Exception:
+        status = "retry_later"
+    finally:
+        if lock is not None:
+            lock.release()
+    return _envelope(account_num, status)

--- a/src/claude_swap/recovery.py
+++ b/src/claude_swap/recovery.py
@@ -87,6 +87,12 @@ _WINDOWS_ENV_ALLOWLIST = frozenset({
 class _UsageStore(Protocol):
     def entries(self, identities: dict[str, tuple[str, str]], models=()): ...
 
+    def clear_dead_token(
+        self,
+        nums: list[str],
+        identities: dict[str, tuple[str, str]],
+    ) -> None: ...
+
 
 class _Switcher(Protocol):
     backup_dir: Path
@@ -157,7 +163,11 @@ def _find_owner(
     email: str,
     org_uuid: str,
 ) -> tuple[_Owner | None, RecoveryStatus | None]:
-    """Return the one live profile allowed to own recovery, failing closed."""
+    """Return the one profile allowed to own recovery, failing closed.
+
+    A matching inactive session profile remains Claude-owned while idle; the
+    recovery canary itself becomes its bounded native credential owner.
+    """
     try:
         default_sessions, default_ides = get_running_instances(
             get_default_claude_config_home()
@@ -175,12 +185,17 @@ def _find_owner(
         # spends this answer on whether a canary may launch against the
         # profile. Unknown has to read as occupied.
         session_live = not profile_is_quiescent(session_dir)
-        session_identity = read_session_identity(session_dir) if session_live else None
+        session_present = session_live or session_dir.is_dir()
+        session_identity = (
+            read_session_identity(session_dir) if session_present else None
+        )
     except Exception:
         return None, "retry_later"
 
     # A live profile with unreadable identity cannot be safely attributed.
     if default_live and default_identity is None:
+        return None, "human_required"
+    if session_present and session_identity is None:
         return None, "human_required"
     if session_live and not _same_identity(session_identity, email, org_uuid):
         return None, "human_required"
@@ -188,7 +203,7 @@ def _find_owner(
     candidates: list[_Owner] = []
     if default_live and _same_identity(default_identity, email, org_uuid):
         candidates.append(_Owner("default", None))
-    if session_live:
+    if session_present and _same_identity(session_identity, email, org_uuid):
         candidates.append(_Owner("session", session_dir))
 
     if len(candidates) != 1:
@@ -527,16 +542,25 @@ def _recover(
     org_uuid: str,
 ) -> RecoveryStatus:
     identity = {account_num: (email, org_uuid or "")}
-    # Keep a known-dead credential out of Claude Code even if it is still in a
-    # live owner profile. This is a cache read only; recovery never observes or
-    # writes usage because that bypasses the collector's claim/fencing protocol.
-    if switcher._usage_store.entries(identity)[account_num].token_dead():
-        return "human_required"
+    token_dead = switcher._usage_store.entries(identity)[account_num].token_dead()
+    if token_dead:
+        # invalid_grant is recorded by the usage collector for the slot backup.
+        # Once a matching session profile exists, that backup can be a consumed
+        # generation while the Claude-owned session lineage remains recoverable.
+        owner, owner_status = _find_owner(
+            switcher, account_num, email, org_uuid
+        )
+        if owner is None:
+            return owner_status or "human_required"
+        if owner.kind != "session":
+            return "human_required"
 
     before, status = _snapshot_owner(switcher, account_num, email, org_uuid)
     if before is None:
         return status or "human_required"
     if before.credential_state != "expired":
+        if token_dead and before.credential_state == "not_needed":
+            switcher._usage_store.clear_dead_token([account_num], identity)
         return before.credential_state
 
     # Re-read immediately before Popen. The command lock serializes recoveries
@@ -572,6 +596,10 @@ def _recover(
         return "human_required"
     if after.credential_state != "not_needed":
         return "retry_later"
+    if token_dead:
+        # This clears only backup-derived failure/quarantine state. The fresh
+        # usage observation remains collector-owned and follows its claim path.
+        switcher._usage_store.clear_dead_token([account_num], identity)
     return "recovered"
 
 

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -50,6 +50,7 @@ from typing import TYPE_CHECKING, NoReturn
 
 from claude_swap import macos_keychain
 from claude_swap.claude_locks import proper_lockfile
+from claude_swap.credentials import ActiveCredentials
 from claude_swap.exceptions import (
     ClaudeCodeLockTimeout,
     CredentialReadError,
@@ -57,6 +58,7 @@ from claude_swap.exceptions import (
 )
 from claude_swap.fsutil import replace_with_retry
 from claude_swap.locking import FileLock
+from claude_swap.macos_keychain import KeychainError
 from claude_swap.models import Platform
 from claude_swap.paths import get_default_global_config_path
 from claude_swap.printer import accent, dimmed, muted, warning
@@ -267,6 +269,33 @@ def delete_macos_keychain_entry(session_dir: Path) -> None:
         )
     except macos_keychain.KEYCHAIN_ERRORS:
         pass  # best-effort; absent entry is already success (rc 44)
+
+
+def read_session_owner_credentials(session_dir: Path) -> ActiveCredentials:
+    """Read a session owner's credential without stale Keychain fallback.
+
+    A missing macOS Keychain item may legitimately mean Claude has not migrated
+    the plaintext seed yet, so the profile file remains valid. A Keychain read
+    failure is different: falling back then could select a consumed seed hidden
+    behind an unreadable newer Keychain generation. Recovery uses this strict
+    result to retry instead.
+    """
+    if not session_dir.is_dir():
+        return ActiveCredentials("", False)
+    if Platform.detect() == Platform.MACOS:
+        try:
+            creds = macos_keychain.get_password(
+                keychain_service_name(session_dir), _keychain_account_name()
+            )
+            if creds:
+                return ActiveCredentials(creds, False)
+        except KeychainError:
+            return ActiveCredentials(None, True)
+    try:
+        value = (session_dir / ".credentials.json").read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return ActiveCredentials("", False)
+    return ActiveCredentials(value, False)
 
 
 def read_session_credentials(session_dir: Path) -> str | None:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -621,6 +621,9 @@ class ClaudeAccountSwitcher:
     def _read_active_credentials(self) -> ActiveCredentials:
         return self._store._read_active_credentials()
 
+    def _read_default_profile_credentials(self) -> ActiveCredentials:
+        return self._store._read_default_profile_credentials()
+
     def _refuse_degraded_capture(self) -> str | None:
         """Refuse to CAPTURE bytes a degraded read produced.
 
@@ -939,6 +942,13 @@ class ClaudeAccountSwitcher:
             os.chmod(config_file, 0o600)
 
     # -- public accessors for session mode (claude_swap.session) ---------
+
+    def recover(self, identifier: str) -> dict:
+        """Ask the credential-owning Claude profile to refresh an expired token."""
+        from claude_swap.recovery import recover_account
+
+        account_num, email, org_uuid = self.resolve_account(identifier)
+        return recover_account(self, account_num, email, org_uuid)
 
     def resolve_account(self, identifier: str) -> tuple[str, str, str]:
         """Resolve NUM|EMAIL to (account_num, email, organizationUuid).

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -4515,6 +4515,7 @@ class ClaudeAccountSwitcher:
 
         from claude_swap.session import (
             read_session_credentials,
+            read_session_identity,
             session_identity_drifted,
         )
 
@@ -4555,16 +4556,19 @@ class ClaudeAccountSwitcher:
                         error=outcome.error,
                         retry_after_s=outcome.retry_after_s,
                     )
-                if has_live_session:
-                    # The live claude refreshes lazily on its next API call;
-                    # requesting now would just 401 (same rule as the owned
-                    # active account in _fetch_active_usage).
+                # A provably matching profile remains the credential owner
+                # while idle. Its expired access token needs Claude's native
+                # refresh; falling back to the backup can test a consumed
+                # generation and falsely quarantine the whole account. A live
+                # process already proves profile ownership; an idle profile
+                # must carry exact identity plus refresh material.
+                if session_oauth.get("refreshToken") and (
+                    has_live_session
+                    or read_session_identity(session_dir)
+                    == (email, org_uuid or "")
+                ):
                     return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
-                # Expired profile credential and no live session: fall through
-                # to the backup path — cswap must not rotate the profile's
-                # family, but a backup family that is still alive (e.g. the
-                # account was re-added after the profile last ran) can serve
-                # and heal via the normal refresh machinery below.
+                session_creds = None
 
         outcome = oauth.try_fetch_usage_for_account(
             str(num), email, creds,
@@ -4646,7 +4650,7 @@ class ClaudeAccountSwitcher:
             entry = entries[num]
             _i = info_by_num[num]
             if self._entry_token_dead(entry, num, _i[1], _i[5], _i[4]):
-                sentinels[num] = USAGE_RELOGIN_REQUIRED
+                sentinels[num] = self._dead_lineage_sentinel(num, _i)
             elif entry.auth_dead_strikes and entry.token_dead():
                 # Struck, but no stored source still matches the condemned
                 # generation — the fingerprint healed the verdict.
@@ -4823,6 +4827,41 @@ class ClaudeAccountSwitcher:
         return bool(backup) and entry.token_dead(
             stored_fp=oauth.credential_fingerprint(backup)
         )
+
+    def _dead_lineage_sentinel(self, num: str, info: tuple) -> str:
+        """Name the quarantine a dead stored lineage actually earns.
+
+        A matching session profile supersedes the backup: an ``invalid_grant``
+        recorded from that consumed backup generation says nothing about the
+        owner-held session lineage. When an idle slot's session profile still
+        holds this account's identity and an expired-but-refreshable OAuth
+        credential, surface it as recoverable (``cswap recover``) rather than
+        falsely demanding a browser re-login.
+
+        The ACTIVE slot is excluded: its live credential is the one the strike
+        was bound against, so there is no second lineage to appeal to.
+        """
+        from claude_swap.session import (
+            read_session_credentials,
+            read_session_identity,
+        )
+
+        account_num, email, _org_name, org_uuid, is_active, _creds, _alias = info
+        if is_active:
+            return USAGE_RELOGIN_REQUIRED
+        session_dir = self._session_dir(str(account_num), email)
+        session_oauth = oauth.extract_oauth_data(
+            read_session_credentials(session_dir) or ""
+        )
+        if (
+            session_oauth
+            and session_oauth.get("accessToken")
+            and session_oauth.get("refreshToken")
+            and read_session_identity(session_dir) == (email, org_uuid or "")
+            and oauth.is_oauth_token_expired(session_oauth.get("expiresAt"))
+        ):
+            return USAGE_TOKEN_EXPIRED
+        return USAGE_RELOGIN_REQUIRED
 
     def _plans_after_fetch(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,7 @@ class TestCLI:
         assert "switch <num|email>" in result.stdout
         assert "list " in result.stdout
         assert "status " in result.stdout
+        assert "recover <num|email> --json" in result.stdout
         # The legacy `--flag` spellings still work but are hidden from the
         # options section; only the "keep working" note may mention them.
         options_section = result.stdout.split("Flags combine with subcommands:")[0]
@@ -774,6 +775,73 @@ class TestSubcommandAliases:
         assert "Multi-Account Switcher" in result.stdout
         assert "Commands:" in result.stdout
         assert "keep working" in result.stdout
+
+
+class TestRecoverCommand:
+    def test_dispatches_and_serializes_one_json_object(self, capsys):
+        payload = {
+            "schemaVersion": 1,
+            "operation": "recover",
+            "accountNumber": 2,
+            "recoveryStatus": "recovered",
+        }
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "recover", "2", "--json"]), \
+             patch("os.geteuid", return_value=1000, create=True):
+            switcher_cls.return_value.recover.return_value = payload
+            cli.main()
+
+        switcher_cls.return_value.recover.assert_called_once_with("2")
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_json_flag_is_required(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "recover", "2"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+        assert "--json" in capsys.readouterr().err
+
+    def test_malformed_json_invocation_still_emits_one_object(self, capsys):
+        with patch.object(
+            sys,
+            "argv",
+            ["claude-swap", "recover", "2", "--json", "--unknown"],
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == {
+            "schemaVersion": 1,
+            "error": {
+                "type": "RecoveryError",
+                "message": "Recovery could not be started.",
+            },
+        }
+
+    def test_handled_failure_is_parseable_and_does_not_echo_pii(self, capsys):
+        from claude_swap.exceptions import ConfigError
+
+        private = "private-user@example.com"
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(
+                 sys, "argv", ["claude-swap", "recover", private, "--json"]
+             ), \
+             patch("os.geteuid", return_value=1000, create=True):
+            switcher_cls.return_value.recover.side_effect = ConfigError(
+                f"owner {private} at /private/path failed"
+            )
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["error"]["type"] == "RecoveryError"
+        assert payload["error"]["message"] == "Recovery could not be started."
+        assert private not in out
+        assert "/private/path" not in out
 
 
 class TestJsonOutputCli:

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -39,12 +39,17 @@ def credentials(*, expired: bool, refresh: bool = True, scopes=None) -> str:
 class FakeStore:
     def __init__(self, *, dead: bool = False):
         self.dead = dead
+        self.cleared: list[tuple[list[str], dict]] = []
 
     def entries(self, identities, models=()):
         return {
             num: SimpleNamespace(token_dead=lambda: self.dead)
             for num in identities
         }
+
+    def clear_dead_token(self, nums, identities):
+        self.dead = False
+        self.cleared.append((list(nums), identities))
 
 
 class FakeSwitcher:
@@ -162,8 +167,6 @@ class TestOwnerSelection:
         )
         assert status is None
 
-<<<<<<< HEAD
-=======
     def test_idle_session_profile_can_own_bounded_recovery(self, monkeypatch):
         switcher = FakeSwitcher()
         session_dir = (
@@ -186,7 +189,6 @@ class TestOwnerSelection:
         assert owner == recovery._Owner("session", session_dir)
         assert status is None
 
->>>>>>> c915be4 (fixup! feat(auth): recover owner-held expired tokens)
     @pytest.mark.parametrize(
         ("default_identity", "default_live", "session_live", "session_identity"),
         [
@@ -526,18 +528,56 @@ class TestRecoverAccount:
         assert result["recoveryStatus"] == "not_needed"
         canary.assert_not_called()
 
-    def test_dead_token_quarantine_is_never_canaried(self, monkeypatch):
+    def test_dead_default_token_quarantine_is_never_canaried(self, monkeypatch):
         switcher = FakeSwitcher([credentials(expired=True)], dead=True)
-        owner = Mock()
+        default_owner(monkeypatch)
         canary = Mock()
-        monkeypatch.setattr(recovery, "_find_owner", owner)
         monkeypatch.setattr(recovery, "run_canary", canary)
 
         result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
 
         assert result["recoveryStatus"] == "human_required"
-        owner.assert_not_called()
         canary.assert_not_called()
+
+    def test_dead_token_owner_probe_preserves_retry_later(self, monkeypatch):
+        switcher = FakeSwitcher(dead=True)
+        monkeypatch.setattr(
+            recovery, "_find_owner", lambda *_args: (None, "retry_later")
+        )
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "retry_later"
+
+    def test_backup_dead_session_owner_recovers_and_clears_quarantine(
+        self, monkeypatch, tmp_path
+    ):
+        switcher = FakeSwitcher(dead=True)
+        owner = recovery._Owner("session", tmp_path / "session")
+        values = iter([
+            credentials(expired=True),
+            credentials(expired=True),
+            credentials(expired=False),
+        ])
+        monkeypatch.setattr(
+            recovery, "_find_owner", lambda *_args: (owner, None)
+        )
+        monkeypatch.setattr(
+            recovery, "read_session_identity", lambda _dir: (EMAIL, ORG)
+        )
+        monkeypatch.setattr(
+            recovery,
+            "read_session_owner_credentials",
+            lambda _dir: ActiveCredentials(next(values), False),
+        )
+        monkeypatch.setattr(recovery, "run_canary", lambda _dir: "exited")
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "recovered"
+        assert switcher._usage_store.cleared == [
+            ([ACCOUNT], {ACCOUNT: (EMAIL, ORG)})
+        ]
 
     def test_no_owner_is_human_required(self, monkeypatch):
         switcher = FakeSwitcher([credentials(expired=True)])

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -299,9 +299,14 @@ class TestCanary:
         assert "ANTHROPIC_BASE_URL" not in kwargs["env"]
         assert kwargs["env"]["HOME"] == str(tmp_path / "home")
         assert kwargs["env"]["PATH"] == "/sealed/bin"
-        assert kwargs["env"]["USER"] == "keychain-owner"
-        assert kwargs["env"]["LOGNAME"] == "keychain-owner"
-        assert set(kwargs["env"]) <= recovery._POSIX_ENV_ALLOWLIST
+        if recovery.sys.platform == "win32":
+            assert "USER" not in kwargs["env"]
+            assert "LOGNAME" not in kwargs["env"]
+            assert set(kwargs["env"]) <= recovery._WINDOWS_ENV_ALLOWLIST
+        else:
+            assert kwargs["env"]["USER"] == "keychain-owner"
+            assert kwargs["env"]["LOGNAME"] == "keychain-owner"
+            assert set(kwargs["env"]) <= recovery._POSIX_ENV_ALLOWLIST
         assert not Path(kwargs["cwd"]).exists()
 
     def test_session_env_sets_only_exact_profile(self, monkeypatch, tmp_path):

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,653 @@
+"""Focused tests for explicit owner-profile token recovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+
+from claude_swap import macos_keychain, oauth, recovery
+from claude_swap.credentials import ActiveCredentials, CredentialStore
+from claude_swap.macos_keychain import KeychainError
+from claude_swap.models import Platform
+
+EMAIL = "private@example.com"
+ORG = "org-private"
+ACCOUNT = "2"
+USAGE = {"five_hour": {"pct": 12.0}}
+
+
+def credentials(*, expired: bool, refresh: bool = True, scopes=None) -> str:
+    data = {
+        "accessToken": "access-private",
+        "expiresAt": 1 if expired else 9_000_000_000_000,
+    }
+    if refresh:
+        data["refreshToken"] = "refresh-private"
+    if scopes is not None:
+        data["scopes"] = scopes
+    return json.dumps({"claudeAiOauth": data})
+
+
+class FakeStore:
+    def __init__(self, *, dead: bool = False):
+        self.dead = dead
+
+    def entries(self, identities, models=()):
+        return {
+            num: SimpleNamespace(token_dead=lambda: self.dead)
+            for num in identities
+        }
+
+
+class FakeSwitcher:
+    def __init__(self, values: list[str] | None = None, *, dead: bool = False):
+        self.backup_dir = Path(tempfile.mkdtemp(prefix="cswap-recovery-"))
+        self._usage_store = FakeStore(dead=dead)
+        self.values = list(values or [])
+        self.kind = "oauth"
+        self.account_reads = 0
+
+    def _account_kind(self, account_num):
+        return self.kind
+
+    def _read_default_profile_credentials(self):
+        self.account_reads += 1
+        return ActiveCredentials(self.values.pop(0), False)
+
+    def _get_sequence_data(self):
+        return {
+            "accounts": {
+                ACCOUNT: {"email": EMAIL, "organizationUuid": ORG}
+            }
+        }
+
+    def _read_account_credentials(self, *_args):  # pragma: no cover - tripwire
+        raise AssertionError("recovery must never read a slot backup")
+
+
+def default_owner(monkeypatch):
+    owner = recovery._Owner("default", None)
+    monkeypatch.setattr(
+        recovery, "_find_owner", lambda *_args: (owner, None)
+    )
+    monkeypatch.setattr(recovery, "_read_default_identity", lambda: (EMAIL, ORG))
+    return owner
+
+
+class TestDefaultCredentialRead:
+    def test_ignores_inherited_session_config_dir(self, monkeypatch, tmp_path):
+        default_dir = tmp_path / ".claude"
+        session_dir = tmp_path / "session"
+        default_dir.mkdir()
+        session_dir.mkdir()
+        (default_dir / ".credentials.json").write_text("default-credentials")
+        (session_dir / ".credentials.json").write_text("session-credentials")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(session_dir))
+        host = SimpleNamespace(
+            platform=Platform.LINUX,
+            credentials_dir=tmp_path / "backups",
+            _logger=SimpleNamespace(error=lambda *_a: None, warning=lambda *_a: None),
+        )
+
+        result = CredentialStore(host)._read_default_profile_credentials()
+
+        assert result == ActiveCredentials("default-credentials", False)
+
+    def test_macos_keychain_failure_never_falls_back_to_default_seed(
+        self, monkeypatch, tmp_path
+    ):
+        default_dir = tmp_path / ".claude"
+        default_dir.mkdir()
+        (default_dir / ".credentials.json").write_text("stale-default-seed")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            macos_keychain,
+            "get_password",
+            Mock(side_effect=KeychainError("locked")),
+        )
+        monkeypatch.setattr("claude_swap.credentials._ACTIVE_READ_RETRY_DELAY", 0)
+        host = SimpleNamespace(
+            platform=Platform.MACOS,
+            credentials_dir=tmp_path / "backups",
+            _logger=SimpleNamespace(error=lambda *_a: None, warning=lambda *_a: None),
+        )
+
+        result = CredentialStore(host)._read_default_profile_credentials()
+
+        assert result == ActiveCredentials(None, True)
+
+
+class TestOwnerSelection:
+    def test_default_profile_owner_for_active_slot(self, monkeypatch):
+        switcher = FakeSwitcher()
+        monkeypatch.setattr(
+            recovery, "get_running_instances", lambda _dir: ([object()], [])
+        )
+        monkeypatch.setattr(recovery, "_read_default_identity", lambda: (EMAIL, ORG))
+        monkeypatch.setattr(recovery, "profile_is_quiescent", lambda _dir: True)
+
+        owner, status = recovery._find_owner(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert owner == recovery._Owner("default", None)
+        assert status is None
+
+    def test_session_profile_owner_for_inactive_slot(self, monkeypatch):
+        switcher = FakeSwitcher()
+        monkeypatch.setattr(
+            recovery, "get_running_instances", lambda _dir: ([object()], [])
+        )
+        monkeypatch.setattr(
+            recovery, "_read_default_identity", lambda: ("other@example.com", "")
+        )
+        monkeypatch.setattr(recovery, "profile_is_quiescent", lambda _dir: False)
+        monkeypatch.setattr(
+            recovery, "read_session_identity", lambda _dir: (EMAIL, ORG)
+        )
+
+        owner, status = recovery._find_owner(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert owner is not None and owner.kind == "session"
+        assert owner.config_dir == (
+            switcher.backup_dir / "sessions" / "2-private_example.com"
+        )
+        assert status is None
+
+<<<<<<< HEAD
+=======
+    def test_idle_session_profile_can_own_bounded_recovery(self, monkeypatch):
+        switcher = FakeSwitcher()
+        session_dir = (
+            switcher.backup_dir / "sessions" / "2-private_example.com"
+        )
+        session_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            recovery, "get_running_instances", lambda _dir: ([], [])
+        )
+        monkeypatch.setattr(
+            recovery, "_read_default_identity", lambda: ("other@example.com", "")
+        )
+        monkeypatch.setattr(recovery, "profile_is_quiescent", lambda _dir: True)
+        monkeypatch.setattr(
+            recovery, "read_session_identity", lambda _dir: (EMAIL, ORG)
+        )
+
+        owner, status = recovery._find_owner(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert owner == recovery._Owner("session", session_dir)
+        assert status is None
+
+>>>>>>> c915be4 (fixup! feat(auth): recover owner-held expired tokens)
+    @pytest.mark.parametrize(
+        ("default_identity", "default_live", "session_live", "session_identity"),
+        [
+            ((EMAIL, ORG), False, False, None),  # no owner
+            ((EMAIL, ORG), True, True, (EMAIL, ORG)),  # two owner profiles
+            (("other@example.com", ""), False, True, ("drift@example.com", ORG)),
+            (None, True, False, None),  # live default identity unreadable
+        ],
+    )
+    def test_zero_ambiguity_and_drift_fail_closed(
+        self,
+        monkeypatch,
+        default_identity,
+        default_live,
+        session_live,
+        session_identity,
+    ):
+        switcher = FakeSwitcher()
+        monkeypatch.setattr(
+            recovery,
+            "get_running_instances",
+            lambda _dir: ([object()] if default_live else [], []),
+        )
+        monkeypatch.setattr(
+            recovery, "_read_default_identity", lambda: default_identity
+        )
+        monkeypatch.setattr(
+            recovery,
+            "profile_is_quiescent",
+            lambda _dir: not session_live,
+        )
+        monkeypatch.setattr(
+            recovery, "read_session_identity", lambda _dir: session_identity
+        )
+
+        owner, status = recovery._find_owner(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert owner is None
+        assert status == "human_required"
+
+    def test_session_owner_requires_provably_inactive_slot(self, monkeypatch):
+        switcher = FakeSwitcher()
+        monkeypatch.setattr(recovery, "get_running_instances", lambda _dir: ([], []))
+        monkeypatch.setattr(recovery, "_read_default_identity", lambda: (EMAIL, ORG))
+        monkeypatch.setattr(recovery, "profile_is_quiescent", lambda _dir: False)
+        monkeypatch.setattr(
+            recovery, "read_session_identity", lambda _dir: (EMAIL, ORG)
+        )
+
+        assert recovery._find_owner(switcher, ACCOUNT, EMAIL, ORG) == (
+            None,
+            "human_required",
+        )
+
+
+class TestCanary:
+    class Process:
+        pid = 4321
+
+        def __init__(self):
+            self.wait_calls = []
+
+        def wait(self, timeout=None):
+            self.wait_calls.append(timeout)
+            return 0
+
+        def poll(self):
+            return 0
+
+    def test_exact_argv_default_env_and_neutral_cwd(self, monkeypatch, tmp_path):
+        seen = {}
+        process = self.Process()
+        monkeypatch.setattr(recovery.shutil, "which", lambda _name: "/bin/claude")
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("PATH", "/sealed/bin")
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/wrong/profile")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "secret")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://private.invalid")
+
+        def popen(argv, **kwargs):
+            seen["argv"] = argv
+            seen["kwargs"] = kwargs
+            assert Path(kwargs["cwd"]).is_dir()
+            return process
+
+        monkeypatch.setattr(recovery.subprocess, "Popen", popen)
+
+        assert recovery.run_canary(None) == "exited"
+        assert seen["argv"] == recovery._canary_argv("/bin/claude")
+        kwargs = seen["kwargs"]
+        assert kwargs["stdin"] is subprocess.DEVNULL
+        assert kwargs["stdout"] is subprocess.DEVNULL
+        assert kwargs["stderr"] is subprocess.DEVNULL
+        assert kwargs["start_new_session"] is True
+        assert "CLAUDE_CONFIG_DIR" not in kwargs["env"]
+        assert "ANTHROPIC_API_KEY" not in kwargs["env"]
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in kwargs["env"]
+        assert "ANTHROPIC_BASE_URL" not in kwargs["env"]
+        assert kwargs["env"]["HOME"] == str(tmp_path / "home")
+        assert kwargs["env"]["PATH"] == "/sealed/bin"
+        assert set(kwargs["env"]) <= recovery._POSIX_ENV_ALLOWLIST
+        assert not Path(kwargs["cwd"]).exists()
+
+    def test_session_env_sets_only_exact_profile(self, monkeypatch, tmp_path):
+        seen = {}
+        monkeypatch.setattr(recovery.shutil, "which", lambda _name: "/bin/claude")
+        monkeypatch.setattr(
+            recovery.subprocess,
+            "Popen",
+            lambda argv, **kwargs: seen.update(argv=argv, kwargs=kwargs) or self.Process(),
+        )
+        profile = tmp_path / "session-profile"
+
+        assert recovery.run_canary(profile) == "exited"
+        assert seen["kwargs"]["env"]["CLAUDE_CONFIG_DIR"] == str(profile)
+
+    def test_timeout_terms_then_kills_posix_group(self, monkeypatch):
+        class Hung(self.Process):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            def wait(self, timeout=None):
+                self.calls += 1
+                if self.calls < 3:
+                    raise subprocess.TimeoutExpired("claude", timeout)
+                return -signal.SIGKILL
+
+            def poll(self):
+                return None
+
+        process = Hung()
+        signals = []
+        monkeypatch.setattr(recovery.shutil, "which", lambda _name: "/bin/claude")
+        monkeypatch.setattr(recovery.subprocess, "Popen", lambda *_a, **_kw: process)
+        monkeypatch.setattr(
+            recovery.os, "killpg", lambda pid, sig: signals.append((pid, sig))
+        )
+
+        assert recovery.run_canary(None) == "timed_out"
+        assert signals == [(4321, signal.SIGTERM), (4321, signal.SIGKILL)]
+
+    def test_sigterm_cleans_tree_and_restores_handlers(self, monkeypatch):
+        class Running(self.Process):
+            def wait(self, timeout=None):
+                assert current[signal.SIGTERM] is not previous[signal.SIGTERM]
+                current[signal.SIGTERM](signal.SIGTERM, None)
+
+            def poll(self):
+                return None
+
+        process = Running()
+        cleaned = []
+        previous = {
+            signal.SIGTERM: signal.SIG_DFL,
+            signal.SIGINT: signal.default_int_handler,
+        }
+        current = dict(previous)
+
+        def install(signum, handler):
+            old = current[signum]
+            current[signum] = handler
+            return old
+
+        monkeypatch.setattr(recovery.shutil, "which", lambda _name: "/bin/claude")
+        monkeypatch.setattr(recovery.subprocess, "Popen", lambda *_a, **_kw: process)
+        monkeypatch.setattr(
+            recovery, "_terminate_process_tree", lambda proc: cleaned.append(proc.pid)
+        )
+        monkeypatch.setattr(recovery.signal, "getsignal", lambda signum: current[signum])
+        monkeypatch.setattr(recovery.signal, "signal", install)
+
+        with pytest.raises(SystemExit) as excinfo:
+            recovery.run_canary(None)
+
+        assert excinfo.value.code == 128 + signal.SIGTERM
+        assert cleaned == [4321]
+        assert current == previous
+
+    def test_sigint_cleans_tree_without_swallowing_keyboardinterrupt(self, monkeypatch):
+        class Running(self.Process):
+            def wait(self, timeout=None):
+                current[signal.SIGINT](signal.SIGINT, None)
+
+            def poll(self):
+                return None
+
+        process = Running()
+        cleaned = []
+        previous = {
+            signal.SIGTERM: signal.SIG_DFL,
+            signal.SIGINT: signal.default_int_handler,
+        }
+        current = dict(previous)
+
+        def install(signum, handler):
+            old = current[signum]
+            current[signum] = handler
+            return old
+
+        monkeypatch.setattr(recovery.shutil, "which", lambda _name: "/bin/claude")
+        monkeypatch.setattr(recovery.subprocess, "Popen", lambda *_a, **_kw: process)
+        monkeypatch.setattr(
+            recovery, "_terminate_process_tree", lambda proc: cleaned.append(proc.pid)
+        )
+        monkeypatch.setattr(recovery.signal, "getsignal", lambda signum: current[signum])
+        monkeypatch.setattr(recovery.signal, "signal", install)
+
+        with pytest.raises(KeyboardInterrupt):
+            recovery.run_canary(None)
+
+        assert cleaned == [4321]
+        assert current == previous
+
+    def test_non_main_thread_skips_signal_guard(self, monkeypatch):
+        signal_calls = []
+        monkeypatch.setattr(recovery.shutil, "which", lambda _name: "/bin/claude")
+        monkeypatch.setattr(
+            recovery.subprocess, "Popen", lambda *_a, **_kw: self.Process()
+        )
+        monkeypatch.setattr(recovery.threading, "main_thread", lambda: object())
+        monkeypatch.setattr(recovery.threading, "current_thread", lambda: object())
+        monkeypatch.setattr(
+            recovery.signal,
+            "signal",
+            lambda *args: signal_calls.append(args),
+        )
+
+        assert recovery.run_canary(None) == "exited"
+        assert signal_calls == []
+
+    def test_windows_cleanup_uses_taskkill_fallback(self, monkeypatch):
+        process = self.Process()
+        process.poll = lambda: None
+        process.send_signal = Mock(side_effect=OSError("no console"))
+        process.kill = Mock()
+        waits = iter([False, True])
+        taskkills = []
+        monkeypatch.setattr(recovery, "_wait_quietly", lambda *_a: next(waits))
+        monkeypatch.setattr(
+            recovery,
+            "_taskkill_tree",
+            lambda pid, force: taskkills.append((pid, force)),
+        )
+
+        recovery._terminate_windows_tree(process)
+
+        assert taskkills == [(4321, False), (4321, True)]
+        process.kill.assert_not_called()
+
+
+class TestRecoverAccount:
+    def test_rereads_owner_without_fetching_or_persisting_usage(self, monkeypatch):
+        switcher = FakeSwitcher(
+            [credentials(expired=True), credentials(expired=True), credentials(expired=False)]
+        )
+        default_owner(monkeypatch)
+        monkeypatch.setattr(recovery, "run_canary", lambda _dir: "exited")
+        usage_fetch = Mock(side_effect=AssertionError("recovery must not fetch usage"))
+        direct_refresh = Mock(side_effect=AssertionError("direct refresh forbidden"))
+        monkeypatch.setattr(oauth, "try_fetch_usage_for_account", usage_fetch)
+        monkeypatch.setattr(oauth, "try_refresh_oauth_credentials", direct_refresh)
+
+        payload = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert payload == {
+            "schemaVersion": 1,
+            "operation": "recover",
+            "accountNumber": 2,
+            "recoveryStatus": "recovered",
+        }
+        assert switcher.account_reads == 3
+        usage_fetch.assert_not_called()
+        direct_refresh.assert_not_called()
+
+    def test_session_owner_rereads_the_same_existing_profile(self, monkeypatch):
+        switcher = FakeSwitcher()
+        profile = Path("/sealed/cswap/sessions/2-private_example.com")
+        owner = recovery._Owner("session", profile)
+        reads = Mock(
+            side_effect=[
+                ActiveCredentials(credentials(expired=True), False),
+                ActiveCredentials(credentials(expired=True), False),
+                ActiveCredentials(credentials(expired=False), False),
+            ]
+        )
+        monkeypatch.setattr(recovery, "_find_owner", lambda *_args: (owner, None))
+        monkeypatch.setattr(recovery, "read_session_owner_credentials", reads)
+        monkeypatch.setattr(
+            recovery, "read_session_identity", lambda path: (EMAIL, ORG)
+        )
+        monkeypatch.setattr(recovery, "run_canary", lambda path: "exited")
+        usage_fetch = Mock(side_effect=AssertionError("recovery must not fetch usage"))
+        monkeypatch.setattr(oauth, "try_fetch_usage_for_account", usage_fetch)
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "recovered"
+        assert reads.call_args_list == [call(profile), call(profile), call(profile)]
+        usage_fetch.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("value", "kind"),
+        [
+            ("sk-ant-api-private", "api_key"),
+            (credentials(expired=True, refresh=False), "oauth"),
+            (credentials(expired=True, scopes=["user:inference"]), "oauth"),
+        ],
+    )
+    def test_api_key_no_refresh_and_setup_token_need_human(
+        self, monkeypatch, value, kind
+    ):
+        switcher = FakeSwitcher([value])
+        switcher.kind = kind
+        default_owner(monkeypatch)
+        canary = Mock()
+        monkeypatch.setattr(recovery, "run_canary", canary)
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "human_required"
+        canary.assert_not_called()
+
+    def test_fresh_token_is_not_needed(self, monkeypatch):
+        switcher = FakeSwitcher([credentials(expired=False)])
+        default_owner(monkeypatch)
+        canary = Mock()
+        monkeypatch.setattr(recovery, "run_canary", canary)
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "not_needed"
+        canary.assert_not_called()
+
+    def test_dead_token_quarantine_is_never_canaried(self, monkeypatch):
+        switcher = FakeSwitcher([credentials(expired=True)], dead=True)
+        owner = Mock()
+        canary = Mock()
+        monkeypatch.setattr(recovery, "_find_owner", owner)
+        monkeypatch.setattr(recovery, "run_canary", canary)
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "human_required"
+        owner.assert_not_called()
+        canary.assert_not_called()
+
+    def test_no_owner_is_human_required(self, monkeypatch):
+        switcher = FakeSwitcher([credentials(expired=True)])
+        monkeypatch.setattr(
+            recovery,
+            "_find_owner",
+            lambda *_args: (None, "human_required"),
+        )
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "human_required"
+        assert switcher.account_reads == 0
+
+    def test_canary_start_failure_is_retry_later(self, monkeypatch):
+        switcher = FakeSwitcher([credentials(expired=True), credentials(expired=True)])
+        default_owner(monkeypatch)
+        monkeypatch.setattr(recovery, "run_canary", lambda _dir: "start_failed")
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "retry_later"
+        assert switcher.account_reads == 2
+
+    def test_timeout_can_still_recover_if_profile_refreshed(self, monkeypatch):
+        switcher = FakeSwitcher(
+            [credentials(expired=True), credentials(expired=True), credentials(expired=False)]
+        )
+        default_owner(monkeypatch)
+        monkeypatch.setattr(recovery, "run_canary", lambda _dir: "timed_out")
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "recovered"
+
+    def test_post_canary_identity_mismatch_never_fetches_usage(self, monkeypatch):
+        switcher = FakeSwitcher(
+            [credentials(expired=True), credentials(expired=True)]
+        )
+        owner = recovery._Owner("default", None)
+        identities = iter([(EMAIL, ORG), (EMAIL, ORG), ("other@example.com", ORG)])
+        monkeypatch.setattr(recovery, "_find_owner", lambda *_args: (owner, None))
+        monkeypatch.setattr(recovery, "run_canary", lambda _dir: "exited")
+        monkeypatch.setattr(recovery, "_read_default_identity", lambda: next(identities))
+        fetch = Mock()
+        monkeypatch.setattr(oauth, "try_fetch_usage_for_account", fetch)
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "human_required"
+        fetch.assert_not_called()
+        assert switcher.account_reads == 2
+
+    def test_prelaunch_credential_change_skips_canary(self, monkeypatch):
+        changed = credentials(expired=True).replace("access-private", "access-new")
+        switcher = FakeSwitcher([credentials(expired=True), changed])
+        default_owner(monkeypatch)
+        canary = Mock()
+        monkeypatch.setattr(recovery, "run_canary", canary)
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "retry_later"
+        canary.assert_not_called()
+
+    def test_recovery_lock_contention_is_retry_later_and_released(self, monkeypatch):
+        switcher = FakeSwitcher()
+        lock = Mock()
+        lock.acquire.return_value = False
+        monkeypatch.setattr(recovery, "_recovery_lock", lambda *_args: lock)
+        owner = Mock()
+        monkeypatch.setattr(recovery, "_find_owner", owner)
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "retry_later"
+        owner.assert_not_called()
+        lock.release.assert_called_once_with()
+
+    def test_recovery_lock_is_per_slot_private_state(self):
+        switcher = FakeSwitcher()
+
+        lock = recovery._recovery_lock(switcher, ACCOUNT)
+
+        assert lock.lock_path == switcher.backup_dir / "recovery-locks" / "2.lock"
+        assert lock.lock_path.parent.is_dir()
+
+    def test_usage_failures_do_not_affect_credential_recovery(self, monkeypatch):
+        switcher = FakeSwitcher(
+            [credentials(expired=True), credentials(expired=True), credentials(expired=False)]
+        )
+        default_owner(monkeypatch)
+        monkeypatch.setattr(recovery, "run_canary", lambda _dir: "exited")
+        fetch = Mock(side_effect=AssertionError("recovery must not fetch usage"))
+        monkeypatch.setattr(oauth, "try_fetch_usage_for_account", fetch)
+
+        result = recovery.recover_account(switcher, ACCOUNT, EMAIL, ORG)
+
+        assert result["recoveryStatus"] == "recovered"
+        fetch.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "status", ["recovered", "not_needed", "retry_later", "human_required"]
+    )
+    def test_envelopes_are_finite_and_pii_free(self, status):
+        payload = recovery._envelope(ACCOUNT, status)
+        text = json.dumps(payload)
+
+        assert set(payload) == {
+            "schemaVersion",
+            "operation",
+            "accountNumber",
+            "recoveryStatus",
+        }
+        assert EMAIL not in text
+        assert "/sealed" not in text
+        assert "4321" not in text

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -262,6 +262,8 @@ class TestCanary:
         monkeypatch.setattr(recovery.shutil, "which", lambda _name: "/bin/claude")
         monkeypatch.setenv("HOME", str(tmp_path / "home"))
         monkeypatch.setenv("PATH", "/sealed/bin")
+        monkeypatch.setenv("USER", "keychain-owner")
+        monkeypatch.setenv("LOGNAME", "keychain-owner")
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/wrong/profile")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
         monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "secret")
@@ -288,6 +290,8 @@ class TestCanary:
         assert "ANTHROPIC_BASE_URL" not in kwargs["env"]
         assert kwargs["env"]["HOME"] == str(tmp_path / "home")
         assert kwargs["env"]["PATH"] == "/sealed/bin"
+        assert kwargs["env"]["USER"] == "keychain-owner"
+        assert kwargs["env"]["LOGNAME"] == "keychain-owner"
         assert set(kwargs["env"]) <= recovery._POSIX_ENV_ALLOWLIST
         assert not Path(kwargs["cwd"]).exists()
 

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -285,7 +285,14 @@ class TestCanary:
         assert kwargs["stdin"] is subprocess.DEVNULL
         assert kwargs["stdout"] is subprocess.DEVNULL
         assert kwargs["stderr"] is subprocess.DEVNULL
-        assert kwargs["start_new_session"] is True
+        if recovery.sys.platform == "win32":
+            assert kwargs["creationflags"] == getattr(
+                subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
+            )
+            assert "start_new_session" not in kwargs
+        else:
+            assert kwargs["start_new_session"] is True
+            assert "creationflags" not in kwargs
         assert "CLAUDE_CONFIG_DIR" not in kwargs["env"]
         assert "ANTHROPIC_API_KEY" not in kwargs["env"]
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in kwargs["env"]
@@ -310,6 +317,9 @@ class TestCanary:
         assert recovery.run_canary(profile) == "exited"
         assert seen["kwargs"]["env"]["CLAUDE_CONFIG_DIR"] == str(profile)
 
+    @pytest.mark.skipif(
+        recovery.sys.platform == "win32", reason="POSIX process-group signals"
+    )
     def test_timeout_terms_then_kills_posix_group(self, monkeypatch):
         class Hung(self.Process):
             def __init__(self):
@@ -336,6 +346,9 @@ class TestCanary:
         assert recovery.run_canary(None) == "timed_out"
         assert signals == [(4321, signal.SIGTERM), (4321, signal.SIGKILL)]
 
+    @pytest.mark.skipif(
+        recovery.sys.platform == "win32", reason="POSIX signal guard"
+    )
     def test_sigterm_cleans_tree_and_restores_handlers(self, monkeypatch):
         class Running(self.Process):
             def wait(self, timeout=None):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,6 +10,7 @@ import sys
 import unicodedata
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -2019,6 +2020,35 @@ class TestReadSessionCredentials:
         )
         creds = session_mod.read_session_credentials(session_dir)
         assert creds is not None and "sk-seed" in creds
+
+    def test_owner_read_allows_file_when_keychain_item_is_absent(
+        self, tmp_path, macos_platform
+    ):
+        session_dir = tmp_path / "sess"
+        session_dir.mkdir()
+        (session_dir / ".credentials.json").write_text("seed")
+
+        result = session_mod.read_session_owner_credentials(session_dir)
+
+        assert result.value == "seed"
+        assert result.keychain_unavailable is False
+
+    def test_owner_read_fails_closed_when_keychain_is_unreadable(
+        self, tmp_path, macos_platform, monkeypatch
+    ):
+        session_dir = tmp_path / "sess"
+        session_dir.mkdir()
+        (session_dir / ".credentials.json").write_text("stale-seed")
+        monkeypatch.setattr(
+            session_mod.macos_keychain,
+            "get_password",
+            Mock(side_effect=session_mod.KeychainError("locked")),
+        )
+
+        result = session_mod.read_session_owner_credentials(session_dir)
+
+        assert result.value is None
+        assert result.keychain_unavailable is True
 
 
 ACTIVE_TOKEN = "active-store-token"

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -787,10 +787,10 @@ class TestFetchAccountUsageSessionProfile:
         assert record.sentinel == USAGE_TOKEN_EXPIRED
         mock_fetch.assert_not_called()
 
-    def test_expired_session_credentials_without_live_session_falls_back(
+    def test_expired_session_credentials_without_live_session_remain_owned(
         self, temp_home: Path
     ):
-        """No live session: the backup path (with refresh machinery) still runs."""
+        """An idle profile still owns its lineage; never test a stale backup."""
         switcher = ClaudeAccountSwitcher()
         backup = _oauth_creds("sk-backup", 7200)
         session = _oauth_creds("sk-session", -60)
@@ -798,6 +798,26 @@ class TestFetchAccountUsageSessionProfile:
         with patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch("claude_swap.session.read_session_credentials",
                    return_value=session), \
+             patch("claude_swap.session.read_session_identity",
+                   return_value=("test@example.com", "org-uuid")), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_not_called()
+
+    def test_expired_session_without_refresh_token_falls_back(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+        session = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-session", "expiresAt": 1,
+        }})
+
+        with patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.session.read_session_identity",
+                   return_value=("test@example.com", "org-uuid")), \
              patch("claude_swap.oauth.try_fetch_usage_for_account",
                    return_value=oauth.UsageOutcome({"five_hour": {"pct": 9}})) as mock_fetch:
             record = switcher._fetch_account_usage(self._info(backup))
@@ -3914,6 +3934,48 @@ class TestDeadTokenQuarantine:
 
         assert entries["2"].sentinel == USAGE_RELOGIN_REQUIRED
         fetch.assert_not_called()  # quarantined: no endless 401/429 loop
+
+    def test_backup_dead_but_expired_session_owner_surfaces_token_expired(
+        self, temp_home
+    ):
+        from claude_swap.json_output import USAGE_TOKEN_EXPIRED
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        self._make_dead(switcher)
+        info = [(2, "test@example.com", "Org", "", False, self._dead_creds(), "")]
+        session = _oauth_creds("sk-session", -60)
+
+        with patch(
+            "claude_swap.session.read_session_credentials", return_value=session
+        ), patch(
+            "claude_swap.session.read_session_identity",
+            return_value=("test@example.com", ""),
+        ), patch.object(switcher, "_run_usage_fetches") as run:
+            entries = switcher._collect_usage_entries(info)
+
+        assert entries["2"].sentinel == USAGE_TOKEN_EXPIRED
+        run.assert_not_called()
+
+    def test_dead_backup_with_unreadable_session_identity_stays_relogin_required(
+        self, temp_home
+    ):
+        from claude_swap.json_output import USAGE_RELOGIN_REQUIRED
+
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        self._make_dead(switcher)
+        info = [(2, "test@example.com", "Org", "", False, self._dead_creds(), "")]
+        session = _oauth_creds("sk-session", -60)
+
+        with patch(
+            "claude_swap.session.read_session_credentials", return_value=session
+        ), patch(
+            "claude_swap.session.read_session_identity", return_value=None
+        ):
+            entries = switcher._collect_usage_entries(info)
+
+        assert entries["2"].sentinel == USAGE_RELOGIN_REQUIRED
 
     def test_relogin_surfaces_same_pass_on_invalid_grant(self, temp_home):
         # A fetch that returns invalid_grant crosses the dead threshold this pass;


### PR DESCRIPTION
## Summary

- add explicit `cswap recover <num|email> --json` for ordinary owner-held expired OAuth access tokens
- ask Claude Code in the exact live owner profile to perform its native synchronized refresh with one bounded, no-tools, non-persistent Haiku request
- re-read the same owner and require matching identity plus a non-expired OAuth credential before reporting recovery
- keep browser login, dead refresh-token lineages, API/setup tokens, profile drift, and ambiguous ownership human-only

Closes #165.

## Safety boundary

`list`, `status`, watch, auto, and the TUI remain read-oriented and never invoke recovery. The command does not directly rotate an owner-held refresh token, read a slot backup as owner truth, bootstrap a profile, or fetch/write usage outside the existing collector claim protocol.

Recovery is single-flight per slot and checks owner/profile/credential identity immediately before the request and again afterward. A manual `/login` after the final preflight is the residual external race; the post-run identity check detects drift. macOS Keychain failures fail closed instead of falling through to a potentially stale plaintext seed.

The canary runs with safe mode, no tools, no session persistence, one low-effort Haiku turn, sealed auth/provider environment, neutral cwd, ignored stdio, a hard deadline, and process-tree cleanup. It may be billable, so recovery is explicit and documented.

## JSON contract

```json
{"schemaVersion":1,"operation":"recover","accountNumber":2,"recoveryStatus":"recovered"}
```

`recoveryStatus` is one of `recovered`, `not_needed`, `retry_later`, or `human_required`. The payload contains no email, credential, path, PID, provider output, or exception text. `recovered` proves credential recovery only; callers continue to use normal `list --json` output as usage authority.

## Validation

- `uv run pytest tests/test_recovery.py tests/test_cli.py tests/test_session.py -q` — **275 passed**
- broad deterministic suite excluding the six known local macOS move/swap baseline failures — **1561 passed, 3 skipped, 6 deselected**
- full suite — **1561 passed, 3 skipped, 6 baseline failures**
- `python -m py_compile` — passed
- `git diff --check` — passed

No real account, credential, or Claude request is used by the tests.


## Follow-up

Also fixes #187: matching idle session profiles remain authoritative after access-token expiry, and stale backup `invalid_grant` can no longer falsely quarantine their newer lineage.
