### PR TITLE
feat(json): expose display-grade last-good usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ cswap switch 2 --json
 
 Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
 
-Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
+Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Once last-good data is too old to drive a decision, `usageStatus` remains `unavailable` and `usage` remains null, while additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
 
 An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
 

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -176,6 +176,22 @@ def usage_freshness_fields(
     return fields
 
 
+def last_good_usage_fields(
+    usage: dict | None, fetched_at: float | None, age_s: float | None
+) -> dict:
+    """Display-grade last-good usage, separate from decision-grade ``usage``."""
+    if not isinstance(usage, dict) or fetched_at is None:
+        return {}
+    freshness = usage_freshness_fields(fetched_at, age_s)
+    out = {
+        "lastGoodUsage": usage_to_json(usage, fetched_at),
+        "lastGoodFetchedAt": freshness["usageFetchedAt"],
+    }
+    if "usageAgeSeconds" in freshness:
+        out["lastGoodAgeSeconds"] = freshness["usageAgeSeconds"]
+    return out
+
+
 def account_row(
     number: int,
     email: str,
@@ -186,6 +202,7 @@ def account_row(
     *,
     usage_fetched_at: float | None = None,
     usage_age_s: float | None = None,
+    last_good_usage: dict | None = None,
     alias: str = "",
     disabled: bool = False,
 ) -> dict:
@@ -209,6 +226,12 @@ def account_row(
         row["disabled"] = True
     if usage is not None:
         row.update(usage_freshness_fields(usage_fetched_at, usage_age_s))
+    else:
+        row.update(
+            last_good_usage_fields(
+                last_good_usage, usage_fetched_at, usage_age_s
+            )
+        )
     return row
 
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -33,6 +33,7 @@ from claude_swap.json_output import (
     USAGE_TOKEN_EXPIRED,
     account_ref,
     account_row,
+    last_good_usage_fields,
     usage_fields,
     usage_freshness_fields,
 )
@@ -3214,6 +3215,7 @@ class ClaudeAccountSwitcher:
                     entry.decision_value(),
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
+                    last_good_usage=entry.last_good,
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, str(num)),
                 )
@@ -3395,6 +3397,12 @@ class ClaudeAccountSwitcher:
             active["alias"] = alias
         if usage is not None:
             active.update(usage_freshness_fields(entry.fetched_at, entry.age_s))
+        else:
+            active.update(
+                last_good_usage_fields(
+                    entry.last_good, entry.fetched_at, entry.age_s
+                )
+            )
         return {
             "schemaVersion": SCHEMA_VERSION,
             "active": active,

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -317,9 +317,13 @@ class TestListJson:
         if expected_status == "ok":
             assert row["usage"]["fiveHour"]["pct"] == 25.0
             assert row["usageAgeSeconds"] >= age_s
+            assert "lastGoodUsage" not in row
         else:
             assert row["usage"] is None
             assert "usageFetchedAt" not in row
+            assert row["lastGoodUsage"]["fiveHour"]["pct"] == 25.0
+            assert row["lastGoodAgeSeconds"] >= age_s
+            assert row["lastGoodFetchedAt"].endswith("Z")
 
 
 # --------------------------------------------------------------------------- #
@@ -363,6 +367,37 @@ class TestStatusJson:
         assert active["usageStatus"] == "ok"
         assert active["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
         assert payload["totalManagedAccounts"] == 2
+
+    def test_status_managed_includes_display_grade_last_good(
+        self, temp_home: Path, mock_claude_config: Path,
+        sample_sequence_data: dict,
+    ):
+        import time as time_mod
+
+        from claude_swap.usage_store import UsageEntry
+
+        sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+        fetched_at = time_mod.time() - 4000
+        entry = UsageEntry(
+            last_good={"five_hour": {"pct": 25.0}},
+            fetched_at=fetched_at,
+            age_s=4000.0,
+        )
+
+        with patch.object(switcher, "_read_active_credentials",
+                          return_value=ActiveCredentials(active_creds, False)), \
+             patch.object(switcher, "_active_account_usage", return_value=entry):
+            payload = switcher.status(json_output=True)
+
+        active = payload["active"]
+        assert active["usageStatus"] == "unavailable"
+        assert active["usage"] is None
+        assert active["lastGoodUsage"]["fiveHour"]["pct"] == 25.0
+        assert active["lastGoodAgeSeconds"] == 4000.0
 
     def test_status_managed_includes_alias(
         self, temp_home: Path, mock_claude_config: Path,


### PR DESCRIPTION
## Summary

Keep stale usage non-actionable while preserving it for human display:

- decision-trusted data continues to use `usage`, `usageFetchedAt`, and `usageAgeSeconds`
- when data is too old to drive a decision, `usageStatus` remains `unavailable` and `usage` remains `null`
- additive `lastGoodUsage`, `lastGoodFetchedAt`, and `lastGoodAgeSeconds` retain the display-only snapshot
- the same contract applies to list rows and the managed active row from `status --json`

This lets conservative automation fail closed without forcing UIs to discard the last useful context.

## Safety

Last-good fields never make an account actionable: `usageStatus` and `usage` remain authoritative. Fresh decision-grade rows do not emit duplicate last-good fields.

## Validation

- `uv run pytest tests/test_json_output.py tests/test_switcher.py tests/test_usage_store.py -q` — **429 passed**
- `python -m py_compile` — passed
- `git diff --check` — passed

