### PR TITLE
fix(theme): consume OSC 11 replies through a DA1 boundary

### DIFF
--- a/src/claude_swap/appearance.py
+++ b/src/claude_swap/appearance.py
@@ -1,14 +1,16 @@
 """Terminal appearance detection and theme resolution.
 
 Determines whether the terminal has a light or dark background by querying it
-with OSC 11 (``ESC ] 11 ; ? BEL``) and reading the ``rgb:…`` reply, then
-classifying by perceived luminance. Cross-cutting: both the CLI printer and the
-TUI resolve their theme through here.
+with OSC 11 (``ESC ] 11 ; ? BEL``) followed by DA1 (``ESC [ c``), reading
+through the ordered DA1 reply, and classifying the preceding ``rgb:…`` reply by
+perceived luminance. Cross-cutting: both the CLI printer and the TUI resolve
+their theme through here.
 
 The query MUST happen while this process owns the terminal in cooked mode —
 before Textual's input driver starts — or the reply is reissued as keystrokes.
 Everything fails safe to ``None`` (→ resolved ``dark``): a terminal that doesn't
-answer, a pipe, Windows, or a parse failure never blocks and never errors.
+answer, a pipe, Windows, or a parse failure never blocks indefinitely and never
+errors.
 """
 
 from __future__ import annotations
@@ -19,15 +21,25 @@ import select
 import sys
 import time
 
-_QUERY = b"\x1b]11;?\x07"           # OSC 11, BEL-terminated
-_TIMEOUT_S = 0.15
-_MAX_REPLY = 64
+_QUERY = b"\x1b]11;?\x07"  # OSC 11, BEL-terminated
+_DA1_QUERY = b"\x1b[c"      # ordered response boundary
+# DA1 lets unsupported terminals return promptly; the cap mainly covers SSH
+# latency or a non-conforming terminal that answers neither query.
+_TIMEOUT_S = 1.0
+_MAX_REPLY = 256
 # The full `ESC ]11;` opener is required so interleaved or echoed input (e.g.
 # a shell echoing back a pasted escape sequence) can't be misparsed as a
 # background reply just because `]11;rgb:`/`]11;#` appears somewhere in the
 # buffer without the ESC that actually starts an OSC sequence.
-_RGB = re.compile(rb"\x1b\]11;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)")
-_HEX = re.compile(rb"\x1b\]11;#([0-9a-fA-F]{6})")
+_RGB = re.compile(
+    rb"\x1b\]11;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)"
+    rb"(?:\x07|\x1b\\)"
+)
+_HEX = re.compile(rb"\x1b\]11;#([0-9a-fA-F]{6})(?:\x07|\x1b\\)")
+# A primary device-attributes reply is CSI ? Ps c. Requiring ``?`` and at
+# least the private marker keeps an echoed DA1 query (CSI c) from looking
+# complete; Ps itself may legally be empty.
+_DA1_REPLY = re.compile(rb"(?:\x1b\[|\x9b)\?[0-9;:]*c")
 
 # Cache: the terminal background can't change within a process, so query once.
 _UNSET = object()
@@ -65,16 +77,24 @@ def _classify(reply: bytes) -> str | None:
 
 
 def _query_terminal_background() -> bytes | None:
-    """Send OSC 11 and read the reply in cooked mode. None on any failure.
+    """Send OSC 11 + DA1 and read through the DA1 reply. None on any failure.
 
     Isolated so tests can substitute a canned reply without a real tty.
 
-    tmux and screen don't give OSC 11 passthrough to the outer terminal by
-    default, so a query sent inside one would just wait out the timeout with
-    no reply; ``$TMUX``/``$STY`` short-circuit to ``None`` (resolving to
+    Terminals process queries in order. DA1 is widely supported, so its reply
+    marks the point after any OSC 11 reply and prevents a slower colour reply
+    from being reissued as shell input after this process restores the tty.
+    The timeout remains a safety cap for high-latency or non-conforming
+    terminals.
+
+    ``TERM=dumb`` and the Linux console don't support this colour query.
+    Likewise, tmux and screen don't pass it through to the outer terminal by
+    default. Those environments short-circuit to ``None`` (resolving to
     ``dark``) without probing. Fails safe either way.
     """
     if os.name == "nt":
+        return None
+    if os.environ.get("TERM") in ("dumb", "linux"):
         return None
     if os.environ.get("TMUX") or os.environ.get("STY"):
         return None
@@ -98,7 +118,7 @@ def _query_terminal_background() -> bytes | None:
         # TCSANOW (not TCSADRAIN): draining first can block under terminal
         # flow control, and there's no pending output to drain anyway.
         tty.setcbreak(fd, termios.TCSANOW)
-        sys.stdout.write(_QUERY.decode("latin-1"))
+        sys.stdout.write((_QUERY + _DA1_QUERY).decode("latin-1"))
         sys.stdout.flush()
         deadline = time.monotonic() + _TIMEOUT_S
         buf = b""
@@ -111,11 +131,9 @@ def _query_terminal_background() -> bytes | None:
             if not chunk:
                 break
             buf += chunk
-            # Only stop early once the buffer holds a complete, parseable
-            # OSC-11 frame — a BEL/ST terminator alone could belong to an
-            # unrelated echoed sequence (e.g. our own query bouncing back)
-            # and end the read before the real reply arrives.
-            if (b"\x07" in buf or b"\x1b\\" in buf) and _parse_osc11(buf) is not None:
+            # Do not stop at the OSC reply: the DA1 response is the ordered
+            # boundary proving that no colour-query bytes are still in flight.
+            if _DA1_REPLY.search(buf) is not None:
                 break
         return buf or None
     except (termios.error, OSError, ValueError):

--- a/tests/test_appearance.py
+++ b/tests/test_appearance.py
@@ -43,12 +43,18 @@ class TestParseOsc11:
     def test_framed_rgb_parses(self):
         assert appearance._parse_osc11(b"\x1b]11;rgb:ffff/ffff/ffff\x07") == (1.0, 1.0, 1.0)
 
+    def test_unterminated_rgb_is_rejected(self):
+        assert appearance._parse_osc11(b"\x1b]11;rgb:ffff/ffff/ffff") is None
+
     def test_unframed_hex_is_rejected(self):
         assert appearance._parse_osc11(b"#ff8000") is None
 
     def test_framed_hex_parses(self):
         r, _, b = appearance._parse_osc11(b"\x1b]11;#ff8000\x07")
         assert r == pytest.approx(1.0) and b == pytest.approx(0.0)
+
+    def test_unterminated_hex_is_rejected(self):
+        assert appearance._parse_osc11(b"\x1b]11;#ff8000") is None
 
 
 class TestClassify:
@@ -66,6 +72,123 @@ class TestClassify:
 
     def test_unparseable_returns_none(self):
         assert appearance._classify(b"nope") is None
+
+
+class TestQueryTerminalBackground:
+    @staticmethod
+    def _fake_tty(monkeypatch, chunks, *, clock=None):
+        termios = pytest.importorskip("termios")
+        import tty
+
+        fd = 42
+        pending = list(chunks)
+        reads = []
+        writes = []
+        select_timeouts = []
+
+        class FakeStdin:
+            @staticmethod
+            def isatty():
+                return True
+
+            @staticmethod
+            def fileno():
+                return fd
+
+        class FakeStdout:
+            @staticmethod
+            def isatty():
+                return True
+
+            @staticmethod
+            def write(value):
+                writes.append(value)
+                return len(value)
+
+            @staticmethod
+            def flush():
+                return None
+
+        def fake_select(readers, _writers, _errors, timeout):
+            assert readers == [fd]
+            select_timeouts.append(timeout)
+            return ([fd], [], []) if pending else ([], [], [])
+
+        def fake_read(read_fd, size):
+            assert read_fd == fd
+            assert size == 32
+            chunk = pending.pop(0)
+            reads.append(chunk)
+            return chunk
+
+        monkeypatch.setenv("TERM", "xterm-256color")
+        monkeypatch.delenv("TMUX", raising=False)
+        monkeypatch.delenv("STY", raising=False)
+        monkeypatch.setattr(sys, "stdin", FakeStdin())
+        monkeypatch.setattr(sys, "stdout", FakeStdout())
+        monkeypatch.setattr(termios, "tcgetattr", lambda read_fd: ["old"])
+        monkeypatch.setattr(termios, "tcsetattr", lambda *args: None)
+        monkeypatch.setattr(tty, "setcbreak", lambda *args: None)
+        monkeypatch.setattr(appearance.select, "select", fake_select)
+        monkeypatch.setattr(appearance.os, "read", fake_read)
+        if clock is not None:
+            monkeypatch.setattr(appearance.time, "monotonic", clock)
+
+        return reads, writes, select_timeouts
+
+    def test_waits_for_da1_after_complete_osc_reply(self, monkeypatch):
+        osc = b"\x1b]11;rgb:1e1d/1e1d/1e1d\x07"
+        da1 = b"\x1b[?1;2c"
+        reads, writes, _ = self._fake_tty(monkeypatch, [osc, da1])
+
+        assert appearance._query_terminal_background() == osc + da1
+        assert reads == [osc, da1]
+        assert writes == [
+            (appearance._QUERY + appearance._DA1_QUERY).decode("latin-1")
+        ]
+
+    def test_accepts_reply_delayed_beyond_old_150ms_window(self, monkeypatch):
+        reply = b"\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2c"
+        times = iter((0.0, 0.2, 0.2))
+        _, _, select_timeouts = self._fake_tty(
+            monkeypatch, [reply], clock=lambda: next(times)
+        )
+
+        assert appearance._query_terminal_background() == reply
+        assert select_timeouts == [pytest.approx(0.8)]
+
+    def test_da1_first_means_osc11_is_unsupported(self, monkeypatch):
+        da1 = b"\x1b[?62;1;2;6c"
+        reads, _, _ = self._fake_tty(monkeypatch, [da1])
+
+        reply = appearance._query_terminal_background()
+
+        assert reads == [da1]
+        assert appearance._classify(reply) is None
+
+    def test_accepts_da1_reply_without_parameters(self, monkeypatch):
+        da1 = b"\x1b[?c"
+        reads, _, _ = self._fake_tty(monkeypatch, [da1])
+
+        assert appearance._query_terminal_background() == da1
+        assert reads == [da1]
+
+    def test_does_not_mistake_echoed_da1_query_for_reply(self, monkeypatch):
+        echoed_query = appearance._DA1_QUERY
+        osc = b"\x1b]11;rgb:0000/0000/0000\x07"
+        da1 = b"\x1b[?1;2c"
+        reads, _, _ = self._fake_tty(monkeypatch, [echoed_query, osc, da1])
+
+        assert appearance._query_terminal_background() == echoed_query + osc + da1
+        assert reads == [echoed_query, osc, da1]
+
+    def test_accepts_fragmented_da1_reply(self, monkeypatch):
+        osc = b"\x1b]11;rgb:0000/0000/0000\x07"
+        fragments = [osc, b"\x1b[?", b"62;1;2;6c"]
+        reads, _, _ = self._fake_tty(monkeypatch, fragments)
+
+        assert appearance._query_terminal_background() == b"".join(fragments)
+        assert reads == fragments
 
 
 class TestResolveTheme:
@@ -196,6 +319,20 @@ def test_query_short_circuits_under_tmux(monkeypatch):
 
     def _boom():
         raise AssertionError("must not probe the tty under tmux")
+
+    monkeypatch.setattr(sys.stdin, "fileno", _boom, raising=False)
+    assert appearance._query_terminal_background() is None
+
+
+@pytest.mark.parametrize("term", ["dumb", "linux"])
+def test_query_short_circuits_on_known_unsupported_terminals(monkeypatch, term):
+    """Known unsupported terminals must not receive escape-sequence probes."""
+    monkeypatch.setenv("TERM", term)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+
+    def _boom():
+        raise AssertionError("must not probe a known unsupported terminal")
 
     monkeypatch.setattr(sys.stdin, "fileno", _boom, raising=False)
     assert appearance._query_terminal_background() is None


### PR DESCRIPTION
## Summary

- send a DA1 query immediately after OSC 11 and keep reading until the ordered DA1 response arrives
- extend the safety timeout from 150 ms to 1 second for SSH latency while letting unsupported terminals return promptly through DA1
- skip probing on `TERM=dumb` and the Linux console, and require complete BEL/ST-terminated OSC 11 frames
- add regression coverage for a response beyond the old 150 ms window, split responses, DA1-only terminals, query echo, and unsupported environments

## Why

With the default `ui.theme=auto`, a terminal that answered OSC 11 after the 150 ms read window could deliver that response after cswap restored the tty. The shell then received the response as input, leaving text such as `11;rgb:...` at the prompt.

DA1 acts as an ordered response boundary: terminals process OSC 11 before the following DA1 query, so consuming the complete DA1 response also consumes any preceding colour response before the tty is restored. This is the same feature-detection approach documented by [terminal-colorsaurus](https://docs.rs/terminal-colorsaurus/latest/terminal_colorsaurus/feature_detection/).

A clarification to #177: `drain_stdin()` is already called on the TUI path before Textual starts; the plain CLI path has no equivalent drain. This change avoids adding an unconditional exit-time `TCIFLUSH`, which could discard real typeahead or stdin consumed by interactive commands.

## Tests

- `uv run pytest` — 1539 passed, 3 skipped (Linux, Python 3.14)
- `uv run --python 3.12 --isolated pytest tests/test_appearance.py tests/test_cli.py -q` — 157 passed

Fixes #177