### PR TITLE
fix: OverflowError in failure backoff after ~1024 consecutive failures

### DIFF
--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -345,8 +345,13 @@ def _rate_limited_trust_ok(
 
 
 def _failure_backoff_s(consecutive_failures: int, retry_after_s: float | None) -> float:
+    # Clamp the exponent before multiplying: a permanently failing account
+    # increments the counter forever, and 2**n stops converting to float at
+    # n >= 1024 (OverflowError) — long before min() could cap the result.
+    # 32 doublings already exceed BACKOFF_CAP_S by orders of magnitude.
     computed = min(
-        BACKOFF_BASE_S * (2 ** max(0, consecutive_failures - 1)), BACKOFF_CAP_S
+        BACKOFF_BASE_S * (2 ** min(max(0, consecutive_failures - 1), 32)),
+        BACKOFF_CAP_S,
     )
     if retry_after_s is None:
         return computed

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -317,6 +317,37 @@ class TestBackoff:
     def test_backoff_cap(self):
         assert usage_store._failure_backoff_s(50, None) == BACKOFF_CAP_S
 
+    def test_huge_failure_count_does_not_overflow(self):
+        # A permanently failing account increments consecutiveFailures forever;
+        # past 1024 failures 2**(n-1) no longer converts to float and the old
+        # code raised OverflowError before min() could cap it — killing every
+        # subsequent tick (the crash also stopped the state write, so the
+        # counter never moved and the loop errored forever).
+        assert usage_store._failure_backoff_s(1025, None) == BACKOFF_CAP_S
+        assert usage_store._failure_backoff_s(10_000, 90.0) == BACKOFF_CAP_S
+
+    def test_record_failure_on_saturated_counter_does_not_raise(self, store, clock):
+        store.path.parent.mkdir(parents=True)
+        store.path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 2,
+                    "accounts": {
+                        "1": {
+                            "email": "a@x.com",
+                            "consecutiveFailures": 1024,
+                            "lastError": "refresh-failed",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        store.record({"1": FetchRecord(error="refresh-failed")}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.consecutive_failures == 1025
+        assert entry.backoff_until == pytest.approx(clock.now + BACKOFF_CAP_S)
+
     def test_retry_after_is_the_floor(self, store, clock):
         store.record(
             {"1": FetchRecord(error="http-429", retry_after_s=90.0)}, IDENT


### PR DESCRIPTION
## Problem

An account that fails permanently (e.g. a dead refresh token producing `refresh-failed` on every poll) increments `consecutiveFailures` without bound. Once the counter passes 1024, `_failure_backoff_s` computes `BACKOFF_BASE_S * (2 ** (n - 1))` — and `2**1024` can no longer be converted to a float, so the function raises `OverflowError: int too large to convert to float` **before** `min()` gets a chance to cap the result.

Worse, the crash aborts the store write, so the counter never advances past the threshold and every subsequent tick fails the same way. The visible symptom is `cswap auto` printing this on every poll, forever:

```
error: OverflowError: int too large to convert to float (will retry)
```

Hit this in the wild on 0.18.1 — one slot had accumulated `consecutiveFailures: 1024` and the auto loop was permanently wedged.

## Fix

Clamp the exponent at 32 doublings before multiplying. `BACKOFF_BASE_S * 2**32` is already orders of magnitude past `BACKOFF_CAP_S`, so behaviour is unchanged for every reachable value below the overflow point.

## Tests

- `test_huge_failure_count_does_not_overflow` — unit check at 1 025 and 10 000 failures (both previously raised).
- `test_record_failure_on_saturated_counter_does_not_raise` — end-to-end through `UsageStore.record` with a stored row at `consecutiveFailures: 1024`, reproducing the real-world wedge.

Both fail with `OverflowError` before the fix; `tests/test_usage_store.py`, `test_autoswitch.py` and `test_poll_policy.py` (223 tests) pass after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)