### PR TITLE
feat: add CLAUDE_SWAP_ROTATE_ONLY auto-rotation allowlist

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -97,6 +97,13 @@ KEYRING_SERVICE = "claude-code"
 # on profile endpoints. Matches Claude Code's CLAUDE_CODE_OAUTH_TOKEN path.
 SETUP_TOKEN_SCOPES = ("user:inference",)
 
+# When set, restricts *automatic* account selection (the auto-switch engine and
+# bare `cswap switch` rotation) to just the listed accounts — an allowlist that
+# complements the per-account `cswap disable` blocklist. Value is a comma- or
+# whitespace-separated list of slot numbers, aliases, or emails. Explicit
+# `cswap switch <num|email>` targets are unaffected. Unset/blank = no restriction.
+ROTATE_ONLY_ENV = "CLAUDE_SWAP_ROTATE_ONLY"
+
 # Delay between successive usage-request launches in one collect pass, so N
 # accounts never burst the shared usage endpoint from one IP in the same
 # instant (request hygiene; see issue #85).
@@ -1430,14 +1437,74 @@ class ClaudeAccountSwitcher:
         disabled (``cswap disable``). Disabled slots stay managed and remain
         valid explicit ``cswap switch <num|email>`` targets — they are only
         held out of automatic rotation and the usage-aware strategies.
+
+        When the :data:`ROTATE_ONLY_ENV` (``CLAUDE_SWAP_ROTATE_ONLY``) allowlist
+        is set, the result is further narrowed to accounts it names — so you can
+        let auto-switch rotate across a chosen pool while leaving every other
+        managed account untouched.
         """
         data = self._get_sequence_data() or {}
+        allow = self._rotate_allowlist_numbers(data)
         return [
             str(num)
             for num in data.get("sequence", [])
             if self._account_is_switchable(str(num))
             and not self._disabled_from_data(data, str(num))
+            and (allow is None or str(num) in allow)
         ]
+
+    @staticmethod
+    def _parse_rotate_only_env() -> list[str] | None:
+        """Tokens from ``CLAUDE_SWAP_ROTATE_ONLY``, or ``None`` when unset/blank.
+
+        Splits on commas and whitespace so ``a@x.com,b@x.com``,
+        ``a@x.com b@x.com``, and newline-separated values all parse. Returns
+        ``None`` (no restriction) when the variable is absent or holds no
+        non-blank token.
+        """
+        raw = os.environ.get(ROTATE_ONLY_ENV)
+        if raw is None:
+            return None
+        tokens = [t for t in re.split(r"[,\s]+", raw.strip()) if t]
+        return tokens or None
+
+    def _rotate_allowlist_numbers(self, data: dict) -> set[str] | None:
+        """Slots the ``CLAUDE_SWAP_ROTATE_ONLY`` allowlist resolves to.
+
+        ``None`` means "no allowlist" (env unset/blank) — callers must treat
+        that as *no restriction*, distinct from an empty set (every token was a
+        typo, so nothing rotates). Each token matches a slot number, alias, then
+        email; an email shared by several accounts includes them all.
+        Unresolvable tokens are skipped with a debug log rather than raised —
+        this runs on the auto-switch hot path, where a typo should only narrow
+        rotation, never crash the engine.
+        """
+        tokens = self._parse_rotate_only_env()
+        if tokens is None:
+            return None
+        accounts = data.get("accounts", {})
+        sequence = {str(n) for n in data.get("sequence", [])}
+        allow: set[str] = set()
+        unresolved: list[str] = []
+        for token in tokens:
+            matched = False
+            if token.isdigit() and token in sequence:
+                allow.add(token)
+                matched = True
+            else:
+                for num, acct in accounts.items():
+                    if acct.get("alias") == token or acct.get("email") == token:
+                        allow.add(str(num))
+                        matched = True
+            if not matched:
+                unresolved.append(token)
+        if unresolved:
+            self._logger.debug(
+                "%s: ignoring unresolved account identifiers: %s",
+                ROTATE_ONLY_ENV,
+                ", ".join(unresolved),
+            )
+        return allow
 
     @staticmethod
     def _disabled_from_data(data: dict, account_num: str) -> bool:

--- a/tests/test_rotate_only.py
+++ b/tests/test_rotate_only.py
@@ -1,0 +1,116 @@
+"""Tests for the CLAUDE_SWAP_ROTATE_ONLY auto-rotation allowlist.
+
+The env var narrows *automatic* selection (`switchable_account_numbers`) to a
+named pool without touching the per-account `cswap disable` blocklist or
+explicit `cswap switch` targets.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap.models import Platform
+from claude_swap.switcher import ROTATE_ONLY_ENV, ClaudeAccountSwitcher
+
+
+class TestRotateOnlyAllowlist:
+    def _setup(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.LINUX
+        s._setup_directories()
+        s._init_sequence_file()
+        return s
+
+    def _seed(self, s: ClaudeAccountSwitcher, num: int, email: str) -> None:
+        s._write_account_credentials(
+            str(num),
+            email,
+            json.dumps({"claudeAiOauth": {
+                "accessToken": f"sk-{num}", "refreshToken": f"rt-{num}"}}),
+        )
+        s._write_account_config(
+            str(num),
+            email,
+            json.dumps({"oauthAccount": {
+                "emailAddress": email, "accountUuid": f"uuid-{num}"}}),
+        )
+        data = s._get_sequence_data() or {
+            "activeAccountNumber": None, "lastUpdated": "",
+            "sequence": [], "accounts": {},
+        }
+        data["accounts"][str(num)] = {
+            "email": email, "uuid": f"uuid-{num}",
+            "organizationUuid": "", "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+            data["sequence"].sort()
+        if data["activeAccountNumber"] is None:
+            data["activeAccountNumber"] = num
+        s._write_json(s.sequence_file, data)
+
+    def _seed_three(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = self._setup(temp_home)
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        self._seed(s, 3, "c@example.com")
+        return s
+
+    def test_unset_env_no_restriction(self, temp_home, monkeypatch):
+        monkeypatch.delenv(ROTATE_ONLY_ENV, raising=False)
+        s = self._seed_three(temp_home)
+        assert s.switchable_account_numbers() == ["1", "2", "3"]
+
+    def test_blank_env_no_restriction(self, temp_home, monkeypatch):
+        monkeypatch.setenv(ROTATE_ONLY_ENV, "   ")
+        s = self._seed_three(temp_home)
+        assert s.switchable_account_numbers() == ["1", "2", "3"]
+
+    def test_allowlist_by_number(self, temp_home, monkeypatch):
+        monkeypatch.setenv(ROTATE_ONLY_ENV, "1,3")
+        s = self._seed_three(temp_home)
+        assert s.switchable_account_numbers() == ["1", "3"]
+
+    def test_allowlist_by_email(self, temp_home, monkeypatch):
+        monkeypatch.setenv(ROTATE_ONLY_ENV, "b@example.com")
+        s = self._seed_three(temp_home)
+        assert s.switchable_account_numbers() == ["2"]
+
+    def test_allowlist_by_alias(self, temp_home, monkeypatch):
+        s = self._seed_three(temp_home)
+        s.set_alias("3", "prod")
+        monkeypatch.setenv(ROTATE_ONLY_ENV, "prod")
+        assert s.switchable_account_numbers() == ["3"]
+
+    def test_whitespace_and_comma_separators_mix(self, temp_home, monkeypatch):
+        monkeypatch.setenv(ROTATE_ONLY_ENV, " 1 ,\tc@example.com ")
+        s = self._seed_three(temp_home)
+        assert s.switchable_account_numbers() == ["1", "3"]
+
+    def test_preserves_sequence_order(self, temp_home, monkeypatch):
+        # Listed out of order, but the result keeps sequence order.
+        monkeypatch.setenv(ROTATE_ONLY_ENV, "3,1")
+        s = self._seed_three(temp_home)
+        assert s.switchable_account_numbers() == ["1", "3"]
+
+    def test_unknown_token_ignored(self, temp_home, monkeypatch):
+        monkeypatch.setenv(ROTATE_ONLY_ENV, "1,does-not-exist")
+        s = self._seed_three(temp_home)
+        assert s.switchable_account_numbers() == ["1"]
+
+    def test_all_tokens_unknown_yields_empty(self, temp_home, monkeypatch):
+        # A pool of only typos rotates across nothing — distinct from "unset".
+        monkeypatch.setenv(ROTATE_ONLY_ENV, "typo1,typo2")
+        s = self._seed_three(temp_home)
+        assert s.switchable_account_numbers() == []
+
+    def test_allowlist_intersects_with_disabled(self, temp_home, monkeypatch):
+        # disable is still honored: an allowlisted-but-disabled slot stays out.
+        monkeypatch.setenv(ROTATE_ONLY_ENV, "1,2")
+        s = self._seed_three(temp_home)
+        s.set_account_disabled("2", True)
+        assert s.switchable_account_numbers() == ["1"]


### PR DESCRIPTION
`cswap disable` holds an account out of auto-rotation. This adds the opposite. Set `CLAUDE_SWAP_ROTATE_ONLY` to a comma or whitespace separated list of slot numbers, aliases, or emails, and automatic selection (the auto-switch engine and a bare `cswap switch`) only rotates across those. Explicit `cswap switch <target>` still works. Tokens that do not match an account are skipped, so a typo narrows the pool instead of breaking the loop.

It works by filtering `switchable_account_numbers()`, so nothing else in the selection path changes.
