### PR TITLE
fix(settings): atomic_write_json writes through a symlink, never over it

### DIFF
--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -449,20 +449,27 @@ def atomic_write_json(path: Path, data: dict) -> None:
     **Writes THROUGH a symlink, never over it.** A rename swaps a directory
     ENTRY and does not follow links, so renaming onto a symlinked path
     DETACHES the link: the write succeeds, the content is right, and the
-    link target silently stops receiving updates. Where these files are
-    dotfiles-managed (a link into a config repo), the next deploy restores
-    the tracked copy and every change written since the detach is gone —
-    measured in the field as a settings section that vanished while the
-    state it configured stayed live. Same shape as #192/#193, which fixed
-    ``session.py``'s own writer; this is the shared writer behind eight
-    call sites. A DANGLING link still writes where it points (that is what
-    linking it asked for), and the temp file is created beside the
-    RESOLVED path so the rename stays same-filesystem and atomic.
+    link target silently stops receiving updates — until something restores
+    the link (a dotfiles deploy), taking every change written since with
+    it. Same shape as #192/#193, which fixed ``session.py``'s own writer;
+    this is the shared JSON writer. Three consequences, each deliberate:
+
+    - A DANGLING link still writes where it points; linking a path is a
+      request to write there.
+    - The temp file is created beside the RESOLVED target, so the rename
+      stays on one filesystem and remains atomic (beside the LINK it would
+      hit EXDEV whenever the target lives on another mount).
+    - The 0700 hardening stays on the directory cswap owns. Applying it to
+      the resolved parent would narrow a directory belonging to something
+      else, and raise ``PermissionError`` outright when that parent is not
+      ours to chmod. The written file still gets 0600, and ``mkstemp``
+      creates it 0600 to begin with, so the secret is never exposed.
     """
     target = Path(os.path.realpath(path)) if path.is_symlink() else path
     target.parent.mkdir(parents=True, exist_ok=True)
     if sys.platform != "win32":
-        os.chmod(target.parent, 0o700)
+        # `path.parent`, NOT the target's: see the docstring.
+        os.chmod(path.parent, 0o700)
     fd, tmp_path = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
     try:
         os.write(fd, json.dumps(data, indent=2).encode("utf-8"))

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -445,18 +445,32 @@ def atomic_write_json(path: Path, data: dict) -> None:
 
     Shared by settings.json and the autoswitch state file (and any future
     machine-local state files beside them).
+
+    **Writes THROUGH a symlink, never over it.** A rename swaps a directory
+    ENTRY and does not follow links, so renaming onto a symlinked path
+    DETACHES the link: the write succeeds, the content is right, and the
+    link target silently stops receiving updates. Where these files are
+    dotfiles-managed (a link into a config repo), the next deploy restores
+    the tracked copy and every change written since the detach is gone —
+    measured in the field as a settings section that vanished while the
+    state it configured stayed live. Same shape as #192/#193, which fixed
+    ``session.py``'s own writer; this is the shared writer behind eight
+    call sites. A DANGLING link still writes where it points (that is what
+    linking it asked for), and the temp file is created beside the
+    RESOLVED path so the rename stays same-filesystem and atomic.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
+    target = Path(os.path.realpath(path)) if path.is_symlink() else path
+    target.parent.mkdir(parents=True, exist_ok=True)
     if sys.platform != "win32":
-        os.chmod(path.parent, 0o700)
-    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        os.chmod(target.parent, 0o700)
+    fd, tmp_path = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
     try:
         os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
         os.close(fd)
         fd = -1
-        replace_with_retry(tmp_path, str(path))
+        replace_with_retry(tmp_path, str(target))
         if sys.platform != "win32":
-            os.chmod(str(path), 0o600)
+            os.chmod(str(target), 0o600)
     except BaseException:
         if fd >= 0:
             os.close(fd)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -279,3 +279,48 @@ class TestMergedWithCli:
     def test_strategy_override(self):
         merged = merged_with_cli(AutoSwitchSettings(), _args(strategy="consume-first"))
         assert merged.strategy == "consume-first"
+
+
+class TestAtomicWriteThroughSymlink:
+    """A rename swaps a directory ENTRY and does not follow links, so a
+    rename onto a symlinked path DETACHES it: the write lands, the target
+    stops updating, and the next dotfiles deploy restores the tracked copy
+    — losing every change since (measured: a settings section that vanished
+    while the state it configured stayed live). Same shape as #192/#193,
+    which fixed session.py only; this is the shared writer behind 8 call
+    sites."""
+
+    def test_write_preserves_the_link_and_updates_the_target(self, tmp_path):
+        import json
+        from claude_swap.settings import atomic_write_json
+        repo = tmp_path / "repo"; repo.mkdir()
+        live = tmp_path / "live"; live.mkdir()
+        tracked = repo / "settings.json"
+        tracked.write_text(json.dumps({"tracked": True}))
+        link = live / "settings.json"
+        link.symlink_to(tracked)
+
+        atomic_write_json(link, {"written": "through"})
+
+        assert link.is_symlink(), "the dotfiles link must survive the write"
+        assert json.loads(tracked.read_text()) == {"written": "through"}
+
+    def test_dangling_link_writes_where_it_points(self, tmp_path):
+        import json
+        from claude_swap.settings import atomic_write_json
+        target = tmp_path / "gone" / "settings.json"
+        link = tmp_path / "settings.json"
+        link.symlink_to(target)
+
+        atomic_write_json(link, {"dangling": "ok"})
+
+        assert link.is_symlink()
+        assert json.loads(target.read_text()) == {"dangling": "ok"}
+
+    def test_plain_file_write_unchanged(self, tmp_path):
+        import json
+        from claude_swap.settings import atomic_write_json
+        p = tmp_path / "settings.json"
+        atomic_write_json(p, {"plain": 1})
+        assert not p.is_symlink()
+        assert json.loads(p.read_text()) == {"plain": 1}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -13,6 +13,7 @@ import pytest
 from claude_swap.exceptions import ConfigError
 from claude_swap.settings import (
     SETTING_SPECS,
+    atomic_write_json,
     AutoSwitchSettings,
     UiSettings,
     effective_settings,
@@ -282,17 +283,14 @@ class TestMergedWithCli:
 
 
 class TestAtomicWriteThroughSymlink:
-    """A rename swaps a directory ENTRY and does not follow links, so a
-    rename onto a symlinked path DETACHES it: the write lands, the target
-    stops updating, and the next dotfiles deploy restores the tracked copy
-    — losing every change since (measured: a settings section that vanished
-    while the state it configured stayed live). Same shape as #192/#193,
-    which fixed session.py only; this is the shared writer behind 8 call
-    sites."""
+    """A rename does not follow links, so renaming onto a symlinked path
+    detaches it and the target silently stops updating. Covers the write
+    itself plus the two placement decisions it forces: the temp file goes
+    beside the RESOLVED target (else EXDEV across mounts), the 0700 chmod
+    stays on the directory cswap owns (else it narrows — or cannot touch —
+    a foreign one)."""
 
     def test_write_preserves_the_link_and_updates_the_target(self, tmp_path):
-        import json
-        from claude_swap.settings import atomic_write_json
         repo = tmp_path / "repo"; repo.mkdir()
         live = tmp_path / "live"; live.mkdir()
         tracked = repo / "settings.json"
@@ -306,8 +304,6 @@ class TestAtomicWriteThroughSymlink:
         assert json.loads(tracked.read_text()) == {"written": "through"}
 
     def test_dangling_link_writes_where_it_points(self, tmp_path):
-        import json
-        from claude_swap.settings import atomic_write_json
         target = tmp_path / "gone" / "settings.json"
         link = tmp_path / "settings.json"
         link.symlink_to(target)
@@ -318,9 +314,44 @@ class TestAtomicWriteThroughSymlink:
         assert json.loads(target.read_text()) == {"dangling": "ok"}
 
     def test_plain_file_write_unchanged(self, tmp_path):
-        import json
-        from claude_swap.settings import atomic_write_json
         p = tmp_path / "settings.json"
         atomic_write_json(p, {"plain": 1})
         assert not p.is_symlink()
         assert json.loads(p.read_text()) == {"plain": 1}
+
+    def test_temp_file_is_created_beside_the_target(self, tmp_path, monkeypatch):
+        """Beside the LINK, the rename hits EXDEV whenever the target is on
+        another mount — the write fails outright. Assert the placement
+        directly; staging two filesystems in a unit test is not portable."""
+        import tempfile
+        from claude_swap import settings as S
+        repo = tmp_path / "repo"; repo.mkdir()
+        live = tmp_path / "live"; live.mkdir()
+        tracked = repo / "settings.json"; tracked.write_text("{}")
+        link = live / "settings.json"; link.symlink_to(tracked)
+        seen = []
+        real_mkstemp = tempfile.mkstemp
+        monkeypatch.setattr(
+            S.tempfile, "mkstemp",
+            lambda *a, **kw: (seen.append(kw.get("dir")), real_mkstemp(*a, **kw))[1],
+        )
+
+        atomic_write_json(link, {"x": 1})
+
+        assert seen == [str(repo)], f"tmp must land beside the target, got {seen}"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes")
+    def test_hardening_stays_on_the_directory_cswap_owns(self, tmp_path):
+        """The 0700 belongs to cswap's own dir. On the target's parent it
+        would narrow a foreign directory, and raise PermissionError when
+        that parent cannot be chmod'ed at all."""
+        repo = tmp_path / "repo"; repo.mkdir(mode=0o755)
+        live = tmp_path / "live"; live.mkdir()
+        tracked = repo / "settings.json"; tracked.write_text("{}")
+        link = live / "settings.json"; link.symlink_to(tracked)
+
+        atomic_write_json(link, {"x": 1})
+
+        assert (repo.stat().st_mode & 0o777) == 0o755, "foreign dir untouched"
+        assert (live.stat().st_mode & 0o777) == 0o700, "our dir hardened"
+        assert (tracked.stat().st_mode & 0o777) == 0o600, "file still 0600"


### PR DESCRIPTION
Found in the field, on three machines, chasing a feature that silently stopped applying.

## The bug

`atomic_write_json` ends in a rename of its temp file onto the destination. A rename swaps a directory **entry** and never follows a symlink — so when the destination is a symlink, the rename **detaches** it. The write succeeds. The content is correct. The link's target just quietly stops receiving updates.

That is invisible until something reconciles the link. Where these files are managed by a dotfiles tool that links them into a config repo, the sequence is:

1. a write detaches the link; the file is now a plain local file
2. every later write lands there — the repo copy is frozen
3. the next deploy restores the tracked copy, **discarding everything written since**

What we actually observed: a settings section written by one feature vanished, while the runtime state that feature had already started kept running — so the daemon was alive, its wiring was in place, and nothing looked broken; the feature had simply stopped being configured. Three machines, three timestamps, each matching that machine's last deploy.

## Why this is not a one-off

This is the same shape as #192 / PR #193, which fixed `session.py`'s own writer. `atomic_write_json` was never touched, and it is the **shared** writer behind eight call sites:

- `settings.py` — `save_settings`, `set_setting`, `unset_setting`
- `autoswitch.py` — state file (2 sites)
- `usage_store.py` — the usage store
- `credentials.py` — the unclaimed-credential manifest
- `session.py` — session profile config

Any of those can detach a managed file today. Nothing about it is specific to the feature that surfaced it.

## The fix

Resolve the path first and rename onto the **resolved** target: the link survives and its target is updated. Two details kept deliberate:

- **A dangling link still writes where it points.** Linking a path is a request to write there; a missing target is a directory to create, not a reason to clobber the link.
- **The temp file is created beside the resolved target**, so the rename stays on one filesystem and remains atomic. Writing beside the *link* and renaming across a filesystem boundary would trade this bug for a worse one.

## Tests

Three regressions: the link survives a write and its target is updated; a dangling link writes through; the plain-file path is unchanged.

Full suite green minus this checkout's pre-existing baseline (44 tui-async + 11 ANSI, identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
