### PR TITLE
feat: pin a directory's account with a .claude-account / .env file

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -138,7 +138,8 @@ Examples:
         "account",
         nargs="?",
         metavar="NUM|EMAIL",
-        help="Account to run (number or email). Omit to use the current "
+        help="Account to run (number or email). Omit to use a project pin "
+        "(.claude-account / CLAUDE_SWAP_ACCOUNT in .env) or the current "
         "directory's mapping (see `cswap map`).",
     )
     parser.add_argument(
@@ -186,7 +187,34 @@ Examples:
             )
             return  # only reachable in tests where exec/exit is mocked
 
-        # No account given: resolve from the current directory's mapping.
+        # No account given: a project pin (.claude-account / .env) in the
+        # working directory or an ancestor wins over the global `cswap map`
+        # table — it's the explicit, committable "this repo uses that account".
+        from claude_swap.project_pin import find_account_pin
+
+        pin = find_account_pin(os.getcwd())
+        if pin is not None:
+            slot, email = switcher.slot_for_identifier(pin.identifier)
+            if slot is not None:
+                print(
+                    dimmed(
+                        f"Using account {email or pin.identifier} "
+                        f"(pinned by {pin.display_source()})"
+                    )
+                )
+                manager.run(
+                    slot,
+                    tail,
+                    share=not args.no_share,
+                    share_history=args.share_history,
+                )
+                return  # only reachable in tests
+            warning(
+                f"{pin.display_source()} pins account '{pin.identifier}', "
+                "which cswap doesn't manage — falling back."
+            )
+
+        # Otherwise resolve from the current directory's mapping.
         slot, email = switcher.slot_for_directory(os.getcwd())
         if slot is not None:
             manager.run(

--- a/src/claude_swap/project_pin.py
+++ b/src/claude_swap/project_pin.py
@@ -1,0 +1,122 @@
+"""Project-local account pins for `cswap run` auto-resolution.
+
+A directory tree can name the account `cswap run` should launch by dropping a
+small, committable file at (or above) the working directory — so a repo checkout
+always opens under the right Claude account without a global `cswap map` entry:
+
+* ``.claude-account`` — a dedicated file whose first non-blank, non-comment line
+  is an account identifier (slot number, alias, or email).
+* ``.env`` — a ``CLAUDE_SWAP_ACCOUNT=<identifier>`` assignment (optionally
+  ``export``-prefixed), for teams that already keep one and would rather not add
+  another dotfile.
+
+Resolution walks from the working directory up to the filesystem root and stops
+at the first directory that carries a pin, so a nested folder can override an
+ancestor. Within a single directory ``.claude-account`` wins over ``.env``.
+
+This module only *reads the identifier string*; it never imports ``switcher``.
+Callers resolve the identifier to a live slot themselves (see
+``ClaudeAccountSwitcher.slot_for_identifier``), which keeps the precedence and
+the "account no longer exists" messaging in one place in the CLI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+PIN_FILENAME = ".claude-account"
+DOTENV_FILENAME = ".env"
+DOTENV_KEY = "CLAUDE_SWAP_ACCOUNT"
+
+
+@dataclass(frozen=True)
+class AccountPin:
+    """A resolved pin: the raw account identifier and where it came from."""
+
+    identifier: str
+    source: Path
+    mechanism: str  # "file" (.claude-account) or "dotenv" (.env)
+
+    def display_source(self) -> str:
+        """Human-readable origin for CLI messages."""
+        if self.mechanism == "dotenv":
+            return f"{DOTENV_KEY} in {self.source}"
+        return str(self.source)
+
+
+def _read_pin_file(path: Path) -> str | None:
+    """First non-blank, non-comment line of a ``.claude-account`` file.
+
+    ``#`` starts a comment (whole-line or trailing). Returns ``None`` when the
+    file is unreadable or holds no identifier.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    for line in text.splitlines():
+        stripped = line.split("#", 1)[0].strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _read_dotenv_account(path: Path) -> str | None:
+    """Value of ``CLAUDE_SWAP_ACCOUNT`` in a ``.env`` file, or ``None``.
+
+    Accepts an optional ``export`` prefix and surrounding single/double quotes.
+    Last assignment wins, matching dotenv precedence. Only this one key is read;
+    the file is never otherwise interpreted.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    found: str | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, sep, value = line.partition("=")
+        if not sep or key.strip() != DOTENV_KEY:
+            continue
+        value = value.strip()
+        if value and value[0] in "\"'":
+            # Quoted: the value ends at the matching quote; a trailing comment
+            # (`="1"  # main`) is outside it and ignored.
+            quote = value[0]
+            end = value.find(quote, 1)
+            value = value[1:end] if end != -1 else value[1:]
+        else:
+            # Unquoted: a ` # note` trailing comment is not part of the value.
+            value = value.split("#", 1)[0].strip()
+        if value:
+            found = value
+    return found
+
+
+def find_account_pin(start: str | Path) -> AccountPin | None:
+    """Nearest project account pin at or above ``start``, or ``None``.
+
+    Walks ``start`` and each parent directory once; the first directory holding
+    a usable pin wins (``.claude-account`` before ``.env`` within a directory).
+    """
+    try:
+        current = Path(start).expanduser().resolve()
+    except OSError:
+        return None
+    if current.is_file():
+        current = current.parent
+    for directory in [current, *current.parents]:
+        pin_file = directory / PIN_FILENAME
+        if pin_file.is_file():
+            identifier = _read_pin_file(pin_file)
+            if identifier:
+                return AccountPin(identifier, pin_file, "file")
+        dotenv = directory / DOTENV_FILENAME
+        if dotenv.is_file():
+            identifier = _read_dotenv_account(dotenv)
+            if identifier:
+                return AccountPin(identifier, dotenv, "dotenv")
+    return None

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1266,6 +1266,32 @@ class ClaudeAccountSwitcher:
         )
         return slot, email
 
+    def slot_for_identifier(
+        self, identifier: str
+    ) -> tuple[str | None, str | None]:
+        """Resolve a NUM|ALIAS|EMAIL to (slot, email), for pin-file launches.
+
+        A soft counterpart to :meth:`resolve_account`: an unknown, empty, or
+        ambiguous identifier returns ``(None, None)`` instead of raising, so a
+        project pin that names a since-removed (or mistyped) account lets
+        ``cswap run`` fall back to the default rather than aborting the launch.
+        """
+        identifier = (identifier or "").strip()
+        if not identifier:
+            return None, None
+        try:
+            num = self._resolve_account_identifier(identifier)
+        except ConfigError:
+            # Ambiguous email — can't pick a slot unattended.
+            return None, None
+        if not num:
+            return None, None
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(str(num))
+        if not record:
+            return None, None
+        return str(num), record.get("email", "")
+
     def list_mappings(self) -> None:
         """Print all directory → account mappings (for `cswap map`)."""
         from claude_swap.mappings import MappingStore

--- a/tests/test_project_pin.py
+++ b/tests/test_project_pin.py
@@ -1,0 +1,225 @@
+"""Tests for project-local account pins (.claude-account / .env) and their
+wiring into `cswap run`."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_swap import cli
+from claude_swap.models import Platform
+from claude_swap.project_pin import (
+    AccountPin,
+    find_account_pin,
+    _read_dotenv_account,
+    _read_pin_file,
+)
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class TestFindAccountPin:
+    def test_reads_claude_account_file(self, tmp_path):
+        (tmp_path / ".claude-account").write_text("work@co.com\n")
+        pin = find_account_pin(tmp_path)
+        assert pin is not None
+        assert pin.identifier == "work@co.com"
+        assert pin.mechanism == "file"
+        assert pin.source == tmp_path / ".claude-account"
+
+    def test_walks_up_to_ancestor(self, tmp_path):
+        (tmp_path / ".claude-account").write_text("2\n")
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        pin = find_account_pin(deep)
+        assert pin is not None and pin.identifier == "2"
+
+    def test_nearest_directory_wins(self, tmp_path):
+        (tmp_path / ".claude-account").write_text("root@co.com\n")
+        child = tmp_path / "child"
+        child.mkdir()
+        (child / ".claude-account").write_text("child@co.com\n")
+        pin = find_account_pin(child)
+        assert pin is not None and pin.identifier == "child@co.com"
+
+    def test_claude_account_wins_over_dotenv_same_dir(self, tmp_path):
+        (tmp_path / ".claude-account").write_text("dedicated@co.com\n")
+        (tmp_path / ".env").write_text("CLAUDE_SWAP_ACCOUNT=dotenv@co.com\n")
+        pin = find_account_pin(tmp_path)
+        assert pin is not None
+        assert pin.identifier == "dedicated@co.com"
+        assert pin.mechanism == "file"
+
+    def test_reads_dotenv_when_no_pin_file(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "OTHER=1\nexport CLAUDE_SWAP_ACCOUNT='env@co.com'  # inline\n"
+        )
+        pin = find_account_pin(tmp_path)
+        assert pin is not None
+        assert pin.identifier == "env@co.com"
+        assert pin.mechanism == "dotenv"
+
+    def test_dotenv_last_assignment_wins(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "CLAUDE_SWAP_ACCOUNT=first@co.com\nCLAUDE_SWAP_ACCOUNT=second@co.com\n"
+        )
+        pin = find_account_pin(tmp_path)
+        assert pin is not None and pin.identifier == "second@co.com"
+
+    def test_dotenv_without_key_is_not_a_pin(self, tmp_path):
+        (tmp_path / ".env").write_text("DATABASE_URL=postgres://x\n")
+        assert find_account_pin(tmp_path) is None
+
+    def test_no_pin_returns_none(self, tmp_path):
+        deep = tmp_path / "x" / "y"
+        deep.mkdir(parents=True)
+        assert find_account_pin(deep) is None
+
+    def test_comment_and_blank_lines_skipped(self, tmp_path):
+        (tmp_path / ".claude-account").write_text(
+            "# which account this repo uses\n\n  prod  # trailing\n"
+        )
+        assert _read_pin_file(tmp_path / ".claude-account") == "prod"
+
+    def test_dotenv_double_quotes_and_comment(self, tmp_path):
+        (tmp_path / ".env").write_text('CLAUDE_SWAP_ACCOUNT="1"  # main\n')
+        assert _read_dotenv_account(tmp_path / ".env") == "1"
+
+    def test_display_source(self, tmp_path):
+        file_pin = AccountPin("2", tmp_path / ".claude-account", "file")
+        assert file_pin.display_source() == str(tmp_path / ".claude-account")
+        env_pin = AccountPin("2", tmp_path / ".env", "dotenv")
+        assert env_pin.display_source() == f"CLAUDE_SWAP_ACCOUNT in {tmp_path / '.env'}"
+
+
+class TestSlotForIdentifier:
+    def _seed(self, s: ClaudeAccountSwitcher, num: int, email: str) -> None:
+        s._write_account_credentials(
+            str(num), email,
+            json.dumps({"claudeAiOauth": {
+                "accessToken": f"sk-{num}", "refreshToken": f"rt-{num}"}}),
+        )
+        s._write_account_config(
+            str(num), email,
+            json.dumps({"oauthAccount": {
+                "emailAddress": email, "accountUuid": f"uuid-{num}"}}),
+        )
+        data = s._get_sequence_data() or {
+            "activeAccountNumber": None, "lastUpdated": "",
+            "sequence": [], "accounts": {},
+        }
+        data["accounts"][str(num)] = {
+            "email": email, "uuid": f"uuid-{num}",
+            "organizationUuid": "", "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+            data["sequence"].sort()
+        if data["activeAccountNumber"] is None:
+            data["activeAccountNumber"] = num
+        s._write_json(s.sequence_file, data)
+
+    def _switcher(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.LINUX
+        s._setup_directories()
+        s._init_sequence_file()
+        self._seed(s, 1, "a@example.com")
+        self._seed(s, 2, "b@example.com")
+        return s
+
+    def test_by_number(self, temp_home):
+        s = self._switcher(temp_home)
+        assert s.slot_for_identifier("2") == ("2", "b@example.com")
+
+    def test_by_email(self, temp_home):
+        s = self._switcher(temp_home)
+        assert s.slot_for_identifier("a@example.com") == ("1", "a@example.com")
+
+    def test_by_alias(self, temp_home):
+        s = self._switcher(temp_home)
+        s.set_alias("2", "dev")
+        assert s.slot_for_identifier("dev") == ("2", "b@example.com")
+
+    def test_unknown_is_soft_miss(self, temp_home):
+        s = self._switcher(temp_home)
+        assert s.slot_for_identifier("nobody@example.com") == (None, None)
+
+    def test_empty_is_soft_miss(self, temp_home):
+        s = self._switcher(temp_home)
+        assert s.slot_for_identifier("   ") == (None, None)
+
+    def test_nonexistent_slot_number_is_soft_miss(self, temp_home):
+        s = self._switcher(temp_home)
+        assert s.slot_for_identifier("9") == (None, None)
+
+
+class TestRunUsesProjectPin:
+    """`cswap run` (no account) launches the project-pinned account, ahead of
+    the global mapping, and falls back cleanly when the pin is unresolvable."""
+
+    def _fake_manager(self, calls):
+        class FakeSessionManager:
+            def __init__(self, switcher):
+                pass
+
+            def run(self, identifier, claude_args, share=True, share_history=False):
+                calls.append(("run", identifier, claude_args, share, share_history))
+
+            def exec_default(self, claude_args):
+                calls.append(("exec_default", claude_args))
+
+        return FakeSessionManager
+
+    def _switcher(self, *, pin_result, dir_result=(None, None)):
+        sw = MagicMock()
+        sw.slot_for_identifier.return_value = pin_result
+        sw.slot_for_directory.return_value = dir_result
+        return sw
+
+    def _run(self, calls, sw, cwd, monkeypatch):
+        monkeypatch.chdir(cwd)
+        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher", return_value=sw), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "run"]):
+            cli.main()
+
+    def test_pin_file_launches_pinned_account(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / ".claude-account").write_text("work@co.com\n")
+        calls = []
+        sw = self._switcher(pin_result=("2", "work@co.com"))
+        self._run(calls, sw, tmp_path, monkeypatch)
+        assert ("run", "2", [], True, False) in calls
+        assert "pinned by" in capsys.readouterr().out
+
+    def test_pin_wins_over_mapping(self, tmp_path, monkeypatch):
+        (tmp_path / ".claude-account").write_text("pinned@co.com\n")
+        calls = []
+        # A directory mapping exists (slot 5) but the pin (slot 2) takes it.
+        sw = self._switcher(pin_result=("2", "pinned@co.com"), dir_result=("5", "m@co.com"))
+        self._run(calls, sw, tmp_path, monkeypatch)
+        assert ("run", "2", [], True, False) in calls
+        sw.slot_for_directory.assert_not_called()
+
+    def test_unresolvable_pin_warns_and_falls_back(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / ".claude-account").write_text("ghost@co.com\n")
+        calls = []
+        # Pin doesn't resolve; no mapping either -> default.
+        sw = self._switcher(pin_result=(None, None), dir_result=(None, None))
+        self._run(calls, sw, tmp_path, monkeypatch)
+        assert ("exec_default", []) in calls
+        out = capsys.readouterr().out
+        assert "ghost@co.com" in out and "falling back" in out
+
+    def test_no_pin_uses_mapping(self, tmp_path, monkeypatch):
+        # No pin files present -> slot_for_identifier never consulted.
+        calls = []
+        sw = self._switcher(pin_result=("9", "x"), dir_result=("3", "map@co.com"))
+        self._run(calls, sw, tmp_path, monkeypatch)
+        assert ("run", "3", [], True, False) in calls
+        sw.slot_for_identifier.assert_not_called()


### PR DESCRIPTION
`cswap run` resolves an account from the global `cswap map` table, which cannot be committed with a repo. This adds a project-local pin: a `.claude-account` file, or `CLAUDE_SWAP_ACCOUNT=` in `.env`, naming a slot, alias, or email. `cswap run` with no argument walks up from the working directory, and the nearest pin wins over the global mapping. If the pin names an account that is not managed, it warns and falls back to the default instead of aborting.
