### PR TITLE
fix(cli): label token status by credential source

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ Not sure which one? `cswap list` is the dashboard — every account's 5-hour and
 
 ```bash
 cswap list
+cswap list --token-status      # show labeled token diagnostics per credential source
 ```
+
+`--token-status` only adds diagnostics: active rows label the active profile, inactive rows distinguish the session profile from the stored backup, and known-drifted session logins are ignored. It never synchronizes credential sources or changes which credential the normal usage path selects.
 
 Or let claude-swap auto-pick by remaining quota — `cswap switch --strategy best` (most quota left) or `--strategy next-available` (skip rate-limited accounts).
 
@@ -190,6 +193,7 @@ cswap run 2                     # Run an account in this terminal only (session 
 cswap auto                      # Auto-switch when nearing rate limits (see above)
 cswap config                    # Show or edit settings (see Configuration below)
 cswap list                      # Show all accounts with 5h/7d usage and reset times
+cswap list --token-status       # Add source-labelled OAuth token diagnostics
 cswap status                    # Show current account
 cswap add --slot 3              # Add account to a specific slot (prompts before overwrite)
 cswap add --alias dev           # Add account and give it a short alias

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -944,6 +944,7 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s switch --strategy best           # pick the account with most quota left
   %(prog)s switch --strategy next-available # rotate, skipping rate-limited accounts
   %(prog)s switch user@example.com
+  %(prog)s list --token-status
   %(prog)s list --json
   %(prog)s add --slot 3                      # add to a specific slot
   %(prog)s add-token sk-ant-oat01-... --email me@example.com
@@ -969,7 +970,7 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     parser.add_argument(
         "--token-status",
         action="store_true",
-        help="Show OAuth token expiry state (use with 'list')",
+        help="Show source-labelled OAuth token diagnostics (use with 'list')",
     )
     parser.add_argument(
         "--json",

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -215,6 +215,17 @@ def _usage_entry_lines(entry: UsageEntry) -> list[str]:
     return [dimmed(detail)]
 
 
+def _label_token_status(source: str, credentials: str) -> str | None:
+    """Return ``oauth.build_token_status`` relabelled by credential source."""
+    status = oauth.build_token_status(credentials)
+    if status is None:
+        return None
+    prefix = "oauth: "
+    if status.startswith(prefix):
+        return f"{source}: {status.removeprefix(prefix)}"
+    return f"{source}: {status}"
+
+
 def _sweep_legacy_keyring(usernames: list[str], removed_items: list[str]) -> None:
     """Best-effort purge of legacy ``KEYRING_SERVICE`` entries via ``keyring``.
 
@@ -1604,6 +1615,37 @@ class ClaudeAccountSwitcher:
         from claude_swap.session import session_dir_for
 
         return session_dir_for(self.backup_dir, account_num, email)
+
+    def _token_status_lines(
+        self, account_info: tuple[int, str, str, str, bool, str, str]
+    ) -> list[str]:
+        """Source-labelled token-status lines for one account's display row."""
+        num, email, _org_name, org_uuid, is_active, creds, _alias = account_info
+        if looks_like_api_key(creds):
+            return []
+        if is_active:
+            line = _label_token_status("active profile", creds)
+            return [line] if line is not None else []
+
+        from claude_swap.session import (
+            read_session_credentials,
+            session_identity_drifted,
+        )
+
+        lines: list[str] = []
+        session_dir = self._session_dir(str(num), email)
+        session_creds = read_session_credentials(session_dir)
+        if session_creds:
+            if session_identity_drifted(session_dir, email, org_uuid):
+                lines.append("session profile: ignored (different account)")
+            else:
+                line = _label_token_status("session profile", session_creds)
+                if line is not None:
+                    lines.append(line)
+        backup_line = _label_token_status("stored backup", creds)
+        if backup_line is not None:
+            lines.append(backup_line)
+        return lines
 
     def _live_session_pids(self, account_num: str, email: str) -> list[int]:
         """PIDs of Claude instances running against an account's session profile."""
@@ -3224,9 +3266,8 @@ class ClaudeAccountSwitcher:
                 print(f"     {line}")
 
             if show_token_status:
-                token_status = oauth.build_token_status(accounts_info[i][5])
-                if token_status:
-                    print(f"     {dimmed('•')} {muted(token_status)}")
+                for line in self._token_status_lines(accounts_info[i]):
+                    print(f"     {dimmed('•')} {muted(line)}")
             if i < len(accounts_info) - 1:
                 print()
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -1082,11 +1082,122 @@ class TestListAccountsUsage:
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
              patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
              patch("claude_swap.oauth.try_fetch_usage_for_account", return_value=oauth.UsageOutcome(None)), \
+             patch("claude_swap.session.read_session_credentials", return_value=None), \
              patch("claude_swap.oauth.build_token_status", return_value="oauth: fresh, refresh token yes"):
             switcher.list_accounts(show_token_status=True)
 
         output = capsys.readouterr().out
-        assert "oauth: fresh, refresh token yes" in output
+        assert "active profile: fresh, refresh token yes" in output
+        assert "stored backup: fresh, refresh token yes" in output
+
+    def test_token_status_lines_for_active_account_use_active_profile(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+
+        with patch("claude_swap.oauth.build_token_status", return_value="oauth: fresh, refresh token yes") as build:
+            lines = switcher._token_status_lines(
+                (1, "active@example.com", "", "", True, "active-creds", "")
+            )
+
+        assert lines == ["active profile: fresh, refresh token yes"]
+        build.assert_called_once_with("active-creds")
+
+    def test_token_status_lines_preserve_api_key_silence(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+
+        with patch("claude_swap.session.read_session_credentials") as read_session, \
+             patch("claude_swap.oauth.build_token_status") as build:
+            lines = switcher._token_status_lines(
+                (2, "key@example.com", "", "", False, "sk-ant-api03-test", "")
+            )
+
+        assert lines == []
+        read_session.assert_not_called()
+        build.assert_not_called()
+
+    def test_token_status_lines_prefer_matching_session_profile_then_backup(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+
+        def build_status(credentials: str) -> str | None:
+            return {
+                "session-creds": "oauth: fresh, refresh token yes",
+                "backup-creds": "oauth: expired, refresh token yes",
+            }.get(credentials)
+
+        with patch("claude_swap.session.read_session_credentials", return_value="session-creds") as read_session, \
+             patch("claude_swap.session.session_identity_drifted", return_value=False) as drifted, \
+             patch("claude_swap.oauth.build_token_status", side_effect=build_status) as build:
+            lines = switcher._token_status_lines(
+                (2, "inactive@example.com", "", "org-2", False, "backup-creds", "")
+            )
+
+        assert lines == [
+            "session profile: fresh, refresh token yes",
+            "stored backup: expired, refresh token yes",
+        ]
+        read_session.assert_called_once()
+        drifted.assert_called_once()
+        assert build.call_args_list == [call("session-creds"), call("backup-creds")]
+
+    def test_token_status_lines_ignore_drifted_session_profile(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+
+        with patch("claude_swap.session.read_session_credentials", return_value="session-creds") as read_session, \
+             patch("claude_swap.session.session_identity_drifted", return_value=True) as drifted, \
+             patch(
+                 "claude_swap.oauth.build_token_status",
+                 return_value="oauth: expired, refresh token yes",
+             ) as build:
+            lines = switcher._token_status_lines(
+                (2, "inactive@example.com", "", "org-2", False, "backup-creds", "")
+            )
+
+        assert lines == [
+            "session profile: ignored (different account)",
+            "stored backup: expired, refresh token yes",
+        ]
+        read_session.assert_called_once()
+        drifted.assert_called_once()
+        build.assert_called_once_with("backup-creds")
+
+    def test_token_status_lines_without_session_show_only_backup(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+
+        with patch("claude_swap.session.read_session_credentials", return_value=None) as read_session, \
+             patch("claude_swap.session.session_identity_drifted") as drifted, \
+             patch(
+                 "claude_swap.oauth.build_token_status",
+                 return_value="oauth: fresh, refresh token yes",
+             ) as build:
+            lines = switcher._token_status_lines(
+                (2, "inactive@example.com", "", "org-2", False, "backup-creds", "")
+            )
+
+        assert lines == ["stored backup: fresh, refresh token yes"]
+        read_session.assert_called_once()
+        drifted.assert_not_called()
+        build.assert_called_once_with("backup-creds")
+
+    def test_token_status_lines_are_read_only(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+
+        with patch("claude_swap.session.read_session_credentials", return_value="session-creds"), \
+             patch("claude_swap.session.session_identity_drifted", return_value=False), \
+             patch(
+                 "claude_swap.oauth.build_token_status",
+                 side_effect=["oauth: fresh, refresh token yes", "oauth: expired, refresh token yes"],
+             ), \
+             patch("claude_swap.oauth.try_refresh_oauth_credentials") as refresh, \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as fetch, \
+             patch.object(switcher, "_write_credentials") as write_live, \
+             patch.object(switcher, "_write_account_credentials") as write_backup:
+            switcher._token_status_lines(
+                (2, "inactive@example.com", "", "org-2", False, "backup-creds", "")
+            )
+
+        refresh.assert_not_called()
+        fetch.assert_not_called()
+        write_live.assert_not_called()
+        write_backup.assert_not_called()
 
     def test_list_uses_cached_usage(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict, capsys


### PR DESCRIPTION
## Summary

`cswap list --token-status` currently formats the stored backup credential for every inactive account. Session-mode accounts intentionally let Claude Code own and rotate a separate profile credential, so the diagnostic can say `expired` while the credential that actually serves usage is fresh.

This change reports read-only OAuth state by credential source:

- active accounts: `active profile`
- inactive accounts with a matching session profile: `session profile`, then `stored backup`
- identity-drifted profiles: explicitly ignored rather than attributed to the slot

## Safety

The added token diagnostics are read-only. They do not refresh, copy, synchronize, persist, or route on credentials, and they do not change normal JSON, usage eligibility, or the ordinary list command's existing usage-fetch behavior. In particular, an expired backup is not overwritten with Claude Code's owner-held session credential.

This follows the credential ownership model established in #96 and makes that already-valid divergence visible instead of presenting the backup as the account's sole token state.

## Validation

- `NO_COLOR=1 uv run pytest tests/test_switcher.py tests/test_cli.py -q` — 442 passed
- Python compilation and `git diff --check`
- live read-only validation showed a fresh session profile and expired stored backup as separate lines while ordinary usage remained healthy
