### PR TITLE
fix(transfer): close world-readable window on exported credentials

### DIFF
--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import sys
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -95,18 +95,36 @@ def _validate_imported_account(switcher: ClaudeAccountSwitcher, account: dict) -
 
 
 def _atomic_write_file(path: Path, content: str) -> None:
-    """Write text atomically with 0600 perms — same pattern as switcher._write_json."""
+    """Write text atomically with 0600 perms, never exposing plaintext content
+    at a world-readable mode.
+
+    Uses ``tempfile.mkstemp`` (0600 from creation, per the process umask being
+    irrelevant to it) rather than ``Path.write_text`` + a follow-up ``chmod``:
+    the export payload carries live OAuth refresh tokens, and a write-then-
+    chmod sequence leaves the temp file at the umask-derived default mode
+    (typically world-readable) for the window between creation and the chmod
+    call. Same pattern as ``credentials.py``/``settings.py``/``migrations.py``.
+    """
     if path.is_dir():
         raise TransferError(
             f"export destination must be a file path, not a directory: {path}"
         )
-    temp_path = path.with_suffix(f".{os.getpid()}.tmp")
-    temp_path.write_text(content, encoding="utf-8")
-    if sys.platform != "win32":
-        os.chmod(temp_path, 0o600)
-    shutil.move(str(temp_path), str(path))
-    if sys.platform != "win32":
-        os.chmod(path, 0o600)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        os.write(fd, content.encode("utf-8"))
+        os.close(fd)
+        fd = -1
+        os.replace(tmp_path, str(path))
+        if sys.platform != "win32":
+            os.chmod(str(path), 0o600)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _slim_config(config_obj: dict, label: str) -> dict:

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -738,6 +739,39 @@ class TestFilePermissions:
 
         mode = os.stat(out).st_mode & 0o777
         assert mode == 0o600
+
+    def test_export_temp_file_never_created_world_readable(
+        self, temp_home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The export payload carries a live OAuth refresh token, so the temp
+        file backing it must be 0600 from the instant it is created — never a
+        write-then-chmod sequence that leaves it at the umask-derived default
+        (typically world-readable) for any window. Spies on tempfile.mkstemp
+        (rather than just checking the final path) so this fails loudly if the
+        implementation ever regresses to Path.write_text + a later chmod: a
+        permissive umask that would produce 0o644 under that pattern must
+        still yield 0o600 immediately at creation.
+        """
+        s = _linux_switcher(temp_home)
+        _seed_account(s, 1, "alice@example.com")
+        out = temp_home / "x.cswap"
+
+        real_mkstemp = tempfile.mkstemp
+        modes_at_creation = []
+
+        def spying_mkstemp(*args, **kwargs):
+            fd, path = real_mkstemp(*args, **kwargs)
+            modes_at_creation.append(os.fstat(fd).st_mode & 0o777)
+            return fd, path
+
+        monkeypatch.setattr(tempfile, "mkstemp", spying_mkstemp)
+        old_umask = os.umask(0o022)  # permissive: 0o644 if write_text created it
+        try:
+            export_accounts(s, str(out))
+        finally:
+            os.umask(old_umask)
+
+        assert modes_at_creation == [0o600]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`cswap --export <path>` writes a JSON envelope containing each account's live OAuth `accessToken`/`refreshToken` (or raw API key). `_atomic_write_file()` in `transfer.py` built the temp file with `Path.write_text()` and only `chmod`'d it to `0600` afterward — the file sat at the umask-derived default mode (typically `0o644`, world-readable) for the window between creation and that `chmod` call.

Every other credential-bearing writer in this codebase (`credentials.py`, `settings.py`, `migrations.py`) avoids this by using `tempfile.mkstemp()`, which is `0600` from the instant the fd is opened — no window at all. `transfer.py` was the one place that didn't follow that pattern, and unlike the internal backup dirs (`credentials_dir`/`configs_dir`, chmod'd `0700`), the export destination is an arbitrary user-chosen path, so directory permissions don't compensate.

Practical impact: on a shared/multi-user host with a default umask, exporting an account for a cross-machine move (`cswap --export ~/backup.json`) briefly leaves a world-readable file containing a live refresh token in the destination directory — enough for a co-resident local user polling the directory to steal it.

## Fix

Swap the `write_text()` + `chmod()` sequence for the same `tempfile.mkstemp()` + `os.write` + `os.replace` pattern already used elsewhere, so the temp file is `0600` from creation with no exposure window. Also drops the now-unused `shutil` import.

## Test plan

- [x] Added `TestFilePermissions.test_export_temp_file_never_created_world_readable`: spies on `tempfile.mkstemp` and asserts the temp file's mode is `0600` immediately at creation under a permissive `umask(0o022)` — this fails against the old `write_text`-based implementation (the spy is never invoked, since `mkstemp` wasn't used).
- [x] `uv run pytest tests/test_transfer.py -q` → 77 passed
- [x] `uv run pytest -q` (full suite) → 1631 passed, 3 skipped