### PR TITLE
Fix OverflowError in failure backoff on huge consecutive-failure counts

### DIFF
--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -78,6 +78,11 @@ RATE_LIMIT_TRUST_MAX_AGE_S = 7200.0
 # Failure backoff when the server sent no Retry-After: 30s · 2^(n-1), capped.
 BACKOFF_BASE_S = 30.0
 BACKOFF_CAP_S = 600.0
+# Bound the shift so 2**(n-1) can't grow into an int that overflows float once
+# a persistently-failing account's failure count climbs unbounded. The result
+# already saturates at BACKOFF_CAP_S by shift 5 (30 · 2^5 > 600), so any cap
+# above that is behaviour-preserving; 20 leaves generous headroom.
+BACKOFF_MAX_SHIFT = 20
 
 # The usage endpoint enforces a per-access-token request budget on
 # non-first-party User-Agents (proven 2026-07-11: an idle token, polling
@@ -346,7 +351,8 @@ def _rate_limited_trust_ok(
 
 def _failure_backoff_s(consecutive_failures: int, retry_after_s: float | None) -> float:
     computed = min(
-        BACKOFF_BASE_S * (2 ** max(0, consecutive_failures - 1)), BACKOFF_CAP_S
+        BACKOFF_BASE_S * (2 ** min(max(0, consecutive_failures - 1), BACKOFF_MAX_SHIFT)),
+        BACKOFF_CAP_S,
     )
     if retry_after_s is None:
         return computed

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -317,6 +317,12 @@ class TestBackoff:
     def test_backoff_cap(self):
         assert usage_store._failure_backoff_s(50, None) == BACKOFF_CAP_S
 
+    def test_backoff_does_not_overflow_on_huge_failure_count(self):
+        # A persistently-failing account grows consecutive_failures unbounded;
+        # 2**(n-1) must not build an int that overflows float on multiply.
+        for n in (1024, 10_000, 10_000_000):
+            assert usage_store._failure_backoff_s(n, None) == BACKOFF_CAP_S
+
     def test_retry_after_is_the_floor(self, store, clock):
         store.record(
             {"1": FetchRecord(error="http-429", retry_after_s=90.0)}, IDENT


### PR DESCRIPTION
Fixes #179.

### Problem

`_failure_backoff_s` (`src/claude_swap/usage_store.py`) builds the exponential term **before** the cap:

```python
computed = min(
    BACKOFF_BASE_S * (2 ** max(0, consecutive_failures - 1)), BACKOFF_CAP_S
)
```

`2 ** (consecutive_failures - 1)` is an unbounded Python `int`. With `BACKOFF_BASE_S = 30.0` (a `float`), the multiply coerces that int to `float`, which raises `OverflowError: int too large to convert to float` once it exceeds the IEEE-754 double max — i.e. when `consecutive_failures` reaches ~1024.

An account whose usage endpoint keeps failing (e.g. a personal-plan account returning HTTP 403/429 on the usage API) increments `consecutiveFailures` every poll with no ceiling, so it eventually trips this. When it does, the exception aborts the whole `tick()` (swallowed as transient, `... (will retry)`) and **every** account's usage stops refreshing.

### Fix

Bound the shift with a `BACKOFF_MAX_SHIFT = 20` constant. The backoff already saturates at `BACKOFF_CAP_S` by shift 5 (`30 · 2^5 = 960 > 600`), so capping the exponent is fully behaviour-preserving for every reachable value — it only keeps the intermediate int finite.

### Verification

- New regression test `test_backoff_does_not_overflow_on_huge_failure_count` (n = 1024 / 10k / 10M → `BACKOFF_CAP_S`); it raises `OverflowError` on `main`.
- Existing backoff suite unchanged: `pytest tests/test_usage_store.py -k backoff` → 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
