### PR TITLE
feat(menubar): start at login via a launchd LaunchAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ cswap alias                     # List all aliases
 cswap move 2 1                  # Assign an account to a slot (relocates to an empty slot, swaps if taken)
 cswap tui                       # Interactive dashboard (also: bare `cswap`)
 cswap watch                     # Dashboard, opened on the live watch page
+cswap autostart on              # Start the macOS menu bar at login (bare: status; `off` to remove)
 cswap upgrade                   # Upgrade claude-swap to the latest version
 cswap purge                     # Remove all claude-swap data
 ```
@@ -249,6 +250,16 @@ cswap menubar
 ```
 
 Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
+
+`cswap menubar` runs in the foreground, so it stops when its terminal closes. *Settings → Start at login* keeps it around: it writes a launchd LaunchAgent (`~/Library/LaunchAgents/com.claude-swap.menubar.plist`) that starts the menu bar at every login and restarts it if it ever crashes — but never after you quit it from the menu. The same toggle is available headlessly, which is the easier route when setting up a second Mac over SSH:
+
+```bash
+cswap autostart          # on / off, and where the LaunchAgent lives
+cswap autostart on       # takes effect at the next login
+cswap autostart off
+```
+
+Reinstalling (`uv tool upgrade`, a move to another Python) relocates the executable the LaunchAgent points at; the menu bar re-points it on its next launch, so autostart survives updates.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ cswap unclaimed                 # List stashed credential entries (slot + why th
 cswap unclaimed --purge ID      # Drop one (deletes its bytes; recover with /login + `cswap add`)
 cswap tui                       # Interactive dashboard (also: bare `cswap`)
 cswap watch                     # Dashboard, opened on the live watch page
+cswap autostart on              # Start the macOS menu bar at login (bare: status; `off` to remove)
 cswap upgrade                   # Upgrade claude-swap to the latest version
 cswap purge                     # Remove all claude-swap data
 ```
@@ -245,6 +246,16 @@ cswap menubar
 ```
 
 Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
+
+`cswap menubar` runs in the foreground, so it stops when its terminal closes. *Settings → Start at login* keeps it around: it writes a launchd LaunchAgent (`~/Library/LaunchAgents/com.claude-swap.menubar.plist`) that starts the menu bar at every login and restarts it if it ever crashes — but never after you quit it from the menu. The same toggle is available headlessly, which is the easier route when setting up a second Mac over SSH:
+
+```bash
+cswap autostart          # on / off, and where the LaunchAgent lives
+cswap autostart on       # takes effect at the next login
+cswap autostart off
+```
+
+Reinstalling (`uv tool upgrade`, a move to another Python) relocates the executable the LaunchAgent points at; the menu bar re-points it on its next launch, so autostart survives updates.
 
 </details>
 

--- a/src/claude_swap/autostart.py
+++ b/src/claude_swap/autostart.py
@@ -1,0 +1,206 @@
+"""Login-item management for the macOS menu bar app ("Start at login").
+
+macOS runs per-user background jobs through launchd, so "start at login" is one
+LaunchAgent plist in ``~/Library/LaunchAgents``. launchd loads that directory on
+its own at every login, which is what lets both operations here stay minimal:
+
+- Enabling only *writes* the plist. It deliberately does not
+  ``launchctl bootstrap`` the job: the only ways to reach this are a menu bar
+  app that is already running, or a CLI call that shouldn't spawn a GUI, so
+  loading the job now would either duplicate the running app or start one
+  behind the user's back. The plist takes effect at the next login.
+- Disabling only *removes* it, and boots the job out when the caller isn't the
+  job itself (booting yourself out is suicide, and the running app should
+  survive the toggle). ``KeepAlive`` is scoped to non-zero exits, so a clean
+  Quit from the menu is never resurrected.
+
+The plist builder and the path helpers are pure, so the whole shape can be
+tested without touching the real LaunchAgents directory or launchd.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+from claude_swap.exceptions import ClaudeSwitchError
+
+LAUNCH_AGENT_LABEL = "com.claude-swap.menubar"
+
+# The agent inherits almost nothing from a login shell, so spell out the PATH it
+# needs: the tool's own bin dir (uv/pipx console scripts), Homebrew (where the
+# `claude` CLI usually lives), and the system defaults for `security`/`open`.
+_PATH_ENTRIES = (
+    "{home}/.local/bin",
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+)
+
+_LAUNCHCTL_TIMEOUT = 10  # seconds to wait on a `launchctl` subprocess
+# launchd won't relaunch a crashing job more than once per this many seconds —
+# a backstop against a busy-crash loop, unrelated to the subprocess timeout.
+_THROTTLE_INTERVAL = 10
+
+
+class AutostartError(ClaudeSwitchError):
+    """Raised when the login item can't be written or removed.
+
+    A ``ClaudeSwitchError`` so the CLI's existing handler renders it as a clean
+    error line (and a JSON error envelope under ``--json``) instead of a traceback.
+    """
+
+
+def launch_agent_path(home: Path | None = None) -> Path:
+    """Path of the menu bar's LaunchAgent plist."""
+    base = home if home is not None else Path.home()
+    return base / "Library" / "LaunchAgents" / f"{LAUNCH_AGENT_LABEL}.plist"
+
+
+def running_as_login_item() -> bool:
+    """True when this process was started by our own LaunchAgent.
+
+    launchd exports the job label as ``XPC_SERVICE_NAME``; a process started
+    from a shell has no such value (or a placeholder). Used to avoid booting
+    ourselves out when the login item is switched off from inside the app.
+    """
+    return os.environ.get("XPC_SERVICE_NAME") == LAUNCH_AGENT_LABEL
+
+
+def menubar_command(executable: str | Path | None = None) -> list[str]:
+    """Absolute command that relaunches the menu bar, for ``ProgramArguments``.
+
+    ``sys.executable`` is the interpreter of the install (uv tool, pipx, venv);
+    the ``claude-swap`` console script sits beside it. Prefer that script: it
+    survives interpreter upgrades within the environment and shows up under its
+    own name in Activity Monitor. Fall back to ``-m claude_swap`` for installs
+    that expose no console script (e.g. a bare checkout).
+    """
+    exe = Path(executable) if executable is not None else Path(sys.executable)
+    script = exe.parent / "claude-swap"
+    if script.exists():
+        return [str(script), "menubar"]
+    return [str(exe), "-m", "claude_swap", "menubar"]
+
+
+def build_agent_plist(
+    command: list[str],
+    *,
+    home: Path,
+    log_path: Path,
+) -> dict:
+    """The LaunchAgent definition, as a plist-ready dict.
+
+    ``KeepAlive`` is deliberately restricted to ``SuccessfulExit: False`` —
+    restart a crash, but respect the menu's Quit. ``ProcessType: Interactive``
+    keeps macOS from throttling a foreground-facing UI process.
+    """
+    return {
+        "Label": LAUNCH_AGENT_LABEL,
+        "ProgramArguments": list(command),
+        "RunAtLoad": True,
+        "KeepAlive": {"SuccessfulExit": False},
+        "ThrottleInterval": _THROTTLE_INTERVAL,
+        "ProcessType": "Interactive",
+        "WorkingDirectory": str(home),
+        "EnvironmentVariables": {
+            "PATH": ":".join(entry.format(home=home) for entry in _PATH_ENTRIES),
+            "HOME": str(home),
+        },
+        "StandardOutPath": str(log_path),
+        "StandardErrorPath": str(log_path),
+    }
+
+
+def is_enabled(path: Path | None = None) -> bool:
+    """True when the login item is installed."""
+    return (path if path is not None else launch_agent_path()).exists()
+
+
+def installed_command(path: Path | None = None) -> list[str] | None:
+    """``ProgramArguments`` of the installed login item, or None if absent/unreadable."""
+    target = path if path is not None else launch_agent_path()
+    try:
+        data = plistlib.loads(target.read_bytes())
+    except (OSError, plistlib.InvalidFileException, ValueError):
+        return None
+    args = data.get("ProgramArguments") if isinstance(data, dict) else None
+    return list(args) if isinstance(args, list) else None
+
+
+def is_stale(path: Path | None = None, *, executable: str | Path | None = None) -> bool:
+    """True when an installed login item points at a different executable.
+
+    A ``uv tool upgrade`` or a reinstall onto another Python can move the
+    console script, leaving a plist that launches nothing. Callers refresh the
+    plist rather than silently keeping a dead login item.
+    """
+    target = path if path is not None else launch_agent_path()
+    if not target.exists():
+        return False
+    return installed_command(target) != menubar_command(executable)
+
+
+def enable(
+    *,
+    log_path: Path,
+    home: Path | None = None,
+    path: Path | None = None,
+    executable: str | Path | None = None,
+) -> Path:
+    """Write (or refresh) the login item. Returns the plist path.
+
+    Writes atomically: an interrupted write must not leave launchd a truncated
+    plist to choke on at the next login.
+    """
+    base = home if home is not None else Path.home()
+    target = path if path is not None else launch_agent_path(base)
+    data = build_agent_plist(menubar_command(executable), home=base, log_path=log_path)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_name(target.name + ".tmp")
+        tmp.write_bytes(plistlib.dumps(data))
+        os.replace(tmp, target)
+    except OSError as exc:
+        raise AutostartError(f"Couldn't write the login item ({target}): {exc}") from exc
+    return target
+
+
+def disable(path: Path | None = None, *, uid: int | None = None) -> bool:
+    """Remove the login item. Returns False when it wasn't installed.
+
+    Also boots out an already-loaded job so the setting takes effect without a
+    logout — unless *this* process is that job, in which case booting out would
+    kill the app the user is still using.
+    """
+    target = path if path is not None else launch_agent_path()
+    existed = target.exists()
+    try:
+        target.unlink(missing_ok=True)
+    except OSError as exc:
+        raise AutostartError(f"Couldn't remove the login item ({target}): {exc}") from exc
+    if existed and not running_as_login_item():
+        _bootout(uid if uid is not None else os.getuid())
+    return existed
+
+
+def _bootout(uid: int) -> None:
+    """Unload the job from the current GUI session, ignoring "not loaded"."""
+    try:
+        subprocess.run(
+            ["/bin/launchctl", "bootout", f"gui/{uid}/{LAUNCH_AGENT_LABEL}"],
+            capture_output=True,
+            timeout=_LAUNCHCTL_TIMEOUT,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # Best-effort: the plist is already gone, so the next login is correct
+        # either way. Not worth failing the toggle over.
+        pass

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -66,6 +66,7 @@ _SUBCOMMAND_FLAGS = {
     "tui": "--tui",
     "watch": "--watch",
     "menubar": "--menubar",
+    "autostart": "--autostart",
 }
 
 
@@ -849,6 +850,57 @@ def _use_native_tls() -> None:
         pass
 
 
+def _autostart_command(mode: str, switcher, *, json_mode: bool) -> int:
+    """Handle `cswap autostart [on|off]` — the menu bar's login item.
+
+    Shares one implementation with the menu bar's "Start at login" toggle, so a
+    headless setup (over SSH, or from a provisioning script) produces exactly
+    the same LaunchAgent the GUI would write. Returns the process exit code.
+    """
+    from claude_swap import autostart
+
+    if sys.platform != "darwin":
+        error("Autostart is only available on macOS.")
+        return 1
+
+    path = autostart.launch_agent_path()
+    if mode == "on":
+        autostart.enable(log_path=switcher.backup_dir / "menubar-agent.log")
+    elif mode == "off":
+        if not autostart.disable(path):
+            if json_mode:
+                print(json.dumps({"enabled": False, "changed": False}, indent=2))
+            else:
+                print(muted("Autostart was not enabled."))
+            return 0
+
+    enabled = autostart.is_enabled(path)
+    if json_mode:
+        print(json.dumps(
+            {
+                "enabled": enabled,
+                "label": autostart.LAUNCH_AGENT_LABEL,
+                "path": str(path),
+                "command": autostart.installed_command(path),
+            },
+            indent=2,
+        ))
+        return 0
+
+    if not enabled:
+        print(f"Autostart: {bolded('off')}")
+        print(muted(f"Enable with: {_prog_name()} autostart on"))
+        return 0
+    print(f"Autostart: {bolded('on')}")
+    print(muted(f"  {path}"))
+    if mode == "on":
+        # launchd loads ~/Library/LaunchAgents at login; the plist is not
+        # bootstrapped now, so say plainly when it first takes effect.
+        print(muted("  Takes effect at the next login. Start it now with: "
+                    f"{_prog_name()} menubar"))
+    return 0
+
+
 def main() -> None:
     """Main entry point for the CLI."""
     force_utf8_output()
@@ -935,6 +987,7 @@ Commands:
   %(prog)s tui                        interactive dashboard (also: bare %(prog)s)
   %(prog)s watch                      dashboard, opened on the live watch page
   %(prog)s menubar                    macOS menu bar app
+  %(prog)s autostart [on|off]         start the menu bar at login (bare: status)
   %(prog)s upgrade                    self-upgrade to latest
   %(prog)s purge                      remove all claude-swap data
 
@@ -1118,6 +1171,14 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         help=argparse.SUPPRESS,
     )
     group.add_argument(
+        "--autostart",
+        metavar="on|off",
+        nargs="?",
+        const="status",
+        choices=("on", "off", "status"),
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
         "--upgrade",
         action="store_true",
         help=argparse.SUPPRESS,
@@ -1145,6 +1206,7 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         or args.tui
         or args.watch
         or args.menubar
+        or args.autostart is not None
         or args.upgrade
         or args.remove_account is not None
         or args.disable_account is not None
@@ -1159,8 +1221,13 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.token_status and not args.list:
         parser.error("--token-status can only be used with 'list'")
 
-    if args.json and not (args.list or args.status or args.switch or args.switch_to):
-        parser.error("--json can only be used with 'list', 'status', or 'switch'")
+    if args.json and not (
+        args.list or args.status or args.switch or args.switch_to
+        or args.autostart is not None
+    ):
+        parser.error(
+            "--json can only be used with 'list', 'status', 'switch', or 'autostart'"
+        )
 
     if args.json and args.token_status:
         # Token status is not part of the JSON v1 schema; reject rather than
@@ -1297,6 +1364,8 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             from claude_swap.menubar import run as menubar_run
 
             sys.exit(menubar_run(switcher))
+        elif args.autostart is not None:
+            sys.exit(_autostart_command(args.autostart, switcher, json_mode=args.json))
     except ClaudeSwitchError as e:
         # In JSON mode keep stdout pure JSON: emit the structured error envelope
         # there (exit 1) instead of a red stderr line.

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -66,6 +66,7 @@ _SUBCOMMAND_FLAGS = {
     "tui": "--tui",
     "watch": "--watch",
     "menubar": "--menubar",
+    "autostart": "--autostart",
 }
 
 
@@ -915,6 +916,57 @@ def _use_native_tls() -> None:
         pass
 
 
+def _autostart_command(mode: str, switcher, *, json_mode: bool) -> int:
+    """Handle `cswap autostart [on|off]` — the menu bar's login item.
+
+    Shares one implementation with the menu bar's "Start at login" toggle, so a
+    headless setup (over SSH, or from a provisioning script) produces exactly
+    the same LaunchAgent the GUI would write. Returns the process exit code.
+    """
+    from claude_swap import autostart
+
+    if sys.platform != "darwin":
+        error("Autostart is only available on macOS.")
+        return 1
+
+    path = autostart.launch_agent_path()
+    if mode == "on":
+        autostart.enable(log_path=switcher.backup_dir / "menubar-agent.log")
+    elif mode == "off":
+        if not autostart.disable(path):
+            if json_mode:
+                print(json.dumps({"enabled": False, "changed": False}, indent=2))
+            else:
+                print(muted("Autostart was not enabled."))
+            return 0
+
+    enabled = autostart.is_enabled(path)
+    if json_mode:
+        print(json.dumps(
+            {
+                "enabled": enabled,
+                "label": autostart.LAUNCH_AGENT_LABEL,
+                "path": str(path),
+                "command": autostart.installed_command(path),
+            },
+            indent=2,
+        ))
+        return 0
+
+    if not enabled:
+        print(f"Autostart: {bolded('off')}")
+        print(muted(f"Enable with: {_prog_name()} autostart on"))
+        return 0
+    print(f"Autostart: {bolded('on')}")
+    print(muted(f"  {path}"))
+    if mode == "on":
+        # launchd loads ~/Library/LaunchAgents at login; the plist is not
+        # bootstrapped now, so say plainly when it first takes effect.
+        print(muted("  Takes effect at the next login. Start it now with: "
+                    f"{_prog_name()} menubar"))
+    return 0
+
+
 def main() -> None:
     """Main entry point for the CLI."""
     force_utf8_output()
@@ -1005,6 +1057,7 @@ Commands:
   %(prog)s tui                        interactive dashboard (also: bare %(prog)s)
   %(prog)s watch                      dashboard, opened on the live watch page
   %(prog)s menubar                    macOS menu bar app
+  %(prog)s autostart [on|off]         start the menu bar at login (bare: status)
   %(prog)s upgrade                    self-upgrade to latest
   %(prog)s purge                      remove all claude-swap data
 
@@ -1189,6 +1242,14 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         help=argparse.SUPPRESS,
     )
     group.add_argument(
+        "--autostart",
+        metavar="on|off",
+        nargs="?",
+        const="status",
+        choices=("on", "off", "status"),
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
         "--upgrade",
         action="store_true",
         help=argparse.SUPPRESS,
@@ -1216,6 +1277,7 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         or args.tui
         or args.watch
         or args.menubar
+        or args.autostart is not None
         or args.upgrade
         or args.remove_account is not None
         or args.disable_account is not None
@@ -1230,8 +1292,13 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.token_status and not args.list:
         parser.error("--token-status can only be used with 'list'")
 
-    if args.json and not (args.list or args.status or args.switch or args.switch_to):
-        parser.error("--json can only be used with 'list', 'status', or 'switch'")
+    if args.json and not (
+        args.list or args.status or args.switch or args.switch_to
+        or args.autostart is not None
+    ):
+        parser.error(
+            "--json can only be used with 'list', 'status', 'switch', or 'autostart'"
+        )
 
     if args.json and args.token_status:
         # Token status is not part of the JSON v1 schema; reject rather than
@@ -1368,6 +1435,8 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             from claude_swap.menubar import run as menubar_run
 
             sys.exit(menubar_run(switcher))
+        elif args.autostart is not None:
+            sys.exit(_autostart_command(args.autostart, switcher, json_mode=args.json))
     except ClaudeSwitchError as e:
         # In JSON mode keep stdout pure JSON: emit the structured error envelope
         # there (exit 1) instead of a red stderr line.

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -27,7 +27,7 @@ from dataclasses import asdict, dataclass, fields
 from datetime import datetime, timezone
 from pathlib import Path
 
-from claude_swap import pace
+from claude_swap import autostart, pace
 from claude_swap.exceptions import ClaudeSwitchError, CredentialReadError
 from claude_swap.switcher import SENTINEL_NOTES
 
@@ -468,6 +468,18 @@ def run(switcher) -> int:
 
     settings_path = switcher.backup_dir / "menubar_settings.json"
     log_path = switcher.backup_dir / "claude-swap.log"
+    # launchd writes the login item's stdout/stderr here — kept apart from the
+    # switch log so a crash trace never interleaves with switch history.
+    agent_log_path = switcher.backup_dir / "menubar-agent.log"
+
+    # A reinstall (uv/pipx upgrade, a move to another Python) relocates the
+    # console script the login item launches, which would leave autostart
+    # silently dead. Re-point it on every launch instead.
+    if autostart.is_enabled() and autostart.is_stale():
+        try:
+            autostart.enable(log_path=agent_log_path)
+        except autostart.AutostartError as exc:
+            logging.getLogger("claude-swap").warning("Could not refresh login item: %s", exc)
 
     class MenuBarApp(rumps.App):
         def __init__(self):
@@ -776,6 +788,13 @@ def run(switcher) -> int:
                 threshold_menu.add(ch)
             menu.add(threshold_menu)
 
+            # App lifecycle, not a display preference — separated so the block
+            # above reads as "what the menu bar shows" and this as "when it runs".
+            menu.add(None)
+            login_item = rumps.MenuItem("Start at login", callback=self.on_toggle_login_item)
+            login_item.state = 1 if autostart.is_enabled() else 0
+            menu.add(login_item)
+
             return menu
 
         # ---- callbacks --------------------------------------------------------
@@ -927,6 +946,23 @@ def run(switcher) -> int:
                 self.refresh_timer.start()
                 self._save_and_rebuild()
             return cb
+
+        def on_toggle_login_item(self, _sender):
+            # State lives in the filesystem (the LaunchAgent plist), not in
+            # menubar_settings.json — launchd is the source of truth, and a
+            # settings copy could disagree with it after a manual edit.
+            try:
+                if autostart.is_enabled():
+                    autostart.disable()
+                    message = "The menu bar will no longer start at login."
+                else:
+                    autostart.enable(log_path=agent_log_path)
+                    message = "The menu bar will start automatically at the next login."
+            except autostart.AutostartError as e:
+                rumps.alert(title="claude-swap", message=str(e))
+                return
+            rumps.notification("claude-swap", "Start at login", message)
+            self.rebuild_menu()
 
         def on_toggle_autoswitch(self, _sender):
             self.settings.auto_switch_enabled = not self.settings.auto_switch_enabled

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -27,7 +27,7 @@ from dataclasses import asdict, dataclass, fields
 from datetime import datetime, timezone
 from pathlib import Path
 
-from claude_swap import pace
+from claude_swap import autostart, pace
 from claude_swap.exceptions import ClaudeSwitchError, CredentialReadError
 from claude_swap.switcher import SENTINEL_NOTES
 
@@ -468,6 +468,18 @@ def run(switcher) -> int:
 
     settings_path = switcher.backup_dir / "menubar_settings.json"
     log_path = switcher.backup_dir / "claude-swap.log"
+    # launchd writes the login item's stdout/stderr here — kept apart from the
+    # switch log so a crash trace never interleaves with switch history.
+    agent_log_path = switcher.backup_dir / "menubar-agent.log"
+
+    # A reinstall (uv/pipx upgrade, a move to another Python) relocates the
+    # console script the login item launches, which would leave autostart
+    # silently dead. Re-point it on every launch instead.
+    if autostart.is_enabled() and autostart.is_stale():
+        try:
+            autostart.enable(log_path=agent_log_path)
+        except autostart.AutostartError as exc:
+            logging.getLogger("claude-swap").warning("Could not refresh login item: %s", exc)
 
     class MenuBarApp(rumps.App):
         def __init__(self):
@@ -795,6 +807,13 @@ def run(switcher) -> int:
                 threshold_menu.add(ch)
             menu.add(threshold_menu)
 
+            # App lifecycle, not a display preference — separated so the block
+            # above reads as "what the menu bar shows" and this as "when it runs".
+            menu.add(None)
+            login_item = rumps.MenuItem("Start at login", callback=self.on_toggle_login_item)
+            login_item.state = 1 if autostart.is_enabled() else 0
+            menu.add(login_item)
+
             return menu
 
         # ---- callbacks --------------------------------------------------------
@@ -946,6 +965,23 @@ def run(switcher) -> int:
                 self.refresh_timer.start()
                 self._save_and_rebuild()
             return cb
+
+        def on_toggle_login_item(self, _sender):
+            # State lives in the filesystem (the LaunchAgent plist), not in
+            # menubar_settings.json — launchd is the source of truth, and a
+            # settings copy could disagree with it after a manual edit.
+            try:
+                if autostart.is_enabled():
+                    autostart.disable()
+                    message = "The menu bar will no longer start at login."
+                else:
+                    autostart.enable(log_path=agent_log_path)
+                    message = "The menu bar will start automatically at the next login."
+            except autostart.AutostartError as e:
+                rumps.alert(title="claude-swap", message=str(e))
+                return
+            rumps.notification("claude-swap", "Start at login", message)
+            self.rebuild_menu()
 
         def on_toggle_autoswitch(self, _sender):
             self.settings.auto_switch_enabled = not self.settings.auto_switch_enabled

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,240 @@
+"""Tests for the menu bar's login item (LaunchAgent) management.
+
+Everything here stays off the real ``~/Library/LaunchAgents`` and never shells
+out to launchd: the plist builder and path helpers are pure, and the one
+subprocess call (``launchctl bootout``) is asserted through a monkeypatched
+``subprocess.run``.
+"""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+import pytest
+
+from claude_swap import autostart
+from claude_swap.exceptions import ClaudeSwitchError
+
+
+@pytest.fixture
+def agent(tmp_path: Path) -> Path:
+    """An isolated LaunchAgent path under a fake home."""
+    return autostart.launch_agent_path(tmp_path)
+
+
+# --- paths & command resolution -----------------------------------------------
+
+def test_launch_agent_path_is_under_library_launchagents(tmp_path: Path):
+    path = autostart.launch_agent_path(tmp_path)
+    assert path == tmp_path / "Library" / "LaunchAgents" / "com.claude-swap.menubar.plist"
+
+
+def test_menubar_command_prefers_console_script(tmp_path: Path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "python").touch()
+    script = bindir / "claude-swap"
+    script.touch()
+
+    assert autostart.menubar_command(bindir / "python") == [str(script), "menubar"]
+
+
+def test_menubar_command_falls_back_to_module_invocation(tmp_path: Path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    python = bindir / "python"
+    python.touch()  # no console script beside it
+
+    assert autostart.menubar_command(python) == [str(python), "-m", "claude_swap", "menubar"]
+
+
+# --- plist shape ---------------------------------------------------------------
+
+def test_build_agent_plist_shape(tmp_path: Path):
+    data = autostart.build_agent_plist(
+        ["/opt/tools/claude-swap", "menubar"],
+        home=tmp_path,
+        log_path=tmp_path / "logs" / "menubar-agent.log",
+    )
+
+    assert data["Label"] == "com.claude-swap.menubar"
+    assert data["ProgramArguments"] == ["/opt/tools/claude-swap", "menubar"]
+    assert data["RunAtLoad"] is True
+    # Restart a crash, but never resurrect a deliberate Quit.
+    assert data["KeepAlive"] == {"SuccessfulExit": False}
+    assert data["StandardOutPath"] == str(tmp_path / "logs" / "menubar-agent.log")
+    assert data["StandardErrorPath"] == data["StandardOutPath"]
+
+
+def test_build_agent_plist_path_covers_tool_and_homebrew_bins(tmp_path: Path):
+    # A fixed POSIX home, not tmp_path: this plist is macOS-only, and a Windows
+    # tmp_path ("C:\\…") would both build a mixed path and split on its drive
+    # colon. The function's PATH is always ':'-joined macOS dirs.
+    home = Path("/Users/someone")
+    data = autostart.build_agent_plist(["/x/claude-swap", "menubar"],
+                                       home=home, log_path=home / "l.log")
+    entries = data["EnvironmentVariables"]["PATH"].split(":")
+
+    assert "/Users/someone/.local/bin" in entries  # uv/pipx console scripts
+    assert "/opt/homebrew/bin" in entries          # where `claude` usually lives
+    assert "/usr/bin" in entries                   # `security`, `open`
+    assert data["EnvironmentVariables"]["HOME"] == str(home)
+
+
+# --- enable / disable ----------------------------------------------------------
+
+def test_enable_writes_a_loadable_plist(tmp_path: Path, agent: Path):
+    written = autostart.enable(
+        log_path=tmp_path / "menubar-agent.log", home=tmp_path, path=agent,
+        executable=tmp_path / "bin" / "python",
+    )
+
+    assert written == agent
+    assert autostart.is_enabled(agent) is True
+    data = plistlib.loads(agent.read_bytes())  # parses => launchd can load it
+    assert data["Label"] == autostart.LAUNCH_AGENT_LABEL
+
+
+def test_enable_creates_missing_launchagents_dir(tmp_path: Path, agent: Path):
+    assert not agent.parent.exists()
+
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent)
+
+    assert agent.parent.is_dir()
+
+
+def test_enable_leaves_no_temp_file_behind(tmp_path: Path, agent: Path):
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent)
+
+    assert [p.name for p in agent.parent.iterdir()] == [agent.name]
+
+
+def test_enable_refreshes_an_existing_plist(tmp_path: Path, agent: Path):
+    agent.parent.mkdir(parents=True)
+    agent.write_bytes(plistlib.dumps({"Label": "stale", "ProgramArguments": ["/gone"]}))
+
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent)
+
+    assert autostart.installed_command(agent) != ["/gone"]
+
+
+def test_enable_raises_claude_switch_error_on_write_failure(tmp_path: Path):
+    blocked = tmp_path / "not-a-dir"
+    blocked.write_text("")  # a file where the LaunchAgents dir would go
+
+    with pytest.raises(ClaudeSwitchError):
+        autostart.enable(log_path=tmp_path / "l.log", home=tmp_path,
+                         path=blocked / "Library" / "agent.plist")
+
+
+def test_disable_removes_the_plist(tmp_path: Path, agent: Path, monkeypatch):
+    monkeypatch.setattr(autostart.subprocess, "run", lambda *a, **k: None)
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent)
+
+    assert autostart.disable(agent, uid=501) is True
+    assert autostart.is_enabled(agent) is False
+
+
+def test_disable_reports_when_nothing_was_installed(tmp_path: Path, agent: Path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(autostart.subprocess, "run", lambda *a, **k: calls.append(a))
+
+    assert autostart.disable(agent, uid=501) is False
+    assert calls == []  # nothing loaded => no launchctl call
+
+
+def test_disable_boots_out_when_not_running_as_the_login_item(
+    tmp_path: Path, agent: Path, monkeypatch
+):
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    calls = []
+    monkeypatch.setattr(autostart.subprocess, "run",
+                        lambda cmd, **k: calls.append(cmd))
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent)
+
+    autostart.disable(agent, uid=501)
+
+    assert calls == [["/bin/launchctl", "bootout", "gui/501/com.claude-swap.menubar"]]
+
+
+def test_disable_does_not_boot_out_itself(tmp_path: Path, agent: Path, monkeypatch):
+    # Toggling autostart off from inside the launchd-started app must not kill
+    # the app the user is still clicking in.
+    monkeypatch.setenv("XPC_SERVICE_NAME", autostart.LAUNCH_AGENT_LABEL)
+    calls = []
+    monkeypatch.setattr(autostart.subprocess, "run", lambda cmd, **k: calls.append(cmd))
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent)
+
+    autostart.disable(agent, uid=501)
+
+    assert calls == []
+    assert autostart.is_enabled(agent) is False
+
+
+def test_bootout_survives_a_failing_launchctl(tmp_path: Path, agent: Path, monkeypatch):
+    def boom(*a, **k):
+        raise OSError("launchctl missing")
+
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    monkeypatch.setattr(autostart.subprocess, "run", boom)
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent)
+
+    assert autostart.disable(agent, uid=501) is True  # plist gone regardless
+
+
+# --- staleness -----------------------------------------------------------------
+
+def test_is_stale_false_for_a_freshly_written_item(tmp_path: Path, agent: Path):
+    exe = tmp_path / "bin" / "python"
+    exe.parent.mkdir(parents=True)
+    exe.touch()
+    (exe.parent / "claude-swap").touch()
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent, executable=exe)
+
+    assert autostart.is_stale(agent, executable=exe) is False
+
+
+def test_is_stale_true_after_the_executable_moves(tmp_path: Path, agent: Path):
+    old = tmp_path / "old" / "python"
+    old.parent.mkdir(parents=True)
+    old.touch()
+    (old.parent / "claude-swap").touch()
+    autostart.enable(log_path=tmp_path / "l.log", home=tmp_path, path=agent, executable=old)
+
+    new = tmp_path / "new" / "python"  # e.g. after `uv tool upgrade`
+    new.parent.mkdir(parents=True)
+    new.touch()
+    (new.parent / "claude-swap").touch()
+
+    assert autostart.is_stale(agent, executable=new) is True
+
+
+def test_is_stale_false_when_not_installed(tmp_path: Path, agent: Path):
+    assert autostart.is_stale(agent) is False
+
+
+def test_is_stale_true_for_a_corrupt_plist(tmp_path: Path, agent: Path):
+    agent.parent.mkdir(parents=True)
+    agent.write_text("not a plist")
+
+    # Unreadable reads as stale, so the next launch rewrites it.
+    assert autostart.is_stale(agent) is True
+    assert autostart.installed_command(agent) is None
+
+
+# --- login-item self-detection -------------------------------------------------
+
+@pytest.mark.parametrize("value,expected", [
+    (autostart.LAUNCH_AGENT_LABEL, True),
+    ("com.example.other", False),
+    ("0", False),
+])
+def test_running_as_login_item(monkeypatch, value, expected):
+    monkeypatch.setenv("XPC_SERVICE_NAME", value)
+    assert autostart.running_as_login_item() is expected
+
+
+def test_running_as_login_item_without_the_variable(monkeypatch):
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    assert autostart.running_as_login_item() is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1613,3 +1613,68 @@ def test_importing_the_module_allocates_no_temp_dir(tmp_path, tmp_path_factory):
     home = Path(_subprocess_env()["HOME"])
     assert home.is_dir(), f"the isolated HOME is not a real directory: {home}"
     assert home.is_relative_to(tmp_path_factory.getbasetemp()), f"{home} escapes basetemp"
+
+
+class TestAutostartCommand:
+    """`cswap autostart [on|off]` — the menu bar's login item, headlessly."""
+
+    def _run(self, argv, tmp_path, capsys, platform="darwin"):
+        agent = tmp_path / "Library" / "LaunchAgents" / "com.claude-swap.menubar.plist"
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch("claude_swap.autostart.launch_agent_path", return_value=agent), \
+             patch("claude_swap.autostart.subprocess.run"), \
+             patch.object(sys, "argv", ["claude-swap", *argv]), \
+             patch.object(cli.sys, "platform", platform), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            switcher_cls.return_value.backup_dir = tmp_path / "backup"
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        return excinfo.value.code, capsys.readouterr(), agent
+
+    def test_translate_subcommand(self):
+        assert cli._translate_subcommand(["autostart"]) == ["--autostart"]
+        assert cli._translate_subcommand(["autostart", "on"]) == ["--autostart", "on"]
+
+    def test_status_when_disabled(self, tmp_path, capsys):
+        code, out, agent = self._run(["autostart"], tmp_path, capsys)
+        assert code == 0
+        assert "off" in out.out
+        assert not agent.exists()
+
+    def test_on_writes_the_login_item(self, tmp_path, capsys):
+        code, out, agent = self._run(["autostart", "on"], tmp_path, capsys)
+        assert code == 0
+        assert agent.exists()
+        assert "next login" in out.out
+
+    def test_off_removes_it(self, tmp_path, capsys):
+        self._run(["autostart", "on"], tmp_path, capsys)
+        code, out, agent = self._run(["autostart", "off"], tmp_path, capsys)
+        assert code == 0
+        assert not agent.exists()
+
+    def test_off_when_never_enabled_is_not_an_error(self, tmp_path, capsys):
+        code, out, _ = self._run(["autostart", "off"], tmp_path, capsys)
+        assert code == 0
+        assert "not enabled" in out.out
+
+    def test_json_status(self, tmp_path, capsys):
+        self._run(["autostart", "on"], tmp_path, capsys)
+        code, out, _ = self._run(["autostart", "--json"], tmp_path, capsys)
+        payload = json.loads(out.out)
+        assert code == 0
+        assert payload["enabled"] is True
+        assert payload["label"] == "com.claude-swap.menubar"
+
+    def test_rejects_unknown_mode(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "autostart", "sometimes"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+
+    def test_refuses_on_non_macos(self, tmp_path, capsys):
+        code, out, agent = self._run(["autostart", "on"], tmp_path, capsys, platform="linux")
+        assert code == 1
+        assert "only available on macOS" in out.err
+        assert not agent.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1491,3 +1491,68 @@ class TestDisableEnableDispatch:
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
         assert excinfo.value.code == 2
+
+
+class TestAutostartCommand:
+    """`cswap autostart [on|off]` — the menu bar's login item, headlessly."""
+
+    def _run(self, argv, tmp_path, capsys, platform="darwin"):
+        agent = tmp_path / "Library" / "LaunchAgents" / "com.claude-swap.menubar.plist"
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch("claude_swap.autostart.launch_agent_path", return_value=agent), \
+             patch("claude_swap.autostart.subprocess.run"), \
+             patch.object(sys, "argv", ["claude-swap", *argv]), \
+             patch.object(cli.sys, "platform", platform), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            switcher_cls.return_value.backup_dir = tmp_path / "backup"
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        return excinfo.value.code, capsys.readouterr(), agent
+
+    def test_translate_subcommand(self):
+        assert cli._translate_subcommand(["autostart"]) == ["--autostart"]
+        assert cli._translate_subcommand(["autostart", "on"]) == ["--autostart", "on"]
+
+    def test_status_when_disabled(self, tmp_path, capsys):
+        code, out, agent = self._run(["autostart"], tmp_path, capsys)
+        assert code == 0
+        assert "off" in out.out
+        assert not agent.exists()
+
+    def test_on_writes_the_login_item(self, tmp_path, capsys):
+        code, out, agent = self._run(["autostart", "on"], tmp_path, capsys)
+        assert code == 0
+        assert agent.exists()
+        assert "next login" in out.out
+
+    def test_off_removes_it(self, tmp_path, capsys):
+        self._run(["autostart", "on"], tmp_path, capsys)
+        code, out, agent = self._run(["autostart", "off"], tmp_path, capsys)
+        assert code == 0
+        assert not agent.exists()
+
+    def test_off_when_never_enabled_is_not_an_error(self, tmp_path, capsys):
+        code, out, _ = self._run(["autostart", "off"], tmp_path, capsys)
+        assert code == 0
+        assert "not enabled" in out.out
+
+    def test_json_status(self, tmp_path, capsys):
+        self._run(["autostart", "on"], tmp_path, capsys)
+        code, out, _ = self._run(["autostart", "--json"], tmp_path, capsys)
+        payload = json.loads(out.out)
+        assert code == 0
+        assert payload["enabled"] is True
+        assert payload["label"] == "com.claude-swap.menubar"
+
+    def test_rejects_unknown_mode(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "autostart", "sometimes"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+
+    def test_refuses_on_non_macos(self, tmp_path, capsys):
+        code, out, agent = self._run(["autostart", "on"], tmp_path, capsys, platform="linux")
+        assert code == 1
+        assert "only available on macOS" in out.err
+        assert not agent.exists()


### PR DESCRIPTION
Closes #141.

`cswap menubar` blocks in the foreground, so the menu bar dies with its terminal and has to be relaunched by hand after every login. This adds a **Settings → Start at login** toggle, plus a headless `cswap autostart [on|off]` — setting up a second Mac over SSH shouldn't require hand-writing a plist.

```
cswap autostart          # on / off, and where the LaunchAgent lives
cswap autostart on       # takes effect at the next login
cswap autostart off
cswap autostart --json   # scriptable
```

Both paths share one implementation (`src/claude_swap/autostart.py`), so the GUI and the CLI can't drift.

### Design notes

- **Enabling only writes the plist**, deliberately not `launchctl bootstrap`. Both entry points are reached from a process that already *is* the menu bar (or a CLI call that shouldn't spawn a GUI), so loading the job now would start a second copy. launchd loads `~/Library/LaunchAgents` at login anyway.
- **Disabling only removes it**, and boots the job out *unless this process is that job* — toggling autostart off from inside the launchd-started app must not kill the app the user is still clicking in. Detected via `XPC_SERVICE_NAME`, which launchd sets to the job label.
- `KeepAlive` is scoped to `SuccessfulExit: false`: restart a crash, never resurrect a deliberate Quit from the menu.
- **Survives reinstalls.** A `uv tool upgrade` or a move to another Python relocates the console script, which would leave autostart silently dead; the menu bar re-points a stale plist on its next launch.
- **State lives in the plist, not `menubar_settings.json`** — launchd is the source of truth, and a settings copy could disagree with it after a manual edit.
- The agent gets an explicit `PATH` (tool bin dir, Homebrew, system) since it inherits nothing from a login shell — without it `claude` and `security` aren't found.

### Tests

31 new tests (`tests/test_autostart.py`, `TestAutostartCommand` in `tests/test_cli.py`). The plist builder and path helpers are pure, so nothing touches the real LaunchAgents directory or launchd; the single `launchctl` call is asserted through a patched `subprocess.run`.

Full suite: 1554 passed. The 6 failures in `test_swap_accounts.py` / `test_move_accounts.py` are pre-existing on `main` at c89e6f9 — I verified they fail identically without this branch applied.

### Verified on real hardware

Running on two Macs (macOS 15.2 and 26.5.1), one of them set up entirely over SSH via `cswap autostart on`. Worth noting for #141: the caveat at `menubar.py:882-889` about launchd blocking Keychain access did **not** reproduce on either machine — a `security find-generic-password -w` from inside a `gui/<uid>` LaunchAgent returned the credential normally. The one machine that did fail returned `rc=36` purely because its login keychain was locked, which is a different (and self-explanatory) condition.

### Relationship to #102

#102 also proposes a LaunchAgent (`--install-menubar`), bundled with an unrelated menu-detail change, and is currently conflicting. This differs in the parts that bite in practice: it sets `PATH`/`KeepAlive`/`ProcessType`, refuses to duplicate a running instance, won't boot itself out, self-heals after reinstalls, and exposes the toggle in the menu where users look for it. Happy to defer or merge ideas if you prefer that PR's direction.