### PR TITLE
fix(session): link shared items to their resolved target

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -689,14 +689,22 @@ class SessionManager:
                     self._remove_managed(dest)
                 continue
 
+            # Link to the fully resolved target. When ~/.claude/<name> is itself
+            # a symlink (a dotfiles setup), linking to the unresolved path makes
+            # a link-to-a-link, and Claude Code's atomic settings write — which
+            # resolves only one hop — renames its temp file over the intermediate
+            # link, silently replacing it with a regular file
+            # (anthropics/claude-code#78162).
+            link_target = src.resolve() if src.is_symlink() else src
+
             if dest.is_symlink():
                 if name not in managed:
                     managed = [*managed, name]  # adopt: only cswap links here
                 if use_symlinks:
                     try:
-                        if dest.readlink() != src:
+                        if dest.readlink() != link_target:
                             dest.unlink()
-                            dest.symlink_to(src)
+                            dest.symlink_to(link_target)
                     except OSError:
                         continue
                     new_managed.append(name)
@@ -717,7 +725,7 @@ class SessionManager:
                 if use_symlinks:
                     if dest.exists():
                         self._remove_managed(dest)
-                    dest.symlink_to(src)
+                    dest.symlink_to(link_target)
                 else:
                     if dest.exists():
                         self._remove_managed(dest)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -643,6 +643,45 @@ class TestSharingPosix:
 
         assert (session_dir / "settings.json").readlink() == source / "settings.json"
 
+    def test_links_to_resolved_target_when_source_is_symlink(
+        self, share_setup, temp_home
+    ):
+        """A dotfiles-managed ~/.claude item is itself a symlink: link straight to
+        its final target so the chain is only ever one hop deep. Claude Code's
+        atomic settings write resolves one hop only, so a link-to-a-link gets its
+        intermediate link replaced by a regular file, silently detaching the user's
+        real source of truth (anthropics/claude-code#78162).
+        """
+        source, session_dir, mgr = share_setup
+        dotfiles = temp_home / "dotfiles"
+        dotfiles.mkdir()
+        real = dotfiles / "settings.json"
+        real.write_text('{"real": true}')
+        link = source / "settings.json"
+        link.unlink()
+        link.symlink_to(real)
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / "settings.json").readlink() == real.resolve()
+
+    def test_repoints_existing_link_to_resolved_target(self, share_setup, temp_home):
+        """An already-adopted link pointing at the intermediate symlink is repointed
+        at the final target, not left one hop short."""
+        source, session_dir, mgr = share_setup
+        dotfiles = temp_home / "dotfiles"
+        dotfiles.mkdir()
+        real = dotfiles / "settings.json"
+        real.write_text("{}")
+        link = source / "settings.json"
+        link.unlink()
+        link.symlink_to(real)
+        (session_dir / "settings.json").symlink_to(link)
+
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert (session_dir / "settings.json").readlink() == real.resolve()
+
 
 class TestSharingWindowsMode:
     """Copy mode, exercised by forcing the platform (runs on any host)."""


### PR DESCRIPTION
Fixes #192.

## Problem

When an item under `~/.claude` is itself a symlink — a common dotfiles setup; mine has `~/.claude/settings.json` pointing at a git-tracked file in my config repo — the share loop links the session profile to the **unresolved** path, producing a link-to-a-link:

```
<profile>/settings.json  ->  ~/.claude/settings.json  ->  <dotfiles>/claude-code/settings.json
```

Claude Code's atomic settings write resolves the chain **one hop only**, so its `rename` lands on the *intermediate* link and replaces it with a regular file — `rename()` overwrites the directory entry and never follows a symlink. The write succeeds and the content is correct, so the break is silent: the user's real source of truth simply stops receiving updates, and their next dotfiles sync overwrites the local file, discarding anything changed in the interim.

Upstream context: anthropics/claude-code#78162 covers the same one-hop resolution. It was originally reported as an EROFS/EACCES *failure* when the intermediate directory is read-only; when that directory is writable you get this silent variant instead. That issue has seen no movement in ~2 weeks, and cswap can sidestep the whole class by never handing Claude Code a link-to-a-link.

## Change

Resolve once in the share loop and use it for both the link comparison and the link creation, so the chain is only ever one hop deep:

```python
link_target = src.resolve() if src.is_symlink() else src
```

`src` itself is deliberately left untouched so `_prepare_history_share()`, `src.is_dir()` and `shutil.copy2()` keep their current behaviour. This is a no-op for anyone whose `~/.claude` items are regular files.

## Testing

- `pytest tests/ -k "session or share"` — **168 passed**
- full suite — **1611 passed, 3 skipped, 6 failed**
- the 6 failures are **pre-existing on my machine**: they reproduce identically on a clean `main` (verified by stashing this change), are all in `test_move_accounts.py` / `test_swap_accounts.py`, and are all permission/rollback tests unrelated to session sharing
- also running this patch locally against my real setup: the profile link now points straight at the repo file, and the intermediate link has stopped being clobbered

## Note

#163 also touches session sharing — happy to rebase onto whatever lands first rather than create a conflict.
