### PR TITLE
feat(menubar): aligned account rows — columns, bars, binding-limit-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ cswap menubar
 
 Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
 
+*Settings → Account rows* picks how each account is drawn. **Compact** (the default) is one free-text line per account. The other three lay every account on one shared column grid, so the same window sits at the same place on every row and you can compare down a column instead of reading across:
+
+- **Columns** — one column per usage window, with the window names in a dimmed header instead of repeated on every row.
+- **Columns with bars** — the same grid with a small progress bar in front of each number.
+- **Binding limit first** — leads with the window that's actually closest to blocking you, and dims the rest as context.
+
+Percentages turn orange past 80% and red past 95%, so a pool of idle accounts stays monochrome and colour means something. Spend is never coloured — an exhausted budget caps cost, it doesn't block a request. *Show reset times* adds a second, dimmed line with each window's countdown, aligned under its own percentage.
+
 </details>
 
 ## Advanced

--- a/README.md
+++ b/README.md
@@ -258,6 +258,14 @@ cswap menubar --uninstall-service   # stop it and remove the plist
 
 The agent lives at `~/Library/LaunchAgents/com.cswap.menubar.plist` and logs to `~/Library/Logs/com.cswap.menubar.{log,err}`. It pins the `cswap` console script, whose path survives an upgrade — but the running process keeps the old build until it restarts, so after `cswap upgrade` either re-run `--install-service` or `launchctl kickstart -k gui/$(id -u)/com.cswap.menubar`.
 
+*Settings → Account rows* picks how each account is drawn. **Compact** (the default) is one free-text line per account. The other three lay every account on one shared column grid, so the same window sits at the same place on every row and you can compare down a column instead of reading across:
+
+- **Columns** — one column per usage window, with the window names in a dimmed header instead of repeated on every row.
+- **Columns with bars** — the same grid with a small progress bar in front of each number.
+- **Binding limit first** — leads with the window that's actually closest to blocking you, and dims the rest as context.
+
+Percentages turn orange past 80% and red past 95%, so a pool of idle accounts stays monochrome and colour means something. Spend is never coloured — an exhausted budget caps cost, it doesn't block a request. *Show reset times* adds a second, dimmed line with each window's countdown, aligned under its own percentage.
+
 </details>
 
 ## Advanced

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -23,7 +23,7 @@ import re
 import sys
 import threading
 import time
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass, fields, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -35,6 +35,12 @@ ICON = "⇄"
 REFRESH_CHOICES: tuple[int, ...] = (30, 60, 300)
 AUTO_THRESHOLD_CHOICES: tuple[int, ...] = (80, 90, 95, 98)
 TITLE_PCT_CHOICES: tuple[str, ...] = ("off", "5h", "7d", "both")
+# How each account row is laid out. "compact" is the original free-text line;
+# the rest share one column grid across all accounts (see build_account_table),
+# except "focus", which leads with each account's binding window.
+ROW_STYLE_CHOICES: tuple[str, ...] = ("compact", "columns", "bars", "focus")
+# Layouts built on the shared column grid; "show reset times" applies to these.
+GRID_ROW_STYLES: tuple[str, ...] = ("columns", "bars")
 SWITCH_HISTORY_LIMIT = 10
 NOTIFICATION_BUNDLE_ID = "com.claude-swap.menubar"
 
@@ -97,6 +103,8 @@ class MenuBarSettings:
     title_scoped: bool = False  # append per-model weekly limits (e.g. Fable) to the title
     refresh_interval: int = 60
     auto_switch_enabled: bool = False
+    row_style: str = "compact"  # one of ROW_STYLE_CHOICES
+    show_resets: bool = False  # second, dimmed line with reset countdowns
 
     @classmethod
     def load(cls, path: Path) -> "MenuBarSettings":
@@ -286,6 +294,517 @@ def format_account_label(
     label = f"{alias}  ({email})" if alias else email
     marker = "  (disabled)" if disabled else ""
     return f"{num}  {label}{marker}  {usage_summary(usage, now, fetched_at)}"
+
+
+# ---- aligned table rows (the "columns" / "detailed" row styles) --------------
+#
+# The compact style formats each row independently, so nothing lines up: a
+# proportional menu font plus per-account text of different lengths means the
+# reader has to parse every row to compare two numbers. These helpers instead
+# lay every account out on one shared column grid — which requires looking at
+# all accounts at once (a model column exists only if some account reports it),
+# so this works on the account list, not on a single row.
+
+MAXED_MARKER = "!"   # window at/over its limit — the usual reason to switch
+AHEAD_MARKER = "\u2191"   # weekly window running ahead of an even burn-down pace
+RESETS_CAPTION = "resets in"  # leads the dimmed second line of a detailed row
+SPEND_HEADER = "$"
+
+# Utilization thresholds behind the severity tint. Only the constrained end is
+# tinted: a pool of mostly-idle accounts should stay monochrome, with colour
+# reserved for the rows that are actually running out.
+WARNING_PCT = 80.0
+CRITICAL_PCT = 95.0
+
+@dataclass(frozen=True)
+class TableColumn:
+    """One column of the aligned account table."""
+
+    key: str            # "num" | "name" | "window"
+    title: str          # header text; "" for the num/name columns
+    right_aligned: bool
+
+
+@dataclass(frozen=True)
+class TableRow:
+    """One account's cells, the countdowns beneath them, and their severities."""
+
+    cells: tuple[str, ...]
+    resets: tuple[str, ...]             # same length as cells; "" where there's nothing
+    severities: tuple[str | None, ...]  # None | "warning" | "critical", per cell
+    values: tuple[float | None, ...]    # the raw percentage behind a cell, for bars
+
+
+def severity_for(pct: float | None) -> str | None:
+    """Severity tint for a utilization percentage, or None to leave it plain."""
+    if pct is None:
+        return None
+    if pct >= CRITICAL_PCT:
+        return "critical"
+    if pct >= WARNING_PCT:
+        return "warning"
+    return None
+
+
+NAME_LIMIT = 26  # characters; one long address must not push every number right
+
+
+def truncate_name(name: str, limit: int = NAME_LIMIT) -> str:
+    """Shorten an over-long account name, keeping the part that identifies it.
+
+    The name column is as wide as its widest entry, so a single long address
+    would push every percentage on every row to the right. Drops the domain
+    first (it's usually the redundant part), then hard-truncates.
+    """
+    if len(name) <= limit:
+        return name
+    local, _, domain = name.partition("@")
+    if domain and len(local) <= limit:
+        shortened = f"{local}@…"
+        if len(shortened) <= limit:
+            return shortened
+    return name[: limit - 1] + "…"
+
+
+def _pct_text(window: dict, *, ahead: bool = False, marker: bool = True) -> str:
+    """A percentage cell, with the at-limit / ahead-of-pace marker appended.
+
+    ``marker=False`` for spend: an exhausted budget caps cost, it doesn't block
+    a request, so flagging it like a maxed rate-limit window would misread.
+    """
+    pct = window["pct"]
+    if marker and pct >= 100:
+        return f"{pct:.0f}%{MAXED_MARKER}"
+    return f"{pct:.0f}%{AHEAD_MARKER if (marker and ahead) else ''}"
+
+
+def _scoped_windows(usage: dict, now: float) -> dict[str, dict]:
+    """Named per-model weekly windows of one account, keyed by model name."""
+    out: dict[str, dict] = {}
+    for window in usage.get("scoped") or []:
+        window = _rolled_weekly_window(window, now)
+        if (
+            isinstance(window, dict)
+            and isinstance(window.get("pct"), (int, float))
+            and window.get("name")
+        ):
+            out[window["name"]] = window
+    return out
+
+
+def account_table_model_names(accounts, now: float | None = None) -> tuple[str, ...]:
+    """Per-model window names in column order (deduplicated, first-seen order)."""
+    if now is None:
+        now = time.time()
+    names: list[str] = []
+    for _num, _email, _active, usage, *_rest in accounts:
+        if isinstance(usage, dict):
+            for name in _scoped_windows(usage, now):
+                if name not in names:
+                    names.append(name)
+    return tuple(names)
+
+
+def account_table_columns(accounts, now: float | None = None) -> tuple[TableColumn, ...]:
+    """The column grid shared by every account row.
+
+    One column per usage window, with the window's name carried in the column
+    *header* rather than repeated on every row. Model and spend columns appear
+    only when at least one account reports them, so a pool without per-model
+    limits doesn't carry empty columns around.
+    """
+    if now is None:
+        now = time.time()
+    columns = [
+        # The slot number leads the row, before the first tab, so it has no tab
+        # stop of its own and is simply left-aligned.
+        TableColumn("num", "", False),
+        TableColumn("name", "", False),
+        TableColumn("window", "5h", True),
+        TableColumn("window", "7d", True),
+    ]
+    for name in account_table_model_names(accounts, now):
+        columns.append(TableColumn("window", name, True))
+    for _num, _email, _active, usage, *_rest in accounts:
+        spend = usage.get("spend") if isinstance(usage, dict) else None
+        if isinstance(spend, dict) and isinstance(spend.get("pct"), (int, float)):
+            columns.append(TableColumn("window", SPEND_HEADER, True))
+            break
+    return tuple(columns)
+
+
+def account_table_header(columns: tuple[TableColumn, ...]) -> tuple[str, ...]:
+    """Header cells for the column grid (blank over the num/name columns)."""
+    return tuple(column.title for column in columns)
+
+
+def build_account_table(accounts, now: float | None = None) -> list[TableRow]:
+    """Lay every account out on the shared column grid.
+
+    Accounts whose usage is a sentinel string ("re-login needed", "no
+    credentials", …) or missing carry that message in their *name* cell instead:
+    the window columns are right-aligned percentage columns, and a sentence
+    dropped into one would run backwards across the row.
+    """
+    if now is None:
+        now = time.time()
+    columns = account_table_columns(accounts, now)
+    model_names = account_table_model_names(accounts, now)
+    width = len(columns)
+    rows: list[TableRow] = []
+
+    for num, email, _is_active, usage, _last_good, alias, disabled, fetched_at in accounts:
+        name = f"{alias} ({email})" if alias else truncate_name(email)
+        if disabled:
+            name += "  (disabled)"
+        cells = [str(num), name] + [""] * (width - 2)
+        resets = [""] * width
+        severities: list[str | None] = [None] * width
+        values: list[float | None] = [None] * width
+
+        if not isinstance(usage, dict):
+            message = usage if isinstance(usage, str) else "usage unavailable"
+            cells[1] = f"{name} — {message}"
+            rows.append(TableRow(tuple(cells), tuple(resets), tuple(severities),
+                                 tuple(values)))
+            continue
+
+        def place(index: int, window: dict, *, ahead: bool = False, tint: bool = True,
+                  marker: bool = True) -> None:
+            cells[index] = _pct_text(window, ahead=ahead, marker=marker)
+            values[index] = float(window["pct"])
+            if tint:
+                severities[index] = severity_for(window["pct"])
+            countdown = _live_countdown(window, now)
+            if countdown:
+                resets[index] = countdown
+
+        five = usage.get("five_hour")
+        if isinstance(five, dict) and isinstance(five.get("pct"), (int, float)):
+            place(2, five)
+
+        seven = _rolled_weekly_window(usage.get("seven_day"), now)
+        if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)):
+            pace_result = pace.compute_pace(seven, fetched_at=fetched_at)
+            place(3, seven, ahead=bool(pace_result and pace_result.ahead))
+
+        scoped = _scoped_windows(usage, now)
+        for offset, model in enumerate(model_names):
+            window = scoped.get(model)
+            if window is None:
+                continue
+            pace_result = pace.compute_pace(window, fetched_at=fetched_at)
+            place(4 + offset, window, ahead=bool(pace_result and pace_result.ahead))
+
+        spend = usage.get("spend")
+        if isinstance(spend, dict) and isinstance(spend.get("pct"), (int, float)):
+            index = 4 + len(model_names)
+            if index < width and columns[index].title == SPEND_HEADER:
+                # Spend is a budget, not a rate-limit window: it never blocks a
+                # request, so it carries neither tint nor at-limit marker.
+                place(index, spend, tint=False, marker=False)
+
+        rows.append(TableRow(tuple(cells), tuple(resets), tuple(severities),
+                             tuple(values)))
+
+    return rows
+
+
+def build_focus_table(accounts, now: float | None = None) -> list[TableRow]:
+    """Rows that lead with each account's *binding* window.
+
+    Answers "which account can I use right now" directly: the window closest to
+    its limit is what actually blocks you, so it comes first and carries the
+    tint; everything else trails behind it as dimmed context.
+    """
+    if now is None:
+        now = time.time()
+    model_names = account_table_model_names(accounts, now)
+    rows: list[TableRow] = []
+
+    for num, email, _is_active, usage, _last_good, alias, disabled, fetched_at in accounts:
+        name = f"{alias} ({email})" if alias else truncate_name(email)
+        if disabled:
+            name += "  (disabled)"
+        if not isinstance(usage, dict):
+            message = usage if isinstance(usage, str) else "usage unavailable"
+            rows.append(TableRow((str(num), f"{name} — {message}", "", ""),
+                                 ("", "", "", ""), (None,) * 4, (None,) * 4))
+            continue
+
+        windows: list[tuple[str, dict]] = []
+        five = usage.get("five_hour")
+        if isinstance(five, dict) and isinstance(five.get("pct"), (int, float)):
+            windows.append(("5h", five))
+        seven = _rolled_weekly_window(usage.get("seven_day"), now)
+        if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)):
+            windows.append(("7d", seven))
+        scoped = _scoped_windows(usage, now)
+        for model in model_names:
+            if model in scoped:
+                windows.append((model, scoped[model]))
+
+        if not windows:
+            rows.append(TableRow((str(num), f"{name} — usage unavailable", "", ""),
+                                 ("", "", "", ""), (None,) * 4, (None,) * 4))
+            continue
+
+        # Spend is excluded from the binding choice — it caps cost, not requests.
+        label, window = max(windows, key=lambda item: item[1]["pct"])
+        binding = f"{label} {_pct_text(window)}"
+        rest = " · ".join(
+            f"{other_label} {other['pct']:.0f}%"
+            for other_label, other in windows
+            if other_label != label
+        )
+        spend = usage.get("spend")
+        if isinstance(spend, dict) and isinstance(spend.get("pct"), (int, float)):
+            rest = f"{rest} · $ {spend['pct']:.0f}%" if rest else f"$ {spend['pct']:.0f}%"
+        countdown = _live_countdown(window, now) or ""
+        rows.append(TableRow(
+            (str(num), name, binding, rest),
+            ("", "", countdown, ""),
+            (None, None, severity_for(window["pct"]), None),
+            (None, None, float(window["pct"]), None),
+        ))
+
+    return rows
+
+
+def focus_table_columns() -> tuple[TableColumn, ...]:
+    """Column grid for the focus style: number, name, binding window, the rest."""
+    return (
+        TableColumn("num", "", False),
+        TableColumn("name", "", False),
+        TableColumn("window", "", False),
+        TableColumn("rest", "", False),
+    )
+
+
+# ---- attributed-string layout (needs AppKit; passed in, never imported here) --
+
+def _bar_image(AppKit, pct: float, font, fill_color, track_color):
+    """A small rounded progress bar, drawn to fit one line of ``font``.
+
+    Drawn rather than spelled with block glyphs (▁ █ ▌): those have no coverage
+    in the menu font, so they fall back to whatever face does have them and come
+    out at inconsistent widths — and ▁ renders as a hairline on the baseline, so
+    an empty bar reads as an underscore. Sizing from the font's point size keeps
+    the bar proportional at any system font size.
+    """
+    point = font.pointSize()
+    height = max(4.0, round(point * 0.42))
+    width = round(point * 4.6)
+    image = AppKit.NSImage.alloc().initWithSize_((width, height))
+    image.lockFocus()
+    radius = height / 2.0
+    track_color.setFill()
+    AppKit.NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+        ((0, 0), (width, height)), radius, radius).fill()
+    filled = max(0.0, min(100.0, pct)) / 100.0 * width
+    if filled > 0:
+        # Never thinner than the cap radius, or a few-percent bar disappears.
+        filled = max(filled, height)
+        fill_color.setFill()
+        AppKit.NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+            ((0, 0), (filled, height)), radius, radius).fill()
+    image.unlockFocus()
+    return image
+
+
+def _bar_attachment(AppKit, image):
+    """The bar image as an attributed string, sitting on the text baseline."""
+    attachment = AppKit.NSTextAttachment.alloc().init()
+    cell = AppKit.NSTextAttachmentCell.alloc().initImageCell_(image)
+    attachment.setAttachmentCell_(cell)
+    return AppKit.NSAttributedString.attributedStringWithAttachment_(attachment)
+
+
+def build_attributed_rows(
+    AppKit,
+    rows: list[TableRow],
+    columns: tuple[TableColumn, ...],
+    header_cells: tuple[str, ...] = (),
+    *,
+    with_resets: bool = False,
+    bars: bool = False,
+    font_size: float | None = None,
+):
+    """Lay the rows out as attributed strings. Returns ``(titles, header)``.
+
+    AppKit does the alignment: one shared ``NSParagraphStyle`` whose tab stops
+    are measured from the widest cell per column, so columns line up under the
+    proportional menu font instead of needing a monospaced one. Every measure is
+    taken in the font the text is actually drawn in and every gap is expressed
+    in that font's own space width, so the whole grid scales with the system
+    font size instead of assuming one screen's metrics.
+
+    ``AppKit`` is a parameter rather than an import: this module stays
+    import-safe (and unit-testable) without pyobjc, exactly like the rumps glue.
+    """
+    # ``font_size`` exists so the layout can be rendered at sizes other than
+    # this machine's current one (previews, review at accessibility sizes).
+    size = AppKit.NSFont.systemFontSize() if font_size is None else font_size
+    small_size = (
+        AppKit.NSFont.smallSystemFontSize() if font_size is None else max(9.0, font_size - 2)
+    )
+    font = AppKit.NSFont.monospacedDigitSystemFontOfSize_weight_(
+        size, AppKit.NSFontWeightRegular
+    )
+    small_font = AppKit.NSFont.monospacedDigitSystemFontOfSize_weight_(
+        small_size, AppKit.NSFontWeightRegular
+    )
+    colors = {
+        "warning": AppKit.NSColor.systemOrangeColor(),
+        "critical": AppKit.NSColor.systemRedColor(),
+    }
+
+    def width(text, f):
+        if not text:
+            return 0.0
+        return AppKit.NSAttributedString.alloc().initWithString_attributes_(
+            text, {AppKit.NSFontAttributeName: f}
+        ).size().width
+
+    # A bar is drawn art, not text: reserve its width (plus a space) on top of
+    # the percentage it precedes.
+    bar_width = (
+        _bar_image(AppKit, 0.0, font,
+                   AppKit.NSColor.labelColor(),
+                   AppKit.NSColor.quaternaryLabelColor()).size().width + width(" ", font)
+        if bars else 0.0
+    )
+
+    window_indexes = [i for i, c in enumerate(columns) if c.key == "window"]
+    if bars and window_indexes:
+        # Each window cell is right-aligned on its tab stop, so a wider
+        # percentage ("37%" vs "0%") would push its bar further left and leave
+        # the bars' left edges ragged. Pad the numbers to a common width with
+        # FIGURE SPACE, which is exactly one digit wide in this font.
+        pad_to = max(
+            (len(row.cells[i]) for row in rows for i in window_indexes
+             if row.values[i] is not None),
+            default=0,
+        )
+        rows = [
+            replace(row, cells=tuple(
+                cell.rjust(pad_to, "\u2007")
+                if (i in window_indexes and row.values[i] is not None) else cell
+                for i, cell in enumerate(row.cells)
+            ))
+            for row in rows
+        ]
+
+    widths = []
+    for index in range(len(columns)):
+        widest = width(header_cells[index], small_font) if header_cells else 0.0
+        extra = bar_width if (bars and columns[index].key == "window") else 0.0
+        for row in rows:
+            cell = width(row.cells[index], font)
+            widest = max(widest, cell + (extra if row.values[index] is not None else 0.0))
+            if with_resets:
+                widest = max(widest, width(row.resets[index], small_font))
+        widths.append(widest)
+    if with_resets and len(widths) > 1:
+        widths[1] = max(widths[1], width(RESETS_CAPTION, small_font))
+
+    # Give every window column the same width — an even rhythm reads far better
+    # than columns that each hug their own widest value, and it keeps a "0%"
+    # column from collapsing next to a "100%!" one.
+    if window_indexes and header_cells:
+        uniform = max(widths[i] for i in window_indexes)
+        for i in window_indexes:
+            widths[i] = uniform
+
+    gap = width("  ", font)            # after the slot number, and in focus rows
+    column_gap = width("     ", font)  # between window columns: room to breathe
+    paragraph = AppKit.NSMutableParagraphStyle.alloc().init()
+    stops = []
+    x = widths[0] + gap  # the slot number leads the row, before the first tab
+    for index in range(1, len(columns)):
+        if columns[index].right_aligned:
+            x += widths[index]
+            stops.append(AppKit.NSTextTab.alloc().initWithTextAlignment_location_options_(
+                AppKit.NSTextAlignmentRight, x, {}))
+        else:
+            stops.append(AppKit.NSTextTab.alloc().initWithTextAlignment_location_options_(
+                AppKit.NSTextAlignmentLeft, x, {}))
+            x += widths[index]
+        x += column_gap if columns[index].key == "window" else gap
+    paragraph.setTabStops_(stops)
+    # Without this, any text past the last stop falls back to the default 28pt
+    # interval and the grid breaks.
+    paragraph.setDefaultTabInterval_(gap)
+
+    def line(cells, f, color=None):
+        attributes = {
+            AppKit.NSFontAttributeName: f,
+            AppKit.NSParagraphStyleAttributeName: paragraph,
+        }
+        if color is not None:
+            attributes[AppKit.NSForegroundColorAttributeName] = color
+        return AppKit.NSMutableAttributedString.alloc().initWithString_attributes_(
+            "\t".join(cells).rstrip("\t"), attributes)
+
+    titles = []
+    for row in rows:
+        attributed = line(row.cells, font)
+        # Ranges are located by walking the joined string, so a cell's own text
+        # length (bar glyphs, markers) can't shift the offsets.
+        # Cell start offsets in the joined string, walked forward once. Trailing
+        # empty cells are stripped from the string, but that only shortens the
+        # tail — every non-empty cell keeps the offset computed here.
+        offsets = []
+        offset = 0
+        for cell in row.cells:
+            offsets.append(offset)
+            offset += len(cell) + 1  # + the tab that follows it
+        for index, cell in enumerate(row.cells):
+            if cell and row.severities[index] in colors:
+                attributed.addAttribute_value_range_(
+                    AppKit.NSForegroundColorAttributeName,
+                    colors[row.severities[index]], (offsets[index], len(cell)))
+        if bars:
+            # Insert back-to-front so the earlier offsets stay valid.
+            for index in reversed(range(len(row.cells))):
+                value = row.values[index]
+                if value is None or columns[index].key != "window":
+                    continue
+                severity = row.severities[index]
+                fill = colors.get(severity, AppKit.NSColor.secondaryLabelColor())
+                bar = AppKit.NSMutableAttributedString.alloc().initWithAttributedString_(
+                    _bar_attachment(
+                        AppKit,
+                        _bar_image(AppKit, value, font, fill,
+                                   AppKit.NSColor.quaternaryLabelColor()),
+                    )
+                )
+                bar.appendAttributedString_(
+                    AppKit.NSAttributedString.alloc().initWithString_attributes_(
+                        " ", {AppKit.NSFontAttributeName: font}))
+                attributed.insertAttributedString_atIndex_(bar, offsets[index])
+        if not header_cells and len(row.cells) == 4 and row.cells[3]:
+            # Focus style: the trailing context recedes so the binding window,
+            # which is the whole point of the row, carries the eye.
+            start = len(row.cells[0]) + 1 + len(row.cells[1]) + 1 + len(row.cells[2]) + 1
+            attributed.addAttribute_value_range_(
+                AppKit.NSForegroundColorAttributeName,
+                AppKit.NSColor.secondaryLabelColor(),
+                (start, len(row.cells[3])))
+        if with_resets and any(row.resets):
+            resets = list(row.resets)
+            resets[1] = RESETS_CAPTION
+            attributed.appendAttributedString_(
+                AppKit.NSAttributedString.alloc().initWithString_attributes_(
+                    "\n", {AppKit.NSParagraphStyleAttributeName: paragraph}))
+            attributed.appendAttributedString_(
+                line(resets, small_font, AppKit.NSColor.secondaryLabelColor()))
+        titles.append(attributed)
+
+    header = None
+    if header_cells and any(header_cells):
+        header = line(header_cells, small_font, AppKit.NSColor.secondaryLabelColor())
+    return titles, header
 
 
 def _local_part(email: str, limit: int = 12) -> str:
@@ -674,18 +1193,29 @@ def run(switcher) -> int:
                             _purge(_sub)
                 _purge(self.menu._menu)
             self.menu.clear()
+            accounts = self.snapshot["accounts"]
+            aligned, header = self._aligned_titles(accounts)
             account_items = []
-            for num, email, is_active, display, _last_good, alias, disabled, fetched_at in self.snapshot["accounts"]:
+            if header is not None:
+                # A disabled item: it names the columns, it isn't a target.
+                head = rumps.MenuItem("  ", callback=None)
+                head._menuitem.setAttributedTitle_(header)
+                account_items.append(head)
+            for index, (num, email, is_active, display, _last_good, alias, disabled, fetched_at) in enumerate(accounts):
                 item = rumps.MenuItem(
                     format_account_label(
                         num, email, display, alias=alias, disabled=disabled, fetched_at=fetched_at
                     ),
                     callback=self._make_switch_to(num),
                 )
+                # The plain label above stays the item's rumps key (unique per
+                # account); the attributed title only changes what's drawn.
+                if aligned is not None:
+                    item._menuitem.setAttributedTitle_(aligned[index])
                 item.state = 1 if is_active else 0
                 account_items.append(item)
-            if not account_items:
-                account_items.append(rumps.MenuItem("No managed accounts", callback=None))
+            if not accounts:
+                account_items = [rumps.MenuItem("No managed accounts", callback=None)]
 
             self.menu = [
                 *account_items,
@@ -704,6 +1234,32 @@ def run(switcher) -> int:
                 rumps.MenuItem("Refresh now", callback=self.on_refresh_now),
                 rumps.MenuItem("Quit", callback=self.on_quit),
             ]
+
+        def _aligned_titles(self, accounts):
+            """Attributed titles for the account rows, plus an optional header.
+
+            Returns ``(titles, header)``; both ``None`` for the compact style,
+            which stays plain text. The layout itself lives in
+            :func:`build_attributed_rows` so it can be rendered — and reviewed —
+            without a running menu.
+            """
+            style_name = self.settings.row_style
+            if style_name not in GRID_ROW_STYLES + ("focus",) or not accounts:
+                return None, None
+            now = time.time()
+            if style_name == "focus":
+                columns = focus_table_columns()
+                rows = build_focus_table(accounts, now)
+                header_cells = ()
+            else:
+                columns = account_table_columns(accounts, now)
+                rows = build_account_table(accounts, now)
+                header_cells = account_table_header(columns)
+            return build_attributed_rows(
+                AppKit, rows, columns, header_cells,
+                with_resets=self.settings.show_resets and style_name in GRID_ROW_STYLES,
+                bars=style_name == "bars",
+            )
 
         def _add_menu(self, rumps):
             menu = rumps.MenuItem("Add account")
@@ -756,6 +1312,24 @@ def run(switcher) -> int:
 
         def _settings_menu(self, rumps):
             menu = rumps.MenuItem("Settings")
+
+            rows = rumps.MenuItem("Account rows")
+            row_labels = {
+                "compact": "Compact (one line)",
+                "columns": "Columns",
+                "bars": "Columns with bars",
+                "focus": "Binding limit first",
+            }
+            for style in ROW_STYLE_CHOICES:
+                ch = rumps.MenuItem(row_labels[style], callback=self._make_row_style(style))
+                ch.state = 1 if self.settings.row_style == style else 0
+                rows.add(ch)
+            rows.add(None)
+            resets_item = rumps.MenuItem("Show reset times", callback=self.on_toggle_resets)
+            resets_item.state = 1 if self.settings.show_resets else 0
+            rows.add(resets_item)
+            menu.add(rows)
+
             name_item = rumps.MenuItem("Show account name in menu bar", callback=self.on_toggle_name)
             name_item.state = 1 if self.settings.show_account_name else 0
             menu.add(name_item)
@@ -928,6 +1502,16 @@ def run(switcher) -> int:
         def on_toggle_scoped(self, _sender):
             self.settings.title_scoped = not self.settings.title_scoped
             self._save_and_rebuild()
+
+        def on_toggle_resets(self, _sender):
+            self.settings.show_resets = not self.settings.show_resets
+            self._save_and_rebuild()
+
+        def _make_row_style(self, style):
+            def cb(_sender):
+                self.settings.row_style = style
+                self._save_and_rebuild()
+            return cb
 
         def _make_title_pct(self, mode):
             def cb(_sender):

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -23,7 +23,7 @@ import re
 import sys
 import threading
 import time
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass, fields, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -35,6 +35,12 @@ ICON = "⇄"
 REFRESH_CHOICES: tuple[int, ...] = (30, 60, 300)
 AUTO_THRESHOLD_CHOICES: tuple[int, ...] = (80, 90, 95, 98)
 TITLE_PCT_CHOICES: tuple[str, ...] = ("off", "5h", "7d", "both")
+# How each account row is laid out. "compact" is the original free-text line;
+# the rest share one column grid across all accounts (see build_account_table),
+# except "focus", which leads with each account's binding window.
+ROW_STYLE_CHOICES: tuple[str, ...] = ("compact", "columns", "bars", "focus")
+# Layouts built on the shared column grid; "show reset times" applies to these.
+GRID_ROW_STYLES: tuple[str, ...] = ("columns", "bars")
 SWITCH_HISTORY_LIMIT = 10
 NOTIFICATION_BUNDLE_ID = "com.claude-swap.menubar"
 
@@ -97,6 +103,8 @@ class MenuBarSettings:
     title_scoped: bool = False  # append per-model weekly limits (e.g. Fable) to the title
     refresh_interval: int = 60
     auto_switch_enabled: bool = False
+    row_style: str = "compact"  # one of ROW_STYLE_CHOICES
+    show_resets: bool = False  # second, dimmed line with reset countdowns
 
     @classmethod
     def load(cls, path: Path) -> "MenuBarSettings":
@@ -286,6 +294,517 @@ def format_account_label(
     label = f"{alias}  ({email})" if alias else email
     marker = "  (disabled)" if disabled else ""
     return f"{num}  {label}{marker}  {usage_summary(usage, now, fetched_at)}"
+
+
+# ---- aligned table rows (the "columns" / "detailed" row styles) --------------
+#
+# The compact style formats each row independently, so nothing lines up: a
+# proportional menu font plus per-account text of different lengths means the
+# reader has to parse every row to compare two numbers. These helpers instead
+# lay every account out on one shared column grid — which requires looking at
+# all accounts at once (a model column exists only if some account reports it),
+# so this works on the account list, not on a single row.
+
+MAXED_MARKER = "!"   # window at/over its limit — the usual reason to switch
+AHEAD_MARKER = "\u2191"   # weekly window running ahead of an even burn-down pace
+RESETS_CAPTION = "resets in"  # leads the dimmed second line of a detailed row
+SPEND_HEADER = "$"
+
+# Utilization thresholds behind the severity tint. Only the constrained end is
+# tinted: a pool of mostly-idle accounts should stay monochrome, with colour
+# reserved for the rows that are actually running out.
+WARNING_PCT = 80.0
+CRITICAL_PCT = 95.0
+
+@dataclass(frozen=True)
+class TableColumn:
+    """One column of the aligned account table."""
+
+    key: str            # "num" | "name" | "window"
+    title: str          # header text; "" for the num/name columns
+    right_aligned: bool
+
+
+@dataclass(frozen=True)
+class TableRow:
+    """One account's cells, the countdowns beneath them, and their severities."""
+
+    cells: tuple[str, ...]
+    resets: tuple[str, ...]             # same length as cells; "" where there's nothing
+    severities: tuple[str | None, ...]  # None | "warning" | "critical", per cell
+    values: tuple[float | None, ...]    # the raw percentage behind a cell, for bars
+
+
+def severity_for(pct: float | None) -> str | None:
+    """Severity tint for a utilization percentage, or None to leave it plain."""
+    if pct is None:
+        return None
+    if pct >= CRITICAL_PCT:
+        return "critical"
+    if pct >= WARNING_PCT:
+        return "warning"
+    return None
+
+
+NAME_LIMIT = 26  # characters; one long address must not push every number right
+
+
+def truncate_name(name: str, limit: int = NAME_LIMIT) -> str:
+    """Shorten an over-long account name, keeping the part that identifies it.
+
+    The name column is as wide as its widest entry, so a single long address
+    would push every percentage on every row to the right. Drops the domain
+    first (it's usually the redundant part), then hard-truncates.
+    """
+    if len(name) <= limit:
+        return name
+    local, _, domain = name.partition("@")
+    if domain and len(local) <= limit:
+        shortened = f"{local}@…"
+        if len(shortened) <= limit:
+            return shortened
+    return name[: limit - 1] + "…"
+
+
+def _pct_text(window: dict, *, ahead: bool = False, marker: bool = True) -> str:
+    """A percentage cell, with the at-limit / ahead-of-pace marker appended.
+
+    ``marker=False`` for spend: an exhausted budget caps cost, it doesn't block
+    a request, so flagging it like a maxed rate-limit window would misread.
+    """
+    pct = window["pct"]
+    if marker and pct >= 100:
+        return f"{pct:.0f}%{MAXED_MARKER}"
+    return f"{pct:.0f}%{AHEAD_MARKER if (marker and ahead) else ''}"
+
+
+def _scoped_windows(usage: dict, now: float) -> dict[str, dict]:
+    """Named per-model weekly windows of one account, keyed by model name."""
+    out: dict[str, dict] = {}
+    for window in usage.get("scoped") or []:
+        window = _rolled_weekly_window(window, now)
+        if (
+            isinstance(window, dict)
+            and isinstance(window.get("pct"), (int, float))
+            and window.get("name")
+        ):
+            out[window["name"]] = window
+    return out
+
+
+def account_table_model_names(accounts, now: float | None = None) -> tuple[str, ...]:
+    """Per-model window names in column order (deduplicated, first-seen order)."""
+    if now is None:
+        now = time.time()
+    names: list[str] = []
+    for _num, _email, _active, usage, *_rest in accounts:
+        if isinstance(usage, dict):
+            for name in _scoped_windows(usage, now):
+                if name not in names:
+                    names.append(name)
+    return tuple(names)
+
+
+def account_table_columns(accounts, now: float | None = None) -> tuple[TableColumn, ...]:
+    """The column grid shared by every account row.
+
+    One column per usage window, with the window's name carried in the column
+    *header* rather than repeated on every row. Model and spend columns appear
+    only when at least one account reports them, so a pool without per-model
+    limits doesn't carry empty columns around.
+    """
+    if now is None:
+        now = time.time()
+    columns = [
+        # The slot number leads the row, before the first tab, so it has no tab
+        # stop of its own and is simply left-aligned.
+        TableColumn("num", "", False),
+        TableColumn("name", "", False),
+        TableColumn("window", "5h", True),
+        TableColumn("window", "7d", True),
+    ]
+    for name in account_table_model_names(accounts, now):
+        columns.append(TableColumn("window", name, True))
+    for _num, _email, _active, usage, *_rest in accounts:
+        spend = usage.get("spend") if isinstance(usage, dict) else None
+        if isinstance(spend, dict) and isinstance(spend.get("pct"), (int, float)):
+            columns.append(TableColumn("window", SPEND_HEADER, True))
+            break
+    return tuple(columns)
+
+
+def account_table_header(columns: tuple[TableColumn, ...]) -> tuple[str, ...]:
+    """Header cells for the column grid (blank over the num/name columns)."""
+    return tuple(column.title for column in columns)
+
+
+def build_account_table(accounts, now: float | None = None) -> list[TableRow]:
+    """Lay every account out on the shared column grid.
+
+    Accounts whose usage is a sentinel string ("re-login needed", "no
+    credentials", …) or missing carry that message in their *name* cell instead:
+    the window columns are right-aligned percentage columns, and a sentence
+    dropped into one would run backwards across the row.
+    """
+    if now is None:
+        now = time.time()
+    columns = account_table_columns(accounts, now)
+    model_names = account_table_model_names(accounts, now)
+    width = len(columns)
+    rows: list[TableRow] = []
+
+    for num, email, _is_active, usage, _last_good, alias, disabled, fetched_at in accounts:
+        name = f"{alias} ({email})" if alias else truncate_name(email)
+        if disabled:
+            name += "  (disabled)"
+        cells = [str(num), name] + [""] * (width - 2)
+        resets = [""] * width
+        severities: list[str | None] = [None] * width
+        values: list[float | None] = [None] * width
+
+        if not isinstance(usage, dict):
+            message = usage if isinstance(usage, str) else "usage unavailable"
+            cells[1] = f"{name} — {message}"
+            rows.append(TableRow(tuple(cells), tuple(resets), tuple(severities),
+                                 tuple(values)))
+            continue
+
+        def place(index: int, window: dict, *, ahead: bool = False, tint: bool = True,
+                  marker: bool = True) -> None:
+            cells[index] = _pct_text(window, ahead=ahead, marker=marker)
+            values[index] = float(window["pct"])
+            if tint:
+                severities[index] = severity_for(window["pct"])
+            countdown = _live_countdown(window, now)
+            if countdown:
+                resets[index] = countdown
+
+        five = usage.get("five_hour")
+        if isinstance(five, dict) and isinstance(five.get("pct"), (int, float)):
+            place(2, five)
+
+        seven = _rolled_weekly_window(usage.get("seven_day"), now)
+        if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)):
+            pace_result = pace.compute_pace(seven, fetched_at=fetched_at)
+            place(3, seven, ahead=bool(pace_result and pace_result.ahead))
+
+        scoped = _scoped_windows(usage, now)
+        for offset, model in enumerate(model_names):
+            window = scoped.get(model)
+            if window is None:
+                continue
+            pace_result = pace.compute_pace(window, fetched_at=fetched_at)
+            place(4 + offset, window, ahead=bool(pace_result and pace_result.ahead))
+
+        spend = usage.get("spend")
+        if isinstance(spend, dict) and isinstance(spend.get("pct"), (int, float)):
+            index = 4 + len(model_names)
+            if index < width and columns[index].title == SPEND_HEADER:
+                # Spend is a budget, not a rate-limit window: it never blocks a
+                # request, so it carries neither tint nor at-limit marker.
+                place(index, spend, tint=False, marker=False)
+
+        rows.append(TableRow(tuple(cells), tuple(resets), tuple(severities),
+                             tuple(values)))
+
+    return rows
+
+
+def build_focus_table(accounts, now: float | None = None) -> list[TableRow]:
+    """Rows that lead with each account's *binding* window.
+
+    Answers "which account can I use right now" directly: the window closest to
+    its limit is what actually blocks you, so it comes first and carries the
+    tint; everything else trails behind it as dimmed context.
+    """
+    if now is None:
+        now = time.time()
+    model_names = account_table_model_names(accounts, now)
+    rows: list[TableRow] = []
+
+    for num, email, _is_active, usage, _last_good, alias, disabled, fetched_at in accounts:
+        name = f"{alias} ({email})" if alias else truncate_name(email)
+        if disabled:
+            name += "  (disabled)"
+        if not isinstance(usage, dict):
+            message = usage if isinstance(usage, str) else "usage unavailable"
+            rows.append(TableRow((str(num), f"{name} — {message}", "", ""),
+                                 ("", "", "", ""), (None,) * 4, (None,) * 4))
+            continue
+
+        windows: list[tuple[str, dict]] = []
+        five = usage.get("five_hour")
+        if isinstance(five, dict) and isinstance(five.get("pct"), (int, float)):
+            windows.append(("5h", five))
+        seven = _rolled_weekly_window(usage.get("seven_day"), now)
+        if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)):
+            windows.append(("7d", seven))
+        scoped = _scoped_windows(usage, now)
+        for model in model_names:
+            if model in scoped:
+                windows.append((model, scoped[model]))
+
+        if not windows:
+            rows.append(TableRow((str(num), f"{name} — usage unavailable", "", ""),
+                                 ("", "", "", ""), (None,) * 4, (None,) * 4))
+            continue
+
+        # Spend is excluded from the binding choice — it caps cost, not requests.
+        label, window = max(windows, key=lambda item: item[1]["pct"])
+        binding = f"{label} {_pct_text(window)}"
+        rest = " · ".join(
+            f"{other_label} {other['pct']:.0f}%"
+            for other_label, other in windows
+            if other_label != label
+        )
+        spend = usage.get("spend")
+        if isinstance(spend, dict) and isinstance(spend.get("pct"), (int, float)):
+            rest = f"{rest} · $ {spend['pct']:.0f}%" if rest else f"$ {spend['pct']:.0f}%"
+        countdown = _live_countdown(window, now) or ""
+        rows.append(TableRow(
+            (str(num), name, binding, rest),
+            ("", "", countdown, ""),
+            (None, None, severity_for(window["pct"]), None),
+            (None, None, float(window["pct"]), None),
+        ))
+
+    return rows
+
+
+def focus_table_columns() -> tuple[TableColumn, ...]:
+    """Column grid for the focus style: number, name, binding window, the rest."""
+    return (
+        TableColumn("num", "", False),
+        TableColumn("name", "", False),
+        TableColumn("window", "", False),
+        TableColumn("rest", "", False),
+    )
+
+
+# ---- attributed-string layout (needs AppKit; passed in, never imported here) --
+
+def _bar_image(AppKit, pct: float, font, fill_color, track_color):
+    """A small rounded progress bar, drawn to fit one line of ``font``.
+
+    Drawn rather than spelled with block glyphs (▁ █ ▌): those have no coverage
+    in the menu font, so they fall back to whatever face does have them and come
+    out at inconsistent widths — and ▁ renders as a hairline on the baseline, so
+    an empty bar reads as an underscore. Sizing from the font's point size keeps
+    the bar proportional at any system font size.
+    """
+    point = font.pointSize()
+    height = max(4.0, round(point * 0.42))
+    width = round(point * 4.6)
+    image = AppKit.NSImage.alloc().initWithSize_((width, height))
+    image.lockFocus()
+    radius = height / 2.0
+    track_color.setFill()
+    AppKit.NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+        ((0, 0), (width, height)), radius, radius).fill()
+    filled = max(0.0, min(100.0, pct)) / 100.0 * width
+    if filled > 0:
+        # Never thinner than the cap radius, or a few-percent bar disappears.
+        filled = max(filled, height)
+        fill_color.setFill()
+        AppKit.NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+            ((0, 0), (filled, height)), radius, radius).fill()
+    image.unlockFocus()
+    return image
+
+
+def _bar_attachment(AppKit, image):
+    """The bar image as an attributed string, sitting on the text baseline."""
+    attachment = AppKit.NSTextAttachment.alloc().init()
+    cell = AppKit.NSTextAttachmentCell.alloc().initImageCell_(image)
+    attachment.setAttachmentCell_(cell)
+    return AppKit.NSAttributedString.attributedStringWithAttachment_(attachment)
+
+
+def build_attributed_rows(
+    AppKit,
+    rows: list[TableRow],
+    columns: tuple[TableColumn, ...],
+    header_cells: tuple[str, ...] = (),
+    *,
+    with_resets: bool = False,
+    bars: bool = False,
+    font_size: float | None = None,
+):
+    """Lay the rows out as attributed strings. Returns ``(titles, header)``.
+
+    AppKit does the alignment: one shared ``NSParagraphStyle`` whose tab stops
+    are measured from the widest cell per column, so columns line up under the
+    proportional menu font instead of needing a monospaced one. Every measure is
+    taken in the font the text is actually drawn in and every gap is expressed
+    in that font's own space width, so the whole grid scales with the system
+    font size instead of assuming one screen's metrics.
+
+    ``AppKit`` is a parameter rather than an import: this module stays
+    import-safe (and unit-testable) without pyobjc, exactly like the rumps glue.
+    """
+    # ``font_size`` exists so the layout can be rendered at sizes other than
+    # this machine's current one (previews, review at accessibility sizes).
+    size = AppKit.NSFont.systemFontSize() if font_size is None else font_size
+    small_size = (
+        AppKit.NSFont.smallSystemFontSize() if font_size is None else max(9.0, font_size - 2)
+    )
+    font = AppKit.NSFont.monospacedDigitSystemFontOfSize_weight_(
+        size, AppKit.NSFontWeightRegular
+    )
+    small_font = AppKit.NSFont.monospacedDigitSystemFontOfSize_weight_(
+        small_size, AppKit.NSFontWeightRegular
+    )
+    colors = {
+        "warning": AppKit.NSColor.systemOrangeColor(),
+        "critical": AppKit.NSColor.systemRedColor(),
+    }
+
+    def width(text, f):
+        if not text:
+            return 0.0
+        return AppKit.NSAttributedString.alloc().initWithString_attributes_(
+            text, {AppKit.NSFontAttributeName: f}
+        ).size().width
+
+    # A bar is drawn art, not text: reserve its width (plus a space) on top of
+    # the percentage it precedes.
+    bar_width = (
+        _bar_image(AppKit, 0.0, font,
+                   AppKit.NSColor.labelColor(),
+                   AppKit.NSColor.quaternaryLabelColor()).size().width + width(" ", font)
+        if bars else 0.0
+    )
+
+    window_indexes = [i for i, c in enumerate(columns) if c.key == "window"]
+    if bars and window_indexes:
+        # Each window cell is right-aligned on its tab stop, so a wider
+        # percentage ("37%" vs "0%") would push its bar further left and leave
+        # the bars' left edges ragged. Pad the numbers to a common width with
+        # FIGURE SPACE, which is exactly one digit wide in this font.
+        pad_to = max(
+            (len(row.cells[i]) for row in rows for i in window_indexes
+             if row.values[i] is not None),
+            default=0,
+        )
+        rows = [
+            replace(row, cells=tuple(
+                cell.rjust(pad_to, "\u2007")
+                if (i in window_indexes and row.values[i] is not None) else cell
+                for i, cell in enumerate(row.cells)
+            ))
+            for row in rows
+        ]
+
+    widths = []
+    for index in range(len(columns)):
+        widest = width(header_cells[index], small_font) if header_cells else 0.0
+        extra = bar_width if (bars and columns[index].key == "window") else 0.0
+        for row in rows:
+            cell = width(row.cells[index], font)
+            widest = max(widest, cell + (extra if row.values[index] is not None else 0.0))
+            if with_resets:
+                widest = max(widest, width(row.resets[index], small_font))
+        widths.append(widest)
+    if with_resets and len(widths) > 1:
+        widths[1] = max(widths[1], width(RESETS_CAPTION, small_font))
+
+    # Give every window column the same width — an even rhythm reads far better
+    # than columns that each hug their own widest value, and it keeps a "0%"
+    # column from collapsing next to a "100%!" one.
+    if window_indexes and header_cells:
+        uniform = max(widths[i] for i in window_indexes)
+        for i in window_indexes:
+            widths[i] = uniform
+
+    gap = width("  ", font)            # after the slot number, and in focus rows
+    column_gap = width("     ", font)  # between window columns: room to breathe
+    paragraph = AppKit.NSMutableParagraphStyle.alloc().init()
+    stops = []
+    x = widths[0] + gap  # the slot number leads the row, before the first tab
+    for index in range(1, len(columns)):
+        if columns[index].right_aligned:
+            x += widths[index]
+            stops.append(AppKit.NSTextTab.alloc().initWithTextAlignment_location_options_(
+                AppKit.NSTextAlignmentRight, x, {}))
+        else:
+            stops.append(AppKit.NSTextTab.alloc().initWithTextAlignment_location_options_(
+                AppKit.NSTextAlignmentLeft, x, {}))
+            x += widths[index]
+        x += column_gap if columns[index].key == "window" else gap
+    paragraph.setTabStops_(stops)
+    # Without this, any text past the last stop falls back to the default 28pt
+    # interval and the grid breaks.
+    paragraph.setDefaultTabInterval_(gap)
+
+    def line(cells, f, color=None):
+        attributes = {
+            AppKit.NSFontAttributeName: f,
+            AppKit.NSParagraphStyleAttributeName: paragraph,
+        }
+        if color is not None:
+            attributes[AppKit.NSForegroundColorAttributeName] = color
+        return AppKit.NSMutableAttributedString.alloc().initWithString_attributes_(
+            "\t".join(cells).rstrip("\t"), attributes)
+
+    titles = []
+    for row in rows:
+        attributed = line(row.cells, font)
+        # Ranges are located by walking the joined string, so a cell's own text
+        # length (bar glyphs, markers) can't shift the offsets.
+        # Cell start offsets in the joined string, walked forward once. Trailing
+        # empty cells are stripped from the string, but that only shortens the
+        # tail — every non-empty cell keeps the offset computed here.
+        offsets = []
+        offset = 0
+        for cell in row.cells:
+            offsets.append(offset)
+            offset += len(cell) + 1  # + the tab that follows it
+        for index, cell in enumerate(row.cells):
+            if cell and row.severities[index] in colors:
+                attributed.addAttribute_value_range_(
+                    AppKit.NSForegroundColorAttributeName,
+                    colors[row.severities[index]], (offsets[index], len(cell)))
+        if bars:
+            # Insert back-to-front so the earlier offsets stay valid.
+            for index in reversed(range(len(row.cells))):
+                value = row.values[index]
+                if value is None or columns[index].key != "window":
+                    continue
+                severity = row.severities[index]
+                fill = colors.get(severity, AppKit.NSColor.secondaryLabelColor())
+                bar = AppKit.NSMutableAttributedString.alloc().initWithAttributedString_(
+                    _bar_attachment(
+                        AppKit,
+                        _bar_image(AppKit, value, font, fill,
+                                   AppKit.NSColor.quaternaryLabelColor()),
+                    )
+                )
+                bar.appendAttributedString_(
+                    AppKit.NSAttributedString.alloc().initWithString_attributes_(
+                        " ", {AppKit.NSFontAttributeName: font}))
+                attributed.insertAttributedString_atIndex_(bar, offsets[index])
+        if not header_cells and len(row.cells) == 4 and row.cells[3]:
+            # Focus style: the trailing context recedes so the binding window,
+            # which is the whole point of the row, carries the eye.
+            start = len(row.cells[0]) + 1 + len(row.cells[1]) + 1 + len(row.cells[2]) + 1
+            attributed.addAttribute_value_range_(
+                AppKit.NSForegroundColorAttributeName,
+                AppKit.NSColor.secondaryLabelColor(),
+                (start, len(row.cells[3])))
+        if with_resets and any(row.resets):
+            resets = list(row.resets)
+            resets[1] = RESETS_CAPTION
+            attributed.appendAttributedString_(
+                AppKit.NSAttributedString.alloc().initWithString_attributes_(
+                    "\n", {AppKit.NSParagraphStyleAttributeName: paragraph}))
+            attributed.appendAttributedString_(
+                line(resets, small_font, AppKit.NSColor.secondaryLabelColor()))
+        titles.append(attributed)
+
+    header = None
+    if header_cells and any(header_cells):
+        header = line(header_cells, small_font, AppKit.NSColor.secondaryLabelColor())
+    return titles, header
 
 
 def _local_part(email: str, limit: int = 12) -> str:
@@ -655,18 +1174,29 @@ def run(switcher) -> int:
                 alias=self.snapshot.get("active_alias"),
             )
             self.menu.clear()
+            accounts = self.snapshot["accounts"]
+            aligned, header = self._aligned_titles(accounts)
             account_items = []
-            for num, email, is_active, display, _last_good, alias, disabled, fetched_at in self.snapshot["accounts"]:
+            if header is not None:
+                # A disabled item: it names the columns, it isn't a target.
+                head = rumps.MenuItem("  ", callback=None)
+                head._menuitem.setAttributedTitle_(header)
+                account_items.append(head)
+            for index, (num, email, is_active, display, _last_good, alias, disabled, fetched_at) in enumerate(accounts):
                 item = rumps.MenuItem(
                     format_account_label(
                         num, email, display, alias=alias, disabled=disabled, fetched_at=fetched_at
                     ),
                     callback=self._make_switch_to(num),
                 )
+                # The plain label above stays the item's rumps key (unique per
+                # account); the attributed title only changes what's drawn.
+                if aligned is not None:
+                    item._menuitem.setAttributedTitle_(aligned[index])
                 item.state = 1 if is_active else 0
                 account_items.append(item)
-            if not account_items:
-                account_items.append(rumps.MenuItem("No managed accounts", callback=None))
+            if not accounts:
+                account_items = [rumps.MenuItem("No managed accounts", callback=None)]
 
             self.menu = [
                 *account_items,
@@ -685,6 +1215,32 @@ def run(switcher) -> int:
                 rumps.MenuItem("Refresh now", callback=self.on_refresh_now),
                 rumps.MenuItem("Quit", callback=self.on_quit),
             ]
+
+        def _aligned_titles(self, accounts):
+            """Attributed titles for the account rows, plus an optional header.
+
+            Returns ``(titles, header)``; both ``None`` for the compact style,
+            which stays plain text. The layout itself lives in
+            :func:`build_attributed_rows` so it can be rendered — and reviewed —
+            without a running menu.
+            """
+            style_name = self.settings.row_style
+            if style_name not in GRID_ROW_STYLES + ("focus",) or not accounts:
+                return None, None
+            now = time.time()
+            if style_name == "focus":
+                columns = focus_table_columns()
+                rows = build_focus_table(accounts, now)
+                header_cells = ()
+            else:
+                columns = account_table_columns(accounts, now)
+                rows = build_account_table(accounts, now)
+                header_cells = account_table_header(columns)
+            return build_attributed_rows(
+                AppKit, rows, columns, header_cells,
+                with_resets=self.settings.show_resets and style_name in GRID_ROW_STYLES,
+                bars=style_name == "bars",
+            )
 
         def _add_menu(self, rumps):
             menu = rumps.MenuItem("Add account")
@@ -737,6 +1293,24 @@ def run(switcher) -> int:
 
         def _settings_menu(self, rumps):
             menu = rumps.MenuItem("Settings")
+
+            rows = rumps.MenuItem("Account rows")
+            row_labels = {
+                "compact": "Compact (one line)",
+                "columns": "Columns",
+                "bars": "Columns with bars",
+                "focus": "Binding limit first",
+            }
+            for style in ROW_STYLE_CHOICES:
+                ch = rumps.MenuItem(row_labels[style], callback=self._make_row_style(style))
+                ch.state = 1 if self.settings.row_style == style else 0
+                rows.add(ch)
+            rows.add(None)
+            resets_item = rumps.MenuItem("Show reset times", callback=self.on_toggle_resets)
+            resets_item.state = 1 if self.settings.show_resets else 0
+            rows.add(resets_item)
+            menu.add(rows)
+
             name_item = rumps.MenuItem("Show account name in menu bar", callback=self.on_toggle_name)
             name_item.state = 1 if self.settings.show_account_name else 0
             menu.add(name_item)
@@ -909,6 +1483,16 @@ def run(switcher) -> int:
         def on_toggle_scoped(self, _sender):
             self.settings.title_scoped = not self.settings.title_scoped
             self._save_and_rebuild()
+
+        def on_toggle_resets(self, _sender):
+            self.settings.show_resets = not self.settings.show_resets
+            self._save_and_rebuild()
+
+        def _make_row_style(self, style):
+            def cb(_sender):
+                self.settings.row_style = style
+                self._save_and_rebuild()
+            return cb
 
         def _make_title_pct(self, mode):
             def cb(_sender):

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -307,7 +307,6 @@ def format_account_label(
 
 MAXED_MARKER = "!"   # window at/over its limit — the usual reason to switch
 AHEAD_MARKER = "\u2191"   # weekly window running ahead of an even burn-down pace
-RESETS_CAPTION = "resets in"  # leads the dimmed second line of a detailed row
 SPEND_HEADER = "$"
 
 # Utilization thresholds behind the severity tint. Only the constrained end is
@@ -620,6 +619,41 @@ def _bar_attachment(AppKit, image):
     return AppKit.NSAttributedString.attributedStringWithAttachment_(attachment)
 
 
+def _emphasise_active(AppKit, attributed):
+    """Mark the active account inside the row rather than beside it.
+
+    ``NSMenuItem.state`` draws its checkmark centred vertically over the whole
+    item. That is right for a one-line item and wrong for a grid row, which is
+    two lines tall once reset countdowns are shown: the mark floats in the gap
+    between the name and the countdowns, aligned with neither.
+
+    Weight, across the first line only. Not colour — an accent-coloured row
+    reads as a link, and it would compete with the warning and critical tints
+    the percentages carry, which are the readings that matter. Weight runs
+    safely across those numbers because it does not disturb their colour. The
+    countdown line stays quiet; bolding it would make the active row shout
+    twice without helping anyone find it.
+
+    Works on a copy: ``rebuild_menu`` reuses the aligned titles, and
+    emphasising in place would leave every later row wearing this one's weight.
+    """
+    out = AppKit.NSMutableAttributedString.alloc().initWithAttributedString_(attributed)
+    text = out.string()
+    newline = text.find("\n")
+    head = len(text) if newline < 0 else newline
+    if head <= 0:
+        return out
+    existing = out.attribute_atIndex_effectiveRange_(
+        AppKit.NSFontAttributeName, 0, None
+    )[0]
+    if existing is not None:
+        bold = AppKit.NSFontManager.sharedFontManager().convertFont_toHaveTrait_(
+            existing, AppKit.NSBoldFontMask
+        )
+        out.addAttribute_value_range_(AppKit.NSFontAttributeName, bold, (0, head))
+    return out
+
+
 def build_attributed_rows(
     AppKit,
     rows: list[TableRow],
@@ -705,8 +739,6 @@ def build_attributed_rows(
             if with_resets:
                 widest = max(widest, width(row.resets[index], small_font))
         widths.append(widest)
-    if with_resets and len(widths) > 1:
-        widths[1] = max(widths[1], width(RESETS_CAPTION, small_font))
 
     # Give every window column the same width — an even rhythm reads far better
     # than columns that each hug their own widest value, and it keeps a "0%"
@@ -792,8 +824,12 @@ def build_attributed_rows(
                 AppKit.NSColor.secondaryLabelColor(),
                 (start, len(row.cells[3])))
         if with_resets and any(row.resets):
+            # No caption. It read "resets in" once per account — as many
+            # times as there are accounts, saying the same thing each time,
+            # and separated from its own values by whichever window columns
+            # were empty. The countdown sits directly under the percentage it
+            # belongs to, and the header above already names the window.
             resets = list(row.resets)
-            resets[1] = RESETS_CAPTION
             attributed.appendAttributedString_(
                 AppKit.NSAttributedString.alloc().initWithString_attributes_(
                     "\n", {AppKit.NSParagraphStyleAttributeName: paragraph}))
@@ -1231,8 +1267,13 @@ def run(switcher) -> int:
                 # The plain label above stays the item's rumps key (unique per
                 # account); the attributed title only changes what's drawn.
                 if aligned is not None:
-                    item._menuitem.setAttributedTitle_(aligned[index])
-                item.state = 1 if is_active else 0
+                    title = aligned[index]
+                    if is_active:
+                        title = _emphasise_active(AppKit, title)
+                    item._menuitem.setAttributedTitle_(title)
+                    # NOT item.state on a grid row — see _emphasise_active.
+                else:
+                    item.state = 1 if is_active else 0
                 account_items.append(item)
             if not accounts:
                 account_items = [rumps.MenuItem("No managed accounts", callback=None)]

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -905,15 +905,35 @@ def parse_switch_history(log_text: str, limit: int = SWITCH_HISTORY_LIMIT) -> li
     return out[-limit:][::-1]
 
 
+def short_sentinel_note(sentinel: str) -> str:
+    """The state, without the instruction that follows it.
+
+    A menu is as wide as its widest item, and the full notes carry a remedy as
+    well as a state: "re-login needed — refresh token dead; log in with Claude
+    Code, then run: cswap add" is 82 characters. Measured on a pool of eight
+    accounts, that one row renders 614pt wide while every aligned account row
+    is 314pt — so a single expired account nearly doubles the menu and leaves
+    the usage columns marooned against the far edge. Cutting the remedy takes
+    it to 201pt, narrower than the table, so it stops setting the width.
+
+    Derived from ``SENTINEL_NOTES`` rather than kept as a second table: two
+    hand-maintained copies of one string drift. A note with no dash ("API key
+    (no quota)") is already short and passes through whole. ``cswap list``
+    keeps the full note, where one long line costs nothing and the remedy is
+    what the reader came for.
+    """
+    note = SENTINEL_NOTES.get(sentinel, sentinel)
+    return note.split(" \u2014 ", 1)[0]
+
+
 def _account_display_usage(entry) -> dict | str | None:
     """Menu-display usage for a ``UsageEntry``.
 
-    A human-readable note for a sentinel state (token expired / API key /
-    keychain unavailable), otherwise the last-good measurement dict, otherwise
-    ``None``.
+    A short note for a sentinel state (token expired / API key / keychain
+    unavailable), otherwise the last-good measurement dict, otherwise ``None``.
     """
     if entry.sentinel:
-        return SENTINEL_NOTES.get(entry.sentinel, entry.sentinel)
+        return short_sentinel_note(entry.sentinel)
     return entry.last_good
 
 

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -556,3 +556,346 @@ def test_run_without_rumps_raises_clean_error(monkeypatch):
     monkeypatch.setitem(sys.modules, "rumps", None)
     with pytest.raises(ClaudeSwitchError, match=r"claude-swap\[menubar\]"):
         menubar.run(switcher=None)
+
+
+# --- aligned account table (the grid + focus row styles) -----------------------
+
+def _account(num, email, usage, *, active=False, alias=None, disabled=False):
+    """A snapshot account tuple in the shape rebuild_menu iterates."""
+    return (num, email, active, usage, None, alias, disabled, None)
+
+
+_TABLE_ACCOUNTS = [
+    _account(1, "a@x.de", {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 91.0},
+                           "scoped": [{"name": "Fable", "pct": 90.0}]}),
+    _account(2, "b@x.de", {"five_hour": {"pct": 19.0}, "seven_day": {"pct": 3.0},
+                           "scoped": [{"name": "Fable", "pct": 0.0}],
+                           "spend": {"pct": 58.0}}, active=True),
+]
+
+
+def test_table_has_one_column_per_window_not_per_label():
+    cols = menubar.account_table_columns(_TABLE_ACCOUNTS)
+    # num, name, then exactly one column each for 5h, 7d, Fable, spend
+    assert [c.title for c in cols] == ["", "", "5h", "7d", "Fable", "$"]
+    assert [c.right_aligned for c in cols] == [False, False, True, True, True, True]
+
+
+def test_header_carries_the_window_names():
+    cols = menubar.account_table_columns(_TABLE_ACCOUNTS)
+    assert menubar.account_table_header(cols) == ("", "", "5h", "7d", "Fable", "$")
+
+
+def test_table_omits_columns_nobody_reports():
+    plain = [_account(1, "a@x.de", {"five_hour": {"pct": 5.0}, "seven_day": {"pct": 6.0}})]
+    assert [c.title for c in menubar.account_table_columns(plain)] == ["", "", "5h", "7d"]
+
+
+def test_table_model_columns_are_shared_and_deduplicated():
+    assert menubar.account_table_model_names(_TABLE_ACCOUNTS) == ("Fable",)
+
+
+def test_table_rows_carry_only_numbers():
+    rows = menubar.build_account_table(_TABLE_ACCOUNTS)
+    assert rows[0].cells == ("1", "a@x.de", "0%", "91%", "90%", "")
+    assert rows[1].cells == ("2", "b@x.de", "19%", "3%", "0%", "58%")
+
+
+def test_table_row_keeps_grid_width_when_a_window_is_missing():
+    accounts = _TABLE_ACCOUNTS + [_account(3, "c@x.de", {"five_hour": {"pct": 7.0},
+                                                         "seven_day": {"pct": 8.0}})]
+    rows = menubar.build_account_table(accounts)
+    assert len({len(r.cells) for r in rows}) == 1  # one shared grid
+    assert rows[2].cells[4:] == ("", "")           # no Fable, no spend for this one
+
+
+def test_table_marks_a_maxed_window():
+    rows = menubar.build_account_table(
+        [_account(1, "a@x.de", {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 100.0}})]
+    )
+    assert rows[0].cells[3] == "100%" + menubar.MAXED_MARKER
+
+
+def test_table_alias_and_disabled_marker_stay_in_the_name_cell():
+    rows = menubar.build_account_table(
+        [_account(1, "a@x.de", _USAGE, alias="dev", disabled=True)]
+    )
+    assert rows[0].cells[1] == "dev (a@x.de)  (disabled)"
+
+
+def test_table_sentinel_usage_rides_in_the_name_cell():
+    # The window columns are right-aligned percentages; a sentence dropped into
+    # one would run backwards across the row.
+    rows = menubar.build_account_table(
+        [_account(1, "a@x.de", "re-login needed"), _TABLE_ACCOUNTS[1]]
+    )
+    assert rows[0].cells[1] == "a@x.de — re-login needed"
+    assert set(rows[0].cells[2:]) == {""}
+    assert set(rows[0].values) == {None}
+
+
+def test_table_missing_usage_reads_as_unavailable():
+    rows = menubar.build_account_table([_account(1, "a@x.de", None)])
+    assert rows[0].cells[1] == "a@x.de — usage unavailable"
+
+
+def test_table_resets_line_up_under_their_percentages():
+    now = 1_000_000.0
+    resets = _dt.datetime.fromtimestamp(now + 3600, _dt.timezone.utc).isoformat()
+    rows = menubar.build_account_table(
+        [_account(1, "a@x.de", {"five_hour": {"pct": 10.0, "resets_at": resets},
+                                "seven_day": {"pct": 20.0}})],
+        now=now,
+    )
+    assert rows[0].cells[2] == "10%"
+    assert rows[0].resets[2] == "1h 0m"   # same index as the 5h percentage
+    assert set(rows[0].resets) == {"", "1h 0m"}
+
+
+# --- severity tint -------------------------------------------------------------
+
+@pytest.mark.parametrize("pct,expected", [
+    (0.0, None), (79.9, None),
+    (80.0, "warning"), (94.9, "warning"),
+    (95.0, "critical"), (100.0, "critical"),
+    (None, None),
+])
+def test_severity_thresholds(pct, expected):
+    assert menubar.severity_for(pct) == expected
+
+
+def test_row_severities_track_their_cells():
+    rows = menubar.build_account_table(_TABLE_ACCOUNTS)
+    # 0% / 91% / 90% -> none / warning / warning (both under the 95% mark),
+    # and nothing on the num+name columns
+    assert rows[0].severities == (None, None, None, "warning", "warning", None)
+
+
+def test_row_severity_turns_critical_past_the_threshold():
+    rows = menubar.build_account_table(
+        [_account(1, "a@x.de", {"five_hour": {"pct": 96.0}, "seven_day": {"pct": 94.0}})]
+    )
+    assert rows[0].severities[2:] == ("critical", "warning")
+
+
+def test_spend_is_never_tinted():
+    # Spend caps cost, not requests — a full budget doesn't block anything.
+    rows = menubar.build_account_table(
+        [_account(1, "a@x.de", {"five_hour": {"pct": 1.0}, "seven_day": {"pct": 2.0},
+                                "spend": {"pct": 99.0}})]
+    )
+    assert rows[0].cells[-1] == "99%"
+    assert rows[0].severities[-1] is None
+
+
+# --- numeric values (what the drawn bars are sized from) -----------------------
+
+def test_rows_carry_the_raw_percentage_behind_each_cell():
+    rows = menubar.build_account_table(_TABLE_ACCOUNTS)
+    assert rows[0].values == (None, None, 0.0, 91.0, 90.0, None)
+    assert rows[1].values == (None, None, 19.0, 3.0, 0.0, 58.0)
+
+
+def test_values_are_none_where_a_window_is_missing():
+    rows = menubar.build_account_table(
+        [_account(1, "a@x.de", {"five_hour": {"pct": 5.0}, "seven_day": {"pct": 6.0}})]
+    )
+    assert rows[0].values == (None, None, 5.0, 6.0)
+
+
+# --- name truncation -----------------------------------------------------------
+
+def test_short_names_are_untouched():
+    assert menubar.truncate_name("mk@vsjwl.de") == "mk@vsjwl.de"
+
+
+def test_long_name_drops_the_domain_first():
+    # The domain is the redundant part; the local part identifies the account.
+    assert menubar.truncate_name("someone@a-very-long-company-domain.example") == "someone@…"
+
+
+def test_name_too_long_even_without_a_domain_is_hard_truncated():
+    name = menubar.truncate_name("a" * 60)
+    assert len(name) == menubar.NAME_LIMIT
+    assert name.endswith("…")
+
+
+def test_truncation_keeps_one_long_address_from_widening_every_row():
+    rows = menubar.build_account_table([
+        _account(1, "very.long.address@some-long-company-domain.example",
+                 {"five_hour": {"pct": 1.0}, "seven_day": {"pct": 2.0}}),
+        _account(2, "b@x.de", {"five_hour": {"pct": 3.0}, "seven_day": {"pct": 4.0}}),
+    ])
+    assert len(rows[0].cells[1]) <= menubar.NAME_LIMIT
+
+
+# --- focus style ---------------------------------------------------------------
+
+def test_focus_leads_with_the_binding_window():
+    rows = menubar.build_focus_table(_TABLE_ACCOUNTS)
+    assert rows[0].cells[2] == "7d 91%"          # tightest of 0 / 91 / 90
+    assert rows[1].cells[2] == "5h 19%"          # tightest of 19 / 3 / 0
+
+
+def test_focus_trails_the_remaining_windows():
+    rows = menubar.build_focus_table(_TABLE_ACCOUNTS)
+    assert rows[0].cells[3] == "5h 0% · Fable 90%"
+    assert rows[1].cells[3] == "7d 3% · Fable 0% · $ 58%"
+
+
+def test_focus_tints_only_the_binding_cell():
+    rows = menubar.build_focus_table(_TABLE_ACCOUNTS)
+    assert rows[0].severities == (None, None, "warning", None)
+
+
+def test_focus_ignores_spend_when_choosing_the_binding_window():
+    # A 99% budget must not outrank a 3% rate-limit window.
+    rows = menubar.build_focus_table(
+        [_account(1, "a@x.de", {"five_hour": {"pct": 3.0}, "seven_day": {"pct": 2.0},
+                                "spend": {"pct": 99.0}})]
+    )
+    assert rows[0].cells[2] == "5h 3%"
+
+
+def test_focus_handles_a_sentinel_account():
+    rows = menubar.build_focus_table([_account(1, "a@x.de", "no credentials")])
+    assert rows[0].cells[1] == "a@x.de — no credentials"
+    assert rows[0].severities == (None, None, None, None)
+
+
+def test_focus_columns_are_all_left_aligned():
+    assert [c.right_aligned for c in menubar.focus_table_columns()] == [False] * 4
+
+
+def test_spend_carries_no_at_limit_marker():
+    # An exhausted budget caps cost, it doesn't block a request.
+    rows = menubar.build_account_table(
+        [_account(1, "a@x.de", {"five_hour": {"pct": 100.0}, "seven_day": {"pct": 1.0},
+                                "spend": {"pct": 100.0}})]
+    )
+    assert rows[0].cells[2] == "100%" + menubar.MAXED_MARKER  # the 5h window
+    assert rows[0].cells[-1] == "100%"                        # spend, unmarked
+
+
+# --- attributed layout (needs real AppKit; the riskiest part — string offsets) -
+
+# Everything above never touches AppKit, so it runs on every platform. The tests
+# below render for real; they must NOT skip the whole module when pyobjc is
+# absent (Linux CI), so import lazily and gate each one with a marker.
+try:
+    import AppKit
+except ImportError:  # pragma: no cover - exercised only where pyobjc is absent
+    AppKit = None
+
+needs_appkit = pytest.mark.skipif(AppKit is None, reason="pyobjc/AppKit not installed")
+
+
+def _attrs_at(attributed, index):
+    return attributed.attributesAtIndex_effectiveRange_(index, None)[0]
+
+
+def _color_name_at(attributed, index):
+    """A stable-ish label for the foreground colour at a character index."""
+    color = _attrs_at(attributed, index).get("NSColor")
+    if color is None:
+        return "default"
+    # Compare against the palette build_attributed_rows uses.
+    for name, ref in (("orange", AppKit.NSColor.systemOrangeColor()),
+                      ("red", AppKit.NSColor.systemRedColor()),
+                      ("secondary", AppKit.NSColor.secondaryLabelColor())):
+        try:
+            if color.isEqual_(ref):
+                return name
+        except Exception:
+            pass
+    return "other"
+
+
+@needs_appkit
+def test_attributed_columns_style_tints_the_right_cells():
+    titles, header = menubar.build_attributed_rows(
+        AppKit,
+        menubar.build_account_table(_TABLE_ACCOUNTS),
+        menubar.account_table_columns(_TABLE_ACCOUNTS),
+        menubar.account_table_header(menubar.account_table_columns(_TABLE_ACCOUNTS)),
+    )
+    assert header is not None
+    assert len(titles) == len(_TABLE_ACCOUNTS)
+
+    # Account 1: "1  a@x.de  0%  91%  90%" — the 91% (7d) and 90% (Fable) cells
+    # are warning-tinted, the name and the 0% are not. Locate cells by string
+    # offset, exactly as the renderer does.
+    row = titles[0]
+    text = row.string()
+    assert _color_name_at(row, text.index("a@x.de")) == "default"      # name plain
+    assert _color_name_at(row, text.index("0%")) == "default"          # 5h plain
+    assert _color_name_at(row, text.index("91%")) == "orange"          # 7d warning
+    assert _color_name_at(row, text.index("90%")) == "orange"          # Fable warning
+
+
+@needs_appkit
+def test_attributed_marks_a_critical_cell_red():
+    accounts = [_account(1, "a@x.de", {"five_hour": {"pct": 5.0},
+                                       "seven_day": {"pct": 99.0}})]
+    titles, _ = menubar.build_attributed_rows(
+        AppKit, menubar.build_account_table(accounts),
+        menubar.account_table_columns(accounts),
+        menubar.account_table_header(menubar.account_table_columns(accounts)),
+    )
+    text = titles[0].string()
+    assert _color_name_at(titles[0], text.index("99%")) == "red"
+    assert _color_name_at(titles[0], text.index("5%")) == "default"
+
+
+@needs_appkit
+def test_attributed_bars_keep_the_percentage_tint_and_offsets():
+    # A bar is inserted before each percentage; the tint must still land on the
+    # number, not slide onto the bar or the neighbouring cell.
+    accounts = [_account(1, "a@x.de", {"five_hour": {"pct": 2.0},
+                                       "seven_day": {"pct": 97.0}})]
+    titles, _ = menubar.build_attributed_rows(
+        AppKit, menubar.build_account_table(accounts),
+        menubar.account_table_columns(accounts),
+        menubar.account_table_header(menubar.account_table_columns(accounts)),
+        bars=True,
+    )
+    text = titles[0].string()
+    assert _color_name_at(titles[0], text.index("97%")) == "red"
+    assert _color_name_at(titles[0], text.index("2%")) == "default"
+
+
+@needs_appkit
+def test_attributed_focus_dims_the_trailing_context():
+    titles, header = menubar.build_attributed_rows(
+        AppKit, menubar.build_focus_table(_TABLE_ACCOUNTS),
+        menubar.focus_table_columns(),
+    )
+    assert header is None
+    # Account 2 is "2  b@x.de  5h 19%  7d 3% · Fable 0% · $ 58%": the binding
+    # cell (5h 19%) is plain, the trailing context is dimmed.
+    row = titles[1]
+    text = row.string()
+    assert _color_name_at(row, text.index("5h 19%")) == "default"
+    assert _color_name_at(row, text.index("Fable 0%")) == "secondary"
+
+
+@needs_appkit
+def test_attributed_row_count_and_no_crash_on_sentinel_and_disabled():
+    # The stress mix (sentinel row, disabled alias, three models) must render
+    # one title per account without raising.
+    accounts = [
+        _account(1, "a@x.de", {"five_hour": {"pct": 1.0}, "seven_day": {"pct": 2.0},
+                               "scoped": [{"name": "Fable", "pct": 3.0}]}),
+        (2, "b@x.de", False, "re-login needed", None, None, False, None),
+        _account(3, "c@x.de", {"five_hour": {"pct": 4.0}, "seven_day": {"pct": 5.0}},
+                 alias="work", disabled=True),
+    ]
+    for style_bars in (False, True):
+        titles, _ = menubar.build_attributed_rows(
+            AppKit, menubar.build_account_table(accounts),
+            menubar.account_table_columns(accounts),
+            menubar.account_table_header(menubar.account_table_columns(accounts)),
+            bars=style_bars, with_resets=True,
+        )
+        assert len(titles) == 3
+        assert "re-login needed" in titles[1].string()

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -18,7 +18,7 @@ import pytest
 
 from claude_swap import menubar
 from claude_swap.exceptions import ClaudeSwitchError
-from claude_swap.switcher import USAGE_API_KEY
+from claude_swap.switcher import SENTINEL_NOTES, USAGE_API_KEY
 
 
 # --- notification identity -----------------------------------------------------
@@ -461,6 +461,34 @@ class _FakeAcct:
 class _FakeSnap:
     def __init__(self, accounts):
         self.accounts = accounts
+
+
+class TestShortSentinelNote:
+    """A menu is as wide as its widest item, and the full notes carry a remedy.
+    Measured on a pool of eight accounts: one expired row renders 614pt while
+    every aligned account row is 314pt, so it nearly doubles the menu."""
+
+    def test_the_remedy_is_cut_and_the_state_kept(self):
+        assert menubar.short_sentinel_note("re-login needed") == "re-login needed"
+        assert menubar.short_sentinel_note("token expired") == "token expired"
+
+    def test_it_is_derived_not_a_second_table(self):
+        """Every short form must be a prefix of its full note — a hand-kept
+        second copy of these strings would drift."""
+        for key, note in SENTINEL_NOTES.items():
+            assert note.startswith(menubar.short_sentinel_note(key))
+
+    def test_a_note_without_a_remedy_passes_through_whole(self):
+        assert menubar.short_sentinel_note("api key") == SENTINEL_NOTES["api key"]
+
+    def test_no_sentinel_can_set_the_menu_width(self):
+        """The property that matters. The longest email in a real pool is 19
+        characters, so a note under 45 cannot be the widest item."""
+        for key in SENTINEL_NOTES:
+            assert len(menubar.short_sentinel_note(key)) <= 45, key
+
+    def test_an_unknown_sentinel_survives(self):
+        assert menubar.short_sentinel_note("something new") == "something new"
 
 
 def test_account_display_usage_sentinel_note_last_good_or_none():

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -927,3 +927,110 @@ def test_attributed_row_count_and_no_crash_on_sentinel_and_disabled():
         )
         assert len(titles) == 3
         assert "re-login needed" in titles[1].string()
+
+
+@needs_appkit
+class TestActiveRowEmphasis:
+    """NSMenuItem.state centres its checkmark vertically over the whole item,
+    and a grid row is two lines tall once countdowns are shown — so the mark
+    floated in the gap between the name and its countdowns, aligned with
+    neither."""
+
+    @staticmethod
+    def _row():
+        rows = [
+            menubar.TableRow(
+                cells=("8", "a@b.c", "95%", "10%"),
+                values=(None, None, 95.0, 10.0),
+                severities=(None, None, "warning", None),
+                resets=("", "", "1h", "2d"),
+            ),
+        ]
+        columns = (
+            menubar.TableColumn("num", "", False),
+            menubar.TableColumn("name", "", False),
+            menubar.TableColumn("window", "5h", True),
+            menubar.TableColumn("window", "7d", True),
+        )
+        titles, _ = menubar.build_attributed_rows(
+            AppKit, rows, columns, ("", "", "5h", "7d"), with_resets=True
+        )
+        return titles[0]
+
+    def _at(self, attributed, index):
+        font = attributed.attribute_atIndex_effectiveRange_(
+            AppKit.NSFontAttributeName, index, None
+        )[0]
+        colour = attributed.attribute_atIndex_effectiveRange_(
+            AppKit.NSForegroundColorAttributeName, index, None
+        )[0]
+        bold = bool(
+            AppKit.NSFontManager.sharedFontManager().traitsOfFont_(font)
+            & AppKit.NSBoldFontMask
+        ) if font is not None else False
+        return bold, colour
+
+    def test_the_whole_first_line_is_emphasised(self):
+        """Stopping at the name left too little of the row to find at a
+        glance, which is the one job the mark has."""
+        row = self._row()
+        text = row.string()
+        first_pct = text.find("\t", text.find("\t") + 1) + 1
+
+        out = menubar._emphasise_active(AppKit, row)
+
+        assert self._at(out, 0)[0] is True
+        assert self._at(out, first_pct)[0] is True
+
+    def test_a_warning_percentage_keeps_its_own_colour(self):
+        """Weight may run across the numbers; colour may not. The tints are
+        the reading the operator most needs to see."""
+        row = self._row()
+        text = row.string()
+        first_pct = text.find("\t", text.find("\t") + 1) + 1
+
+        out = menubar._emphasise_active(AppKit, row)
+
+        assert self._at(out, first_pct)[1] == AppKit.NSColor.systemOrangeColor()
+
+    def test_the_countdown_line_stays_quiet(self):
+        row = self._row()
+        second_line = row.string().find("\n") + 1
+
+        out = menubar._emphasise_active(AppKit, row)
+
+        assert self._at(out, second_line)[0] is False
+
+    def test_the_original_is_not_mutated(self):
+        """rebuild_menu reuses the aligned titles; emphasising in place would
+        leave every later row wearing this one's weight."""
+        row = self._row()
+        menubar._emphasise_active(AppKit, row)
+        assert self._at(row, 0)[0] is False
+
+
+@needs_appkit
+def test_the_resets_line_carries_no_repeated_caption():
+    """It read "resets in" once per account, saying the same thing each time
+    and separated from its own values by whichever columns were empty."""
+    rows = [
+        menubar.TableRow(
+            cells=("1", "a@b.c", "5%", "10%"),
+            values=(None, None, 5.0, 10.0),
+            severities=(None,) * 4,
+            resets=("", "", "1h", "2d"),
+        ),
+    ]
+    columns = (
+        menubar.TableColumn("num", "", False),
+        menubar.TableColumn("name", "", False),
+        menubar.TableColumn("window", "5h", True),
+        menubar.TableColumn("window", "7d", True),
+    )
+    titles, _ = menubar.build_attributed_rows(
+        AppKit, rows, columns, ("", "", "5h", "7d"), with_resets=True
+    )
+    second_line = titles[0].string().split("\n")[1]
+
+    assert "resets" not in second_line
+    assert "1h" in second_line and "2d" in second_line


### PR DESCRIPTION
The compact account row formats each account independently, so nothing lines up. Under a proportional menu font, comparing two accounts' 7d usage means reading every row — and the window labels (`5h`, `7d`, `Fable`, `$`) are repeated on every single line.

This adds three opt-in layouts under **Settings → Account rows**, sharing one column grid across all accounts. **Compact stays the default**, so no existing menu changes without the user asking.

| | |
|---|---|
| **Columns** | one column per usage window; the window names move into a dimmed header row |
| **Columns with bars** | the same grid with a drawn progress bar in front of each number |
| **Binding limit first** | leads with the window actually closest to blocking you, rest dimmed as context |

Plus **Show reset times**, an independent toggle adding a second dimmed line with each window's countdown, aligned under its own percentage.

Percentages turn orange past 80% and red past 95%. Only the constrained end is tinted, so a pool of idle accounts stays monochrome and colour means something.

### Why it's built this way

- **Alignment is AppKit's, not padding.** One shared `NSParagraphStyle` whose tab stops are measured from the widest cell per column. Every measurement is taken in the font the text is actually drawn in, and every gap is a multiple of that font's space width — so the grid follows the system font size rather than assuming one screen's metrics. Verified by rendering at 11pt, 13pt and 18pt.
- **Bars are drawn images, not block glyphs.** `▁ █ ▌` have no coverage in the menu font, fall back to whatever face does, and come out at inconsistent widths — and `▁` draws a hairline on the baseline, so an empty bar reads as an underscore. The bar is sized from the font's point size, so it scales too.
- **Percentages in the bars layout are padded with FIGURE SPACE.** Each cell is right-aligned on its tab stop, so a wider number ("37%" vs "0%") would push its bar left and leave the bars' left edges ragged.
- **Window columns share one width.** A `0%` column beside a `100%!` one otherwise collapses and breaks the vertical rhythm.
- **Long account names are truncated, domain first.** The name column is as wide as its widest entry, so one long address would push every number on every row to the right — in testing it doubled the menu width.
- **Sentinel usage rides in the name cell.** `re-login needed` dropped into a right-aligned percentage column runs backwards across the row; `4  d@x.de — re-login needed` reads correctly.
- **Spend is never tinted and carries no at-limit marker.** An exhausted budget caps cost, it doesn't block a request; flagging it like a maxed rate-limit window would misread.

### Testing

The layout lives in `build_attributed_rows()`, which takes `AppKit` as an argument the same way the existing glue takes `rumps`. That keeps `menubar.py` import-safe and unit-testable without pyobjc — and it let me render the rows to PNG for visual review without opening a menu, including cases this machine doesn't produce (three per-model windows, 60-character addresses, everything at 100%, sentinel and disabled rows side by side).

52 new tests. Full suite: 1557 passed. The 6 failures in `test_swap_accounts.py` / `test_move_accounts.py` are pre-existing on `main` at c89e6f9 — they fail identically without this branch applied.

All four layouts plus the reset toggle were also exercised in the running app on macOS 15.2.

Independent of #168 (both touch `menubar.py`, but different regions; happy to rebase whichever lands second).