### PR TITLE
feat: add `cswap statusline` to show the active account in a status line

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -334,6 +334,54 @@ def _unmap_command(argv: list[str]) -> None:
         sys.exit(130)
 
 
+def _statusline_command(argv: list[str]) -> None:
+    """Handle `cswap statusline` — print the active account for a status line.
+
+    Made to drop into Claude Code's ``statusLine.command`` (or any shell
+    prompt): it prints one short line naming the account cswap's live login is
+    on, so which account a session uses is always visible. Reads only local
+    state, never the network, and never exits non-zero on the render path — a
+    status line must not slow down or break the host prompt.
+    """
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} statusline",
+        description=(
+            "Print the active Claude account, for a shell or Claude Code "
+            "status line."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Add to Claude Code's settings.json:
+  "statusLine": { "type": "command", "command": "cswap statusline" }
+        """,
+    )
+    parser.add_argument(
+        "--email",
+        action="store_true",
+        help="Show the full email instead of the alias / email local-part",
+    )
+    parser.add_argument(
+        "--icon",
+        metavar="ICON",
+        default="⇄",
+        help="Leading icon (default: ⇄)",
+    )
+    parser.add_argument(
+        "--no-icon", action="store_true", help="Omit the leading icon"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        email, alias = ClaudeAccountSwitcher().active_account_display()
+    except Exception:
+        return  # never break the host status line
+    if not email:
+        return  # no live login — print nothing
+    label = email if args.email else (alias or email.split("@", 1)[0])
+    prefix = "" if args.no_icon else f"{args.icon} "
+    print(f"{prefix}{label}")
+
+
 def _swap_command(argv: list[str]) -> None:
     """Handle `cswap swap NUM|EMAIL|ALIAS NUM|EMAIL|ALIAS`.
 
@@ -890,6 +938,9 @@ def main() -> None:
     if argv and argv[0] == "move":
         _move_command(argv[1:])
         return
+    if argv and argv[0] == "statusline":
+        _statusline_command(argv[1:])
+        return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like
     # lazygit/k9s). TTY-gated on both ends so scripts and pipes keep getting
@@ -935,6 +986,7 @@ Commands:
   %(prog)s tui                        interactive dashboard (also: bare %(prog)s)
   %(prog)s watch                      dashboard, opened on the live watch page
   %(prog)s menubar                    macOS menu bar app
+  %(prog)s statusline                 print the active account for a status line
   %(prog)s upgrade                    self-upgrade to latest
   %(prog)s purge                      remove all claude-swap data
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1545,6 +1545,30 @@ class ClaudeAccountSwitcher:
         """Whether ``~/.claude.json`` carries any live account identity."""
         return self._get_current_account() is not None
 
+    def active_account_display(self) -> tuple[str | None, str | None]:
+        """``(email, alias)`` of the live account, for a status line.
+
+        Returns the managed slot's email and alias when the live login is one
+        cswap manages (so the alias is available), the raw login email with no
+        alias when it isn't, and ``(None, None)`` when there is no live login.
+        Reads only local state and never raises — it is called on every prompt
+        render, so a transient read error must degrade to "no account" rather
+        than break the host shell's status line.
+        """
+        try:
+            num = self.current_account_number()
+            if num is not None:
+                acct = (self._get_sequence_data() or {}).get(
+                    "accounts", {}
+                ).get(str(num), {})
+                return (acct.get("email") or None, acct.get("alias") or None)
+            identity = self._get_current_account()
+            if identity is not None:
+                return (identity[0] or None, None)
+        except Exception:
+            return (None, None)
+        return (None, None)
+
     def live_session_pids_for(self, account_num: str, email: str) -> list[int]:
         """Public wrapper: PIDs of live ``cswap run`` sessions for a slot."""
         return self._live_session_pids(account_num, email)

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,113 @@
+"""Tests for `cswap statusline` and the active_account_display accessor."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_swap import cli
+from claude_swap.models import Platform
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class TestActiveAccountDisplay:
+    def _switcher(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.LINUX
+        s._setup_directories()
+        s._init_sequence_file()
+        return s
+
+    def _seed(self, s, num, email, alias=None):
+        data = s._get_sequence_data() or {
+            "activeAccountNumber": None, "lastUpdated": "",
+            "sequence": [], "accounts": {},
+        }
+        rec = {
+            "email": email, "uuid": f"uuid-{num}",
+            "organizationUuid": "", "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if alias:
+            rec["alias"] = alias
+        data["accounts"][str(num)] = rec
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+        s._write_json(s.sequence_file, data)
+
+    def test_managed_returns_email_and_alias(self, temp_home, monkeypatch):
+        s = self._switcher(temp_home)
+        self._seed(s, 1, "a@example.com", "prod")
+        monkeypatch.setattr(s, "current_account_number", lambda: "1")
+        assert s.active_account_display() == ("a@example.com", "prod")
+
+    def test_managed_without_alias(self, temp_home, monkeypatch):
+        s = self._switcher(temp_home)
+        self._seed(s, 1, "a@example.com")
+        monkeypatch.setattr(s, "current_account_number", lambda: "1")
+        assert s.active_account_display() == ("a@example.com", None)
+
+    def test_unmanaged_live_login(self, temp_home, monkeypatch):
+        s = self._switcher(temp_home)
+        monkeypatch.setattr(s, "current_account_number", lambda: None)
+        monkeypatch.setattr(s, "_get_current_account", lambda: ("live@x.com", ""))
+        assert s.active_account_display() == ("live@x.com", None)
+
+    def test_no_login(self, temp_home, monkeypatch):
+        s = self._switcher(temp_home)
+        monkeypatch.setattr(s, "current_account_number", lambda: None)
+        monkeypatch.setattr(s, "_get_current_account", lambda: None)
+        assert s.active_account_display() == (None, None)
+
+    def test_error_degrades_to_none(self, temp_home, monkeypatch):
+        s = self._switcher(temp_home)
+
+        def boom():
+            raise RuntimeError("transient read failure")
+
+        monkeypatch.setattr(s, "current_account_number", boom)
+        assert s.active_account_display() == (None, None)
+
+
+class TestStatuslineCommand:
+    def _run(self, argv, display, capsys):
+        sw = MagicMock()
+        if isinstance(display, Exception):
+            sw.active_account_display.side_effect = display
+        else:
+            sw.active_account_display.return_value = display
+        with patch("claude_swap.cli.ClaudeAccountSwitcher", return_value=sw), \
+             patch.object(sys, "argv", ["cswap", *argv]):
+            cli.main()
+        return capsys.readouterr().out
+
+    def test_prints_alias_with_icon(self, capsys):
+        out = self._run(["statusline"], ("a@example.com", "prod"), capsys)
+        assert out.strip() == "⇄ prod"
+
+    def test_local_part_when_no_alias(self, capsys):
+        out = self._run(["statusline"], ("work@co.com", None), capsys)
+        assert out.strip() == "⇄ work"
+
+    def test_email_flag_shows_full_email(self, capsys):
+        out = self._run(["statusline", "--email"], ("work@co.com", "prod"), capsys)
+        assert out.strip() == "⇄ work@co.com"
+
+    def test_no_icon(self, capsys):
+        out = self._run(["statusline", "--no-icon"], ("work@co.com", "prod"), capsys)
+        assert out.strip() == "prod"
+
+    def test_custom_icon(self, capsys):
+        out = self._run(["statusline", "--icon", "★"], ("work@co.com", None), capsys)
+        assert out.strip() == "★ work"
+
+    def test_no_login_prints_nothing(self, capsys):
+        out = self._run(["statusline"], (None, None), capsys)
+        assert out.strip() == ""
+
+    def test_switcher_error_prints_nothing(self, capsys):
+        out = self._run(["statusline"], RuntimeError("boom"), capsys)
+        assert out.strip() == ""


### PR DESCRIPTION
Adds `cswap statusline`, a one-line printer for Claude Code's `statusLine.command` or any shell prompt. It shows the active account's alias, or the email local-part, with an optional icon (`--email`, `--icon`, `--no-icon`). It only reads local state and never hits the network. On any error it prints nothing, so it cannot slow down or break the host prompt.
