### PR TITLE
fix(add): capture the CLAUDE_CONFIG_DIR profile's own credential

### DIFF
--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -53,6 +53,16 @@ def get_global_config_path() -> Path:
     return base / ".claude.json"
 
 
+def get_default_claude_config_home() -> Path:
+    """Return the *default* profile's config home, ignoring ``CLAUDE_CONFIG_DIR``.
+
+    ``_read_capture_credentials`` has to tell an env var that names the default
+    profile from one that names another, since only the former's credential is
+    the active store's.
+    """
+    return Path.home() / ".claude"
+
+
 def get_default_global_config_path() -> Path:
     """Return the global config path of the *default* profile.
 
@@ -61,7 +71,7 @@ def get_default_global_config_path() -> Path:
     (session sharing) must not source from another session when invoked from
     inside one.
     """
-    legacy = Path.home() / ".claude" / ".config.json"
+    legacy = get_default_claude_config_home() / ".config.json"
     if legacy.exists():
         return legacy
     return Path.home() / ".claude.json"

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -161,14 +161,16 @@ def session_dir_for(backup_dir: Path, account_num: str, email: str) -> Path:
     return backup_dir / "sessions" / f"{account_num}-{slugify_email(email)}"
 
 
-def keychain_service_name(session_dir: Path) -> str:
+def keychain_service_name(config_dir: Path | str) -> str:
     """Keychain service name Claude Code derives for this config dir.
 
     Claude hashes the raw ``CLAUDE_CONFIG_DIR`` env var value, NFC-normalized
     and unresolved (claude src ``envUtils.ts``/``macOsKeychainHelpers.ts``).
     Hash exactly the string we export — never a resolved/realpath variant.
+    Accepts a ``str`` so a caller holding the raw env value can hash it without
+    a ``Path`` round-trip, which would drop a trailing slash or ``./``.
     """
-    normalized = unicodedata.normalize("NFC", str(session_dir))
+    normalized = unicodedata.normalize("NFC", str(config_dir))
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:8]
     return f"Claude Code-credentials-{digest}"
 
@@ -212,19 +214,32 @@ def read_session_credentials(session_dir: Path) -> str | None:
     writes the hashed entry). Returns ``None`` when the profile has no
     readable credential material.
     """
-    if not session_dir.is_dir():
+    return read_config_dir_credentials(str(session_dir))
+
+
+def read_config_dir_credentials(config_dir: str) -> str | None:
+    """Same read for an arbitrary ``CLAUDE_CONFIG_DIR`` value.
+
+    Takes the raw string rather than a ``Path``: claude derives the keychain
+    service name from the exported value verbatim, so a ``Path`` round-trip —
+    which drops a trailing slash or a leading ``./`` — would look up a service
+    name claude never wrote and fall back to the (possibly stale) plaintext
+    seed instead.
+    """
+    directory = Path(config_dir)
+    if not directory.is_dir():
         return None
     if Platform.detect() == Platform.MACOS:
         try:
             creds = macos_keychain.get_password(
-                keychain_service_name(session_dir), _keychain_account_name()
+                keychain_service_name(config_dir), _keychain_account_name()
             )
             if creds:
                 return creds
         except KeychainError:
             pass  # locked/denied/timeout — the plaintext seed is the next-best truth
     try:
-        return (session_dir / ".credentials.json").read_text(encoding="utf-8")
+        return (directory / ".credentials.json").read_text(encoding="utf-8")
     except (OSError, ValueError):
         # ValueError covers UnicodeDecodeError: a byte-corrupt file is "no
         # readable credential material", not an error to propagate.

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -71,6 +71,7 @@ from claude_swap.printer import (
 from claude_swap.paths import (
     get_backup_root,
     get_credentials_path,
+    get_default_claude_config_home,
     get_global_config_path,
     get_legacy_backup_root,
     migrate_legacy_backup_dir,
@@ -224,6 +225,20 @@ def _label_token_status(source: str, credentials: str) -> str | None:
     if status.startswith(prefix):
         return f"{source}: {status.removeprefix(prefix)}"
     return f"{source}: {status}"
+
+
+def _same_directory(left: Path, right: Path) -> bool:
+    """Whether two paths name the same directory, symlinks and ``..`` included.
+
+    Resolved rather than compared as strings: a ``$HOME`` reached through a
+    symlink spells the same directory two ways, and the caller is deciding
+    which profile a path belongs to — not deriving a keychain service name,
+    where claude hashes the raw value and resolving would be wrong.
+    """
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:  # unreadable mount / permission — compare as written
+        return left == right
 
 
 def _sweep_legacy_keyring(usernames: list[str], removed_items: list[str]) -> None:
@@ -430,6 +445,45 @@ class ClaudeAccountSwitcher:
 
     def _read_active_credentials(self) -> ActiveCredentials:
         return self._store._read_active_credentials()
+
+    def _read_capture_credentials(self) -> str | None:
+        """Read the credential of the profile ``CLAUDE_CONFIG_DIR`` points at.
+
+        ``add_account`` fills one slot from two reads: the identity out of
+        ``.claude.json`` and the credential out of the active store. The active
+        store's file backend follows ``CLAUDE_CONFIG_DIR`` (through
+        ``get_claude_config_home``), but its macOS Keychain backend is pinned to
+        the unsuffixed ``CLAUDE_CODE_KEYCHAIN_SERVICE``. So on macOS the two
+        reads land in different profiles and the slot ends up holding one
+        account's email against another account's token.
+
+        Read the OAuth credential the way claude resolves it for the same
+        environment, so the slot's email and token come from one profile.
+        Two fallbacks stay inside that profile. An env var naming the default
+        profile means the active store, since a user exporting
+        ``CLAUDE_CONFIG_DIR=~/.claude`` may only have the unsuffixed item.
+        A managed API key sits outside any OAuth store, and
+        :meth:`_reject_live_api_key_capture` still has to answer for one.
+
+        Read-only. cswap does not write claude's hashed keychain entry — see
+        the ``session`` module docstring for why.
+        """
+        config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+        if not config_dir:
+            return self._read_credentials()
+
+        from claude_swap.session import read_config_dir_credentials
+
+        creds = read_config_dir_credentials(config_dir)
+        if creds:
+            return creds
+        if _same_directory(Path(config_dir), get_default_claude_config_home()):
+            return self._read_credentials()
+        # Only this profile's own ``primaryApiKey`` — never the unsuffixed
+        # "Claude Code" Keychain item, which belongs to the default profile
+        # and would answer for a login that is not the one being added.
+        key = (self._read_json(get_global_config_path()) or {}).get("primaryApiKey")
+        return key if isinstance(key, str) else ""
 
     def _write_credentials(self, credentials: str) -> None:
         self._store._write_credentials(credentials)
@@ -2009,7 +2063,7 @@ class ClaudeAccountSwitcher:
                         f"Alias '{alias}' is already used by account {conflict}"
                     )
 
-            current_creds = self._read_credentials()
+            current_creds = self._read_capture_credentials()
             if current_creds is None:
                 raise CredentialReadError("Failed to read credentials for current account")
             if not current_creds:
@@ -2118,7 +2172,7 @@ class ClaudeAccountSwitcher:
                 )
 
         # Read new account credentials BEFORE any destructive operations
-        current_creds = self._read_credentials()
+        current_creds = self._read_capture_credentials()
         if current_creds is None:
             raise CredentialReadError("Failed to read credentials for current account")
         if not current_creds:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,10 +12,18 @@ from types import SimpleNamespace
 
 import pytest
 
+from claude_swap import macos_keychain
 from claude_swap import oauth
 from claude_swap import session as session_mod
-from claude_swap.exceptions import AccountNotFoundError, SessionError
+from claude_swap.credentials import CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE
+from claude_swap.exceptions import (
+    AccountNotFoundError,
+    CredentialReadError,
+    SessionError,
+    ValidationError,
+)
 from claude_swap.models import Platform
+from claude_swap.paths import get_global_config_path
 from claude_swap.session import (
     MCP_DISPLACED_STASH,
     MCP_MIRROR_MARKER,
@@ -1612,3 +1620,218 @@ class TestReadSessionCredentials:
         )
         creds = session_mod.read_session_credentials(session_dir)
         assert creds is not None and "sk-seed" in creds
+
+
+ACTIVE_TOKEN = "active-store-token"
+CONFIG_DIR_TOKEN = "config-dir-token"
+ACTIVE_CREDS = json.dumps({"claudeAiOauth": {"accessToken": ACTIVE_TOKEN}})
+CONFIG_DIR_CREDS = json.dumps({"claudeAiOauth": {"accessToken": CONFIG_DIR_TOKEN}})
+CONFIG_DIR_CONFIG = json.dumps(
+    {
+        "oauthAccount": {
+            "emailAddress": "elsewhere@example.com",
+            "accountUuid": "uuid-elsewhere",
+            "organizationUuid": "org-elsewhere",
+        }
+    }
+)
+API_KEY = "sk-ant-api03-" + "x" * 20
+
+
+class TestCaptureCredentials:
+    """``add_account`` under ``CLAUDE_CONFIG_DIR``.
+
+    The identity comes from the env-resolved ``.claude.json`` while the
+    credential came from the active store, whose macOS Keychain backend ignores
+    the env var — so a slot could hold one account's email and another's token.
+    """
+
+    @staticmethod
+    def _switcher(platform, monkeypatch) -> ClaudeAccountSwitcher:
+        monkeypatch.setattr(Platform, "detect", classmethod(lambda cls: platform))
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        return switcher
+
+    @staticmethod
+    def _config_dir(base: Path, *, credentials: str | None = CONFIG_DIR_CREDS) -> Path:
+        directory = base / "elsewhere"
+        directory.mkdir()
+        (directory / ".claude.json").write_text(CONFIG_DIR_CONFIG, encoding="utf-8")
+        if credentials is not None:
+            (directory / ".credentials.json").write_text(credentials, encoding="utf-8")
+        return directory
+
+    @staticmethod
+    def _stored(switcher: ClaudeAccountSwitcher) -> str:
+        return switcher._read_account_credentials("1", "elsewhere@example.com")
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_captures_config_dir_token(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        switcher = self._switcher(platform, monkeypatch)
+        switcher._write_credentials(ACTIVE_CREDS)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(self._config_dir(tmp_path)))
+
+        switcher.add_account()
+
+        assert CONFIG_DIR_TOKEN in self._stored(switcher)
+        assert ACTIVE_TOKEN not in self._stored(switcher)
+
+    def test_macos_prefers_hashed_keychain_entry(
+        self, temp_home: Path, tmp_path: Path, block_real_keychain, monkeypatch
+    ):
+        switcher = self._switcher(Platform.MACOS, monkeypatch)
+        switcher._write_credentials(ACTIVE_CREDS)
+        config_dir = self._config_dir(tmp_path)
+        block_real_keychain.set_password(
+            keychain_service_name(config_dir),
+            session_mod._keychain_account_name(),
+            json.dumps({"claudeAiOauth": {"accessToken": "rotated"}}),
+        )
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+        switcher.add_account()
+
+        assert "rotated" in self._stored(switcher)
+
+    def test_trailing_slash_still_finds_keychain_entry(
+        self, temp_home: Path, tmp_path: Path, block_real_keychain, monkeypatch
+    ):
+        """Claude hashes the exported string verbatim, so the service name has
+        to be derived from it and not from a normalized ``Path``."""
+        switcher = self._switcher(Platform.MACOS, monkeypatch)
+        config_dir = self._config_dir(tmp_path)
+        exported = f"{config_dir}/"
+        block_real_keychain.set_password(
+            keychain_service_name(exported),
+            session_mod._keychain_account_name(),
+            json.dumps({"claudeAiOauth": {"accessToken": "rotated"}}),
+        )
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", exported)
+
+        switcher.add_account()
+
+        assert "rotated" in self._stored(switcher)
+        assert CONFIG_DIR_TOKEN not in self._stored(switcher)
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_default_config_dir_uses_active_store(
+        self, platform, temp_home: Path, monkeypatch
+    ):
+        """``CLAUDE_CONFIG_DIR=~/.claude`` names the default profile, whose
+        credential is the active store's."""
+        switcher = self._switcher(platform, monkeypatch)
+        switcher._write_credentials(ACTIVE_CREDS)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
+        get_global_config_path().write_text(CONFIG_DIR_CONFIG, encoding="utf-8")
+
+        switcher.add_account()
+
+        assert ACTIVE_TOKEN in self._stored(switcher)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation is POSIX-only")
+    def test_symlinked_default_config_dir_uses_active_store(
+        self, temp_home: Path, tmp_path: Path, block_real_keychain, monkeypatch
+    ):
+        """A ``$HOME`` reached through a symlink spells the default profile a
+        second way; it is still the profile the active store belongs to."""
+        switcher = self._switcher(Platform.MACOS, monkeypatch)
+        switcher._write_credentials(ACTIVE_CREDS)
+        link = tmp_path / "home-link"
+        link.symlink_to(Path.home())
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(link / ".claude"))
+        get_global_config_path().write_text(CONFIG_DIR_CONFIG, encoding="utf-8")
+
+        switcher.add_account()
+
+        assert ACTIVE_TOKEN in self._stored(switcher)
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_api_key_login_still_reaches_guard(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        """A managed key is not in any profile's OAuth store, but
+        ``_reject_live_api_key_capture`` still has to answer for it."""
+        switcher = self._switcher(platform, monkeypatch)
+        config_dir = self._config_dir(tmp_path, credentials=None)
+        (config_dir / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "oauthAccount": {"emailAddress": "elsewhere@example.com"},
+                    "primaryApiKey": API_KEY,
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+        with pytest.raises(ValidationError, match="API-key account"):
+            switcher.add_account()
+
+    def test_machine_managed_key_does_not_answer_for_config_dir(
+        self, temp_home: Path, tmp_path: Path, block_real_keychain, monkeypatch
+    ):
+        """The unsuffixed "Claude Code" Keychain item is the default profile's.
+        Reading it here would report an API-key login for an OAuth profile."""
+        switcher = self._switcher(Platform.MACOS, monkeypatch)
+        block_real_keychain.set_password(
+            CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
+            macos_keychain.keychain_account_name(),
+            API_KEY,
+        )
+        monkeypatch.setenv(
+            "CLAUDE_CONFIG_DIR", str(self._config_dir(tmp_path, credentials=None))
+        )
+
+        with pytest.raises(CredentialReadError):
+            switcher.add_account()
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_credentialless_config_dir_does_not_fall_back(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        switcher = self._switcher(platform, monkeypatch)
+        switcher._write_credentials(ACTIVE_CREDS)
+        monkeypatch.setenv(
+            "CLAUDE_CONFIG_DIR", str(self._config_dir(tmp_path, credentials=None))
+        )
+
+        with pytest.raises(CredentialReadError):
+            switcher.add_account()
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_in_place_refresh_uses_same_source(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        switcher = self._switcher(platform, monkeypatch)
+        switcher._write_credentials(ACTIVE_CREDS)
+        config_dir = self._config_dir(tmp_path)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        switcher.add_account()
+
+        (config_dir / ".credentials.json").write_text(
+            json.dumps({"claudeAiOauth": {"accessToken": "rotated"}}), encoding="utf-8"
+        )
+        switcher.add_account()
+
+        assert "rotated" in self._stored(switcher)
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    @pytest.mark.parametrize("value", [None, ""])
+    def test_no_config_dir_uses_active_store(
+        self, value, platform, temp_home: Path, monkeypatch
+    ):
+        if value is None:
+            monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        else:
+            monkeypatch.setenv("CLAUDE_CONFIG_DIR", value)
+        switcher = self._switcher(platform, monkeypatch)
+        switcher._write_credentials(ACTIVE_CREDS)
+        get_global_config_path().write_text(CONFIG_DIR_CONFIG, encoding="utf-8")
+
+        switcher.add_account()
+
+        assert ACTIVE_TOKEN in self._stored(switcher)


### PR DESCRIPTION
On macOS, `cswap add` can file a slot with one account's email and a different
account's token. It reports success, and nothing you can check afterwards
disagrees. This makes `add_account` read the credential from the same profile it
read the identity from.

## What I wanted

Two accounts at the same time: one terminal on account B, everything else on
account A, sharing the same settings, skills, and transcripts. That is what
session mode is for. The README opens with:

> Easily switch between multiple Claude accounts without logging out

and describes session mode as:

> every other terminal and the VS Code extension stay on your default account,
> so two accounts can work in parallel

On macOS, adding the second account broke both of those promises.

## What happened

I registered account B and launched it with `cswap run`. Every session on my
default profile logged out, mid-work.

Once I was back in, nothing looked wrong. `cswap list` showed both accounts, and
`claude auth status` in the new session reported account B. Neither one checks
the token, though — both print stored metadata. So I resolved each slot's access
token against `GET /api/oauth/profile` directly. Slot 1 came back as account A.
So did slot 2.

Slot 2 had never captured account B. Both "accounts" were drawing on one
account's 5h and 7d budget. Two accounts, one quota.

The repo already has that oracle: `oauth.fetch_oauth_profile`, the "whose token
is this" call `switcher.py` uses when resolving an identity. It just isn't on
the `add` path.

The logout follows from the same root. `cswap run` refreshes the profile's
credential while bootstrapping it (`session.py`, `_bootstrap`), and an OAuth
refresh rotates the token family. Slot 2's token belonged to the default
profile, so that rotation invalidated the copy every other terminal was still
using.

## Why

`add_account` fills a slot from two reads. The credential read has two backends,
and only one of them follows the env var:

| read | looks at | follows `CLAUDE_CONFIG_DIR` |
| --- | --- | --- |
| identity — `.claude.json` | `paths.get_global_config_path` | yes |
| credential — file backend | `paths.get_claude_config_home` | yes |
| credential — macOS Keychain | `CLAUDE_CODE_KEYCHAIN_SERVICE` | **no** |

That service name is a constant, so it always points at the default profile. On
Linux and Windows the credential comes from the file backend, which follows the
env var, so both reads land in the same profile. On macOS they don't.

Nothing in the suite captures a credential with `CLAUDE_CONFIG_DIR` set, which
is why CI stays green. The macOS job runs only the Keychain wrapper tests
(`test_macos_keychain.py`, `test_macos_keychain_contract.py`), and the new tests
below fake the platform, so they fail on any runner.

## The fix

Read the credential from the same profile the identity came from.

`_read_capture_credentials` does that, and `add_account`'s two capture points
call it. It tries three sources, all inside the profile `CLAUDE_CONFIG_DIR`
names:

1. The profile's hashed Keychain entry, then its `.credentials.json`
   (`session.read_config_dir_credentials`).
2. The active store — but only if the env var names the default profile. Then
   they are the same profile, and someone exporting
   `CLAUDE_CONFIG_DIR=~/.claude` may only have the unsuffixed item.
3. The profile's own `primaryApiKey`, so an API-key login still gets
   `_reject_live_api_key_capture`'s message instead of a generic read error.

Writing is untouched. cswap deliberately never writes claude's hashed Keychain
entry — `session.py`'s module docstring gives the reason, and this fix doesn't
need it. Reading that entry is already done (`read_session_credentials`);
writing it isn't.

Two details the diff turns on:

**Hash the raw string, not a `Path`.** Claude hashes the exported value exactly
as written (`session.py`: "Hash exactly the string we export"). `Path()` strips
a trailing slash and a leading `./`. So `export CLAUDE_CONFIG_DIR=/path/to/p/`
would look up a name claude never wrote, miss, and fall back to the old seed
file — the same wrong-token bug, silently. `keychain_service_name` now takes
`str | Path`, and `read_session_credentials` calls the new function, so existing
callers don't change.

**Resolve paths when comparing them, never when hashing them.** `_same_directory`
resolves both sides so a `$HOME` reached through a symlink still counts as the
default profile. Same pattern as `paths.migrate_legacy_backup_dir` — `resolve()`,
and a literal compare if that raises `OSError`.

## Out of scope

The write path has the same split, and it is worth recording. With
`CLAUDE_CONFIG_DIR` set, `cswap switch` writes `<config_dir>/.credentials.json`
on Linux, but the default profile's Keychain item on macOS — and then
`_refresh_stale_credentials_file` rewrites `<config_dir>/.credentials.json` as
well. So on macOS a `cswap switch` inside a session shell writes account B
twice: into the default profile's Keychain, and into the session profile's seed
file. The session profile's own hashed entry still holds account A, and claude
reads that first. Closing this means writing claude's hashed entry, which the
docstring above rules out, so it needs its own discussion. Happy to open an
issue and follow up.

One smaller gap in this change. The active store retries a busy Keychain read
(`_ACTIVE_READ_ATTEMPTS`) before falling back to the plaintext file; the profile
read tries once, matching `read_session_credentials`'s existing behavior. So a
Keychain that is locked right at capture time can still capture an old seed
token, silently. Both paths end at the same file, so the window is narrower than
before — but it is still there. Fixing it means a strict mode on
`read_config_dir_credentials` for the capture call only, which I left out to
keep this to one change.

## Scope

```
src/claude_swap/paths.py      +11  -1   get_default_claude_config_home
src/claude_swap/session.py    +20  -5   read_config_dir_credentials
src/claude_swap/switcher.py   +56  -2   _read_capture_credentials, _same_directory
tests/test_session.py        +224  -1   TestCaptureCredentials
```

No new configuration, no new dependencies.

Tests sit in `test_session.py` next to `TestReadSessionCredentials`, since this
is `CLAUDE_CONFIG_DIR` profile resolution rather than the account bookkeeping
`test_switcher.py`'s `add_account` tests cover.

## Validation

All runs use `env -u CLAUDE_CONFIG_DIR` — an exported value changes what the
suite exercises.

- New tests against unmodified `main` (`db55bc2`): **6 failed, 12 passed**. The
  six failures are the macOS cases, which is the bug. The twelve that pass are
  the Linux cases and the guards, pinning behavior that already works.
- Full suite on this branch: **1549 passed, 6 failed, 3 skipped**. Those six
  also fail on unmodified `main` (`test_move_accounts` 2, `test_swap_accounts`
  4) and are unrelated.
- `uv run python -m compileall -q src`, `git diff --check`.

Most of these started as a failing test: a trailing slash on the env var, an env
var naming the default profile, a `$HOME` reached through a symlink (POSIX-only,
skipped on Windows), a machine-wide API key answering for an OAuth profile, and
a credential-less profile falling back to a different one. The rest pin guards —
the env var unset or empty, and the in-place refresh branch reading the same
source as the first capture.
