### PR TITLE
fix(tui): observe external usage refreshes

### DIFF
--- a/src/claude_swap/snapshot_source.py
+++ b/src/claude_swap/snapshot_source.py
@@ -15,8 +15,13 @@ from a background thread, never a UI event loop.
 
 from __future__ import annotations
 
-from claude_swap.models import AccountsSnapshot
+import threading
+from dataclasses import replace
+
+from claude_swap.json_output import USAGE_TOKEN_EXPIRED
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
 from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.usage_store import UsageEntry
 
 
 class SnapshotSource:
@@ -31,6 +36,7 @@ class SnapshotSource:
     def __init__(self, switcher: ClaudeAccountSwitcher) -> None:
         self.switcher = switcher
         self._last: AccountsSnapshot | None = None
+        self._lock = threading.Lock()
 
     def take(
         self, *, full: bool = False, store_only: bool = False
@@ -38,5 +44,51 @@ class SnapshotSource:
         """Blocking snapshot pass; call from a thread worker."""
         fetch: set[str] | None = set() if store_only else None
         snap = self.switcher.accounts_snapshot(fetch=fetch)
-        self._last = snap
-        return snap
+        with self._lock:
+            snap = self._reconcile(snap)
+            self._last = snap
+            return snap
+
+    def _reconcile(self, snap: AccountsSnapshot) -> AccountsSnapshot:
+        if self._last is None:
+            return snap
+        previous = {acc.number: acc for acc in self._last.accounts}
+        accounts = tuple(
+            self._reconcile_account(acc, previous.get(acc.number), snap.taken_at)
+            for acc in snap.accounts
+        )
+        return replace(snap, accounts=accounts)
+
+    def _reconcile_account(
+        self,
+        acc: AccountSnapshot,
+        prev: AccountSnapshot | None,
+        taken_at: float,
+    ) -> AccountSnapshot:
+        if prev is None or _account_identity(acc) != _account_identity(prev):
+            return acc
+
+        prev_fetched = prev.usage.fetched_at
+        fetched = acc.usage.fetched_at
+        if prev_fetched is not None and (fetched is None or fetched < prev_fetched):
+            return replace(acc, usage=_with_current_age(prev.usage, taken_at))
+        if acc.usage.sentinel is not None:
+            return acc
+
+        if (
+            prev.usage.sentinel == USAGE_TOKEN_EXPIRED
+            and fetched == prev_fetched
+        ):
+            return replace(acc, usage=replace(acc.usage, sentinel=USAGE_TOKEN_EXPIRED))
+        return acc
+
+
+def _account_identity(acc: AccountSnapshot) -> tuple[str, str, str]:
+    return (acc.email, acc.org_uuid, acc.kind)
+
+
+def _with_current_age(usage: UsageEntry, taken_at: float) -> UsageEntry:
+    fetched = usage.fetched_at
+    if fetched is None:
+        return usage
+    return replace(usage, age_s=max(0.0, taken_at - fetched))

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -8,6 +8,8 @@ loop never touches file locks, keychain subprocesses, or the network.
 
 from __future__ import annotations
 
+import time
+from dataclasses import replace
 from functools import partial
 
 from textual.app import App
@@ -21,7 +23,7 @@ from claude_swap.settings import load_settings, load_ui_settings, set_setting
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui.autoview import AutoScreen
 from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
-from claude_swap.tui.data import ActionResult, SnapshotSource, run_action
+from claude_swap.tui.data import ActionResult, SnapshotSource, format_duration, run_action
 from claude_swap.tui.modals import AddTokenModal, ConfirmModal, OutputModal, TokenForm
 from claude_swap.tui.theme import CSWAP_DARK, CSWAP_LIGHT
 
@@ -39,6 +41,7 @@ class CswapApp(App):
     POLL_INTERVAL_S = 3.0  # matches the old watch view's recapture cadence
 
     snapshot: reactive[AccountsSnapshot | None] = reactive(None)
+    refresh_status: reactive[str] = reactive("")
     busy: reactive[bool] = reactive(False)
 
     def __init__(
@@ -55,7 +58,11 @@ class CswapApp(App):
         self.source = SnapshotSource(switcher)
         self._store_only = False
         self._full_next = False
-        self._refreshing = False
+        self._normal_refreshing = False
+        self._store_refreshing = False
+        self._normal_started_at: float | None = None
+        self._refresh_generation = 0
+        self._applied_generation = 0
         self._last_refresh_error = ""
         # The auto-switch threshold, drawn as a tick on the status strip's
         # bars everywhere. Missing/invalid settings fall back to the default.
@@ -82,32 +89,113 @@ class CswapApp(App):
             # Stacked over the dashboard so Esc lands there, not on exit.
             self.push_screen(WatchScreen())
         self.set_interval(self.POLL_INTERVAL_S, self._tick)
+        self.set_interval(1.0, self._update_refresh_status)
         self._tick()
 
     # -- snapshot poll loop ---------------------------------------------------
 
     def _tick(self) -> None:
-        """Start a refresh pass unless one is already in flight."""
-        if self._refreshing:
+        """Start one eligible refresh lane.
+
+        Normal mode prefers the fetch-enabled lane. When that lane is blocked,
+        the poll tick may still observe another process's store update through
+        one store-only lane. Auto mode already has an engine fetching, so it
+        launches only store-only snapshots.
+        """
+        if self._store_only:
+            self._start_store_refresh()
+        elif not self._normal_refreshing:
+            full, self._full_next = self._full_next, False
+            self._start_normal_refresh(full=full)
+        else:
+            self._start_store_refresh()
+
+    def _start_normal_refresh(self, *, full: bool) -> None:
+        if self._normal_refreshing:
             return
-        self._refreshing = True
-        full, self._full_next = self._full_next, False
+        self._normal_refreshing = True
+        self._normal_started_at = time.time()
+        generation = self._next_refresh_generation()
+        self._update_refresh_status()
         self.run_worker(
-            partial(self._refresh_blocking, full, self._store_only),
+            partial(self._refresh_blocking, generation, "normal", full, False),
             thread=True,
-            group="refresh",
+            group="refresh-normal",
             exit_on_error=False,
             name="snapshot-refresh",
         )
 
-    def _refresh_blocking(self, full: bool, store_only: bool) -> None:
-        snap = self.source.take(full=full, store_only=store_only)
-        self.call_from_thread(self._apply_snapshot, snap)
+    def _start_store_refresh(self) -> None:
+        if self._store_refreshing:
+            return
+        self._store_refreshing = True
+        generation = self._next_refresh_generation()
+        self._update_refresh_status()
+        self.run_worker(
+            partial(self._refresh_blocking, generation, "store", False, True),
+            thread=True,
+            group="refresh-store",
+            exit_on_error=False,
+            name="snapshot-store-refresh",
+        )
 
-    def _apply_snapshot(self, snap: AccountsSnapshot) -> None:
-        self._refreshing = False
+    def _next_refresh_generation(self) -> int:
+        self._refresh_generation += 1
+        return self._refresh_generation
+
+    def _refresh_blocking(
+        self, generation: int, lane: str, full: bool, store_only: bool
+    ) -> None:
+        snap = self.source.take(full=full, store_only=store_only)
+        self.call_from_thread(self._apply_snapshot, generation, lane, snap)
+
+    def _apply_snapshot(
+        self, generation: int, lane: str, snap: AccountsSnapshot
+    ) -> None:
+        if lane == "normal":
+            self._normal_refreshing = False
+            self._normal_started_at = None
+        else:
+            self._store_refreshing = False
         self._last_refresh_error = ""
-        self.snapshot = snap
+        if generation >= self._applied_generation:
+            self._applied_generation = generation
+            self.snapshot = snap
+        elif self.snapshot is not None:
+            # A later-started store repaint owns account metadata, but the
+            # older worker may have completed a genuinely newer provider fetch.
+            # SnapshotSource has already rejected per-account regressions, so
+            # merge its canonical usage rows without restoring stale metadata.
+            current = self.snapshot
+            incoming = {acc.number: acc for acc in snap.accounts}
+            accounts = tuple(
+                replace(acc, usage=other.usage)
+                if (
+                    (other := incoming.get(acc.number)) is not None
+                    and (acc.email, acc.org_uuid, acc.kind)
+                    == (other.email, other.org_uuid, other.kind)
+                )
+                else acc
+                for acc in current.accounts
+            )
+            self.snapshot = replace(
+                current,
+                accounts=accounts,
+                taken_at=max(current.taken_at, snap.taken_at),
+            )
+        self._update_refresh_status()
+
+    def _update_refresh_status(self) -> None:
+        parts: list[str] = []
+        now = time.time()
+        if self.snapshot is not None:
+            age = max(0.0, now - self.snapshot.taken_at)
+            parts.append(f"snapshot {format_duration(age)} ago")
+        if self._normal_refreshing and self._normal_started_at is not None:
+            elapsed = now - self._normal_started_at
+            if elapsed >= self.POLL_INTERVAL_S:
+                parts.append(f"refreshing {format_duration(elapsed)}")
+        self.refresh_status = " · ".join(parts)
 
     def request_refresh(self, *, full: bool = False) -> None:
         if full:
@@ -122,13 +210,19 @@ class CswapApp(App):
     def on_worker_state_changed(self, event) -> None:
         if event.state is not WorkerState.ERROR:
             return
-        if event.worker.group == "refresh":
-            self._refreshing = False
+        if event.worker.group in {"refresh-normal", "refresh-store"}:
+            if event.worker.group == "refresh-normal":
+                self._normal_refreshing = False
+                self._normal_started_at = None
+            else:
+                self._store_refreshing = False
+            self._update_refresh_status()
             msg = str(event.worker.error)
             if msg != self._last_refresh_error:
                 self._last_refresh_error = msg
+                lane = "store refresh" if event.worker.group == "refresh-store" else "refresh"
                 self.notify(
-                    f"Refresh failed: {msg}", severity="warning", timeout=6
+                    f"{lane.capitalize()} failed: {msg}", severity="warning", timeout=6
                 )
         elif event.worker.group == "action":
             self.busy = False

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -354,8 +354,19 @@ class WatchScreen(AccountListScreen):
         self._selecting = False
 
     def on_mount(self) -> None:
-        self.query_one("#list-title", Static).update(self._WATCH_TITLE)
+        self.watch(self.app, "refresh_status", self._on_refresh_status)
+        self.query_one("#list-title", Static).update(self._title_text())
         super().on_mount()
+
+    def _title_text(self) -> str:
+        if self._selecting:
+            return self._SELECT_TITLE
+        status = self.app.refresh_status
+        return f"{self._WATCH_TITLE} · {status}" if status else self._WATCH_TITLE
+
+    def _on_refresh_status(self, status: str) -> None:
+        if not self._selecting:
+            self.query_one("#list-title", Static).update(self._title_text())
 
     def check_action(self, action: str, parameters: tuple) -> bool | None:
         if action == "select_highlighted" and not self._selecting:
@@ -382,7 +393,7 @@ class WatchScreen(AccountListScreen):
         else:
             listview.index = None
             self.set_focus(None)
-            title.update(self._WATCH_TITLE)
+            title.update(self._title_text())
         self.refresh_bindings()
 
     def action_toggle_select(self) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -8,6 +8,7 @@ flows) — no scraping, no real credentials, no network.
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import json
 import sys
@@ -92,6 +93,20 @@ def make_account(
         usage=entry if entry is not None else make_entry(),
         alias=alias,
         disabled=disabled,
+    )
+
+
+def make_usage_at(
+    fetched_at: float | None,
+    pct: float = 25.0,
+    *,
+    sentinel: str | None = None,
+) -> UsageEntry:
+    return UsageEntry(
+        sentinel=sentinel,
+        last_good={"five_hour": {"pct": pct, "resets_at": _iso_in(7200)}},
+        fetched_at=fetched_at,
+        age_s=(time.time() - fetched_at) if fetched_at is not None else None,
     )
 
 
@@ -183,6 +198,46 @@ class FakeSwitcher:
         self._poll_inputs_override = None
 
 
+class BlockingSnapshotSwitcher(FakeSwitcher):
+    """Fake switcher with independently gated normal/store snapshot lanes."""
+
+    def __init__(
+        self,
+        normal_account: AccountSnapshot,
+        store_account: AccountSnapshot,
+        backup_dir: Path,
+    ):
+        super().__init__([normal_account], backup_dir)
+        self.normal_account = normal_account
+        self.store_account = store_account
+        self.normal_started = threading.Event()
+        self.normal_release = threading.Event()
+        self.normal_done = threading.Event()
+        self.store_started = threading.Event()
+        self.store_release = threading.Event()
+        self.store_done = threading.Event()
+        self.block_store = False
+
+    def accounts_snapshot(self, fetch: set[str] | None = None) -> AccountsSnapshot:
+        self.fetch_sets.append(fetch)
+        if fetch is None:
+            self.normal_started.set()
+            self.normal_release.wait(timeout=2)
+            self.normal_done.set()
+            account = self.normal_account
+        else:
+            self.store_started.set()
+            if self.block_store:
+                self.store_release.wait(timeout=2)
+            self.store_done.set()
+            account = self.store_account
+        return AccountsSnapshot(
+            active_number=account.number,
+            accounts=(account,),
+            taken_at=time.time(),
+        )
+
+
 def make_app(fake: FakeSwitcher):
     from claude_swap.tui.app import CswapApp
 
@@ -201,6 +256,10 @@ async def settle(pilot) -> None:
         await app.workers.wait_for_complete(pending)
     await pilot.pause()
     await pilot.pause()
+
+
+async def wait_event(event: threading.Event, timeout: float = 1.0) -> None:
+    assert await asyncio.to_thread(event.wait, timeout)
 
 
 async def menu_select(pilot, action_id: str) -> None:
@@ -348,6 +407,87 @@ class TestSnapshotSource:
         fake, source = self._source(tmp_path)
         source.take(store_only=True)
         assert fake.fetch_sets == [set()]
+
+    def test_expired_sentinel_retained_until_fetched_at_advances(self, tmp_path):
+        expired = make_account(
+            1,
+            active=True,
+            entry=make_usage_at(100.0, sentinel=USAGE_TOKEN_EXPIRED),
+        )
+        fresh_same_stamp = make_account(1, active=True, entry=make_usage_at(100.0))
+        fresh_new_stamp = make_account(1, active=True, entry=make_usage_at(101.0))
+        fake, source = self._source(tmp_path, [expired])
+
+        assert source.take().accounts[0].usage.sentinel == USAGE_TOKEN_EXPIRED
+        fake._accounts = [fresh_same_stamp]
+        assert source.take(store_only=True).accounts[0].usage.sentinel == USAGE_TOKEN_EXPIRED
+        fake._accounts = [fresh_new_stamp]
+        assert source.take(store_only=True).accounts[0].usage.sentinel is None
+
+    def test_expired_sentinel_clears_on_superseding_sentinel(self, tmp_path):
+        expired = make_account(
+            1,
+            active=True,
+            entry=make_usage_at(100.0, sentinel=USAGE_TOKEN_EXPIRED),
+        )
+        api_key = make_account(
+            1,
+            active=True,
+            kind="api_key",
+            entry=make_usage_at(None, sentinel=USAGE_API_KEY),
+        )
+        fake, source = self._source(tmp_path, [expired])
+
+        source.take()
+        fake._accounts = [api_key]
+        assert source.take(store_only=True).accounts[0].usage.sentinel == USAGE_API_KEY
+
+    def test_expired_sentinel_clears_on_identity_replacement(self, tmp_path):
+        expired = make_account(
+            1,
+            active=True,
+            email="old@example.com",
+            entry=make_usage_at(100.0, sentinel=USAGE_TOKEN_EXPIRED),
+        )
+        replacement = make_account(
+            1,
+            active=True,
+            email="new@example.com",
+            entry=make_usage_at(100.0),
+        )
+        fake, source = self._source(tmp_path, [expired])
+
+        source.take()
+        fake._accounts = [replacement]
+        assert source.take(store_only=True).accounts[0].usage.sentinel is None
+
+    def test_late_worker_fetched_at_regression_is_rejected(self, tmp_path):
+        newer = make_account(1, active=True, entry=make_usage_at(200.0, pct=80.0))
+        older = make_account(1, active=True, entry=make_usage_at(100.0, pct=10.0))
+        fake, source = self._source(tmp_path, [newer])
+
+        source.take()
+        fake._accounts = [older]
+        snap = source.take(store_only=True)
+        usage = snap.accounts[0].usage
+        assert usage.fetched_at == 200.0
+        assert usage.last_good["five_hour"]["pct"] == 80.0
+
+    def test_late_expired_sentinel_cannot_replace_newer_usage(self, tmp_path):
+        newer = make_account(1, active=True, entry=make_usage_at(200.0, pct=80.0))
+        older = make_account(
+            1,
+            active=True,
+            entry=make_usage_at(100.0, pct=10.0, sentinel=USAGE_TOKEN_EXPIRED),
+        )
+        fake, source = self._source(tmp_path, [newer])
+
+        source.take()
+        fake._accounts = [older]
+        usage = source.take(store_only=True).accounts[0].usage
+        assert usage.sentinel is None
+        assert usage.fetched_at == 200.0
+        assert usage.last_good["five_hour"]["pct"] == 80.0
 
 
 class TestUsageRows:
@@ -1045,6 +1185,90 @@ class TestWatchScreen:
             await pilot.press("escape")
             await pilot.pause()
             assert isinstance(app.screen, DashboardScreen)
+
+    async def test_blocked_normal_allows_store_only_repaint_without_stale_overpaint(
+        self, tmp_path
+    ):
+        normal = make_account(1, active=True, entry=make_usage_at(100.0, pct=10.0))
+        store = make_account(1, active=True, entry=make_usage_at(200.0, pct=80.0))
+        fake = BlockingSnapshotSwitcher(normal, store, tmp_path)
+        app = make_app(fake)
+
+        async with app.run_test(size=(100, 40)) as pilot:
+            await wait_event(fake.normal_started)
+            app._tick()
+            await wait_event(fake.store_done)
+            await pilot.pause()
+            assert app.snapshot.accounts[0].usage.last_good["five_hour"]["pct"] == 80.0
+
+            fake.normal_release.set()
+            await wait_event(fake.normal_done)
+            await pilot.pause()
+            assert app.snapshot.accounts[0].usage.last_good["five_hour"]["pct"] == 80.0
+            assert fake.fetch_sets == [None, set()]
+
+    async def test_late_normal_can_advance_usage_after_store_repaint(self, tmp_path):
+        normal = make_account(1, active=True, entry=make_usage_at(200.0, pct=80.0))
+        store = make_account(1, active=True, entry=make_usage_at(100.0, pct=10.0))
+        fake = BlockingSnapshotSwitcher(normal, store, tmp_path)
+        app = make_app(fake)
+
+        async with app.run_test(size=(100, 40)) as pilot:
+            await wait_event(fake.normal_started)
+            app._tick()
+            await wait_event(fake.store_done)
+            await pilot.pause()
+            assert app.snapshot.accounts[0].usage.last_good["five_hour"]["pct"] == 10.0
+
+            fake.normal_release.set()
+            await wait_event(fake.normal_done)
+            await pilot.pause()
+            assert app.snapshot.accounts[0].usage.last_good["five_hour"]["pct"] == 80.0
+
+    async def test_repeated_ticks_keep_store_lane_single_flight(self, tmp_path):
+        normal = make_account(1, active=True, entry=make_usage_at(100.0, pct=10.0))
+        store = make_account(1, active=True, entry=make_usage_at(200.0, pct=80.0))
+        fake = BlockingSnapshotSwitcher(normal, store, tmp_path)
+        fake.block_store = True
+        app = make_app(fake)
+
+        async with app.run_test(size=(100, 40)):
+            await wait_event(fake.normal_started)
+            app._tick()
+            await wait_event(fake.store_started)
+            app._tick()
+            app._tick()
+            assert fake.fetch_sets == [None, set()]
+            fake.store_release.set()
+            fake.normal_release.set()
+            await wait_event(fake.store_done)
+            await wait_event(fake.normal_done)
+
+    async def test_store_only_mode_launches_only_store_lane(self, tmp_path):
+        fake = self._fake(tmp_path)
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            fake.fetch_sets.clear()
+            app.set_store_only(True)
+            await settle(pilot)
+            assert fake.fetch_sets == [set()]
+
+    async def test_watch_title_shows_snapshot_age_and_long_refresh(self, tmp_path):
+        app = make_app(self._fake(tmp_path))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from textual.widgets import Static
+
+            title = app.screen.query_one("#list-title", Static)
+            assert "snapshot" in title.render().plain
+            app._normal_refreshing = True
+            app._normal_started_at = time.time() - app.POLL_INTERVAL_S - 1.0
+            app._update_refresh_status()
+            await pilot.pause()
+            assert "refreshing" in title.render().plain
 
 
 def fake_calls(app) -> list[tuple]:


### PR DESCRIPTION
## Summary

`cswap watch` currently drops every three-second tick while a fetch-enabled snapshot worker is running. If another process refreshes a session credential and publishes newer shared usage during that bounded fetch, the watch frame cannot observe it until its own worker returns. Transient `token expired` overlays can also disappear on a same-measurement pass or be repainted by a late worker.

This change:

- keeps one fetch-enabled worker and one strictly store-only repaint worker as independent single-flight lanes;
- uses the existing `fetch=set()` path for repainting, so provider cadence is unchanged;
- reconciles snapshots so a token-expired overlay survives until a newer measurement or superseding state arrives;
- rejects late per-account measurement regressions in the TUI-local snapshot source; and
- shows snapshot age and a long-running refresh indication in the watch title.

## Safety

The new concurrent lane is read-only and network-ineligible. No credential ownership, usage-store persistence, poll planning, routing, or provider request cadence changes. Network workers are never cancelled or duplicated.

This composes with the fetch-lease outcome fencing in #160: that PR protects the shared store from late writers, while this PR protects the watch frame and lets it observe newer shared state promptly.

## Validation

- `NO_COLOR=1 uv run pytest tests/test_tui.py -q` — 84 passed
- combined local integration stack — 840 passed
- Python compilation and `git diff --check`
