### PR TITLE
Make API-key account switches land in running sessions — in both directions — and give the key back when a subscription recovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,16 @@ setup-token. It switches like any other account; since API keys have no subscrip
 quota, they show no usage and the usage-aware `switch` strategies never skip them as
 rate-limited.
 
+Because those keys bill metered usage rather than draw on a plan, `cswap auto`
+treats them as a last resort in both directions. Opted in with
+`autoswitch.includeApiKeyAccounts`, a key is only ever chosen once no
+subscription account can take the traffic — and once the engine is on one it
+returns to the first subscription account whose utilization falls
+`hysteresisPct` below the threshold, without waiting for a quota it does not
+have to cross. Note the key itself is never watched for health while it is
+active: it reports no usage, and treating that as "unhealthy" would fail the
+engine off a perfectly working key.
+
 ## Uninstall
 
 Remove all data:

--- a/src/claude_swap/api_key_helper.py
+++ b/src/claude_swap/api_key_helper.py
@@ -40,10 +40,22 @@ Two constraints shape the implementation:
   alone and logs why, rather than hijacking the hook. Those users keep the old
   restart-to-pick-up behaviour instead of silently losing their helper.
 
-Everything here is best-effort. The authoritative write is still
-``primaryApiKey`` (which is what a *newly started* session reads); this channel
-only decides whether sessions that are already running have to be restarted, so
-no failure in it may fail a switch.
+When this channel is live it is also the *only* place the key is stored: the
+``primaryApiKey`` write is dropped rather than kept as a belt-and-braces copy.
+That is deliberate, and it is what makes the switch *away* from an API-key
+account land too. ``primaryApiKey`` is memoized for the lifetime of a process
+and cleared only by that process's own ``/login`` / ``/logout``, so any session
+that starts while it is set is pinned to that key permanently — activating an
+OAuth account later removes the value from the file but cannot touch the memo,
+and a managed key outranks the claude.ai credential. Sessions started during a
+spell on an API-key account would otherwise keep billing it while ``cswap
+status`` reported the subscription account. A newly started session reads the
+helper just as readily, so nothing is lost by making it the sole home.
+
+Everything here is still best-effort: when the channel is unavailable (Windows,
+a foreign helper, an I/O failure) the caller falls back to writing
+``primaryApiKey`` and those sessions keep the old restart-to-pick-up behaviour.
+No failure in it may fail a switch.
 """
 
 from __future__ import annotations
@@ -152,6 +164,29 @@ class ApiKeyHelperChannel:
                 self.key_path.unlink()
         except OSError as e:
             self._logger.warning(f"Could not remove the active-API-key file: {e}")
+
+    def active_key(self) -> str:
+        """The key this channel is currently serving, or "" when it isn't.
+
+        A read source, not a probe: when the helper holds the key it is the only
+        copy on disk, so ``_read_managed_key`` has to be able to find it here or
+        cswap would report an active API-key account as having no credential.
+
+        Ownership is checked against ``settings.json`` rather than the key file's
+        mere existence: ``remove()`` unregisters the hook before unlinking the
+        file, and a foreign helper's registration means the key file left behind
+        by an older cswap is not what Claude Code is reading.
+        """
+        try:
+            registered = self._read_settings(self.settings_path).get(SETTINGS_KEY)
+        except ValueError:
+            return ""
+        if registered != str(self.script_path):
+            return ""
+        try:
+            return self.key_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
 
     def supported(self) -> bool:
         """Whether this channel can run here.

--- a/src/claude_swap/api_key_helper.py
+++ b/src/claude_swap/api_key_helper.py
@@ -33,7 +33,8 @@ Two constraints shape the implementation:
   (it forces the API-key axis for the whole session), so leaving it in place
   would pin every session to the key and break the OAuth accounts. It is
   installed when an API-key account is activated and removed when an OAuth one
-  is.
+  is — including the activation ``add_account`` performs when it captures a live
+  ``/login`` as a new account, which Claude Code cannot clean up itself.
 - **A foreign ``apiKeyHelper`` is never touched.** If ``settings.json`` already
   points somewhere else, that is the user's own auth plumbing: cswap leaves it
   alone and logs why, rather than hijacking the hook. Those users keep the old

--- a/src/claude_swap/api_key_helper.py
+++ b/src/claude_swap/api_key_helper.py
@@ -1,0 +1,278 @@
+"""Carry an API-key account switch into *already running* Claude Code sessions.
+
+Switching to an OAuth account lands in a running session for free: Claude Code
+reads ``.credentials.json`` uncached on every auth resolution and watches the
+file's mtime, dropping its memoized token when it changes. Rewriting the file is
+the whole mechanism (it is what #86 leans on).
+
+The managed-API-key axis has no such property:
+
+- ``primaryApiKey`` is read out of an in-memory snapshot of ``~/.claude.json``
+  that Claude Code never re-stats on the read path, and
+- the resolved key is additionally memoized for the lifetime of the process.
+  That memo is cleared only by the *same* process saving or removing a key (its
+  own ``/login`` / ``/logout``) — never by an outside writer.
+
+So activating an API-key account used to be invisible to every running session,
+and *worse* than invisible: the OAuth credential is cleared for mutual exclusion,
+the credentials-file watcher fires, and the session drops to "Login expired —
+please run /login" while the fresh key sits unread in ``~/.claude.json``.
+
+``apiKeyHelper`` is the one API-key channel Claude Code re-reads at runtime. It
+is a settings hook, and Claude Code both (a) watches the settings files and drops
+its settings cache when one changes, and (b) awaits the helper while building the
+client for a request, re-running it once the cached value ages past
+``CLAUDE_CODE_API_KEY_HELPER_TTL_MS`` (default 5 minutes). Pointing it at a
+script that prints the active managed key therefore makes an API-key switch land
+in a running session the same way an OAuth switch does.
+
+Two constraints shape the implementation:
+
+- **The hook is toggled, never left installed.** A configured ``apiKeyHelper``
+  outranks the claude.ai OAuth credential in Claude Code's source resolution
+  (it forces the API-key axis for the whole session), so leaving it in place
+  would pin every session to the key and break the OAuth accounts. It is
+  installed when an API-key account is activated and removed when an OAuth one
+  is.
+- **A foreign ``apiKeyHelper`` is never touched.** If ``settings.json`` already
+  points somewhere else, that is the user's own auth plumbing: cswap leaves it
+  alone and logs why, rather than hijacking the hook. Those users keep the old
+  restart-to-pick-up behaviour instead of silently losing their helper.
+
+Everything here is best-effort. The authoritative write is still
+``primaryApiKey`` (which is what a *newly started* session reads); this channel
+only decides whether sessions that are already running have to be restarted, so
+no failure in it may fail a switch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import sys
+import tempfile
+from pathlib import Path
+
+from claude_swap.paths import get_backup_root, get_claude_config_home
+
+# Basename of the generated helper script and of the file it prints, both under
+# the cswap backup root (the same 0700 tree that already holds credentials).
+HELPER_SCRIPT_NAME = "api-key-helper.sh"
+ACTIVE_KEY_NAME = "active-api-key"
+
+# Claude Code's user-level settings file, inside the config home, and the hook
+# key within it.
+SETTINGS_FILENAME = "settings.json"
+SETTINGS_KEY = "apiKeyHelper"
+
+# ``set -eu`` plus an explicit readability probe: when the key file is gone the
+# helper must fail loudly rather than print an empty key, which Claude Code would
+# surface as a confusing empty-credential error instead of "helper is failing".
+_HELPER_SCRIPT = """#!/bin/sh
+# Managed by claude-swap — do not edit; regenerated on every switch.
+#
+# Prints the API key of the currently active cswap account. Claude Code re-runs
+# this on a TTL, so a *running* session picks up an API-key switch on its next
+# request instead of needing a restart. Removed again when an OAuth account is
+# activated (an installed apiKeyHelper would otherwise outrank the OAuth login).
+set -eu
+key_file={key_file}
+[ -r "$key_file" ] || exit 1
+exec cat "$key_file"
+"""
+
+
+class ApiKeyHelperChannel:
+    """Installs and removes the ``apiKeyHelper`` hook that carries a live switch.
+
+    Stateless apart from its logger: every path is resolved at call time, so a
+    test (or a user) changing ``HOME`` / ``CLAUDE_CONFIG_DIR`` / ``XDG_DATA_HOME``
+    between calls is honored, exactly as the rest of ``paths`` behaves.
+    """
+
+    def __init__(self, logger: logging.Logger) -> None:
+        self._logger = logger
+
+    # -- locations ----------------------------------------------------------
+
+    @property
+    def script_path(self) -> Path:
+        """The generated helper script."""
+        return get_backup_root() / HELPER_SCRIPT_NAME
+
+    @property
+    def key_path(self) -> Path:
+        """The file the helper prints: the active account's raw API key."""
+        return get_backup_root() / ACTIVE_KEY_NAME
+
+    @property
+    def settings_path(self) -> Path:
+        """Claude Code's user settings file, where the hook is registered."""
+        return get_claude_config_home() / SETTINGS_FILENAME
+
+    # -- public API ---------------------------------------------------------
+
+    def install(self, api_key: str) -> bool:
+        """Point Claude Code's ``apiKeyHelper`` at ``api_key``. True when live.
+
+        Writes the key file first and the script second, so the hook is never
+        registered before the thing it reads exists. Returns False (having
+        changed nothing the caller depends on) when the channel is unavailable:
+        an unsupported platform, an I/O failure, or a foreign helper we refuse to
+        overwrite. The switch itself is unaffected either way — a False just
+        means running sessions will need a restart to see this account.
+        """
+        if not self.supported():
+            return False
+        try:
+            self._write_key_file(api_key)
+            self._write_script()
+        except OSError as e:
+            self._logger.warning(
+                f"Could not write the apiKeyHelper files ({e}); running sessions "
+                "will need a restart to pick up this API key"
+            )
+            return False
+        return self._set_hook(str(self.script_path))
+
+    def remove(self) -> None:
+        """Unregister the hook and shred the key file. Best-effort, never raises.
+
+        Unregisters *before* deleting the key file so there is no window where a
+        live hook points at a missing file. A foreign helper is left registered
+        (and its key file, which is not ours, untouched).
+        """
+        if not self._set_hook(None):
+            return
+        try:
+            if self.key_path.exists():
+                self.key_path.unlink()
+        except OSError as e:
+            self._logger.warning(f"Could not remove the active-API-key file: {e}")
+
+    def supported(self) -> bool:
+        """Whether this channel can run here.
+
+        The helper is a POSIX ``/bin/sh`` script; Windows has no equivalent yet,
+        so cswap keeps the old behaviour there rather than registering a hook
+        Claude Code cannot execute.
+        """
+        return sys.platform != "win32"
+
+    # -- files --------------------------------------------------------------
+
+    def _write_key_file(self, api_key: str) -> None:
+        """Atomically write the raw key, owner-readable only."""
+        self._atomic_write(self.key_path, api_key.strip(), mode=0o600)
+
+    def _write_script(self) -> None:
+        """(Re)write the helper script, owner-executable only.
+
+        Rewritten on every install rather than written once: the key-file path it
+        embeds moves with ``XDG_DATA_HOME``, and a script left over from an older
+        cswap must not keep pointing at a stale location.
+        """
+        body = _HELPER_SCRIPT.format(key_file=shlex.quote(str(self.key_path)))
+        self._atomic_write(self.script_path, body, mode=0o700)
+
+    def _atomic_write(self, path: Path, content: str, mode: int) -> None:
+        """Write ``content`` to ``path`` via a same-directory temp file + rename."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            os.write(fd, content.encode("utf-8"))
+            os.close(fd)
+            fd = -1
+            os.chmod(tmp_path, mode)
+            os.replace(tmp_path, str(path))
+        except BaseException:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    # -- settings.json ------------------------------------------------------
+
+    def _set_hook(self, value: str | None) -> bool:
+        """Set (``value``) or unset (``None``) ``apiKeyHelper``. True on success.
+
+        Returns True without writing when the file already says what we want —
+        an unnecessary rewrite would wake every running session's settings
+        watcher for nothing. Returns False, untouched, when the hook belongs to
+        someone else or the file cannot be parsed.
+        """
+        path = self.settings_path
+        try:
+            data = self._read_settings(path)
+        except ValueError as e:
+            self._logger.warning(
+                f"Not touching {path} ({e}); running sessions will need a restart "
+                "to pick up this account"
+            )
+            return False
+
+        current = data.get(SETTINGS_KEY)
+        if current == value:
+            return True
+        if current is not None and current != str(self.script_path):
+            self._logger.warning(
+                f"{path} already sets {SETTINGS_KEY} to {current!r}; leaving your "
+                "own helper in place. Running sessions will not pick up cswap "
+                "API-key switches until it is removed."
+            )
+            return False
+
+        if value is None:
+            data.pop(SETTINGS_KEY, None)
+        else:
+            data[SETTINGS_KEY] = value
+
+        try:
+            self._write_settings(path, data)
+        except OSError as e:
+            self._logger.warning(
+                f"Could not update {path} ({e}); running sessions will need a "
+                "restart to pick up this account"
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _read_settings(path: Path) -> dict:
+        """Parse ``settings.json``. ``{}`` when absent; raises on unusable content.
+
+        Raises:
+            ValueError: The file exists but is not readable JSON, or is not a
+                JSON object. Either way it is a file we must not rewrite — doing
+                so would destroy settings we failed to parse.
+        """
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except OSError as e:
+            raise ValueError(f"cannot read it: {e}") from e
+        except json.JSONDecodeError as e:
+            raise ValueError(f"it is not valid JSON: {e}") from e
+        if not isinstance(data, dict):
+            raise ValueError("its top level is not a JSON object")
+        return data
+
+    def _write_settings(self, path: Path, data: dict) -> None:
+        """Atomically rewrite ``settings.json``, preserving its permissions.
+
+        Claude Code's watcher reacts to the rename, which is what makes the hook
+        change land in a running session. An existing file keeps its mode (this
+        is the user's own settings file, not ours to lock down); a file we create
+        starts owner-only.
+        """
+        try:
+            mode = path.stat().st_mode & 0o777
+        except OSError:
+            mode = 0o600
+        self._atomic_write(path, json.dumps(data, indent=2) + "\n", mode=mode)

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -729,10 +729,15 @@ class AutoSwitchEngine:
         if not self._model_check_done:
             self._check_model_names(quarantined, usage)
 
-        if (
-            self.switcher.account_kind_for(current) == "api_key"
-            and not settings.include_api_key_accounts
-        ):
+        if self.switcher.account_kind_for(current) == "api_key":
+            # Unconditional: ``includeApiKeyAccounts`` decides whether an API-key
+            # slot is an eligible *target*, not whether the active one has a quota
+            # — it never does. Gating this exemption on the setting meant the
+            # users who opted API-key slots into rotation were the only ones who
+            # reached the usage path with them, where "usage unknown" counts as
+            # unhealthy: three ticks later the engine failed over off a perfectly
+            # working key, found every OAuth account at its limit, declared all
+            # accounts exhausted and slept for hours.
             self._emit(
                 NoSwitchEvent(
                     reason="active-api-key",

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -738,13 +738,17 @@ class AutoSwitchEngine:
             # unhealthy: three ticks later the engine failed over off a perfectly
             # working key, found every OAuth account at its limit, declared all
             # accounts exhausted and slept for hours.
-            self._emit(
-                NoSwitchEvent(
-                    reason="active-api-key",
-                    detail="API-key accounts have no quota to watch",
-                )
+            #
+            # Exempt from the *quota* machinery is not parked, though: an API-key
+            # slot is the last resort the ranking already treats it as, and it
+            # bills metered money for as long as it stays active. Returning to a
+            # subscription account has to happen here or nowhere — the key has no
+            # utilization of its own to ever cross the threshold and trigger the
+            # normal path, so the old unconditional NO_ACTION sat on it until a
+            # human noticed.
+            return self._return_to_subscription(
+                current, quarantined, headroom, settings, state
             )
-            return TickOutcome.NO_ACTION
 
         active_headroom = headroom.get(current)
         if active_headroom is not None:
@@ -996,6 +1000,71 @@ class AutoSwitchEngine:
             return TickOutcome.BLOCKED
 
         # -- freshen + switch ----------------------------------------------
+        return self._freshen_and_switch(ordered, trigger, entries)
+
+    def _return_to_subscription(
+        self,
+        current: str,
+        quarantined: set[str],
+        headroom: dict[str, float | None],
+        settings: AutoSwitchSettings,
+        state: dict,
+    ) -> TickOutcome:
+        """Leave a last-resort API-key account once a subscription has room.
+
+        The mirror of the last-resort rule in candidate selection: an API-key
+        slot is only ever a target when no OAuth account can take the traffic,
+        so it must be given back the moment one can. Candidates are ranked by
+        headroom (best first) and must clear the threshold by ``hysteresis_pct``
+        — a barely-recovered account would otherwise cross the threshold on its
+        first requests and bounce straight back onto the metered key.
+
+        Only OAuth candidates qualify: moving from one metered key to another is
+        never the improvement this exists to make. Cooldown applies, as it does
+        to any other proactive move.
+        """
+        ceiling = settings.threshold - settings.hysteresis_pct
+        candidates = [
+            num
+            for num in self.switcher.switchable_account_numbers()
+            if num != current
+            and num not in quarantined
+            and self.switcher.account_kind_for(num) != "api_key"
+            and (h := headroom.get(num)) is not None
+            and (100.0 - h) < ceiling
+        ]
+        if not candidates:
+            self._emit(
+                NoSwitchEvent(
+                    reason="active-api-key",
+                    detail=(
+                        "API-key accounts have no quota to watch; no "
+                        "subscription account is under "
+                        f"{pct_label(ceiling)}% to return to yet"
+                    ),
+                )
+            )
+            return TickOutcome.NO_ACTION
+        if self._in_cooldown(state):
+            self._emit(NoSwitchEvent(reason="cooldown"))
+            return TickOutcome.NO_ACTION
+        candidates.sort(key=lambda n: headroom[n] or 0.0, reverse=True)
+        return self._freshen_and_switch(candidates, "api-key-return")
+
+    def _freshen_and_switch(
+        self,
+        ordered: list[str],
+        trigger: str,
+        entries: dict | None = None,
+    ) -> TickOutcome:
+        """Freshen each ranked target in turn and activate the first that holds.
+
+        Quarantines a target whose credential is dead or belongs to someone
+        else and slides to the next; a transient (network) failure across every
+        target is reported as such rather than as "no viable target", because
+        the two want different retry behaviour upstream.
+        """
+        entries = entries or {}
         transient_failure = False
         for num in ordered:
             email = self.switcher.account_email(num)

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import NamedTuple, Protocol
 
 from claude_swap import macos_keychain
+from claude_swap.api_key_helper import ApiKeyHelperChannel
 from claude_swap.exceptions import CredentialError, CredentialWriteError
 from claude_swap.models import Platform
 from claude_swap.paths import (
@@ -234,6 +235,16 @@ class CredentialStore:
         # pending re-probe (never failed, or forced to file mode deliberately).
         self._keychain_disabled_until: float = 0.0
         self._last_active_credentials_backend: str | None = None
+
+    @property
+    def _api_key_helper(self) -> ApiKeyHelperChannel:
+        """The ``apiKeyHelper`` channel that carries a key switch into live sessions.
+
+        Built per access, not cached: the channel is stateless, and its logger has
+        to come from the host *at call time* like every other host-sourced value
+        (see ``_StoreHost``).
+        """
+        return ApiKeyHelperChannel(self._host._logger)
 
     def _kc_call(self, fn, *args):
         """Run a ``macos_keychain`` wrapper call, learning Keychain usability.
@@ -511,6 +522,11 @@ class CredentialStore:
           Keychain "Claude Code" when usable, else ``~/.claude.json`` ``primaryApiKey``),
           then clear the OAuth credential (Keychain item + ``.credentials.json``).
 
+        Both branches also toggle the ``apiKeyHelper`` hook, which is what makes a
+        key switch visible to sessions that are *already running* — Claude Code
+        never re-reads ``primaryApiKey``, but it does re-run that helper. See
+        ``api_key_helper`` for why it has to be toggled rather than left installed.
+
         Raises:
             CredentialWriteError: If writing credentials fails.
         """
@@ -576,6 +592,19 @@ class CredentialStore:
         except Exception as e:
             raise CredentialWriteError(f"Failed to write managed API key: {e}")
 
+        if wrote_to_keychain:
+            # Keychain users deliberately keep no plaintext key on disk, and this
+            # channel needs one to hand to the helper script — so they keep the
+            # restart-to-pick-up behaviour. Drop any helper left over from a spell
+            # in file mode, which would otherwise keep serving that older key.
+            self._api_key_helper.remove()
+        else:
+            # Hand the key to already-running sessions *before* the OAuth
+            # credential goes away, so a live session is never left holding
+            # neither axis (see ``api_key_helper``). Best-effort: a failure here
+            # only means those sessions need a restart.
+            self._api_key_helper.install(api_key)
+
         # Mutual exclusion: drop the OAuth credential so it can't shadow the key.
         self._clear_oauth_credential()
         if self._host.platform == Platform.MACOS and not wrote_to_keychain:
@@ -597,7 +626,12 @@ class CredentialStore:
         ``customApiKeyResponses.approved`` untouched — ``removeApiKey`` doesn't clear
         it either, and removing it would force recovering ``key[-20:]`` from the
         Keychain for no benefit. A no-op (no config rewrite) when no key is present.
+
+        Also unregisters the ``apiKeyHelper`` hook. That is not housekeeping: an
+        installed helper outranks the OAuth credential the caller just wrote, so
+        leaving it would pin every running session to the key we are clearing.
         """
+        self._api_key_helper.remove()
         if self._host.platform == Platform.MACOS:
             try:
                 macos_keychain.delete_password(

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import NamedTuple, Protocol
 
 from claude_swap import macos_keychain
+from claude_swap import pinned_sessions
 from claude_swap.api_key_helper import ApiKeyHelperChannel
 from claude_swap.exceptions import CredentialError, CredentialWriteError
 from claude_swap.models import Platform
@@ -623,8 +624,11 @@ class CredentialStore:
                 # No live channel (Windows, a foreign helper, an I/O failure):
                 # fall back to the field a newly started session reads and
                 # accept that running ones need a restart — and that the pin
-                # above applies to them until they do.
+                # above applies to them until they do. Recorded so `cswap
+                # status` can name the sessions it pins instead of leaking
+                # silently; see ``pinned_sessions``.
                 cfg["primaryApiKey"] = api_key
+                pinned_sessions.open_spell(self._host.current_account_number() or "?")
 
         try:
             self._update_global_config(_mutate)
@@ -677,6 +681,10 @@ class CredentialStore:
                 self._update_global_config(_drop)
             except Exception as e:
                 self._host._logger.warning(f"Failed to clear primaryApiKey: {e}")
+            else:
+                # Every session started while it was readable is now pinned to a
+                # key that is no longer the active account.
+                pinned_sessions.close_spell()
 
     def _clear_oauth_credential(self) -> None:
         """Clear the active OAuth credential — Keychain item and plaintext file.

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -403,7 +403,11 @@ class CredentialStore:
 
         macOS Keychain "Claude Code" (when usable) first, then ``~/.claude.json``
         ``primaryApiKey`` — mirroring Claude Code's
-        ``getApiKeyFromConfigOrMacOSKeychain``.
+        ``getApiKeyFromConfigOrMacOSKeychain`` — and finally the ``apiKeyHelper``
+        key file, which is where the key actually lives whenever that channel is
+        live (see ``api_key_helper``). Without that last source an active
+        API-key account would read as an empty slot, since it is deliberately
+        the *only* copy on disk.
         """
         if self._use_keychain():
             try:
@@ -422,7 +426,7 @@ class CredentialStore:
             key = cfg.get("primaryApiKey")
             if isinstance(key, str) and key:
                 return key
-        return ""
+        return self._api_key_helper.active_key()
 
     def _read_global_config(self) -> dict | None:
         """Read and parse ``~/.claude.json``, or None when absent/unreadable."""
@@ -519,8 +523,10 @@ class CredentialStore:
           then clear any managed key (Keychain "Claude Code" + ``primaryApiKey``;
           ``approved`` left intact, as ``removeApiKey`` does).
         - **API key** → record ``key[-20:]`` in ``approved`` and store the key (macOS
-          Keychain "Claude Code" when usable, else ``~/.claude.json`` ``primaryApiKey``),
-          then clear the OAuth credential (Keychain item + ``.credentials.json``).
+          Keychain "Claude Code" when usable, else the ``apiKeyHelper`` key file,
+          falling back to ``~/.claude.json`` ``primaryApiKey`` only when neither
+          channel is available), then clear the OAuth credential (Keychain item +
+          ``.credentials.json``).
 
         Both branches also toggle the ``apiKeyHelper`` hook, which is what makes a
         key switch visible to sessions that are *already running* — Claude Code
@@ -542,8 +548,11 @@ class CredentialStore:
         Always records ``key[-20:]`` in ``customApiKeyResponses.approved`` (Claude
         Code does this on every platform, even on Keychain success — otherwise it
         re-prompts to approve the key). Stores the key in the macOS Keychain when
-        usable, else ``~/.claude.json`` ``primaryApiKey`` (matching ``saveApiKey``'s
-        keychain-then-config fallback). Finally clears the OAuth credential.
+        usable, else in the ``apiKeyHelper`` key file, falling back to
+        ``~/.claude.json`` ``primaryApiKey`` (``saveApiKey``'s own
+        keychain-then-config behaviour) only when neither channel is available —
+        see ``api_key_helper`` for why a stored ``primaryApiKey`` pins every
+        session started alongside it. Finally clears the OAuth credential.
 
         Raises:
             CredentialWriteError: If persisting the key fails.
@@ -567,6 +576,20 @@ class CredentialStore:
 
         approved = approved_form(api_key)
 
+        # Hand the key to already-running sessions *first*, before the OAuth
+        # credential goes away, so a live session is never left holding neither
+        # axis (see ``api_key_helper``). Best-effort: a False only means those
+        # sessions need a restart, and it decides the storage below.
+        if wrote_to_keychain:
+            # Keychain users deliberately keep no plaintext key on disk, and this
+            # channel needs one to hand to the helper script — so they keep the
+            # restart-to-pick-up behaviour. Drop any helper left over from a spell
+            # in file mode, which would otherwise keep serving that older key.
+            self._api_key_helper.remove()
+            helper_live = False
+        else:
+            helper_live = self._api_key_helper.install(api_key)
+
         def _mutate(cfg: dict) -> None:
             responses = cfg.get("customApiKeyResponses")
             if not isinstance(responses, dict):
@@ -579,10 +602,28 @@ class CredentialStore:
             responses["approved"] = approved_list
             responses.setdefault("rejected", [])
             cfg["customApiKeyResponses"] = responses
-            if wrote_to_keychain:
-                # Keychain holds the key; keep it out of plaintext config.
+            if wrote_to_keychain or helper_live:
+                # The Keychain or the helper holds the key; keep it out of
+                # plaintext config. Not just hygiene — this is what makes the
+                # *next* switch reach running sessions. ``primaryApiKey`` is
+                # read from an in-memory snapshot of ``~/.claude.json`` and the
+                # resolved key is memoized for the lifetime of the process,
+                # cleared only by that process's own /login or /logout. Every
+                # session that starts while it is set is therefore pinned to
+                # this key permanently: activating an OAuth account later
+                # removes the value from the file but cannot touch the memo,
+                # and a managed key outranks the claude.ai credential, so those
+                # sessions keep billing the metered key while ``cswap status``
+                # reports the subscription account. The helper has no such memo
+                # — Claude Code re-runs it on a TTL and it dies with the hook —
+                # and a newly started session reads it just as readily, so it
+                # is the better home for the key on both axes.
                 cfg.pop("primaryApiKey", None)
             else:
+                # No live channel (Windows, a foreign helper, an I/O failure):
+                # fall back to the field a newly started session reads and
+                # accept that running ones need a restart — and that the pin
+                # above applies to them until they do.
                 cfg["primaryApiKey"] = api_key
 
         try:
@@ -591,19 +632,6 @@ class CredentialStore:
             raise
         except Exception as e:
             raise CredentialWriteError(f"Failed to write managed API key: {e}")
-
-        if wrote_to_keychain:
-            # Keychain users deliberately keep no plaintext key on disk, and this
-            # channel needs one to hand to the helper script — so they keep the
-            # restart-to-pick-up behaviour. Drop any helper left over from a spell
-            # in file mode, which would otherwise keep serving that older key.
-            self._api_key_helper.remove()
-        else:
-            # Hand the key to already-running sessions *before* the OAuth
-            # credential goes away, so a live session is never left holding
-            # neither axis (see ``api_key_helper``). Best-effort: a failure here
-            # only means those sessions need a restart.
-            self._api_key_helper.install(api_key)
 
         # Mutual exclusion: drop the OAuth credential so it can't shadow the key.
         self._clear_oauth_credential()

--- a/src/claude_swap/pinned_sessions.py
+++ b/src/claude_swap/pinned_sessions.py
@@ -1,0 +1,159 @@
+"""Find sessions still billing an API key cswap has already switched away from.
+
+A managed API key stored in ``~/.claude.json`` as ``primaryApiKey`` is resolved
+once and memoized for the lifetime of a Claude Code process, cleared only by
+that process's own ``/login`` / ``/logout``. So a session that starts while one
+is set is pinned to that key permanently: activating an OAuth account later
+removes the value from the file but cannot touch the memo, and a managed key
+outranks the claude.ai credential. ``cswap status`` then reports the
+subscription account while those sessions keep billing metered requests.
+
+Nothing cswap writes can undo that from outside the process — the only cure is
+restarting the session. What it can do is stop the leak being *silent*, which is
+what this module is for.
+
+``credentials`` records a **spell**: the window during which a ``primaryApiKey``
+that cswap wrote was readable. It opens only on the fallback path that actually
+writes the field (Keychain and ``apiKeyHelper`` storage create no pin, so they
+open no spell) and closes when that key is cleared. Any session whose start time
+falls inside a *closed* spell is pinned. Sessions inside the open spell are
+correctly on the key that is still active, and are not reported.
+
+The ledger is advisory: every write is best-effort and every read failure is an
+empty answer. A broken ledger must never fail a switch or a status.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from claude_swap.paths import get_backup_root
+from claude_swap.process_detection import ClaudeSession, list_sessions
+
+LEDGER_NAME = "api_key_spells.json"
+SCHEMA_VERSION = 1
+# Spells older than this are dropped on write: no session that predates it is
+# plausibly still running, and the file must not grow without bound.
+MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+
+_logger = logging.getLogger("claude-swap")
+
+
+@dataclass(frozen=True)
+class PinnedSession:
+    """A running session pinned to a key that is no longer the active account."""
+
+    session: ClaudeSession
+    account: str  # the API-key account number whose key it is stuck on
+
+
+def ledger_path() -> Path:
+    return get_backup_root() / LEDGER_NAME
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _read() -> list[dict]:
+    try:
+        data = json.loads(ledger_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    spells = data.get("spells") if isinstance(data, dict) else None
+    return [s for s in spells if isinstance(s, dict)] if isinstance(spells, list) else []
+
+
+def _write(spells: list[dict]) -> None:
+    cutoff = _now_ms() - MAX_AGE_MS
+    kept = [s for s in spells if s.get("end") is None or s.get("end", 0) >= cutoff]
+    path = ledger_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"schemaVersion": SCHEMA_VERSION, "spells": kept}, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as e:
+        _logger.warning(f"Could not update the API-key spell ledger: {e}")
+
+
+def open_spell(account: str) -> None:
+    """Record that a pinning ``primaryApiKey`` is now readable. Idempotent.
+
+    Called only from the path that actually writes the field — an already-open
+    spell is left as-is so a re-activation of the same key does not split one
+    window into two and lose the sessions started in between.
+    """
+    spells = _read()
+    if any(s.get("end") is None for s in spells):
+        return
+    spells.append({"account": str(account), "start": _now_ms(), "end": None})
+    _write(spells)
+
+
+def close_spell() -> None:
+    """Record that the key is cleared: sessions inside the window are now stale."""
+    spells = _read()
+    changed = False
+    for s in spells:
+        if s.get("end") is None:
+            s["end"] = _now_ms()
+            changed = True
+    if changed:
+        _write(spells)
+
+
+def find_pinned(sessions: list[ClaudeSession] | None = None) -> list[PinnedSession]:
+    """Running sessions that started inside a closed spell, oldest first.
+
+    A session with no usable start time is skipped rather than guessed at: a
+    false "this is costing you money" is worse than a miss, since the only
+    remedy it can offer is restarting work in progress.
+    """
+    spells = [
+        s for s in _read()
+        if isinstance(s.get("start"), (int, float))
+        and isinstance(s.get("end"), (int, float))
+    ]
+    if not spells:
+        return []
+    try:
+        live = sessions if sessions is not None else list_sessions()
+    except Exception:  # pragma: no cover - defensive; detection is best-effort
+        return []
+    pinned = []
+    for sess in live:
+        if not sess.started_at:
+            continue
+        for s in spells:
+            if s["start"] <= sess.started_at <= s["end"]:
+                pinned.append(PinnedSession(sess, str(s.get("account", "?"))))
+                break
+    return sorted(pinned, key=lambda p: p.session.started_at)
+
+
+def warning_lines(pinned: list[PinnedSession]) -> list[str]:
+    """Human lines for ``cswap status``. Empty when there is nothing to say."""
+    if not pinned:
+        return []
+    n = len(pinned)
+    lines = [
+        f"{n} running session{'s' if n > 1 else ''} still billing the API key of "
+        f"Account-{pinned[0].account}:",
+    ]
+    for p in pinned:
+        started = time.strftime("%b %d %H:%M", time.localtime(p.session.started_at / 1000))
+        cwd = p.session.cwd or "?"
+        lines.append(f"  pid {p.session.pid}  started {started}  {cwd}")
+    lines.append(
+        "They started while that key was active and memoized it for their "
+        "process lifetime; switching accounts cannot reach them. Restart them "
+        "(or run /logout then /login inside each) to move them onto the active "
+        "account."
+    )
+    return lines

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -75,6 +75,7 @@ from claude_swap.paths import (
     get_legacy_backup_root,
     migrate_legacy_backup_dir,
 )
+from claude_swap import pinned_sessions
 from claude_swap.process_detection import get_running_instances
 from claude_swap import poll_policy
 from claude_swap.settings import load_settings, parse_model_names, settings_path
@@ -3356,6 +3357,16 @@ class ClaudeAccountSwitcher:
                     if counts["ide"]:
                         parts.append("IDE")
                     print(f"  {dimmed('●')} {muted(label)}   {muted(cwd)}  {dimmed(f'({", ".join(parts)})')}")
+
+            # A switch cannot reach a session that memoized a managed API key,
+            # so the only honest thing to do is name them. Silence here reads as
+            # "everything is on the active account" when it is not.
+            lines = pinned_sessions.warning_lines(pinned_sessions.find_pinned(sessions))
+            if lines:
+                print()
+                warning(lines[0])
+                for line in lines[1:]:
+                    print(muted(line))
         except Exception:
             self._logger.debug("Failed to detect running instances", exc_info=True)
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -434,6 +434,9 @@ class ClaudeAccountSwitcher:
     def _write_credentials(self, credentials: str) -> None:
         self._store._write_credentials(credentials)
 
+    def _clear_managed_key(self) -> None:
+        self._store._clear_managed_key()
+
     def _prepare_credentials_for_activation(
         self, target_credentials: str, live_credentials: str | None
     ) -> str:
@@ -1974,6 +1977,13 @@ class ClaudeAccountSwitcher:
     ) -> None:
         """Add current account to managed accounts.
 
+        The captured account also becomes the active one, so this reconciles the
+        auth axis the way a switch does: the live login is OAuth (an API-key login
+        is rejected above), so any managed key left behind by the previously active
+        account is cleared — most importantly the ``apiKeyHelper`` hook, which
+        outranks the OAuth credential and which Claude Code's own ``/login`` cannot
+        clean up because it does not know cswap installed it.
+
         Args:
             slot: Specify the slot number to store the account in.
                   When None, auto-assigns the next available number.
@@ -2018,6 +2028,16 @@ class ClaudeAccountSwitcher:
             if not current_creds:
                 raise CredentialReadError("No credentials found for current account")
             self._reject_live_api_key_capture(current_creds)
+            # Capturing a login *activates* it, so the managed key of the account
+            # that was active until now has to be cleared exactly as a switch onto
+            # OAuth clears it. Claude Code's own ``/login`` drops ``primaryApiKey``
+            # but knows nothing about the ``apiKeyHelper`` hook cswap installed,
+            # and that hook outranks the OAuth credential: left in place it pins
+            # every session — the ones already running and every new one — to the
+            # old key, while cswap reports the captured account as active. Cleared
+            # before the config snapshot below so the previous account's key is not
+            # copied into this slot's backup either.
+            self._clear_managed_key()
 
             config_path = self._get_claude_config_path()
             try:
@@ -2127,6 +2147,9 @@ class ClaudeAccountSwitcher:
         if not current_creds:
             raise CredentialReadError("No credentials found for current account")
         self._reject_live_api_key_capture(current_creds)
+        # Activating the captured login clears the previous account's managed key,
+        # for the reason spelled out in the refresh-in-place branch above.
+        self._clear_managed_key()
 
         config_path = self._get_claude_config_path()
         try:

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -9,12 +9,14 @@ display, the ``cswap run`` session guard, and export/import of raw keys.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
 
 from claude_swap import macos_keychain
 from claude_swap import session as session_mod
+from claude_swap.api_key_helper import ApiKeyHelperChannel
 from claude_swap.credentials import (
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
@@ -54,6 +56,12 @@ def _macos_switcher() -> ClaudeAccountSwitcher:
 
 def _read_global_config() -> dict:
     return json.loads(get_global_config_path().read_text(encoding="utf-8"))
+
+
+def _helper() -> ApiKeyHelperChannel:
+    """A fresh channel: it resolves every path at call time, so it reads
+    whatever the switcher under test just wrote under the patched HOME."""
+    return ApiKeyHelperChannel(logging.getLogger("test"))
 
 
 # ---------------------------------------------------------------------------
@@ -146,19 +154,52 @@ class TestWriteCredentialsLinux:
         cred_file.parent.mkdir(parents=True, exist_ok=True)
         cred_file.write_text(OAUTH_JSON, encoding="utf-8")
 
-        # Activate the API key: primaryApiKey + approved set, OAuth file cleared.
+        # Activate the API key: the helper holds it, approved is recorded, the
+        # OAuth file is cleared — and primaryApiKey is deliberately NOT written,
+        # because a session that starts alongside one memoizes it for its whole
+        # lifetime and can never be switched off it again.
         s._write_credentials(API_KEY)
         cfg = _read_global_config()
-        assert cfg["primaryApiKey"] == API_KEY
+        assert "primaryApiKey" not in cfg
+        assert _helper().active_key() == API_KEY
         assert API_KEY[-20:] in cfg["customApiKeyResponses"]["approved"]
         assert not cred_file.exists()
+        # cswap must still be able to read back the credential it just activated.
+        assert s._read_credentials() == API_KEY
 
-        # Switch back to OAuth: file restored, primaryApiKey dropped, approved kept.
+        # Switch back to OAuth: file restored, helper unregistered, approved kept.
         s._write_credentials(OAUTH_JSON)
         assert cred_file.read_text(encoding="utf-8") == OAUTH_JSON
         cfg = _read_global_config()
         assert "primaryApiKey" not in cfg
+        assert _helper().active_key() == ""
         assert API_KEY[-20:] in cfg["customApiKeyResponses"]["approved"]
+
+    def test_activate_key_falls_back_to_config_without_the_helper(
+        self, temp_home: Path
+    ):
+        """A foreign apiKeyHelper is left alone, so the key needs its old home.
+
+        Those users keep the restart-to-pick-up behaviour rather than silently
+        losing their own helper — and must still get a working switch.
+        """
+        s = _linux_switcher()
+        settings = _helper().settings_path
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        settings.write_text(
+            json.dumps({"apiKeyHelper": "/opt/mine/print-key.sh"}), encoding="utf-8"
+        )
+
+        s._write_credentials(API_KEY)
+
+        cfg = _read_global_config()
+        assert cfg["primaryApiKey"] == API_KEY
+        assert s._read_credentials() == API_KEY
+        # Their helper is untouched, and ours never claimed the key.
+        assert json.loads(settings.read_text(encoding="utf-8"))["apiKeyHelper"] == (
+            "/opt/mine/print-key.sh"
+        )
+        assert _helper().active_key() == ""
 
     def test_read_credentials_returns_active_key(self, temp_home: Path):
         s = _linux_switcher()

--- a/tests/test_api_key_helper.py
+++ b/tests/test_api_key_helper.py
@@ -25,7 +25,11 @@ import pytest
 
 from claude_swap.api_key_helper import SETTINGS_KEY, ApiKeyHelperChannel
 from claude_swap.models import Platform
-from claude_swap.paths import get_claude_config_home
+from claude_swap.paths import (
+    get_claude_config_home,
+    get_credentials_path,
+    get_global_config_path,
+)
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 API_KEY = "sk-ant-api03-" + "a1b2c3d4e5" * 4
@@ -301,3 +305,93 @@ def test_a_keychain_backed_key_keeps_no_plaintext_helper(temp_home, block_real_k
         else {}
     )
     assert SETTINGS_KEY not in settings
+
+
+# ---------------------------------------------------------------------------
+# Adopting a live login (``cswap add``)
+# ---------------------------------------------------------------------------
+
+
+def _login_as(email: str) -> None:
+    """Stand in for a Claude Code ``/login``: OAuth credential + identity on disk.
+
+    Mirrors what Claude Code itself leaves behind, including dropping
+    ``primaryApiKey`` (its ``removeApiKey``) — the point being that its login has
+    no way to clean up the ``apiKeyHelper`` hook, which is cswap's to own.
+    """
+    get_credentials_path().parent.mkdir(parents=True, exist_ok=True)
+    get_credentials_path().write_text(OAUTH_JSON, encoding="utf-8")
+    config_path = get_global_config_path()
+    config = (
+        json.loads(config_path.read_text(encoding="utf-8"))
+        if config_path.exists()
+        else {}
+    )
+    config.pop("primaryApiKey", None)
+    config["oauthAccount"] = {
+        "emailAddress": email,
+        "accountUuid": "uuid-" + email,
+        "organizationUuid": "",
+        "organizationName": "",
+    }
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+
+def test_adding_a_live_login_unregisters_an_api_key_accounts_hook(temp_home, capsys):
+    """``add`` activates the captured account, so the old hook must not survive it.
+
+    Regression: the helper outranks the OAuth credential, so an ``add`` that left
+    it registered reported the new account as active while every session — the
+    ones already running *and* every new one — kept billing the previous
+    account's key.
+    """
+    switcher = _linux_switcher()
+    switcher._store._write_credentials(API_KEY)  # an API-key account is active
+    helper = ApiKeyHelperChannel(logging.getLogger("test"))
+    assert _settings(helper)[SETTINGS_KEY] == str(helper.script_path)
+
+    _login_as("new@example.com")
+    switcher.add_account()
+
+    assert SETTINGS_KEY not in _settings(helper)
+    assert not helper.key_path.exists()
+    seq = json.loads(switcher.sequence_file.read_text(encoding="utf-8"))
+    assert seq["accounts"][str(seq["activeAccountNumber"])]["email"] == "new@example.com"
+
+
+def test_adding_a_live_login_clears_a_residual_managed_key(temp_home, capsys):
+    """Mutual exclusion holds however the key got left behind, not just via the hook."""
+    switcher = _linux_switcher()
+    switcher._store._write_credentials(API_KEY)
+
+    _login_as("new@example.com")
+    # A key Claude Code's own login did not clear (e.g. written by another tool).
+    config_path = get_global_config_path()
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["primaryApiKey"] = API_KEY
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    switcher.add_account()
+
+    assert "primaryApiKey" not in json.loads(
+        config_path.read_text(encoding="utf-8")
+    )
+    # ...and it is not carried into the new slot's config backup either.
+    backup = next(switcher.configs_dir.glob(".claude-config-*-new@example.com.json"))
+    assert "primaryApiKey" not in json.loads(backup.read_text(encoding="utf-8"))
+
+
+def test_re_adding_the_active_account_also_unregisters_the_hook(temp_home, capsys):
+    """The refresh-in-place branch of ``add`` activates a slot the same way."""
+    switcher = _linux_switcher()
+    _login_as("existing@example.com")
+    switcher.add_account()
+    switcher._store._write_credentials(API_KEY)  # switch away to an API-key account
+    helper = ApiKeyHelperChannel(logging.getLogger("test"))
+    assert _settings(helper)[SETTINGS_KEY] == str(helper.script_path)
+
+    _login_as("existing@example.com")
+    switcher.add_account()  # re-add the same account: refreshes it in place
+
+    assert SETTINGS_KEY not in _settings(helper)
+    assert not helper.key_path.exists()

--- a/tests/test_api_key_helper.py
+++ b/tests/test_api_key_helper.py
@@ -1,0 +1,303 @@
+"""Tests for the ``apiKeyHelper`` channel that carries an API-key switch live.
+
+Claude Code never re-reads ``primaryApiKey`` in a running process, so activating
+an API-key account is invisible to open sessions unless the ``apiKeyHelper`` hook
+carries it. These cover the channel itself (file emission, the hook's toggle
+semantics, refusing to touch a foreign helper) and its wiring into
+``CredentialStore._write_credentials`` in both directions.
+
+The emitted script is *executed*, not just string-matched: a helper that Claude
+Code cannot run is exactly the failure this module exists to prevent, and a
+substring assertion would pass right through it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_swap.api_key_helper import SETTINGS_KEY, ApiKeyHelperChannel
+from claude_swap.models import Platform
+from claude_swap.paths import get_claude_config_home
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+API_KEY = "sk-ant-api03-" + "a1b2c3d4e5" * 4
+OTHER_KEY = "sk-ant-api03-" + "z9y8x7w6v5" * 4
+OAUTH_JSON = json.dumps(
+    {"claudeAiOauth": {"accessToken": "tok", "refreshToken": "rtok", "expiresAt": 9}}
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX /bin/sh helper; unsupported on Windows"
+)
+
+
+@pytest.fixture
+def channel(temp_home: Path) -> ApiKeyHelperChannel:
+    return ApiKeyHelperChannel(logging.getLogger("test"))
+
+
+def _settings(channel: ApiKeyHelperChannel) -> dict:
+    path = channel.settings_path
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+
+
+def _write_settings(channel: ApiKeyHelperChannel, data: dict) -> None:
+    channel.settings_path.parent.mkdir(parents=True, exist_ok=True)
+    channel.settings_path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _linux_switcher() -> ClaudeAccountSwitcher:
+    s = ClaudeAccountSwitcher()
+    s.platform = Platform.LINUX
+    s._setup_directories()
+    s._init_sequence_file()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Emission: the files the hook depends on
+# ---------------------------------------------------------------------------
+
+
+def test_install_registers_hook_and_writes_both_files(channel):
+    assert channel.install(API_KEY) is True
+
+    assert _settings(channel)[SETTINGS_KEY] == str(channel.script_path)
+    assert channel.key_path.read_text(encoding="utf-8") == API_KEY
+    assert channel.script_path.exists()
+
+
+def test_emitted_helper_actually_prints_the_key(channel):
+    """Execute the script the way Claude Code does, and check what it prints."""
+    channel.install(API_KEY)
+
+    result = subprocess.run(
+        [str(channel.script_path)], capture_output=True, text=True, timeout=10
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == API_KEY
+
+
+def test_emitted_helper_survives_a_path_with_spaces(tmp_path, monkeypatch):
+    """The key-file path is interpolated into shell source; it must be quoted."""
+    home = tmp_path / "home with spaces"
+    (home / ".claude").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    channel = ApiKeyHelperChannel(logging.getLogger("test"))
+
+    channel.install(API_KEY)
+    result = subprocess.run(
+        [str(channel.script_path)], capture_output=True, text=True, timeout=10
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == API_KEY
+
+
+def test_emitted_helper_fails_loudly_when_the_key_file_is_gone(channel):
+    """Better a failing helper than one that prints an empty credential."""
+    channel.install(API_KEY)
+    channel.key_path.unlink()
+
+    result = subprocess.run(
+        [str(channel.script_path)], capture_output=True, text=True, timeout=10
+    )
+
+    assert result.returncode != 0
+    assert result.stdout.strip() == ""
+
+
+def test_emitted_files_are_owner_only(channel):
+    channel.install(API_KEY)
+
+    assert stat.S_IMODE(channel.key_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(channel.script_path.stat().st_mode) == 0o700
+
+
+def test_reinstall_updates_the_key_in_place(channel):
+    channel.install(API_KEY)
+    channel.install(OTHER_KEY)
+
+    assert channel.key_path.read_text(encoding="utf-8") == OTHER_KEY
+    result = subprocess.run(
+        [str(channel.script_path)], capture_output=True, text=True, timeout=10
+    )
+    assert result.stdout.strip() == OTHER_KEY
+
+
+# ---------------------------------------------------------------------------
+# Removal
+# ---------------------------------------------------------------------------
+
+
+def test_remove_unregisters_the_hook_and_shreds_the_key(channel):
+    channel.install(API_KEY)
+
+    channel.remove()
+
+    assert SETTINGS_KEY not in _settings(channel)
+    assert not channel.key_path.exists()
+
+
+def test_remove_is_a_no_op_when_never_installed(channel):
+    channel.remove()  # must not raise
+
+    assert not channel.settings_path.exists()
+
+
+def test_remove_preserves_the_rest_of_settings(channel):
+    _write_settings(channel, {"model": "opus", "permissions": {"defaultMode": "auto"}})
+    channel.install(API_KEY)
+
+    channel.remove()
+
+    assert _settings(channel) == {
+        "model": "opus",
+        "permissions": {"defaultMode": "auto"},
+    }
+
+
+def test_install_preserves_the_rest_of_settings(channel):
+    _write_settings(channel, {"model": "opus"})
+
+    channel.install(API_KEY)
+
+    assert _settings(channel) == {
+        "model": "opus",
+        SETTINGS_KEY: str(channel.script_path),
+    }
+
+
+def test_install_preserves_an_existing_files_permissions(channel):
+    _write_settings(channel, {"model": "opus"})
+    os.chmod(channel.settings_path, 0o644)
+
+    channel.install(API_KEY)
+
+    assert stat.S_IMODE(channel.settings_path.stat().st_mode) == 0o644
+
+
+# ---------------------------------------------------------------------------
+# A helper that isn't ours
+# ---------------------------------------------------------------------------
+
+
+def test_install_refuses_to_hijack_a_foreign_helper(channel):
+    _write_settings(channel, {SETTINGS_KEY: "/usr/local/bin/my-own-helper"})
+
+    assert channel.install(API_KEY) is False
+    assert _settings(channel)[SETTINGS_KEY] == "/usr/local/bin/my-own-helper"
+
+
+def test_remove_leaves_a_foreign_helper_alone(channel):
+    _write_settings(channel, {SETTINGS_KEY: "/usr/local/bin/my-own-helper"})
+
+    channel.remove()
+
+    assert _settings(channel)[SETTINGS_KEY] == "/usr/local/bin/my-own-helper"
+
+
+def test_unparseable_settings_are_never_rewritten(channel):
+    channel.settings_path.parent.mkdir(parents=True, exist_ok=True)
+    channel.settings_path.write_text("{ not json", encoding="utf-8")
+
+    assert channel.install(API_KEY) is False
+    assert channel.settings_path.read_text(encoding="utf-8") == "{ not json"
+
+
+def test_a_settings_file_that_is_not_an_object_is_never_rewritten(channel):
+    channel.settings_path.parent.mkdir(parents=True, exist_ok=True)
+    channel.settings_path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    assert channel.install(API_KEY) is False
+    assert channel.settings_path.read_text(encoding="utf-8") == "[1, 2, 3]"
+
+
+def test_reinstalling_the_same_hook_does_not_rewrite_settings(channel):
+    """An idle rewrite would wake every running session's settings watcher."""
+    channel.install(API_KEY)
+    before = channel.settings_path.stat().st_mtime_ns
+
+    channel.install(OTHER_KEY)
+
+    assert channel.settings_path.stat().st_mtime_ns == before
+
+
+# ---------------------------------------------------------------------------
+# Wiring into the switch itself
+# ---------------------------------------------------------------------------
+
+
+def test_activating_an_api_key_account_installs_the_hook(temp_home):
+    switcher = _linux_switcher()
+
+    switcher._store._write_credentials(API_KEY)
+
+    settings = json.loads(
+        (get_claude_config_home() / "settings.json").read_text(encoding="utf-8")
+    )
+    helper = ApiKeyHelperChannel(logging.getLogger("test"))
+    assert settings[SETTINGS_KEY] == str(helper.script_path)
+    assert helper.key_path.read_text(encoding="utf-8") == API_KEY
+
+
+def test_activating_an_oauth_account_removes_the_hook(temp_home):
+    """Otherwise the stale hook would outrank the OAuth login we just wrote."""
+    switcher = _linux_switcher()
+    switcher._store._write_credentials(API_KEY)
+
+    switcher._store._write_credentials(OAUTH_JSON)
+
+    helper = ApiKeyHelperChannel(logging.getLogger("test"))
+    settings_path = get_claude_config_home() / "settings.json"
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert SETTINGS_KEY not in settings
+    assert not helper.key_path.exists()
+
+
+def test_the_hook_serves_the_key_the_switch_just_activated(temp_home):
+    """End to end: switch to key A, then key B, and run the helper each time."""
+    switcher = _linux_switcher()
+    helper = ApiKeyHelperChannel(logging.getLogger("test"))
+
+    switcher._store._write_credentials(API_KEY)
+    first = subprocess.run(
+        [str(helper.script_path)], capture_output=True, text=True, timeout=10
+    )
+    switcher._store._write_credentials(OTHER_KEY)
+    second = subprocess.run(
+        [str(helper.script_path)], capture_output=True, text=True, timeout=10
+    )
+
+    assert first.stdout.strip() == API_KEY
+    assert second.stdout.strip() == OTHER_KEY
+
+
+def test_a_keychain_backed_key_keeps_no_plaintext_helper(temp_home, block_real_keychain):
+    """macOS Keychain users must not silently gain a plaintext key on disk."""
+    switcher = ClaudeAccountSwitcher()
+    switcher.platform = Platform.MACOS
+    switcher._setup_directories()
+    switcher._init_sequence_file()
+
+    switcher._store._write_credentials(API_KEY)
+
+    helper = ApiKeyHelperChannel(logging.getLogger("test"))
+    assert not helper.key_path.exists()
+    settings_path = get_claude_config_home() / "settings.json"
+    settings = (
+        json.loads(settings_path.read_text(encoding="utf-8"))
+        if settings_path.exists()
+        else {}
+    )
+    assert SETTINGS_KEY not in settings

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -1076,23 +1076,30 @@ class TestApiKeyAccounts:
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
 
-    def test_active_api_key_idles_engine(self, temp_home):
+    def test_active_api_key_returns_to_subscription_with_room(self, temp_home):
+        """An API-key slot is last resort, so it is given back as soon as it can.
+
+        Nothing else can make this move: the key has no utilization of its own
+        to cross the threshold, so the normal proactive path never fires and the
+        engine used to bill metered requests until a human switched by hand.
+        """
         h = EngineHarness(temp_home)
         h.seed(1, "key@token.local")
         h.seed(2, "b@example.com")
         h.make_live("key@token.local", 1)
         self._mark_api_key(h, 1)
         outcome = h.tick_with_usage({"1": "api key", "2": _usage(10)})
-        assert outcome is TickOutcome.NO_ACTION
-        assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
-            "active-api-key"
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert [e.trigger for e in h.events if isinstance(e, SwitchEvent)] == [
+            "api-key-return"
         ]
 
-    def test_active_api_key_idles_engine_when_included_in_rotation(self, temp_home):
-        """includeApiKeyAccounts picks targets; it must not start watching quota.
+    def test_active_api_key_returns_when_included_in_rotation(self, temp_home):
+        """The return does not depend on includeApiKeyAccounts either.
 
-        An API key reports no usage, so counting that as "unhealthy" burned the
-        failover ticks and dropped the engine off a working key.
+        That setting picks whether a key is an eligible *target*; leaving it is
+        unconditional, exactly as the quota exemption around it is.
         """
         h = EngineHarness(temp_home, include_api_key_accounts=True)
         h.seed(1, "key@token.local")
@@ -1100,10 +1107,73 @@ class TestApiKeyAccounts:
         h.make_live("key@token.local", 1)
         self._mark_api_key(h, 1)
         outcome = h.tick_with_usage({"1": "api key", "2": _usage(10)})
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_active_api_key_idles_when_no_subscription_has_room(self, temp_home):
+        """Recovered-but-still-hot does not count: 85% fails the 80% ceiling.
+
+        Returning to an account that is already past threshold-minus-hysteresis
+        would cross the threshold on its first requests and bounce straight back
+        onto the key.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "key@token.local")
+        h.seed(2, "b@example.com")
+        h.make_live("key@token.local", 1)
+        self._mark_api_key(h, 1)
+        outcome = h.tick_with_usage({"1": "api key", "2": _usage(85)})
         assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
         assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
             "active-api-key"
         ]
+
+    def test_active_api_key_never_returns_to_another_api_key(self, temp_home):
+        """Swapping one metered key for another is not the improvement here.
+
+        Account 2 is handed a readable low utilization on purpose. A key
+        normally reports none, so the headroom filter would reject it and hide
+        whether the kind is checked at all — but a stale or hand-edited store
+        entry can supply one, and that must not be enough to land on it.
+        """
+        h = EngineHarness(temp_home, include_api_key_accounts=True)
+        h.seed(1, "key@token.local")
+        h.seed(2, "other-key@token.local")
+        h.seed(3, "c@example.com")
+        h.make_live("key@token.local", 1)
+        self._mark_api_key(h, 1)
+        self._mark_api_key(h, 2)
+        outcome = h.tick_with_usage({
+            "1": "api key", "2": _usage(5), "3": _usage(100),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+
+    def test_active_api_key_return_respects_cooldown(self, temp_home):
+        """The move onto the key sets the cooldown; the return honours it.
+
+        Without this an account that recovers a second after the switch onto the
+        key would ping-pong the pair at tick cadence.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "key@token.local")
+        h.seed(2, "b@example.com")
+        h.make_live("key@token.local", 1)
+        self._mark_api_key(h, 1)
+        h.engine._mutate_state(lambda s: s.update(lastSwitchAt=h.clock() - 10))
+        outcome = h.tick_with_usage({"1": "api key", "2": _usage(10)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
+            "cooldown"
+        ]
+        # ...and takes it once the cooldown has elapsed.
+        h.clock.advance(h.settings.cooldown_seconds + 1)
+        assert h.tick_with_usage({"1": "api key", "2": _usage(10)}) is (
+            TickOutcome.SWITCHED
+        )
+        assert h.active_number() == 2
 
     def test_active_api_key_never_fails_over_when_oauth_is_exhausted(self, temp_home):
         """The exact regression: every OAuth account at its limit, key still fine.

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -1088,6 +1088,45 @@ class TestApiKeyAccounts:
             "active-api-key"
         ]
 
+    def test_active_api_key_idles_engine_when_included_in_rotation(self, temp_home):
+        """includeApiKeyAccounts picks targets; it must not start watching quota.
+
+        An API key reports no usage, so counting that as "unhealthy" burned the
+        failover ticks and dropped the engine off a working key.
+        """
+        h = EngineHarness(temp_home, include_api_key_accounts=True)
+        h.seed(1, "key@token.local")
+        h.seed(2, "b@example.com")
+        h.make_live("key@token.local", 1)
+        self._mark_api_key(h, 1)
+        outcome = h.tick_with_usage({"1": "api key", "2": _usage(10)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
+            "active-api-key"
+        ]
+
+    def test_active_api_key_never_fails_over_when_oauth_is_exhausted(self, temp_home):
+        """The exact regression: every OAuth account at its limit, key still fine.
+
+        Three unhealthy ticks used to trigger failover, find nothing with room,
+        and put the engine to sleep for hours instead of just staying on the key.
+        """
+        h = EngineHarness(temp_home, include_api_key_accounts=True)
+        h.seed(1, "key@token.local")
+        h.seed(2, "b@example.com")
+        h.make_live("key@token.local", 1)
+        self._mark_api_key(h, 1)
+
+        outcomes = [
+            h.tick_with_usage({"1": "api key", "2": _usage(100)}) for _ in range(4)
+        ]
+
+        assert outcomes == [TickOutcome.NO_ACTION] * 4
+        assert h.active_number() == 1
+        assert {e.reason for e in h.events if isinstance(e, NoSwitchEvent)} == {
+            "active-api-key"
+        }
+
 
 class TestFreshening:
     def test_near_expiry_target_is_refreshed_and_persisted(self, temp_home):

--- a/tests/test_pinned_sessions.py
+++ b/tests/test_pinned_sessions.py
@@ -1,0 +1,120 @@
+"""Detection of sessions still billing a key cswap has already switched away from.
+
+The pin itself lives in another process's memory and cannot be undone from here
+(see ``pinned_sessions``), so the whole value of this module is that it reports
+the right sessions: a miss leaks money silently, and a false positive tells
+someone to restart work in progress for nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_swap import pinned_sessions
+from claude_swap.paths import get_backup_root
+from claude_swap.process_detection import ClaudeSession
+
+KEY = "sk-ant-api03-" + "a1b2c3d4e5" * 4
+
+
+def _session(pid: int, started_at: int, cwd: str = "/work") -> ClaudeSession:
+    return ClaudeSession(
+        pid=pid,
+        session_id=f"s{pid}",
+        cwd=cwd,
+        started_at=started_at,
+        kind="interactive",
+        entrypoint="cli",
+    )
+
+
+def _spells(temp_home: Path) -> list[dict]:
+    return json.loads(pinned_sessions.ledger_path().read_text(encoding="utf-8"))["spells"]
+
+
+class TestLedger:
+    def test_open_then_close_records_one_window(self, temp_home: Path):
+        get_backup_root().mkdir(parents=True, exist_ok=True)
+        pinned_sessions.open_spell("5")
+        pinned_sessions.close_spell()
+        spells = _spells(temp_home)
+        assert len(spells) == 1
+        assert spells[0]["account"] == "5"
+        assert spells[0]["start"] <= spells[0]["end"]
+
+    def test_reopening_does_not_split_the_window(self, temp_home: Path):
+        """A re-activation of the same key must not lose the sessions between.
+
+        Splitting one window into two leaves a gap, and a session that started
+        in the gap reads as clean while it is pinned.
+        """
+        get_backup_root().mkdir(parents=True, exist_ok=True)
+        pinned_sessions.open_spell("5")
+        pinned_sessions.open_spell("5")
+        assert len(_spells(temp_home)) == 1
+
+    def test_unreadable_ledger_is_an_empty_answer(self, temp_home: Path):
+        get_backup_root().mkdir(parents=True, exist_ok=True)
+        pinned_sessions.ledger_path().write_text("{ not json", encoding="utf-8")
+        assert pinned_sessions.find_pinned([_session(1, 1000)]) == []
+
+
+class TestFindPinned:
+    def _closed_spell(self, start: int, end: int, account: str = "5") -> None:
+        get_backup_root().mkdir(parents=True, exist_ok=True)
+        pinned_sessions.ledger_path().write_text(
+            json.dumps({
+                "schemaVersion": 1,
+                "spells": [{"account": account, "start": start, "end": end}],
+            }),
+            encoding="utf-8",
+        )
+
+    def test_session_started_inside_a_closed_spell_is_pinned(self, temp_home: Path):
+        self._closed_spell(1000, 2000)
+        found = pinned_sessions.find_pinned([_session(42, 1500)])
+        assert [p.session.pid for p in found] == [42]
+        assert found[0].account == "5"
+
+    def test_sessions_outside_the_window_are_clean(self, temp_home: Path):
+        """Both sides matter: before the key was written, and after it was cleared."""
+        self._closed_spell(1000, 2000)
+        found = pinned_sessions.find_pinned([_session(1, 999), _session(2, 2001)])
+        assert found == []
+
+    def test_open_spell_pins_nothing(self, temp_home: Path):
+        """While the key is still active those sessions are correctly on it."""
+        get_backup_root().mkdir(parents=True, exist_ok=True)
+        pinned_sessions.open_spell("5")
+        started = json.loads(
+            pinned_sessions.ledger_path().read_text(encoding="utf-8")
+        )["spells"][0]["start"]
+        assert pinned_sessions.find_pinned([_session(7, started + 1)]) == []
+
+    def test_session_without_a_start_time_is_skipped(self, temp_home: Path):
+        """Guessing would tell someone to restart working sessions for nothing."""
+        self._closed_spell(1000, 2000)
+        assert pinned_sessions.find_pinned([_session(9, 0)]) == []
+
+    def test_no_spells_means_no_work(self, temp_home: Path):
+        assert pinned_sessions.find_pinned([_session(1, 1500)]) == []
+
+
+class TestWarningLines:
+    def test_silent_when_nothing_is_pinned(self):
+        assert pinned_sessions.warning_lines([]) == []
+
+    def test_names_each_session_and_the_remedy(self, temp_home: Path):
+        pinned = [
+            pinned_sessions.PinnedSession(_session(11, 1_600_000_000_000, "/a"), "5"),
+            pinned_sessions.PinnedSession(_session(12, 1_600_000_100_000, "/b"), "5"),
+        ]
+        lines = pinned_sessions.warning_lines(pinned)
+        body = "\n".join(lines)
+        assert "2 running sessions" in lines[0]
+        assert "Account-5" in lines[0]
+        # The pid is what the reader acts on, so it has to be there.
+        assert "pid 11" in body and "pid 12" in body
+        assert "/a" in body and "/b" in body
+        assert "Restart" in body


### PR DESCRIPTION
Five fixes to the managed-API-key lane, found while an API-key slot was the last account with any quota left. They are independent and separately reviewable (one commit each). (3) and (4) are bugs (1) introduces, both caught on a live box days later; (5) is the other half of (2).

## 1. An API-key switch is invisible to running sessions — and logs them out

The README says a switch takes effect on your next message, no restart needed. That is true for OAuth accounts and not true for API-key ones.

Claude Code's two auth axes behave differently:

| Axis | Re-read at runtime? |
|---|---|
| OAuth | **Yes** — `.credentials.json` is read uncached on every auth resolution, and a poller watches its mtime and drops the memoized token when it changes |
| Managed API key | **No** — `primaryApiKey` is served from an in-memory snapshot of `~/.claude.json` that the read path never re-stats, and the resolved key is additionally memoized for the process lifetime (cleared only by that process's own `/login` / `/logout`) |

So activating an API-key account is worse than invisible: `_write_managed_credentials` clears the OAuth credential for mutual exclusion, the credentials-file watcher fires, and every open session drops to *"Login expired — please run /login"* while the fresh key sits unread. The user has to sign in by hand, which also displaces the login cswap just activated.

`apiKeyHelper` is the one API-key channel Claude Code re-reads at runtime: it watches the settings files and drops its settings cache on change, and it awaits the helper while building each request's client, re-running it once the cached value ages past `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` (default 5 min). This PR points it at a generated script that prints the active account's key, so an API-key switch lands live like an OAuth one.

Two constraints shaped it:

- **The hook is toggled, not left installed.** A configured `apiKeyHelper` forces the API-key axis for the whole session and outranks the claude.ai OAuth credential, so a permanent one would pin every session to the key and break the OAuth accounts. Installed on API-key activation, removed on OAuth activation (ordered so a live session is never left holding neither axis).
- **A user's own `apiKeyHelper` is never overwritten or removed.** cswap logs why and leaves it; those users keep today's restart-to-pick-up behaviour.

macOS Keychain users also keep today's behaviour rather than silently gaining a plaintext key on disk — the channel needs a file to hand the helper, so it is skipped when the key went to the Keychain (and any helper left over from a spell in file mode is dropped, so it can't keep serving an older key).

New module `api_key_helper.py`; `credentials.py` only gains the two toggle calls.

## 2. Auto-switch fails over off a perfectly working API key

The active-account exemption was gated on `includeApiKeyAccounts`:

```python
if (self.switcher.account_kind_for(current) == "api_key"
        and not settings.include_api_key_accounts):
```

That setting decides whether an API-key slot is an eligible failover *target*. It says nothing about whether the *active* account has a quota to watch — an API key never does. So the users who opted their key into rotation were the only ones whose active key reached the usage path, where "usage unknown" counts as an unhealthy tick. Observed live:

```
16:59  Switched Account-2 -> Account-5 (api-platform@token.local) (at-limit)
17:00  no switch: active-usage-unknown (1/3 before failover)
17:01  no switch: active-usage-unknown (2/3 before failover)
17:02  all accounts exhausted; earliest reset 2026-07-29T21:00:00Z
17:02  sleeping 360m
```

Three ticks after moving to a working key, the engine failed over off it, found every OAuth account at its limit, and slept for six hours. The exemption is now unconditional.

## 3. `cswap add` leaves the hook installed, pinning every session to the old key

A regression the hook in (1) introduces, hit live: with the API-key account active, sign into a new account with `/login` and run `cswap add`. cswap reports the new account as active and `cswap status` agrees — but nothing changes. Every session, already-running and new alike, keeps billing the API key, and the new account's usage stays at 0%.

`add_account` snapshots the live login and sets `activeAccountNumber`, but it never went through `_write_credentials`, so it never reconciled the auth axis. The `apiKeyHelper` the previous account installed stayed registered, and it outranks the OAuth credential — so the "active" account was active in `sequence.json` only.

Nothing else undoes it. Claude Code's own `/login` clears `primaryApiKey`, which is why this lane worked before the hook existed, but it cannot clear a hook it does not know cswap installed. The recovery is `cswap --switch-to <n> --force`, which is not a thing a user knows to run when the tool says the account is already active.

Both `add_account` branches (new slot, and refresh-in-place when re-adding an existing account) now clear the managed key exactly as switching onto an OAuth account does — before the config snapshot, so the previous account's key is not copied into the new slot's config backup either.

## 4. The switch *back off* a key still cannot reach running sessions

(1) made a switch **onto** an API-key account land live. The reverse direction still could not, and it is the direction that costs money.

`_write_managed_credentials` kept writing `primaryApiKey` alongside installing the hook, as the authoritative copy "a newly started session reads". But per the table in (1) that field is memoized for the lifetime of the process and cleared only by that process's own `/login` / `/logout`. So **every session that starts while an API-key account is active is pinned to that key permanently.** Activating an OAuth account later removes the value from the file, and cannot touch the memo — and a managed key outranks the claude.ai credential, so the pinned session keeps billing metered requests while `cswap status` reports the subscription account. There is no log line, no error, and no way to tell from outside the process.

Observed live: after switching back to a subscription account, three of nineteen open sessions were still on the key — exactly the three that had been started during the spell on it. Nothing short of restarting them fixes it, because nothing outside the process can clear that memo.

The fix is to stop creating the pin. When the helper channel is live it now holds the key **alone**, and the `primaryApiKey` write is dropped rather than kept as a second copy. Nothing is lost: a newly started session reads `settings.json` at startup and resolves the helper just as readily, and the helper is re-run on a TTL and dies with the hook. The old behaviour stays for anyone the channel cannot serve — Windows, a foreign `apiKeyHelper`, an I/O failure — who keep restart-to-pick-up, and now the fallback is the *only* thing that writes the field.

`_read_managed_key` gains the helper's key file as a read source, ownership-checked against `settings.json` rather than the file merely existing: the key is now the only copy on disk, so without it cswap reports the account it just activated as an empty slot.

## 5. Once on an API key, the engine never comes back

An API-key account is already last resort on the way *in* — `_rank_candidates` only falls through to `api_key_candidates` when no OAuth candidate qualifies. On the way *out* it was permanent.

The exemption from (2) returned `NO_ACTION` unconditionally, and nothing else could move the engine: a key has no utilization of its own, so it never crosses the threshold and the proactive path never fires for it. Whatever the subscription accounts do afterwards, the engine stays on metered billing until a human runs `cswap switch` by hand. Live, on the box that prompted this:

```
01:28  Switched from account 6 to 5     (every OAuth account at its 7d limit)
06:xx  account 6's 5h window resets; 7d sits at 20%
10:14  Switched from account 5 to 6     <- by hand, 8h46m later
```

The quota exemption itself is kept exactly as (2) left it — a key reports no usage, and counting that as "unhealthy" is what used to fail the engine off a working key. What is added next to it is the return: rank the OAuth candidates by headroom and take the best one sitting `hysteresisPct` below the threshold. The margin is load-bearing — returning to an account already near the line would cross it on its first requests and bounce straight back onto the key. API-key candidates are excluded (one metered key for another is not the improvement this exists to make), and cooldown applies as to any other proactive move.

The freshen-and-switch loop is extracted to `_freshen_and_switch` so the return path quarantines dead and misowned credentials through the same code rather than reimplementing it.

Two tests from (2) now encode the new outcome instead of the old one: an active key with a subscription account at 10% switches back rather than idling. The property they were guarding — never failing over off a working key because its usage is unknown — is unchanged and still covered by `test_active_api_key_never_fails_over_when_oauth_is_exhausted`, plus the new "no subscription under the ceiling" idle case.

## 6. The leak is silent

(4) stops new pins being created; nothing can undo an existing one. A session that memoized a managed API key holds it in process memory, and no file cswap writes can reach it — restarting the session is the only cure. So the remaining failure is that `cswap status` reports the subscription account while those sessions keep billing metered requests, with nothing anywhere saying so.

`pinned_sessions` records a **spell**: the window during which a `primaryApiKey` cswap wrote was readable. It opens only on the fallback path that actually writes the field (Keychain and `apiKeyHelper` storage create no pin, so they open no spell) and closes when that key is cleared. Any running session whose start time falls inside a *closed* spell is pinned, and the instances block names it:

```
Running instances:
  ● CLI   ~/work  (19 sessions)

2 running sessions still billing the API key of Account-5:
  pid 2679688  started Jul 28 21:02  /home/me/work
  pid 527259   started Jul 29 09:41  /home/me/work
They started while that key was active and memoized it for their process
lifetime; switching accounts cannot reach them. Restart them (or run /logout
then /login inside each) to move them onto the active account.
```

Sessions inside the still-open spell are correctly on the key that is still active and are not reported. A session with no usable start time is skipped rather than guessed at: the only remedy this can offer is restarting work in progress, so a false positive costs more than a miss. Every ledger write is best-effort and every read failure is an empty answer — an advisory warning must never fail a switch or a status.

## Tests

`1622 passed, 3 skipped`. 39 new tests. The emitted helper script is *executed* rather than string-matched (including from a path with spaces, and with the key file removed) — a helper Claude Code cannot run is exactly the failure this is meant to prevent, and a substring assertion would pass straight through it.

Every new test is mutation-checked: the guard it covers is inverted, the test confirmed failing, then restored. For (4) and (5) that is six mutations — drop the hysteresis margin, let API-key slots be return targets, skip the cooldown, restore the unconditional `NO_ACTION`, always write `primaryApiKey`, and let `active_key()` ignore hook ownership. Five were caught on the first pass; the sixth was not, and the check earned its keep:

`test_active_api_key_never_returns_to_another_api_key` passed with the kind filter removed, because a second API-key slot reports no usage and the headroom filter had already excluded it — the test asserted the right outcome for the wrong reason and would never have failed if the guard regressed. It now hands that slot a readable low utilization, which a stale or hand-edited store entry can produce, so the kind check is what the assertion actually rests on. It fails without it.

Verified on a live box (19 open sessions, six managed accounts): the switch installs the hook and the helper prints the active key, with no `primaryApiKey` left in `~/.claude.json` for a session to memoize. The pinning in (4) was diagnosed there rather than inferred — sessions started during the spell on the key were still billing it after the switch back, and they were exactly the sessions whose start time fell inside that window. The patched build is installed and `cswap auto` is running on it; the return in (5) has not yet had a live firing, since it needs every subscription account exhausted and then one recovering.
