### PR TITLE
fix(autoswitch): don't trade real headroom for a reset days away

### DIFF
--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -109,6 +109,17 @@ RECOVERY_HORIZON_S = 4 * 3600.0
 # to a quarter of the headroom it just beat.
 HORIZON_HEADROOM_RATIO = 2.0
 
+# Below this much headroom an account is spent for practical purposes, and
+# comparing headroom between two spent accounts compares noise: at the burn
+# rates measured on 2026-07-30 a one-point edge is under ten minutes of work,
+# less than two poll intervals. When EVERY candidate is down here the ranking
+# has to fall back to the reset — sit where the quota returns first, so the
+# reset finds us already on it — no matter how far out that reset is. Without
+# this, three accounts at 99% left the engine with no qualifying candidate and
+# it parked on whichever it happened to hold, including the one resetting
+# 59 hours after a peer.
+SPENT_HEADROOM_PCT = 3.0
+
 # Adaptive scheduling: the baseline request volume is O(1) per tick — the
 # active account plus ONE due candidate (stalest data first) — instead of
 # every account in parallel, and the per-account cadence itself (movement,
@@ -1183,8 +1194,18 @@ class AutoSwitchEngine:
         # the landing-health gate has no other answer here). An UNKNOWN
         # recovery is no evidence rather than a distant one, so it keeps the
         # recovery axis and that gate keeps deciding. See RECOVERY_HORIZON_S.
+        # Everyone spent: headroom can no longer tell the candidates apart, so
+        # the reset is the only thing left worth ranking on (see
+        # SPENT_HEADROOM_PCT). Checked before the horizon, which is about
+        # whether a sooner reset is worth REAL headroom — a question that only
+        # arises while some real headroom exists.
+        all_spent = all_above and all(
+            (headroom.get(n) is not None and headroom[n] <= SPENT_HEADROOM_PCT)
+            for n in oauth_candidates
+        ) and (active_headroom is not None and active_headroom <= SPENT_HEADROOM_PCT)
         recovery_useful = all_above and (
-            active_recovery_ts == float("inf")
+            all_spent
+            or active_recovery_ts == float("inf")
             or active_recovery_ts - now <= RECOVERY_HORIZON_S
         )
         qualifying: list[tuple[tuple, str]] = []

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -106,6 +106,72 @@ HORIZON_HEADROOM_RATIO = 2.0
 # whichever account we happen to hold.
 SPENT_HEADROOM_PCT = 3.0
 
+def _recovery_is_useful(
+    candidate_recovery_ts: float,
+    active_recovery_ts: float,
+    active_headroom: float,
+    best_candidate_headroom: float,
+    threshold: float,
+    now: float,
+) -> bool:
+    """Rank THIS candidate by soonest reset, or by headroom?
+
+    One place, because four independent gates over two axes produce sixteen
+    combinations and a review found reachable holes in four of them. Each
+    clause below is a hole that was measured, not a hypothesis.
+
+    Reset wins when:
+
+    * **Everything is spent.** Below ``SPENT_HEADROOM_PCT`` a headroom edge is
+      under ten minutes of work — less than two poll intervals — so comparing
+      two spent accounts compares noise, and the only real question is which
+      returns first. Asked of the active and the BEST candidate — "is there
+      anything worth having?" — not of every account. Requiring EVERY account
+      to be spent made the answer non-monotone in headroom (2/2/3.0 took the
+      soonest reset; improving one peer to 3.5 flipped the axis and parked on
+      the account resetting 59h later) and let one unknown headroom — a
+      sentinel row, a locked keychain — veto the check for everybody, which
+      parked three accounts at 99% on the one resetting LAST. The maximum
+      answers both: an unknown is not a maximum, and a peer improving can only
+      move the answer toward "keep the headroom".
+    * **This candidate is back soon.** Asked per candidate, not once on the
+      active: an active bound by its WEEKLY window sits days out while a
+      peer's five-hour window returns in minutes, and asking the active
+      refused that peer — the #202 case this is supposed to preserve.
+
+    Past the horizon we rank by headroom and, when no candidate can meet the
+    ratio, nobody qualifies — deliberately. An active holding materially more
+    quota than any peer can offer SHOULD keep the work; that is the whole
+    finding this horizon encodes. The one thing that must not happen is the
+    engine parking while a peer holds meaningfully more, and the ratio cannot
+    produce that: it is unreachable only when the active already holds more
+    than half of what the threshold permits, i.e. more than any candidate.
+
+    KNOWN RESIDUE, deliberately left: inside the spent band the axis is the
+    reset, above it the ratio, and the step between them is not monotone —
+    2 / 2 / 3.0 switches to the soonest reset while 2 / 2 / 3.5 parks, because
+    3.5 leaves the spent band without meeting 2x. Every fix tried was worse:
+    ranking that band by reset re-armed the days-away trade for 9 / 10 / 10
+    and broke the return-leg flap guard. The band is 0.5 points wide at the
+    default constants and both outcomes keep a working account, so it is
+    recorded rather than papered over.
+
+    An UNKNOWN active recovery (``inf``, which also means "already elapsed")
+    deliberately does NOT keep the recovery axis. It used to, and that re-armed
+    the exact trade this horizon forbids: 9 points of headroom for a peer
+    resetting 50h out, whenever the active's ``resets_at`` was missing or
+    stale. No evidence a sooner reset helps is a reason to keep the headroom,
+    not to spend it.
+    """
+    if active_headroom <= SPENT_HEADROOM_PCT and best_candidate_headroom <= (
+        SPENT_HEADROOM_PCT
+    ):
+        return True
+    if candidate_recovery_ts - now <= RECOVERY_HORIZON_S:
+        return True
+    return False
+
+
 # Adaptive scheduling: the baseline request volume is O(1) per tick — the
 # active account plus ONE due candidate (stalest data first) — instead of
 # every account in parallel, and the per-account cadence itself (movement,
@@ -1171,21 +1237,28 @@ class AutoSwitchEngine:
         all_above = _every_account_above_threshold(
             oauth_candidates, headroom, active_headroom, settings.threshold
         )
+        # The most headroom any candidate offers — "is there anything worth
+        # having?" Unknown headrooms are excluded rather than counted as zero:
+        # a row we cannot read is not evidence of an empty account.
+        best_candidate_headroom = max(
+            (h for h in (headroom.get(n) for n in oauth_candidates) if h is not None),
+            default=0.0,
+        )
         active_recovery_ts = (
             _binding_recovery_ts(usage.get(current), self._models, now)
             if all_above
             else 0.0  # unread unless all_above; never a live sentinel
         )
-        # The horizon asks whether a sooner reset is worth REAL headroom, so
-        # it only applies while real headroom exists — hence the spent check
-        # first. An UNKNOWN recovery is no evidence rather than a distant one,
-        # so it keeps the recovery axis.
-        recovery_useful = all_above and (
-            all(h is not None and h <= SPENT_HEADROOM_PCT for h in headroom.values())
-            or active_recovery_ts == float("inf")
-            or active_recovery_ts - now <= RECOVERY_HORIZON_S
-        )
+        # The headrooms the ranking may actually choose between: the active,
+        # plus every candidate whose headroom is KNOWN. An unknown one is not
+        # evidence that somebody has quota left — the loop skips it a few
+        # lines down for exactly that reason — so it must not veto the spent
+        # check either. Measured: one sentinel row (expired token, locked
+        # keychain) made `all(...)` False forever, and three accounts at 99%
+        # days out left the engine parked on the one resetting LAST.
+
         qualifying: list[tuple[tuple, str]] = []
+        axis_recovery: dict[str, bool] = {}  # per candidate, set in the loop
         any_known = False
         for num in oauth_candidates:
             h = headroom.get(num)
@@ -1221,26 +1294,33 @@ class AutoSwitchEngine:
                     # binding recovery, two different axes, and left
                     # consume-first users with no anti-flap guard at all.)
                     #
-                    # Hysteresis measured on the axis we actually rank by. A
-                    # headroom margin is unmeetable here by construction —
-                    # everything is in the last few percent, so no candidate can
-                    # be 10 points better — and applying it would block the
-                    # escape rather than protect anything. The flap it exists to
-                    # prevent is still prevented: the target must come back
-                    # meaningfully sooner than where we are, so the reverse move
-                    # never qualifies.
-                    if (
-                        recovery_useful
-                        and recovery_ts >= active_recovery_ts - RECOVERY_HYSTERESIS_S
-                    ):
-                        continue
-                    if not recovery_useful and h < (
-                        (active_headroom or 0.0) * HORIZON_HEADROOM_RATIO
-                    ):
-                        # Headroom axis instead, with its own anti-flap margin:
-                        # a target must hold HORIZON_HEADROOM_RATIO times what
-                        # we do, so the reverse move can never qualify.
-                        continue
+                    # WHICH AXIS is decided per candidate, in one place — see
+                    # _recovery_is_useful for the four holes that came from
+                    # deciding it once, globally, from four scattered gates.
+                    by_recovery = _recovery_is_useful(
+                        recovery_ts,
+                        active_recovery_ts,
+                        active_headroom or 0.0,
+                        best_candidate_headroom,
+                        settings.threshold,
+                        now,
+                    )
+                    axis_recovery[num] = by_recovery
+                    if by_recovery:
+                        # Hysteresis on the axis we actually rank by. It bounds
+                        # the flap RATE rather than making a reverse move
+                        # impossible: the target must come back meaningfully
+                        # sooner than where we are.
+                        if recovery_ts >= active_recovery_ts - RECOVERY_HYSTERESIS_S:
+                            continue
+                    else:
+                        # Headroom axis, with a RATIO margin. Also a rate bound,
+                        # not impossibility — headroom moves, so a target that
+                        # burns down to a quarter of what it beat can qualify
+                        # in reverse. That takes a 4x relative burn instead of
+                        # the one point a strictly-greater test would need.
+                        if h < (active_headroom or 0.0) * HORIZON_HEADROOM_RATIO:
+                            continue
                 elif consume_first:
                     # Purely proactive on reset ordering: below the threshold,
                     # only move to accounts whose weekly window resets sooner
@@ -1258,7 +1338,7 @@ class AutoSwitchEngine:
                     # qualifies; near-line pairs can't flap back).
                     if h - active_headroom < settings.hysteresis_pct:
                         continue
-            if recovery_useful and trigger in ("proactive", "consume-first"):
+            if axis_recovery.get(num) and trigger in ("proactive", "consume-first"):
                 # Soonest BINDING recovery first — the window actually holding
                 # this account back, not the weekly one. With everything in the
                 # 90s the only thing worth optimizing is how long until work can
@@ -1269,7 +1349,23 @@ class AutoSwitchEngine:
                 # which skip that gate deliberately: there the account with the
                 # most headroom must win, because we are escaping a dead or
                 # blocked active account rather than optimising a return time.
-                key: tuple = (recovery_ts, -h)
+                #
+                # TIER 0. The axis is per candidate, so the key must stay
+                # comparable across both: a candidate that returns inside the
+                # horizon beats one that does not, whatever its headroom, and
+                # ties are broken by how soon. Without the tier the two key
+                # SHAPES were compared elementwise — a raw headroom against an
+                # epoch timestamp — and the headroom candidate always won on
+                # magnitude alone.
+                key: tuple = (0, recovery_ts, -h)
+            elif all_above and trigger in ("proactive", "consume-first"):
+                # TIER 1: ranked on HEADROOM, because that is what its gate
+                # decided on. Falling through to the consume-first weekly key
+                # split the filter and the sort across two axes — the same
+                # mismatch the comment above records as a prior bug — and
+                # picked the candidate with LESS headroom whenever its weekly
+                # reset happened to be sooner.
+                key = (1, 0.0, -h)
             elif consume_first:
                 # Soonest weekly reset first (unknown resets sort last), most
                 # headroom breaks ties, then sequence order.

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1445,7 +1445,7 @@ class AutoSwitchEngine:
         if (
             isinstance(left_headroom, (int, float))
             and h is not None
-            and h >= left_headroom + SPENT_HEADROOM_PCT
+            and h >= min(left_headroom + SPENT_HEADROOM_PCT, 100.0)
         ):
             return True
         # `None` is the JSON-safe spelling of "unknown or already past", which

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -179,12 +179,18 @@ def _recovery_is_useful(
     The #202 case oscillated on the original code too — its test ticks once,
     so it only ever observed the outbound leg.
 
-    The step between the two axes used to be non-monotone. That was a property
-    of `best_candidate_headroom`'s ratio floor, not of this predicate. Swept
-    directly over the predicate — active 1..12 pts against a peer walked
-    0.5..40 at 0.05, four reset shapes — a strictly-improving peer never flips
-    a move into a refusal: 0 inversions. The one refusal left in
-    [3.00, 10.00] is at peer == active exactly, where the tie is the answer.
+    The step between the two axes is NOT monotone, and an earlier version of
+    this docstring claimed it was ("0 inversions"). Re-swept directly over the
+    predicate — active 1..12 pts against a peer walked 0.5..40 at 0.05, four
+    reset shapes — a strictly-better peer does flip a move into a refusal, and
+    every case sits on one point: `peer_h` crossing SPENT_HEADROOM_PCT, where
+    the spent clause goes false and the axis changes underneath the comparison.
+
+    That is the axis boundary, not a leak, and it is NOT reachable through
+    `tick()`: the fallback at the bottom of the ranking loop re-admits exactly
+    those candidates. A reviewer re-took the same sweep and got a different
+    count from mine, which is the point — the count depends on the sweep's step
+    and reset shapes, so it is stated as WHERE rather than HOW MANY.
     """
     if (
         active_headroom <= SPENT_HEADROOM_PCT
@@ -1108,11 +1114,32 @@ class AutoSwitchEngine:
             return TickOutcome.BLOCKED
 
         consume_first = settings.strategy == "consume-first"
-        ordered, any_known, active_reset_ts = self._rank_candidates(
+
+        def _rank(**kw):
+            """Rank with the no-return bar, and WITHOUT it if that empties.
+
+            The bar has no release of its own — `lastSwitchFrom` is rewritten
+            only by a successful switch — so a bar that leaves nothing is
+            permanent, not anti-flap. Two predicates that tried to predict
+            emptiness both landed a gate short of the loop (see
+            `_no_return_account`), so the question is put to the ranking
+            itself. Exact by construction, and it cannot fall behind the gates
+            because it is not a second copy of them.
+
+            Cheap: the retry runs only when the barred list came back empty,
+            which is the tick that was about to do nothing anyway.
+            """
+            ranked = self._rank_candidates(no_return=no_return, **kw)
+            if no_return is not None and not ranked[0]:
+                unbarred = self._rank_candidates(no_return=None, **kw)
+                if unbarred[0]:
+                    return unbarred
+            return ranked
+
+        ordered, any_known, active_reset_ts = _rank(
             trigger=trigger,
             consume_first=consume_first,
             oauth_candidates=oauth_candidates,
-            no_return=no_return,
             usage=usage,
             headroom=headroom,
             current=current,
@@ -1139,11 +1166,10 @@ class AutoSwitchEngine:
             usage = {num: entry.decision_value() for num, entry in entries.items()}
             headroom = _headroom_by_account(usage, self._models)
             active_headroom = headroom.get(current)
-            ordered, any_known, active_reset_ts = self._rank_candidates(
+            ordered, any_known, active_reset_ts = _rank(
                 trigger=trigger,
                 consume_first=consume_first,
                 oauth_candidates=oauth_candidates,
-                no_return=no_return,
                 usage=usage,
                 headroom=headroom,
                 current=current,
@@ -1318,23 +1344,38 @@ class AutoSwitchEngine:
         anti-flap margin uses: that is not the flip this bars, it is a move the
         outbound leg would have made on its own merits.
 
-        And released when the bar would leave NOTHING to choose. Identity has
-        no release condition of its own — `lastSwitchFrom` is rewritten only by
-        a successful switch, the one it prevents — so on a 2-account fleet it
-        was permanent: measured, one ordinary proactive move then 20 ticks of
-        `no-candidates` with the peer at 0%, surviving a restart. The ratio
-        release does not cover it, because `left >= active x 2` is
-        unsatisfiable for any active headroom above 50 and consume-first fires
-        exactly there: measured, active 70 pts against a peer at 100 pts,
-        locked out for 10h and still locked after seven days of wall clock.
-        A bar that leaves the engine nothing is not anti-flap, it is a stall.
+        THE LEAVES-NOTHING RELEASE IS NOT HERE. It used to be, and it was
+        rewritten twice for the same reason both times: this function cannot
+        see the gates that decide. `lastSwitchFrom` is rewritten only by a
+        successful switch — the one thing the bar prevents — so a bar that
+        empties the ranking is permanent, and each attempt to predict emptiness
+        landed one gate short of the ranking loop:
+
+            all(n == barred ...)              "does another account EXIST"
+            (headroom.get(n) or 0.0) > 0.0    "is another account not at its limit"
+
+        The loop also applies the threshold, `h >= active x HORIZON_HEADROOM_
+        RATIO`, the spent fallback's `h >= active` plus a sooner reset, and the
+        recovery hysteresis. A third account on ONE point clears both
+        predicates above and none of those, so the n=2 stall came back at n>=3
+        and then again one point up. Measured: barred peer 3.5 pts / back in
+        10h, active 2 pts / 500h out, third 1 pt — 30 ticks all BLOCKED, and
+        the same fleet with `lastSwitchFrom` popped switches on the first.
+
+        `_tick_inner` now ASKS the ranking instead: it ranks with the bar, and
+        re-ranks without it when the result is empty. That is exact by
+        construction, covers the recovery axis this predicate never could, and
+        cannot be one gate behind because it is not a separate copy of the
+        gates.
         """
         came_from = state.get("lastSwitchFrom")
         if trigger not in ("proactive", "consume-first") or came_from is None:
             return None
+        # No membership check on `oauth_candidates`: the loop compares
+        # `num == no_return` while iterating that same list, so naming an
+        # account that is not in it bars nothing. The check was a no-op and
+        # nothing killed it under mutation.
         barred = str(came_from)
-        if barred not in oauth_candidates:
-            return None
         left_headroom = headroom.get(barred)
         if (
             left_headroom is not None
@@ -1342,23 +1383,6 @@ class AutoSwitchEngine:
             and left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO
         ):
             return None                      # beats us outright; not a flip
-        # CHOOSABLE, not merely present. `all(n == barred ...)` asked whether
-        # any OTHER account exists — and a third account that exists but can
-        # never qualify (spent, or headroom unknown) answered yes while
-        # offering the ranking nothing. Measured, one ordinary proactive move
-        # and no seeded state: active on 2 pts, the barred peer on 3, a third
-        # at its limit — 30 ticks / 30h all BLOCKED, and the same fleet with
-        # the bar cleared switches on the first one. The n=2 stall the release
-        # was added for simply moved to n>=3.
-        #
-        # A candidate the loop would skip anyway (`h is None` or `h <= 0`) is
-        # not an alternative, so barring on its account is still barring on
-        # nothing.
-        if not any(
-            n != barred and (headroom.get(n) or 0.0) > 0.0
-            for n in oauth_candidates
-        ):
-            return None                      # barring it leaves nothing
         return barred
 
     def _rank_candidates(

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1439,8 +1439,10 @@ class AutoSwitchEngine:
         the key is PRESENT with unknown values, which is real evidence that
         the departure's severity could not be measured, not an absence of
         evidence. The conservative default for unknown severity is to HOLD the
-        bar, not release it - the recovery leg or the ratio release in
-        `_no_return_account` can still lift it once real evidence shows up.
+        bar - but only on the proactive/consume-first return this predicate
+        gates. `_no_return_account` scopes at-limit and failover out of the
+        bar by design, so either trigger still escapes the account untouched,
+        and the next successful switch overwrites the snapshot outright.
         """
         came_from = state.get("lastSwitchFrom")
         if came_from is None:

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -97,16 +97,12 @@ RECOVERY_HYSTERESIS_S = 300.0
 RECOVERY_HORIZON_S = 4 * 3600.0
 
 # Anti-flap margin for the headroom axis past RECOVERY_HORIZON_S, as a RATIO
-# rather than percentage points. The ordinary hysteresis_pct (10 points) is
-# unmeetable here by construction — everything is within a few points of its
-# limit — so requiring it would park the engine and let it ride into the wall.
-# Requiring strictly-more was the opposite error: one point is enough to move,
-# the target burns it back, and the engine ping-pongs (measured 2026-07-30,
-# four switches in 35 minutes, each buying one point and each costing a
-# credential rewrite). A ratio is the right unit in the endgame — with two
-# points left, what matters is how many TIMES more runway the target has — and
-# it makes the move one-way: the reverse leg would need the new active to fall
-# to a quarter of the headroom it just beat.
+# rather than percentage points. Requiring strictly-more is no margin at all:
+# one point is enough to move, the target burns it back, and the engine
+# ping-pongs (measured 2026-07-30: four switches in 35 minutes, each buying one
+# point and each costing a credential rewrite). A ratio makes the move one-way
+# — the reverse leg would need the new active to fall to a quarter of the
+# headroom it just beat.
 HORIZON_HEADROOM_RATIO = 2.0
 
 # Below this much headroom an account is spent for practical purposes, and
@@ -1190,19 +1186,13 @@ class AutoSwitchEngine:
             if all_above
             else 0.0  # unread unless all_above; never a live sentinel
         )
-        # Past the horizon, rank by headroom instead (the escape itself stays:
-        # the landing-health gate has no other answer here). An UNKNOWN
-        # recovery is no evidence rather than a distant one, so it keeps the
-        # recovery axis and that gate keeps deciding. See RECOVERY_HORIZON_S.
-        # Everyone spent: headroom can no longer tell the candidates apart, so
-        # the reset is the only thing left worth ranking on (see
-        # SPENT_HEADROOM_PCT). Checked before the horizon, which is about
-        # whether a sooner reset is worth REAL headroom — a question that only
-        # arises while some real headroom exists.
+        # all_spent is checked first: the horizon asks whether a sooner reset
+        # is worth REAL headroom, which only arises while real headroom exists.
+        # An UNKNOWN recovery is no evidence rather than a distant one, so it
+        # keeps the recovery axis. See SPENT_HEADROOM_PCT, RECOVERY_HORIZON_S.
         all_spent = all_above and all(
-            (headroom.get(n) is not None and headroom[n] <= SPENT_HEADROOM_PCT)
-            for n in oauth_candidates
-        ) and (active_headroom is not None and active_headroom <= SPENT_HEADROOM_PCT)
+            h is not None and h <= SPENT_HEADROOM_PCT for h in headroom.values()
+        )
         recovery_useful = all_above and (
             all_spent
             or active_recovery_ts == float("inf")

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1245,11 +1245,30 @@ class AutoSwitchEngine:
         all_above = _every_account_above_threshold(
             oauth_candidates, headroom, active_headroom, settings.threshold
         )
-        # The most headroom any candidate offers — "is there anything worth
-        # having?" Unknown headrooms are excluded rather than counted as zero:
-        # a row we cannot read is not evidence of an empty account.
+        # The most headroom any candidate the ranking could ACTUALLY CHOOSE
+        # offers — "is there anything worth having?" Unknown headrooms are
+        # excluded rather than counted as zero: a row we cannot read is not
+        # evidence of an empty account.
+        #
+        # Scoped to choosable candidates, not all of them. A peer 0.05 points
+        # above SPENT_HEADROOM_PCT answers "yes, something is worth having" and
+        # so turns the spent check off for EVERYBODY — while being unchoosable
+        # itself, because it does not meet HORIZON_HEADROOM_RATIO against the
+        # active. Nothing then qualifies and the engine parks on the account
+        # that returns LAST. Measured: active 3.00 pts/200h, peer 3.00 pts/10h,
+        # vetoer 3.05 pts/500h -> base switches to the 10h peer, this branch
+        # blocked. The band is (SPENT_HEADROOM_PCT, active x RATIO], up to 3
+        # points wide at the defaults.
+        #
+        # A candidate below the ratio cannot win the headroom axis, so counting
+        # it here only ever suppresses the OTHER axis on its behalf.
+        _ratio_floor = (active_headroom or 0.0) * HORIZON_HEADROOM_RATIO
         best_candidate_headroom = max(
-            (h for h in (headroom.get(n) for n in oauth_candidates) if h is not None),
+            (
+                h
+                for h in (headroom.get(n) for n in oauth_candidates)
+                if h is not None and h >= _ratio_floor
+            ),
             default=0.0,
         )
         active_recovery_ts = (
@@ -1358,7 +1377,18 @@ class AutoSwitchEngine:
                 # Scoped to the SAME triggers as the gate above: at-limit and
                 # failover skip that gate deliberately, because there we are
                 # escaping a dead account rather than optimising a return time.
-                key: tuple = (0, recovery_ts, -h) if by_recovery else (1, 0.0, -h)
+                # `recovery_ts` in BOTH tiers. Tier 1 hard-coded 0.0 there,
+                # which threw away a fact already in hand: two peers with equal
+                # headroom past the horizon then tied, and the tie fell through
+                # to sequence order. Measured — active 4 pts/300h, two peers
+                # 8 pts each, one returning in 5h and one in 500h: base picks
+                # the 5h account whichever slot it occupies, this branch picked
+                # whichever came first in the list. Headroom still decides
+                # first within the tier; the reset only breaks its ties, where
+                # sooner is plainly better than lower slot number.
+                key: tuple = (
+                    (0, recovery_ts, -h) if by_recovery else (1, -h, recovery_ts)
+                )
             elif consume_first:
                 # Soonest weekly reset first (unknown resets sort last), most
                 # headroom breaks ties, then sequence order.

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -125,26 +125,16 @@ HORIZON_HEADROOM_RATIO = 2.0
 # ratio removes both: 1.0 empties this band and re-arms the veto the filter
 # exists to stop, 2.0 does the reverse. Measured, not argued.
 #
-# THAT ALGEBRA BOUNDS THE CONSTANT, NOT THE RANKING, and an earlier version of
-# this comment confused the two — it told the next reader the residue needed a
-# redesign. It did not. The fix is the fallback in `_rank_candidates`: drop the
-# floor from `best_candidate_headroom` so the worth-having question stops
-# keying on the active account's own headroom, and re-admit margin failures
-# through a one-way list used only when nothing else qualifies. Measured, same
-# scenario, 0.05 steps across [3.00, 10.00]:
+# That bounds the CONSTANT, not the ranking. The fix is elsewhere: drop the
+# floor from `best_candidate_headroom` and re-admit margin failures through a
+# one-way fallback used only when nothing else qualifies. Sweep across
+# [3.00, 10.00] at 0.05: 42 refusals before, 0 now.
 #
-#     here, before   42 refusals of 141, band [3.90, 5.95]
-#     here, now       0 refusals of 141
-#
-# with the suite at 1717 passed and every horizon protection intact.
-#
-# Two OTHER fixes were tried and both measured worse. Making the floor absolute
-# (`> SPENT_HEADROOM_PCT`, fleet-wide rather than relative) refuses 4 of the 5
-# sampled points — no narrower than the band it replaces — AND breaks
+# Two other fixes measured worse. An absolute floor (`> SPENT_HEADROOM_PCT`)
+# refuses 4 of the 5 sampled points and breaks
 # `test_an_unchoosable_peer_does_not_veto_the_reset_ranking`. Dropping the
-# filter with no fallback gives `0457cb0`'s row (REF REF REF REF move), which
-# re-arms that veto. The fallback is exactly what separates the working fix
-# from that one.
+# filter with NO fallback gives `0457cb0`'s row, re-arming that veto — the
+# fallback is what separates the working fix from that one.
 WORTH_HAVING_RATIO = 1.3
 
 # Below this an account is spent, and headroom comparisons between two spent
@@ -213,11 +203,9 @@ def _recovery_is_useful(
     The #202 case oscillated on the original code too — its test ticks once,
     so it only ever observed the outbound leg.
 
-    The step between the two axes used to be non-monotone — adding headroom to
-    a peer flipped a move into a refusal, 42 refusals across a 0.05-step sweep.
-    That was a property of `best_candidate_headroom`'s ratio floor, not of this
-    predicate: the floor is gone and margin failures are re-admitted through a
-    one-way fallback, so the sweep now refuses nowhere. See WORTH_HAVING_RATIO.
+    The step between the two axes used to be non-monotone. That was a property
+    of `best_candidate_headroom`'s ratio floor, not of this predicate — the
+    floor is gone and the sweep now refuses nowhere. See WORTH_HAVING_RATIO.
     """
     if (
         active_headroom <= SPENT_HEADROOM_PCT
@@ -1310,18 +1298,12 @@ class AutoSwitchEngine:
         # blocked. The band is (SPENT_HEADROOM_PCT, active x RATIO], up to 3
         # points wide at the defaults.
         #
-        # The headrooms the ranking may actually choose between: every
-        # candidate whose headroom is KNOWN. An unknown one is not evidence
-        # that somebody has quota left — the loop skips it a few lines down
-        # for exactly that reason — so it must not veto the spent check
-        # either. Measured: one sentinel row (expired token, locked keychain)
-        # made `all(...)` False forever, and three accounts at 99% days out
-        # left the engine parked on the one resetting LAST.
-        #
-        # Unfiltered. A floor scoped by WORTH_HAVING_RATIO used to sit here,
-        # which made the worth-having question key on the ACTIVE account's own
-        # headroom and inverted monotonicity across a 2-point band. The
-        # margin-failure fallback below is what lets it go. See the constant.
+        # Every candidate whose headroom is KNOWN, unfiltered. An unknown one
+        # is not evidence that somebody has quota left — measured, one
+        # sentinel row (expired token, locked keychain) made `all(...)` False
+        # forever and parked the engine on the account resetting LAST. A
+        # WORTH_HAVING_RATIO floor used to sit here too and inverted
+        # monotonicity; the fallback below is what lets it go.
         best_candidate_headroom = max(
             (
                 h
@@ -1405,9 +1387,7 @@ class AutoSwitchEngine:
                                 and recovery_ts
                                 < active_recovery_ts - RECOVERY_HYSTERESIS_S
                             ):
-                                fallback.append(
-                                    ((0, recovery_ts, -h), num)
-                                )
+                                fallback.append(((0, recovery_ts, -h), num))
                             continue
                 elif consume_first:
                     # Purely proactive on reset ordering: below the threshold,
@@ -1459,8 +1439,7 @@ class AutoSwitchEngine:
                 key = (-h,)
             qualifying.append((key, num))
         # Ascending by the strategy's key; list order (sequence order) breaks ties.
-        if not qualifying and fallback:
-            qualifying = fallback
+        qualifying = qualifying or fallback
         qualifying.sort(key=lambda t: t[0])
         return [num for _, num in qualifying], any_known, active_reset_ts
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1108,7 +1108,12 @@ class AutoSwitchEngine:
             # ranking had already thrown away — `left=20 active=30` bars,
             # `left=90 active=10` releases, and phase 2 is where that flips.
             recovered = self._left_account_recovered(
-                state, kw["usage"], kw["headroom"], kw["active_headroom"], kw["now"]
+                state,
+                kw["usage"],
+                kw["headroom"],
+                kw["active_headroom"],
+                kw["settings"],
+                kw["now"],
             )
             no_return = self._no_return_account(
                 trigger, state, kw["headroom"], kw["active_headroom"], recovered
@@ -1399,6 +1404,7 @@ class AutoSwitchEngine:
         usage: dict[str, dict | str | None],
         headroom: dict[str, float | None],
         active_headroom: float | None,
+        settings: AutoSwitchSettings,
         now: float,
     ) -> bool:
         """Is the account we left a better proposition than when we left it?
@@ -1416,21 +1422,61 @@ class AutoSwitchEngine:
         active had changed. That is the flap: the ranking flipped underneath a
         target that did nothing.
 
-        Three legs, checked in this order, each with the margin its axis
-        already uses. Burn cannot manufacture any of them: headroom rises
-        only when a window rolls over, the ratio needs the active to lose
-        HALF its remaining headroom, and the binding reset moves nearer only
-        when a nearer window starts binding.
+        FAILOVER FIRST, before any leg reads the active — checked ahead of
+        dominance because round 5 put dominance first and it starved this
+        branch: `test_a_failover_departure_does_not_disarm_the_bar` broke on
+        its FIRST tick the instant the active fell far enough for `4.0 >
+        active x 2` to go true (measured at active=1.8, one fifth of a point
+        past the boundary this branch's own sibling test already sits on).
+        A `(None, None)` snapshot means severity was genuinely unmeasured at
+        departure — there is no `leftHeadroom` to diff against and never was
+        — so the only signal left that does not depend on the active's LIVE
+        state is whether the peer, right now, would itself be a healthy place
+        to land: `h > 100 - settings.threshold`, the same "would the ranking
+        accept this as a landing spot" test `_rank_candidates` already runs
+        (`:1617`) on every candidate, reused rather than inventing a fresh
+        constant. It cannot tell "genuinely recovered" from "was already this
+        good" — there is nothing recorded to tell them apart — so R-A and R-B
+        collapse onto the same answer here. Measured which side that answer
+        should land on: MREL-sweeping this same leg for the ordinary path
+        (round 5 review, F3) showed an absolute floor is silently
+        reintroducible with a green suite, so this is not free of that risk
+        either — the difference is this constant is `settings.threshold`, not
+        a hardcoded number, so a user's OWN policy decides how conservative
+        the hold is, and it moves when they change it (pinned directly,
+        below). Deliberately MORE conservative than the ordinary path below:
+        a peer sitting at 4 points held through the whole walk that broke
+        round 5's dominance leg, with no upper bound short of the peer
+        crossing the threshold itself. Bounded, not permanent — at-limit
+        still escapes untouched (`_no_return_account` scopes this trigger
+        out entirely), so the worst case is one bounded hold, not a lockout.
 
-          dominance   `> active x HORIZON_HEADROOM_RATIO` against the
-                      ACTIVE, checked first and needing no departure
-                      baseline. A peer moved AWAY from for a reason other
-                      than headroom (e.g. consume-first's reset ordering)
-                      can dominate the active from the moment it was left,
-                      and self-improvement against its own departure
-                      baseline never fires for an account that had nothing
-                      to improve on. Same ratio `_no_return_account` and
-                      the ranking's headroom axis (`:1626`) already use.
+        THE ORDINARY PATH HAS A REAL BASELINE (`leftHeadroom` is a number,
+        not null), so it gets three legs, checked in this order, each with
+        the margin its axis already uses. Burn cannot manufacture any of
+        them: headroom rises only when a window rolls over, the ratio needs
+        the active to lose more than half its remaining headroom AND clear
+        an extra `SPENT_HEADROOM_PCT` on top, and the binding reset moves
+        nearer only when a nearer window starts binding.
+
+          dominance   `> active x HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT`
+                      against the ACTIVE. A peer moved AWAY from for a reason
+                      other than headroom (e.g. consume-first's reset
+                      ordering) can dominate the active from the moment it
+                      was left, and self-improvement against its own
+                      departure baseline never fires for an account that had
+                      nothing to improve on. The `+SPENT_HEADROOM_PCT` on top
+                      of the bare ratio is what round 5 was missing: measured
+                      on the branch's own flap fleet (peer frozen 4.0 pts,
+                      active burning 98.0% -> 98.4%), the bare ratio flips
+                      true at active=1.8 pts purely because the active kept
+                      burning; the same walk with the margin added stays
+                      false through active=1.6 and only opens once the active
+                      is down to a genuine sliver (`x < 0.5`), which is the
+                      at-limit escape's territory, not a return worth calling
+                      anti-flap. `test_a_burn_walk_never_returns_to_what_it_
+                      left` still settles with the margin in place — it makes
+                      the boundary harder to cross, not impossible.
           headroom    `+SPENT_HEADROOM_PCT` against the DEPARTURE baseline
                       — below that an edge is under two poll intervals, the
                       same reason the spent band exists.
@@ -1442,29 +1488,11 @@ class AutoSwitchEngine:
         by a switch that never recorded one, carries no evidence either way —
         and of the two failure modes the permanent proactive lockout is the
         worse one, because it is persisted and survives a restart and a week of
-        wall clock. Absence of evidence releases.
-
-        That is "no snapshot" - the key ABSENT. A failover departure writes a
-        snapshot too, but with both values `null` (`active_headroom` is
-        unreadable by definition, and its `inf` recovery serializes that way):
-        the key is PRESENT with unknown values, which is real evidence that
-        the departure's severity could not be measured, not an absence of
-        evidence. `(None, None)` conflates two different peer states, though:
-        "still unmeasurable" (hold) and "measurable again, dominant" (a real
-        change of state -- release). There is no recorded baseline for either
-        headroom-vs-departure or recovery-vs-departure to diff against, so
-        beyond the dominance leg above the only trustworthy signal left is
-        whether the peer is still unmeasurable or not yet good enough:
-        neither is release. In particular the headroom leg CANNOT fall back
-        to an absolute floor on the peer alone here — `account_headroom` is
-        `100 - max(pct)`, so any peer that has spent more than
-        `SPENT_HEADROOM_PCT` of its weekly window could never clear a fixed
-        `100 - SPENT_HEADROOM_PCT` bar, no matter how far ahead of the
-        ACTIVE it is; that is exactly the failure the dominance leg exists to
-        catch instead. This only gates the proactive/consume-first return;
-        `_no_return_account` scopes at-limit and failover out of the bar by
-        design, so either trigger still escapes the account untouched, and
-        the next successful switch overwrites the snapshot outright.
+        wall clock. Absence of evidence releases. This only gates the
+        proactive/consume-first return; `_no_return_account` scopes at-limit
+        and failover out of the bar by design, so either trigger still
+        escapes the account untouched, and the next successful switch
+        overwrites the snapshot outright.
         """
         came_from = state.get("lastSwitchFrom")
         if came_from is None:
@@ -1473,36 +1501,27 @@ class AutoSwitchEngine:
         if "leftHeadroom" not in state:
             return True          # pre-upgrade record: genuinely no evidence
         h = headroom.get(barred)
-        # Dominance over the ACTIVE, checked before either baseline-relative
-        # leg below: a peer that was already miles ahead of the active at
-        # departure (moved for a DIFFERENT reason -- e.g. consume-first's
-        # reset ordering, not headroom) never "improves" on its own baseline
-        # and would stall on self-improvement alone despite dominating
-        # throughout. Same ratio `_no_return_account` and the ranking's
-        # headroom axis (`:1626`) already use, so a peer that beats the
-        # active this hard is a move the outbound leg would make on its own
-        # merits regardless of departure history -- and it needs no stored
-        # baseline, so it applies to the failover `(None, None)` case too.
-        if (
-            h is not None
-            and active_headroom is not None
-            and h > active_headroom * HORIZON_HEADROOM_RATIO
-        ):
-            return True
         left_headroom = state.get("leftHeadroom")
         left_recovery = state.get("leftRecoveryAt")
         if left_headroom is None and left_recovery is None:
-            # Failover: real departure, severity unmeasured at the time -- not
-            # absence of evidence. There is no recorded baseline to diff
-            # against (that is exactly what "unmeasured" means) and dominance
-            # was already checked above, so the only thing left is: still
-            # unmeasurable, or not yet good enough. Hold. The recovery leg
-            # has no baseline-relative form here either -- with no baseline
-            # `was` would collapse to `inf`, which any known reset beats for
-            # free, disarming on the first readable tick regardless of how
-            # little recovered. That is the exact flap 0b369e0 fixed, so
-            # recovery sits out this branch.
-            return False
+            # Failover: real departure, severity unmeasured at the time --
+            # not absence of evidence, and there is no baseline to diff
+            # against (that is exactly what "unmeasured" means), so this
+            # cannot use the active at all -- see docstring for why that is
+            # what round 5 got wrong and the walk that proved it.
+            return h is not None and h > 100.0 - settings.threshold
+        # Dominance over the ACTIVE, only reached once a real baseline is
+        # confirmed to exist above -- a peer that was already miles ahead of
+        # the active at departure (moved for a DIFFERENT reason -- e.g.
+        # consume-first's reset ordering, not headroom) never "improves" on
+        # its own baseline and would stall on self-improvement alone despite
+        # dominating throughout.
+        if (
+            h is not None
+            and active_headroom is not None
+            and h > active_headroom * HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT
+        ):
+            return True
         if (
             isinstance(left_headroom, (int, float))
             and h is not None

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1447,11 +1447,7 @@ class AutoSwitchEngine:
         # to sit here too and inverted monotonicity; removing it is what let
         # the fallback do the job.
         best_candidate_headroom = max(
-            (
-                h
-                for h in (headroom.get(n) for n in oauth_candidates)
-                if h is not None
-            ),
+            (h for h in map(headroom.get, oauth_candidates) if h is not None),
             default=0.0,
         )
         active_recovery_ts = (

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1034,6 +1034,28 @@ class AutoSwitchEngine:
         oauth_candidates = [
             n for n in candidates if self.switcher.account_kind_for(n) != "api_key"
         ]
+        # NEVER UNDO THE PREVIOUS MOVE. Each anti-flap gate is one-way on its
+        # own axis, but the axis is a property of the pair's STATE and burn
+        # changes that state: the ratio gate is relative (`h >= active x 2`)
+        # and the spent gate absolute (`active <= 3.0`), so a burning pair
+        # crosses the boundary repeatedly and each crossing re-opens a move.
+        # Measured, both resets past the horizon, only the active burning:
+        #
+        #     t8   1->2  headroom axis   active 4.0 / best 8.0
+        #     t20  2->1  headroom axis   active 2.0 / best 4.0
+        #     t22  1->2  recovery axis   active 3.0 / best 2.0
+        #
+        # move sequence [1, 2, 1, 2] where base makes one move. Nothing
+        # bounded how many crossings could happen.
+        #
+        # Only the account we left LAST, and only until we move again — so a
+        # three-account fleet still reaches every peer, and any later move
+        # releases the previous one. This bounds the direction, not the rate:
+        # the cooldown already bounds the rate, and it had lapsed at every one
+        # of the moves above (301s ticks against a 300s cooldown).
+        came_from = state.get("lastSwitchFrom")
+        if came_from is not None and str(came_from) in oauth_candidates:
+            oauth_candidates = [n for n in oauth_candidates if n != str(came_from)]
         api_key_candidates = (
             [n for n in candidates if self.switcher.account_kind_for(n) == "api_key"]
             if settings.include_api_key_accounts
@@ -1637,6 +1659,18 @@ class AutoSwitchEngine:
             state["schemaVersion"] = STATE_SCHEMA_VERSION
             state["lastSwitchAt"] = self.clock()
             state["lastSwitchTo"] = number
+            # WHERE we came from, so the next tick can refuse to undo this.
+            # Each anti-flap gate is one-way on its own axis, but burn moves a
+            # pair across `SPENT_HEADROOM_PCT` and the axis changes with it —
+            # measured, both resets past the horizon, only the active burning:
+            #
+            #     t8   1->2  headroom axis   active 4.0 / best 8.0
+            #     t20  2->1  headroom axis   active 2.0 / best 4.0
+            #     t22  1->2  recovery axis   active 3.0 / best 2.0
+            #
+            # so the move sequence was [1, 2, 1, 2] where base makes one move.
+            # Nothing bounded how many times the pair could cross.
+            state["lastSwitchFrom"] = (result.get("from") or {}).get("number")
             atomic_write_json(self.state_path, state)
 
         self._emit(

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1536,7 +1536,26 @@ class AutoSwitchEngine:
         h = headroom.get(barred)
         left_headroom = state.get("leftHeadroom")
         left_recovery = state.get("leftRecoveryAt")
-        if left_headroom is None and left_recovery is None:
+        # I-B (R8 review): a `consume-first` departure can ALSO write
+        # (None, None) -- the same shape a real failover writes -- whenever
+        # the phase-2 refetch's active row is unmeasurable for headroom but
+        # still has a known weekly reset (the split shape `oauth.
+        # build_usage_result` emits for `utilization: null` plus a
+        # `resets_at`). Inferring "failover" from the two nulls then ran the
+        # more permissive failover legs (landing floor + recovery-only) on
+        # what was really an ordinary departure -- reachable on 32%+ of
+        # swept fleets, both directions. `leftTrigger` records the actual
+        # trigger so this never has to guess again; a record written before
+        # this field existed has no such key, so fall back to the old
+        # two-null inference for it (unchanged behaviour for pre-upgrade
+        # state).
+        left_trigger = state.get("leftTrigger")
+        is_failover_snapshot = (
+            left_trigger == "failover"
+            if left_trigger is not None
+            else (left_headroom is None and left_recovery is None)
+        )
+        if is_failover_snapshot:
             # Failover: real departure, severity unmeasured at the time --
             # not absence of evidence, and there is no baseline to diff
             # against (that is exactly what "unmeasured" means), so this
@@ -1577,8 +1596,24 @@ class AutoSwitchEngine:
             # active to have a genuine, known reset before the comparison
             # even runs -- unknown holds, exactly like unreadable already
             # does on the headroom axis (F6).
+            #
+            # But two of the five `inf` states are ordinary shapes for an
+            # active that is plainly alive and burning -- a `pct` reported
+            # with no `resets_at`, or a `resets_at` already elapsed -- not
+            # unknowns (R8 review, I-A). Reading all five as "unknown, hold"
+            # pins the engine on a near-spent active for up to a full window
+            # even when the peer is back within `RECOVERY_HORIZON_S`, the
+            # same constant this PR already uses for "near enough to
+            # matter" (`_recovery_is_useful`). Requiring EITHER a known
+            # active reset OR a peer inside that horizon keeps C-1's
+            # intended release (a known active vs. an arbitrarily-far peer
+            # still needs `isfinite`) while letting a near peer through
+            # regardless of why the active's own reset reads `inf`.
             return (
-                math.isfinite(active_recovery_ts)
+                (
+                    math.isfinite(active_recovery_ts)
+                    or peer_recovery_ts - now <= RECOVERY_HORIZON_S
+                )
                 and peer_recovery_ts < active_recovery_ts - RECOVERY_HYSTERESIS_S
             )
         # Dominance over the ACTIVE, only reached once a real baseline is
@@ -2027,6 +2062,15 @@ class AutoSwitchEngine:
             state["lastSwitchFrom"] = (result.get("from") or {}).get("number")
             state["leftHeadroom"], recovery = left
             state["leftRecoveryAt"] = None if recovery == float("inf") else recovery
+            # I-B (R8 review): a `consume-first` phase-2 refetch can write the
+            # SAME (None, None) shape a `failover` departure writes, whenever
+            # the refetched active row has a `pct` but is otherwise
+            # unmeasurable in the same tick its weekly reset is known --
+            # `account_headroom` needs a numeric `pct`, `_seven_day_reset_ts`
+            # needs only `resets_at`. Inferring the trigger from the two
+            # nulls then runs the wrong legs. Record it directly so the
+            # reader never has to guess.
+            state["leftTrigger"] = trigger
             atomic_write_json(self.state_path, state)
 
         self._emit(

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1438,11 +1438,19 @@ class AutoSwitchEngine:
         unreadable by definition, and its `inf` recovery serializes that way):
         the key is PRESENT with unknown values, which is real evidence that
         the departure's severity could not be measured, not an absence of
-        evidence. The conservative default for unknown severity is to HOLD the
-        bar - but only on the proactive/consume-first return this predicate
-        gates. `_no_return_account` scopes at-limit and failover out of the
-        bar by design, so either trigger still escapes the account untouched,
-        and the next successful switch overwrites the snapshot outright.
+        evidence. `(None, None)` conflates two different peer states, though:
+        "still unmeasurable" (hold) and "measurable again, at/near full" (a
+        real change of state -- release). There is no recorded baseline for
+        either axis to diff against, so the only trustworthy signal is
+        whether the peer is now READABLE and close to full: `h >= 100 -
+        SPENT_HEADROOM_PCT`, the same margin the headroom leg below uses,
+        applied against the 100 cap instead of a stored `left_headroom`. A
+        peer that is readable but still poor (the flap 0b369e0 fixed) does
+        not clear that bar and the hold stands. This only gates the
+        proactive/consume-first return; `_no_return_account` scopes at-limit
+        and failover out of the bar by design, so either trigger still
+        escapes the account untouched, and the next successful switch
+        overwrites the snapshot outright.
         """
         came_from = state.get("lastSwitchFrom")
         if came_from is None:
@@ -1453,7 +1461,17 @@ class AutoSwitchEngine:
         left_headroom = state.get("leftHeadroom")
         left_recovery = state.get("leftRecoveryAt")
         if left_headroom is None and left_recovery is None:
-            return False         # failover: real departure, severity unknown -> hold
+            # Failover: real departure, severity unmeasured at the time -- not
+            # absence of evidence. There is no recorded baseline to diff
+            # against (that is exactly what "unmeasured" means), so the only
+            # trustworthy signal is the peer's OWN headroom now: require it
+            # within SPENT_HEADROOM_PCT of the 100 cap, the margin the
+            # headroom leg below already uses. The recovery leg has no such
+            # floor here -- with no baseline `was` would collapse to `inf`,
+            # which any known reset beats for free, disarming on the first
+            # readable tick regardless of how little recovered. That is the
+            # exact flap 0b369e0 fixed, so recovery sits out this branch.
+            return (headroom.get(barred) or 0.0) >= 100.0 - SPENT_HEADROOM_PCT
         h = headroom.get(barred)
         if (
             isinstance(left_headroom, (int, float))

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1432,15 +1432,26 @@ class AutoSwitchEngine:
         and of the two failure modes the permanent proactive lockout is the
         worse one, because it is persisted and survives a restart and a week of
         wall clock. Absence of evidence releases.
+
+        That is "no snapshot" - the key ABSENT. A failover departure writes a
+        snapshot too, but with both values `null` (`active_headroom` is
+        unreadable by definition, and its `inf` recovery serializes that way):
+        the key is PRESENT with unknown values, which is real evidence that
+        the departure's severity could not be measured, not an absence of
+        evidence. The conservative default for unknown severity is to HOLD the
+        bar, not release it - the recovery leg or the ratio release in
+        `_no_return_account` can still lift it once real evidence shows up.
         """
         came_from = state.get("lastSwitchFrom")
         if came_from is None:
             return True
         barred = str(came_from)
+        if "leftHeadroom" not in state:
+            return True          # pre-upgrade record: genuinely no evidence
         left_headroom = state.get("leftHeadroom")
         left_recovery = state.get("leftRecoveryAt")
         if left_headroom is None and left_recovery is None:
-            return True
+            return False         # failover: real departure, severity unknown -> hold
         h = headroom.get(barred)
         if (
             isinstance(left_headroom, (int, float))

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -88,16 +88,12 @@ IDLE_HOLD_MAX_S = 30 * 60.0
 # it needs its own unit rather than a reused one.
 RECOVERY_HYSTERESIS_S = 300.0
 
-# Horizon past which "soonest recovery" stops being worth real headroom.
-# The escape above was measured on minutes-scale resets (#202: a peer back in
-# 8 minutes), where waiting is plainly better than burning the last of the
-# active account. Days-scale is the opposite trade: measured live at active
-# 91% / 109h against 98% / 50h, the engine moved from 9 points of headroom to
-# 2, and neither account returns within the session either way — so the 9
-# points were the only resource that could still do work. Past this bound,
-# ranking falls back to headroom, which is what decides whether work
-# continues when nobody comes back soon. 4h covers a 5-hour window's whole
-# cycle, so same-day resets keep the recovery ranking.
+# Horizon past which "soonest recovery" stops being worth real headroom. The
+# escape above was measured on minutes-scale resets (#202: a peer back in 8
+# minutes). Days-scale is the opposite trade — measured live, active 91% /
+# 109h lost to 98% / 50h, and neither returns within the session, so the 9
+# points were the only resource that could still work. 4h covers a whole
+# 5-hour cycle, so same-day resets keep the recovery ranking.
 RECOVERY_HORIZON_S = 4 * 3600.0
 
 # Adaptive scheduling: the baseline request volume is O(1) per tick — the
@@ -1170,13 +1166,10 @@ class AutoSwitchEngine:
             if all_above
             else 0.0  # unread unless all_above; never a live sentinel
         )
-        # Past the horizon, "soonest" buys nothing real: keep the escape (the
-        # landing-health gate has no other answer when everything is above the
-        # line) but rank by headroom instead of recovery. An UNKNOWN recovery
-        # (inf) is not "past the horizon" — it is no evidence at all, and the
-        # pre-existing rule is that a candidate over the threshold must not be
-        # landed on without it. Treat it as the recovery axis so that gate
-        # keeps deciding. See RECOVERY_HORIZON_S.
+        # Past the horizon, rank by headroom instead (the escape itself stays:
+        # the landing-health gate has no other answer here). An UNKNOWN
+        # recovery is no evidence rather than a distant one, so it keeps the
+        # recovery axis and that gate keeps deciding. See RECOVERY_HORIZON_S.
         recovery_useful = all_above and (
             active_recovery_ts == float("inf")
             or active_recovery_ts - now <= RECOVERY_HORIZON_S

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -211,19 +211,15 @@ def _recovery_is_useful(
         active_headroom <= SPENT_HEADROOM_PCT
         and best_candidate_headroom <= SPENT_HEADROOM_PCT
     ):
-        # The axis CAN change as the fleet burns, and that is not a leak.
-        # Measured, only the active burning, both resets past the horizon:
+        # The axis CAN change as the fleet burns, and that is not a leak:
         #
-        #     out    active 2.0 / peer 4.0   headroom axis, ratio 4.0 >= 2.0x2
+        #     out    active 2.0 / peer 4.0   headroom axis, 4.0 >= 2.0x2
         #     back   active 3.0 / peer 2.0   recovery  axis, 10h vs 80h
         #
-        # Each leg is legitimate on the axis its own state selects: at the
-        # first the fleet still held real headroom, by the second every
-        # account is spent, which is the regime the reset axis exists for.
-        # 21 of 576 burn walks make that transition and read as A-B-A;
-        # constraining either gate to stop them (candidate-spent on the
-        # fallback, `max`/`min` over the pair here) changes the count by 0,
-        # because the transition is in the DATA rather than in the gates.
+        # Each leg is legitimate on the axis its own state selects. 21 of 576
+        # burn walks make that transition and read as A-B-A; constraining
+        # either gate changes the count by 0, because the transition is in the
+        # DATA rather than in the gates.
         return True
     return (
         candidate_recovery_ts - now <= RECOVERY_HORIZON_S

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1108,7 +1108,7 @@ class AutoSwitchEngine:
             # ranking had already thrown away — `left=20 active=30` bars,
             # `left=90 active=10` releases, and phase 2 is where that flips.
             recovered = self._left_account_recovered(
-                state, kw["usage"], kw["headroom"], kw["now"]
+                state, kw["usage"], kw["headroom"], kw["active_headroom"], kw["now"]
             )
             no_return = self._no_return_account(
                 trigger, state, kw["headroom"], kw["active_headroom"], recovered
@@ -1398,6 +1398,7 @@ class AutoSwitchEngine:
         state: dict,
         usage: dict[str, dict | str | None],
         headroom: dict[str, float | None],
+        active_headroom: float | None,
         now: float,
     ) -> bool:
         """Is the account we left a better proposition than when we left it?
@@ -1415,17 +1416,27 @@ class AutoSwitchEngine:
         active had changed. That is the flap: the ranking flipped underneath a
         target that did nothing.
 
-        Two axes, matching the ranking's two, each with the margin that axis
-        already uses:
+        Three legs, checked in this order, each with the margin its axis
+        already uses. Burn cannot manufacture any of them: headroom rises
+        only when a window rolls over, the ratio needs the active to lose
+        HALF its remaining headroom, and the binding reset moves nearer only
+        when a nearer window starts binding.
 
-          headroom   `+SPENT_HEADROOM_PCT` — below that an edge is under two
-                     poll intervals, the same reason the spent band exists.
-          recovery   `-RECOVERY_HYSTERESIS_S` — the same margin the recovery
-                     axis ranks by one gate later.
-
-        Burn cannot manufacture either: headroom rises only when a window rolls
-        over, and the binding reset moves nearer only when a nearer window
-        starts binding.
+          dominance   `> active x HORIZON_HEADROOM_RATIO` against the
+                      ACTIVE, checked first and needing no departure
+                      baseline. A peer moved AWAY from for a reason other
+                      than headroom (e.g. consume-first's reset ordering)
+                      can dominate the active from the moment it was left,
+                      and self-improvement against its own departure
+                      baseline never fires for an account that had nothing
+                      to improve on. Same ratio `_no_return_account` and
+                      the ranking's headroom axis (`:1626`) already use.
+          headroom    `+SPENT_HEADROOM_PCT` against the DEPARTURE baseline
+                      — below that an edge is under two poll intervals, the
+                      same reason the spent band exists.
+          recovery    `-RECOVERY_HYSTERESIS_S` against the DEPARTURE
+                      baseline — the same margin the recovery axis ranks by
+                      one gate later.
 
         NO SNAPSHOT MEANS RELEASE. State written before this field existed, or
         by a switch that never recorded one, carries no evidence either way —
@@ -1439,18 +1450,21 @@ class AutoSwitchEngine:
         the key is PRESENT with unknown values, which is real evidence that
         the departure's severity could not be measured, not an absence of
         evidence. `(None, None)` conflates two different peer states, though:
-        "still unmeasurable" (hold) and "measurable again, at/near full" (a
-        real change of state -- release). There is no recorded baseline for
-        either axis to diff against, so the only trustworthy signal is
-        whether the peer is now READABLE and close to full: `h >= 100 -
-        SPENT_HEADROOM_PCT`, the same margin the headroom leg below uses,
-        applied against the 100 cap instead of a stored `left_headroom`. A
-        peer that is readable but still poor (the flap 0b369e0 fixed) does
-        not clear that bar and the hold stands. This only gates the
-        proactive/consume-first return; `_no_return_account` scopes at-limit
-        and failover out of the bar by design, so either trigger still
-        escapes the account untouched, and the next successful switch
-        overwrites the snapshot outright.
+        "still unmeasurable" (hold) and "measurable again, dominant" (a real
+        change of state -- release). There is no recorded baseline for either
+        headroom-vs-departure or recovery-vs-departure to diff against, so
+        beyond the dominance leg above the only trustworthy signal left is
+        whether the peer is still unmeasurable or not yet good enough:
+        neither is release. In particular the headroom leg CANNOT fall back
+        to an absolute floor on the peer alone here — `account_headroom` is
+        `100 - max(pct)`, so any peer that has spent more than
+        `SPENT_HEADROOM_PCT` of its weekly window could never clear a fixed
+        `100 - SPENT_HEADROOM_PCT` bar, no matter how far ahead of the
+        ACTIVE it is; that is exactly the failure the dominance leg exists to
+        catch instead. This only gates the proactive/consume-first return;
+        `_no_return_account` scopes at-limit and failover out of the bar by
+        design, so either trigger still escapes the account untouched, and
+        the next successful switch overwrites the snapshot outright.
         """
         came_from = state.get("lastSwitchFrom")
         if came_from is None:
@@ -1458,21 +1472,37 @@ class AutoSwitchEngine:
         barred = str(came_from)
         if "leftHeadroom" not in state:
             return True          # pre-upgrade record: genuinely no evidence
+        h = headroom.get(barred)
+        # Dominance over the ACTIVE, checked before either baseline-relative
+        # leg below: a peer that was already miles ahead of the active at
+        # departure (moved for a DIFFERENT reason -- e.g. consume-first's
+        # reset ordering, not headroom) never "improves" on its own baseline
+        # and would stall on self-improvement alone despite dominating
+        # throughout. Same ratio `_no_return_account` and the ranking's
+        # headroom axis (`:1626`) already use, so a peer that beats the
+        # active this hard is a move the outbound leg would make on its own
+        # merits regardless of departure history -- and it needs no stored
+        # baseline, so it applies to the failover `(None, None)` case too.
+        if (
+            h is not None
+            and active_headroom is not None
+            and h > active_headroom * HORIZON_HEADROOM_RATIO
+        ):
+            return True
         left_headroom = state.get("leftHeadroom")
         left_recovery = state.get("leftRecoveryAt")
         if left_headroom is None and left_recovery is None:
             # Failover: real departure, severity unmeasured at the time -- not
             # absence of evidence. There is no recorded baseline to diff
-            # against (that is exactly what "unmeasured" means), so the only
-            # trustworthy signal is the peer's OWN headroom now: require it
-            # within SPENT_HEADROOM_PCT of the 100 cap, the margin the
-            # headroom leg below already uses. The recovery leg has no such
-            # floor here -- with no baseline `was` would collapse to `inf`,
-            # which any known reset beats for free, disarming on the first
-            # readable tick regardless of how little recovered. That is the
-            # exact flap 0b369e0 fixed, so recovery sits out this branch.
-            return (headroom.get(barred) or 0.0) >= 100.0 - SPENT_HEADROOM_PCT
-        h = headroom.get(barred)
+            # against (that is exactly what "unmeasured" means) and dominance
+            # was already checked above, so the only thing left is: still
+            # unmeasurable, or not yet good enough. Hold. The recovery leg
+            # has no baseline-relative form here either -- with no baseline
+            # `was` would collapse to `inf`, which any known reset beats for
+            # free, disarming on the first readable tick regardless of how
+            # little recovered. That is the exact flap 0b369e0 fixed, so
+            # recovery sits out this branch.
+            return False
         if (
             isinstance(left_headroom, (int, float))
             and h is not None

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -108,6 +108,7 @@ SPENT_HEADROOM_PCT = 3.0
 
 def _recovery_is_useful(
     candidate_recovery_ts: float,
+    active_recovery_ts: float,
     active_headroom: float,
     best_candidate_headroom: float,
     now: float,
@@ -132,15 +133,51 @@ def _recovery_is_useful(
     nobody qualifies — an active holding more quota than any peer can offer
     should keep the work.
 
+    THE AXIS IS A PROPERTY OF THE PAIR, not of the candidate alone, and that
+    is what stops the two guards leaking into each other. Each anti-flap gate
+    is one-way on its OWN axis — hysteresis on recovery, a ratio on headroom —
+    but a switch swaps which account is "active". Keying the choice on the
+    candidate alone flipped the axis with it, so a pair straddling the horizon
+    took one gate going out and the OTHER coming back, and neither guard ever
+    saw both legs:
+
+        acct 1   8 points, reset 109h out      acct 2   3 points, reset 3.5h out
+        active=1 -> candidate inside  -> recovery: 3.5h < 109h      moves
+        active=2 -> candidate outside -> headroom: 8 >= 3*2         moves back
+
+    Measured: 47 credential rewrites over 3.9h on frozen inputs, ending only
+    when the sooner reset landed. ``either side inside`` is symmetric under
+    that swap, so the axis survives the move and the gate that permitted the
+    outbound leg is the one asked about the return — where hysteresis refuses
+    it, because the account we just left is now the distant one.
+
+    Why EITHER and not BOTH: requiring both would refuse the #202 case this
+    horizon exists to preserve — a weekly-bound active sitting days out while
+    a peer's five-hour window returns in eight minutes. Measured across
+    multiple ticks, both rules were checked against both shapes:
+
+        rule    oscillating pair        #202 pair
+        cand    moves, moves back       moves, moves back   (the bug)
+        both    never moves             never moves         (breaks #202)
+        either  moves, then holds       moves, then holds   (wanted)
+
+    The #202 case oscillated on the original code too — its test ticks once,
+    so it only ever observed the outbound leg.
+
     KNOWN RESIDUE: the step between the two axes is not monotone (2/2/3.0 takes
     the soonest reset, 2/2/3.5 parks). The band is 0.5 points wide at the
     default constants and both outcomes keep a working account. Every fix tried
     re-armed the days-away trade this horizon exists to forbid.
     """
-    return (
+    if (
         active_headroom <= SPENT_HEADROOM_PCT
         and best_candidate_headroom <= SPENT_HEADROOM_PCT
-    ) or candidate_recovery_ts - now <= RECOVERY_HORIZON_S
+    ):
+        return True
+    return (
+        candidate_recovery_ts - now <= RECOVERY_HORIZON_S
+        or active_recovery_ts - now <= RECOVERY_HORIZON_S
+    )
 
 
 # Adaptive scheduling: the baseline request volume is O(1) per tick — the
@@ -1271,6 +1308,7 @@ class AutoSwitchEngine:
                     # condition, so it is always assigned before the key below.
                     by_recovery = _recovery_is_useful(
                         recovery_ts,
+                        active_recovery_ts,
                         active_headroom or 0.0,
                         best_candidate_headroom,
                         now,

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -100,23 +100,18 @@ RECOVERY_HORIZON_S = 4 * 3600.0
 HORIZON_HEADROOM_RATIO = 2.0
 
 # "Is anything worth having?" — a DIFFERENT question from the anti-flap margin
-# above, and it needs its own number. Reusing HORIZON_HEADROOM_RATIO for both
-# excluded peers that plainly have quota: at 2x-minus-epsilon a peer is very
-# much worth having, it merely fails this tick's margin. With every candidate
-# below that floor `max(..., default=0.0)` yields 0.0, which SATISFIES the
-# spent clause — so the clause fired for everybody and ranking fell to soonest
-# reset regardless of headroom. Measured: active 3.00 pts, peerA 5.99, peerB
-# 0.10 -> took peerB, discarding 60x the runway.
+# above, and lower, because it is weaker: not "is this peer enough better to
+# justify a move?" but "does this peer have anything at all?"
 #
-# Lower than the margin because it answers a weaker question: not "is this peer
-# enough better to justify a move?" but "does this peer have anything at all?"
-#
-# KNOWN RESIDUE, and it is structural rather than a bad constant. This floor and
-# HORIZON_HEADROOM_RATIO are both anchored to `active_headroom`, so they leave a
-# gap: a peer between them is VISIBLE (the spent clause goes false, the reset
-# axis switches off) yet UNCHOOSABLE (it misses the larger margin). Monotonicity
-# inverts there — adding headroom flips a move into a refusal. Measured, active
-# 3.00 pts / 500h against ONE peer better on BOTH axes:
+# BOTH ARE ANCHORED TO `active_headroom`, and that is the defect neither number
+# can fix. They leave a gap where a peer is VISIBLE (the spent clause goes
+# false, so the reset axis switches off) yet UNCHOOSABLE (it misses the larger
+# margin) — and either end of the gap is a real misbehaviour. Below it, an
+# empty `max(..., default=0.0)` reads as "nothing is worth having" and ranking
+# falls to soonest reset: measured, active 3.00 pts took a 0.10-pt peer over a
+# 5.99-pt one, discarding 60x the runway. Inside it, monotonicity inverts —
+# adding headroom flips a move into a refusal. Measured, active 3.00 pts / 500h
+# against ONE peer better on BOTH axes:
 #
 #     peer pts   3.88   3.90   4.50   5.99   6.00
 #     base       move   move   move   move   move

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -91,8 +91,12 @@ RECOVERY_HYSTERESIS_S = 300.0
 
 # Horizon past which a sooner reset stops being worth real headroom. The escape
 # above was measured on minutes-scale resets; days-scale is the opposite trade,
-# since neither account returns within the session. 4h covers a whole 5-hour
-# cycle, so same-day resets keep the recovery ranking.
+# since neither account returns within the session. 4h keeps most of a 5-hour
+# cycle on the recovery ranking: a 5h window can be up to 5h from resetting, so
+# a peer bound by one that is 4h-5h out falls back to headroom ranking instead.
+# Deliberately the conservative side of that boundary -- ranking by headroom
+# where the reset is still an hour away costs at most one extra move, while a
+# wider horizon would rank by a reset the session may never see.
 RECOVERY_HORIZON_S = 4 * 3600.0
 
 # Anti-flap margin on the headroom axis, as a RATIO rather than percentage
@@ -1124,6 +1128,7 @@ class AutoSwitchEngine:
                 kw["active_headroom"],
                 recovered,
                 kw["settings"],
+                kw["current"],
             )
             ranked = self._rank_candidates(no_return=no_return, **kw)
             if no_return is not None and not ranked[0] and recovered:
@@ -1331,6 +1336,7 @@ class AutoSwitchEngine:
         active_headroom: float | None,
         recovered: bool,
         settings: AutoSwitchSettings,
+        current: str | None = None,
     ) -> str | None:
         """The account this engine most recently left, while it is still barred.
 
@@ -1345,6 +1351,24 @@ class AutoSwitchEngine:
         SCOPED like every sibling gate — `at-limit` and `failover` skip the
         anti-flap gates by design. Unscoped this stranded a 2-account fleet on
         an exhausted active with the peer at 0%.
+
+        AND SCOPED TO THE ENGINE'S OWN LANDING (`lastSwitchTo == current`).
+        The bar refuses to undo THIS ENGINE'S last move; once the user
+        switches by hand the engine is no longer sitting where it put itself
+        and that move is already undone, so the bar protects nothing and
+        merely withholds the fleet's best account. Reproduced: engine 1 -> 2,
+        user 2 -> 3 by hand, account 1 on 4 pts still barred against an
+        active on 2, every reset far out, no release leg reachable — the
+        `not recovered` return below fires before the ratio leg is read, and
+        `recovered` is False because account 1 was 4 pts at departure too.
+        The engine then holds the worse account until the at-limit escape.
+        Both sides are `str`-normalised: `lastSwitchTo` is a `str` from
+        `_perform` and `lastSwitchFrom` an `int` from `account_ref`. A state
+        record written before `lastSwitchTo` existed has no such key and
+        cannot prove the engine moved away, so it KEEPS the bar — the same
+        conservative reading this module gives every other missing field, and
+        the only one that does not silently drop the anti-flap bound for an
+        upgrade cycle.
 
         RELEASED when the account we left now beats us by the same ratio the
         anti-flap margin uses: that is not the flip this bars, it is a move the
@@ -1392,6 +1416,16 @@ class AutoSwitchEngine:
         came_from = state.get("lastSwitchFrom")
         if trigger not in ("proactive", "consume-first") or came_from is None:
             return None
+        # Only while we are still standing where that switch put us. A manual
+        # switch away already undid the move, so there is nothing left to
+        # refuse to undo. `str` on both sides: `lastSwitchTo` is written from
+        # `_perform`'s `number: str`, `lastSwitchFrom` from `account_ref`'s
+        # `number: int`, and an int/str mismatch here would disarm the bar
+        # everywhere rather than only after a hand switch.
+        landed_on = state.get("lastSwitchTo")
+        if landed_on is not None and current is not None:
+            if str(landed_on) != str(current):
+                return None
         # No membership check on `oauth_candidates`: the loop compares
         # `num == no_return` while iterating that same list, so naming an
         # account that is not in it bars nothing. The check was a no-op and
@@ -1408,10 +1442,10 @@ class AutoSwitchEngine:
                 settings is not None
                 and left_headroom > 100.0 - settings.threshold
             ):
-                # F6 (round-6 review): an unreadable active must not be
-                # silently scored as "the peer does not beat it" -- same
-                # landing-eligible fallback `_left_account_recovered` uses
-                # when it, too, has no active to compare against.
+                # An unreadable active must not be silently scored as "the
+                # peer does not beat it" -- same landing-eligible fallback
+                # `_left_account_recovered` uses when it, too, has no active
+                # to compare against.
                 return None
         return barred
 
@@ -1441,11 +1475,11 @@ class AutoSwitchEngine:
         target that did nothing.
 
         FAILOVER FIRST, before any leg reads the active — checked ahead of
-        dominance because round 5 put dominance first and it starved this
-        branch: `test_a_failover_departure_does_not_disarm_the_bar` broke on
-        its FIRST tick the instant the active fell far enough for `4.0 >
-        active x 2` to go true (measured at active=1.8, one fifth of a point
-        past the boundary this branch's own sibling test already sits on).
+        dominance, because dominance-first starves this branch:
+        `test_a_failover_departure_does_not_disarm_the_bar` broke on its
+        FIRST tick the instant the active fell far enough for `4.0 > active
+        x 2` to go true (measured at active=1.8, one fifth of a point past
+        the boundary this branch's own sibling test already sits on).
         A `(None, None)` snapshot means severity was genuinely unmeasured at
         departure — there is no `leftHeadroom` to diff against and never was
         — so the two signals that do not depend on the active's LIVE state
@@ -1454,30 +1488,30 @@ class AutoSwitchEngine:
         accept this as a landing spot" test `_rank_candidates` already runs
         (`:1617`) on every candidate, reused rather than inventing a fresh
         constant; and (2), when the landing floor cannot answer, whether the
-        peer's own binding reset is meaningfully sooner than the active's
-        (C1, round-6 review). The landing floor is the exact complement of
-        `_every_account_above_threshold`, so it is UNSATISFIABLE whenever the
+        peer's own binding reset is meaningfully sooner than the active's.
+        The landing floor is the exact complement of
+        `_every_account_above_threshold`, so it is UNSATISFIABLE whenever
+        the
         fleet is all-spent — the recovery leg is what keeps the hold from
         becoming unconditional in exactly that regime. Neither leg can tell
         "genuinely recovered" from "was already this good" — there is
-        nothing recorded to tell them apart — so R-A and R-B collapse onto
-        the same answer here. Measured which side the landing floor should
-        land on: MREL-sweeping this same leg for the ordinary path (round 5
-        review, F3) showed an absolute floor is silently reintroducible with
-        a green suite, so this is not free of that risk either — the
+        nothing recorded to tell them apart. Measured which side the landing
+        floor should land on: sweeping mutations of this same leg for the
+        ordinary path showed an absolute floor is silently reintroducible
+        with a green suite, so this is not free of that risk either — the
         difference is this constant is `settings.threshold`, not a
-        hardcoded number, so a user's OWN policy decides how conservative
-        the hold is, and it moves when they change it (pinned directly,
-        below). Deliberately MORE conservative than the ordinary path below:
-        a peer sitting at 4 points held through the whole walk that broke
-        round 5's dominance leg, with no upper bound short of the peer
-        crossing the threshold itself OR its binding reset pulling
-        meaningfully ahead of the active's. Bounded, not permanent —
-        at-limit still escapes untouched (`_no_return_account` scopes this
-        trigger out entirely), and the recovery leg means the bound is no
-        longer just "the active reaches its own hard limit" (round-6
-        review, C1/M4): a peer that resets first releases the hold on its
-        own schedule, without the active ever needing to burn down to it.
+        hardcoded number, so a
+        user's OWN policy decides how conservative the hold is, and it moves
+        when they change it (pinned directly, below). Deliberately MORE
+        conservative than the ordinary path below: a peer sitting at 4 points
+        held through the whole walk that broke a bare dominance leg, with no
+        upper bound short of the peer crossing the threshold itself OR its
+        binding reset pulling meaningfully ahead of the active's. Bounded,
+        not permanent — at-limit still escapes untouched
+        (`_no_return_account` scopes this trigger out entirely), and the
+        recovery leg means the bound is no longer just "the active reaches
+        its own hard limit": a peer that resets first releases the hold on
+        its own schedule, without the active ever needing to burn down to it.
 
         THE ORDINARY PATH HAS A REAL BASELINE (`leftHeadroom` is a number,
         not null), so it gets three legs, checked in this order, each with
@@ -1494,9 +1528,9 @@ class AutoSwitchEngine:
                       was left, and self-improvement against its own
                       departure baseline never fires for an account that had
                       nothing to improve on. The `+SPENT_HEADROOM_PCT` on top
-                      of the bare ratio is what round 5 was missing: measured
-                      on the branch's own flap fleet (peer frozen 4.0 pts,
-                      active burning 98.0% -> 98.4%), the bare ratio flips
+                      of the bare ratio is what the bare ratio misses:
+                      measured on this branch's own flap fleet (peer frozen
+                      4.0 pts, active burning 98.0% -> 98.4%), it flips
                       true at active=1.8 pts purely because the active kept
                       burning; the same walk with the margin added stays
                       false through active=1.6 and only opens once the active
@@ -1524,11 +1558,11 @@ class AutoSwitchEngine:
         """
         came_from = state.get("lastSwitchFrom")
         if came_from is None:
-            # M2 (round-6 review): this return value is unreachable through
-            # `_no_return_account`, the only caller -- it returns `None` at
-            # its own `came_from is None` check before `recovered` is ever
-            # read. Kept `True` (not load-bearing) so a future direct caller
-            # gets "no evidence, release" rather than a silent hold.
+            # Unreachable through `_no_return_account`, the only caller: it
+            # returns `None` at its own `came_from is None` check before
+            # `recovered` is ever read. Kept `True` (not load-bearing) so a
+            # future direct caller gets "no evidence, release" rather than a
+            # silent hold.
             return True
         barred = str(came_from)
         if "leftHeadroom" not in state:
@@ -1536,10 +1570,10 @@ class AutoSwitchEngine:
         h = headroom.get(barred)
         left_headroom = state.get("leftHeadroom")
         left_recovery = state.get("leftRecoveryAt")
-        # I-B (R8 review): a `consume-first` departure can ALSO write
-        # (None, None) -- the same shape a real failover writes -- whenever
-        # the phase-2 refetch's active row is unmeasurable for headroom but
-        # still has a known weekly reset (the split shape `oauth.
+        # A `consume-first` departure can ALSO write (None, None) -- the
+        # same shape a real failover writes -- whenever the phase-2 refetch's
+        # active row is unmeasurable for headroom but still has a known
+        # weekly reset (the split shape `oauth.
         # build_usage_result` emits for `utilization: null` plus a
         # `resets_at`). Inferring "failover" from the two nulls then ran the
         # more permissive failover legs (landing floor + recovery-only) on
@@ -1560,9 +1594,9 @@ class AutoSwitchEngine:
             # not absence of evidence, and there is no baseline to diff
             # against (that is exactly what "unmeasured" means), so this
             # cannot use the active's HEADROOM at all -- see docstring for
-            # why that is what round 5 got wrong and the walk that proved
-            # it. Two legs, both read-only against CURRENT state (no
-            # departure baseline exists to diff against):
+            # why reading the active's headroom here is wrong, and the walk
+            # that proved it. Two legs, both read-only against CURRENT state
+            # (no departure baseline exists to diff against):
             #
             #   landing   `h > 100 - settings.threshold` -- would the
             #             ranking accept this peer as a landing spot right
@@ -1572,16 +1606,16 @@ class AutoSwitchEngine:
             #             `_recovery_is_useful` switches to once headroom
             #             stops being informative. Needed because `landing`
             #             is the exact complement of `_every_account_above_
-            #             threshold` (C1, round-6 review): whenever the
-            #             fleet is all-spent, `landing` is unsatisfiable by
-            #             construction, no matter how soon the peer's own
+            #             threshold`: whenever the fleet is all-spent,
+            #             `landing` is unsatisfiable by construction, no
+            #             matter how soon the peer's own
             #             window resets, and that regime is precisely where
             #             the recovery axis is the one the engine trusts.
             #
             # Burn cannot fake the recovery leg: a reset moves nearer only
             # when a nearer window starts binding, never as a side effect
-            # of the active spending down (round 5's failure mode, guarded
-            # against directly by `MF-round5` in the mutation table).
+            # of the active spending down -- the failure mode a bare
+            # dominance leg has, guarded directly in the mutation table.
             if h is not None and h > 100.0 - settings.threshold:
                 return True
             peer_recovery_ts = _binding_recovery_ts(usage.get(barred), self._models, now)
@@ -1592,20 +1626,20 @@ class AutoSwitchEngine:
             # `resets_at`, or a stale/past `resets_at`). Reading `inf` as
             # "never" here made `peer < inf - HYST` true for ANY finite
             # peer reset, releasing onto a peer arbitrarily far out on no
-            # evidence (R7 review, C-1). `math.isfinite` requires the
-            # active to have a genuine, known reset before the comparison
-            # even runs -- unknown holds, exactly like unreadable already
-            # does on the headroom axis (F6).
+            # evidence. `math.isfinite` requires the active to have a
+            # genuine, known reset before the comparison even runs --
+            # unknown holds, exactly like unreadable already does on the
+            # headroom axis.
             #
             # But two of the five `inf` states are ordinary shapes for an
             # active that is plainly alive and burning -- a `pct` reported
             # with no `resets_at`, or a `resets_at` already elapsed -- not
-            # unknowns (R8 review, I-A). Reading all five as "unknown, hold"
-            # pins the engine on a near-spent active for up to a full window
-            # even when the peer is back within `RECOVERY_HORIZON_S`, the
+            # unknowns. Reading all five as "unknown, hold" pins the engine
+            # on a near-spent active for up to a full window even when the
+            # peer is back within `RECOVERY_HORIZON_S`, the
             # same constant this PR already uses for "near enough to
             # matter" (`_recovery_is_useful`). Requiring EITHER a known
-            # active reset OR a peer inside that horizon keeps C-1's
+            # active reset OR a peer inside that horizon keeps `isfinite`'s
             # intended release (a known active vs. an arbitrarily-far peer
             # still needs `isfinite`) while letting a near peer through
             # regardless of why the active's own reset reads `inf`.
@@ -1623,9 +1657,9 @@ class AutoSwitchEngine:
         # its own baseline and would stall on self-improvement alone despite
         # dominating throughout.
         #
-        # `active_headroom is None` (F6, round-6 review) means "we could not
-        # read the active this tick" -- reachable through the consume-first
-        # two-phase commit, which reassigns `active_headroom` from a fresh
+        # `active_headroom is None` means "we could not read the active this
+        # tick" -- reachable through the consume-first two-phase commit,
+        # which reassigns `active_headroom` from a fresh
         # refetch without re-classifying the trigger. That is a DIFFERENT
         # state from "readable, but does not dominate" and must not answer
         # the same way: fall back to the landing-eligible test the failover
@@ -1633,8 +1667,8 @@ class AutoSwitchEngine:
         # either, rather than silently treating "unreadable" as "no
         # dominance".
         #
-        # DEFENSIVE, not currently outcome-changing (I-2, R7 review):
-        # measured exhaustively, `active_headroom=None` on this path closes
+        # DEFENSIVE, not currently outcome-changing: measured exhaustively,
+        # `active_headroom=None` on this path closes
         # BOTH of `_rank_candidates`'s gates before this leg is ever asked
         # (`_every_account_above_threshold` is False on a None active, and
         # the consume-first `active_reset_ts` gate is None too), so no
@@ -1642,7 +1676,8 @@ class AutoSwitchEngine:
         # outcome. Kept because the call IS reachable (confirmed via the
         # phase-2 refetch) and a future change to those gates could make it
         # live without anyone revisiting this function -- silently reading
-        # None as "no dominance" would then be exactly F6's original bug.
+        # None as "no dominance" would then be exactly the bug the
+        # unreadable-active fallback was added for.
         if h is not None:
             if active_headroom is not None:
                 if h > active_headroom * HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT:
@@ -2062,10 +2097,10 @@ class AutoSwitchEngine:
             state["lastSwitchFrom"] = (result.get("from") or {}).get("number")
             state["leftHeadroom"], recovery = left
             state["leftRecoveryAt"] = None if recovery == float("inf") else recovery
-            # I-B (R8 review): a `consume-first` phase-2 refetch can write the
-            # SAME (None, None) shape a `failover` departure writes, whenever
-            # the refetched active row has a `pct` but is otherwise
-            # unmeasurable in the same tick its weekly reset is known --
+            # A `consume-first` phase-2 refetch can write the SAME (None,
+            # None) shape a `failover` departure writes, whenever the
+            # refetched active row has a `pct` but is otherwise unmeasurable
+            # in the same tick its weekly reset is known --
             # `account_headroom` needs a numeric `pct`, `_seven_day_reset_ts`
             # needs only `resets_at`. Inferring the trigger from the two
             # nulls then runs the wrong legs. Record it directly so the

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1660,16 +1660,7 @@ class AutoSwitchEngine:
             state["lastSwitchAt"] = self.clock()
             state["lastSwitchTo"] = number
             # WHERE we came from, so the next tick can refuse to undo this.
-            # Each anti-flap gate is one-way on its own axis, but burn moves a
-            # pair across `SPENT_HEADROOM_PCT` and the axis changes with it —
-            # measured, both resets past the horizon, only the active burning:
-            #
-            #     t8   1->2  headroom axis   active 4.0 / best 8.0
-            #     t20  2->1  headroom axis   active 2.0 / best 4.0
-            #     t22  1->2  recovery axis   active 3.0 / best 2.0
-            #
-            # so the move sequence was [1, 2, 1, 2] where base makes one move.
-            # Nothing bounded how many times the pair could cross.
+            # See the filter in `_tick_inner` for why.
             state["lastSwitchFrom"] = (result.get("from") or {}).get("number")
             atomic_write_json(self.state_path, state)
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1053,8 +1053,20 @@ class AutoSwitchEngine:
         # releases the previous one. This bounds the direction, not the rate:
         # the cooldown already bounds the rate, and it had lapsed at every one
         # of the moves above (301s ticks against a 300s cooldown).
+        # SCOPED like every sibling gate. `at-limit` and `failover` skip the
+        # anti-flap gates by design — there we are escaping a dead account, not
+        # optimising a return time. Unscoped this stranded a 2-account fleet on
+        # an exhausted active with the peer at 0% quota, emitting
+        # "no-candidates" every tick with nothing to release it (the field is
+        # rewritten only by a successful switch, and the field is what prevents
+        # the switch), and on 3 accounts it raised a false AllExhaustedEvent
+        # that reaches the user as a notification and a critical TUI row.
         came_from = state.get("lastSwitchFrom")
-        if came_from is not None and str(came_from) in oauth_candidates:
+        if (
+            trigger in ("proactive", "consume-first")
+            and came_from is not None
+            and str(came_from) in oauth_candidates
+        ):
             oauth_candidates = [n for n in oauth_candidates if n != str(came_from)]
         api_key_candidates = (
             [n for n in candidates if self.switcher.account_kind_for(n) == "api_key"]

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -99,6 +99,19 @@ RECOVERY_HORIZON_S = 4 * 3600.0
 # target burns it back, and it ping-pongs. A ratio makes the move one-way.
 HORIZON_HEADROOM_RATIO = 2.0
 
+# "Is anything worth having?" — a DIFFERENT question from the anti-flap margin
+# above, and it needs its own number. Reusing HORIZON_HEADROOM_RATIO for both
+# excluded peers that plainly have quota: at 2x-minus-epsilon a peer is very
+# much worth having, it merely fails this tick's margin. With every candidate
+# below that floor `max(..., default=0.0)` yields 0.0, which SATISFIES the
+# spent clause — so the clause fired for everybody and ranking fell to soonest
+# reset regardless of headroom. Measured: active 3.00 pts, peerA 5.99, peerB
+# 0.10 -> took peerB, discarding 60x the runway.
+#
+# Lower than the margin because it answers a weaker question: not "is this peer
+# enough better to justify a move?" but "does this peer have anything at all?"
+WORTH_HAVING_RATIO = 1.3
+
 # Below this an account is spent, and headroom comparisons between two spent
 # accounts compare noise (a point is under ten minutes of work, less than two
 # poll intervals). When EVERY candidate is down here, rank by reset instead —
@@ -1260,9 +1273,11 @@ class AutoSwitchEngine:
         # blocked. The band is (SPENT_HEADROOM_PCT, active x RATIO], up to 3
         # points wide at the defaults.
         #
-        # A candidate below the ratio cannot win the headroom axis, so counting
-        # it here only ever suppresses the OTHER axis on its behalf.
-        _ratio_floor = (active_headroom or 0.0) * HORIZON_HEADROOM_RATIO
+        # Scoped by WORTH_HAVING_RATIO, not the anti-flap margin. Using the
+        # margin here excluded peers that plainly have quota and emptied the
+        # max, and an empty max reads as "nothing is worth having" — the exact
+        # opposite of what a 5.99-point peer means. See the constant.
+        _ratio_floor = (active_headroom or 0.0) * WORTH_HAVING_RATIO
         best_candidate_headroom = max(
             (
                 h

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -110,6 +110,34 @@ HORIZON_HEADROOM_RATIO = 2.0
 #
 # Lower than the margin because it answers a weaker question: not "is this peer
 # enough better to justify a move?" but "does this peer have anything at all?"
+#
+# KNOWN RESIDUE, and it is structural rather than a bad constant. This floor and
+# HORIZON_HEADROOM_RATIO are both anchored to `active_headroom`, so they leave a
+# gap: a peer between them is VISIBLE (the spent clause goes false, the reset
+# axis switches off) yet UNCHOOSABLE (it misses the larger margin). Monotonicity
+# inverts there — adding headroom flips a move into a refusal. Measured, active
+# 3.00 pts / 500h against ONE peer better on BOTH axes:
+#
+#     peer pts   3.88   3.90   4.50   5.99   6.00
+#     base       move   move   move   move   move
+#     0457cb0    REF    REF    REF    REF    move
+#     db25990    move   move   move   move   move
+#     here       move   REF    REF    REF    move
+#
+# The two bands trade against each other and their widths sum to a constant
+# (`active x HORIZON_HEADROOM_RATIO - SPENT_HEADROOM_PCT`), so no value of this
+# ratio removes both: 1.0 empties this band and re-arms the veto the filter
+# exists to stop, 2.0 does the reverse. Measured, not argued.
+#
+# Two fixes were tried and BOTH measured worse than shipping the residue.
+# Making the floor absolute (`> SPENT_HEADROOM_PCT`, fleet-wide rather than
+# relative) leaves the band at 2 of 5 points AND breaks
+# `test_an_unchoosable_peer_does_not_veto_the_reset_ranking`. Dropping the
+# filter entirely returns to `db25990`, which is the veto this PR fixed.
+#
+# The real fix decouples the two axes rather than retuning a constant, and that
+# is a redesign of the ranking rather than a bound on it. Recorded here so the
+# next reader starts from the measurement instead of the constant.
 WORTH_HAVING_RATIO = 1.3
 
 # Below this an account is spent, and headroom comparisons between two spent

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1342,7 +1342,22 @@ class AutoSwitchEngine:
             and left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO
         ):
             return None                      # beats us outright; not a flip
-        if all(n == barred for n in oauth_candidates):
+        # CHOOSABLE, not merely present. `all(n == barred ...)` asked whether
+        # any OTHER account exists — and a third account that exists but can
+        # never qualify (spent, or headroom unknown) answered yes while
+        # offering the ranking nothing. Measured, one ordinary proactive move
+        # and no seeded state: active on 2 pts, the barred peer on 3, a third
+        # at its limit — 30 ticks / 30h all BLOCKED, and the same fleet with
+        # the bar cleared switches on the first one. The n=2 stall the release
+        # was added for simply moved to n>=3.
+        #
+        # A candidate the loop would skip anyway (`h is None` or `h <= 0`) is
+        # not an alternative, so barring on its account is still barring on
+        # nothing.
+        if not any(
+            n != barred and (headroom.get(n) or 0.0) > 0.0
+            for n in oauth_candidates
+        ):
             return None                      # barring it leaves nothing
         return barred
 
@@ -1387,27 +1402,26 @@ class AutoSwitchEngine:
         all_above = _every_account_above_threshold(
             oauth_candidates, headroom, active_headroom, settings.threshold
         )
-        # The most headroom any candidate the ranking could ACTUALLY CHOOSE
-        # offers — "is there anything worth having?" Unknown headrooms are
-        # excluded rather than counted as zero: a row we cannot read is not
-        # evidence of an empty account.
+        # "Is anything worth having?" — the most headroom any candidate with a
+        # READABLE row offers. Two exclusions and no others:
         #
-        # Scoped to choosable candidates, not all of them. A peer 0.05 points
-        # above SPENT_HEADROOM_PCT answers "yes, something is worth having" and
-        # so turns the spent check off for EVERYBODY — while being unchoosable
-        # itself, because it does not meet HORIZON_HEADROOM_RATIO against the
-        # active. Nothing then qualifies and the engine parks on the account
-        # that returns LAST. Measured: active 3.00 pts/200h, peer 3.00 pts/10h,
-        # vetoer 3.05 pts/500h -> base switches to the 10h peer, this branch
-        # blocked. The band is (SPENT_HEADROOM_PCT, active x RATIO], up to 3
-        # points wide at the defaults.
-        #
-        # Every candidate whose headroom is KNOWN, unfiltered. An unknown one
-        # is not evidence that somebody has quota left — measured, one
+        # Unknown headrooms are skipped rather than counted as zero. A row we
+        # cannot read is not evidence of an empty account — measured, one
         # sentinel row (expired token, locked keychain) made `all(...)` False
-        # forever and parked the engine on the account resetting LAST. A ratio
-        # floor used to sit here too and inverted monotonicity; the fallback
-        # below is what lets it go.
+        # forever and parked the engine on the account resetting LAST.
+        #
+        # Nothing else is filtered, INCLUDING the no-return bar. An earlier
+        # version of this comment claimed it was "scoped to choosable
+        # candidates"; the code below has never done that and the two
+        # paragraphs contradicted each other. Leaving the barred account in is
+        # deliberate: this answers whether the FLEET has quota, and the bar is
+        # about which account to move to, not about what exists. A peer just
+        # above SPENT_HEADROOM_PCT can therefore turn the spent check off while
+        # being unchoosable itself — the band is (SPENT_HEADROOM_PCT, active x
+        # RATIO], up to 3 points wide at the defaults, and the one-way fallback
+        # below is what stops that band parking the engine. A ratio floor used
+        # to sit here too and inverted monotonicity; removing it is what let
+        # the fallback do the job.
         best_candidate_headroom = max(
             (
                 h

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -88,6 +88,18 @@ IDLE_HOLD_MAX_S = 30 * 60.0
 # it needs its own unit rather than a reused one.
 RECOVERY_HYSTERESIS_S = 300.0
 
+# Horizon past which "soonest recovery" stops being worth real headroom.
+# The escape above was measured on minutes-scale resets (#202: a peer back in
+# 8 minutes), where waiting is plainly better than burning the last of the
+# active account. Days-scale is the opposite trade: measured live at active
+# 91% / 109h against 98% / 50h, the engine moved from 9 points of headroom to
+# 2, and neither account returns within the session either way — so the 9
+# points were the only resource that could still do work. Past this bound,
+# ranking falls back to headroom, which is what decides whether work
+# continues when nobody comes back soon. 4h covers a 5-hour window's whole
+# cycle, so same-day resets keep the recovery ranking.
+RECOVERY_HORIZON_S = 4 * 3600.0
+
 # Adaptive scheduling: the baseline request volume is O(1) per tick — the
 # active account plus ONE due candidate (stalest data first) — instead of
 # every account in parallel, and the per-account cadence itself (movement,
@@ -1158,6 +1170,17 @@ class AutoSwitchEngine:
             if all_above
             else 0.0  # unread unless all_above; never a live sentinel
         )
+        # Past the horizon, "soonest" buys nothing real: keep the escape (the
+        # landing-health gate has no other answer when everything is above the
+        # line) but rank by headroom instead of recovery. An UNKNOWN recovery
+        # (inf) is not "past the horizon" — it is no evidence at all, and the
+        # pre-existing rule is that a candidate over the threshold must not be
+        # landed on without it. Treat it as the recovery axis so that gate
+        # keeps deciding. See RECOVERY_HORIZON_S.
+        recovery_useful = all_above and (
+            active_recovery_ts == float("inf")
+            or active_recovery_ts - now <= RECOVERY_HORIZON_S
+        )
         qualifying: list[tuple[tuple, str]] = []
         any_known = False
         for num in oauth_candidates:
@@ -1202,7 +1225,14 @@ class AutoSwitchEngine:
                     # prevent is still prevented: the target must come back
                     # meaningfully sooner than where we are, so the reverse move
                     # never qualifies.
-                    if recovery_ts >= active_recovery_ts - RECOVERY_HYSTERESIS_S:
+                    if (
+                        recovery_useful
+                        and recovery_ts >= active_recovery_ts - RECOVERY_HYSTERESIS_S
+                    ):
+                        continue
+                    if not recovery_useful and h <= (active_headroom or 0.0):
+                        # Headroom axis instead: only move to strictly more
+                        # quota than we hold, so this cannot flap either.
                         continue
                 elif consume_first:
                     # Purely proactive on reset ordering: below the threshold,
@@ -1221,7 +1251,7 @@ class AutoSwitchEngine:
                     # qualifies; near-line pairs can't flap back).
                     if h - active_headroom < settings.hysteresis_pct:
                         continue
-            if all_above and trigger in ("proactive", "consume-first"):
+            if recovery_useful and trigger in ("proactive", "consume-first"):
                 # Soonest BINDING recovery first — the window actually holding
                 # this account back, not the weekly one. With everything in the
                 # 90s the only thing worth optimizing is how long until work can

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -211,6 +211,19 @@ def _recovery_is_useful(
         active_headroom <= SPENT_HEADROOM_PCT
         and best_candidate_headroom <= SPENT_HEADROOM_PCT
     ):
+        # The axis CAN change as the fleet burns, and that is not a leak.
+        # Measured, only the active burning, both resets past the horizon:
+        #
+        #     out    active 2.0 / peer 4.0   headroom axis, ratio 4.0 >= 2.0x2
+        #     back   active 3.0 / peer 2.0   recovery  axis, 10h vs 80h
+        #
+        # Each leg is legitimate on the axis its own state selects: at the
+        # first the fleet still held real headroom, by the second every
+        # account is spent, which is the regime the reset axis exists for.
+        # 21 of 576 burn walks make that transition and read as A-B-A;
+        # constraining either gate to stop them (candidate-spent on the
+        # fallback, `max`/`min` over the pair here) changes the count by 0,
+        # because the transition is in the DATA rather than in the gates.
         return True
     return (
         candidate_recovery_ts - now <= RECOVERY_HORIZON_S

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -201,10 +201,9 @@ def _recovery_is_useful(
         #     out    active 2.0 / peer 4.0   headroom axis, 4.0 >= 2.0x2
         #     back   active 3.0 / peer 2.0   recovery  axis, 10h vs 80h
         #
-        # Each leg is legitimate on the axis its own state selects. 21 of 576
-        # burn walks make that transition and read as A-B-A; constraining
-        # either gate changes the count by 0, because the transition is in the
-        # DATA rather than in the gates.
+        # Each leg is legitimate on the axis its own state selects, and the
+        # transition is in the DATA rather than in the gates: constraining
+        # either gate does not remove it.
         return True
     return (
         candidate_recovery_ts - now <= RECOVERY_HORIZON_S
@@ -1019,65 +1018,10 @@ class AutoSwitchEngine:
         oauth_candidates = [
             n for n in candidates if self.switcher.account_kind_for(n) != "api_key"
         ]
-        # NEVER UNDO THE PREVIOUS MOVE. Each anti-flap gate is one-way on its
-        # own axis, but the axis is a property of the pair's STATE and burn
-        # changes that state: the ratio gate is relative (`h >= active x 2`)
-        # and the spent gate absolute (`active <= 3.0`), so a burning pair
-        # crosses the boundary repeatedly and each crossing re-opens a move.
-        # Measured, both resets past the horizon, only the active burning:
-        #
-        #     t8   1->2  headroom axis   active 4.0 / best 8.0
-        #     t20  2->1  headroom axis   active 2.0 / best 4.0
-        #     t22  1->2  recovery axis   active 3.0 / best 2.0
-        #
-        # move sequence [1, 2, 1, 2] where base makes one move. Nothing
-        # bounded how many crossings could happen.
-        #
-        # Only the account we left LAST, and only until we move again — so a
-        # three-account fleet still reaches every peer, and any later move
-        # releases the previous one. This bounds the direction, not the rate:
-        # the cooldown already bounds the rate, and it had lapsed at every one
-        # of the moves above (301s ticks against a 300s cooldown).
-        # SCOPED like every sibling gate: `at-limit` and `failover` skip the
-        # anti-flap gates by design. Unscoped this stranded a 2-account fleet
-        # on an exhausted active with the peer at 0%, "no-candidates" every
-        # tick, with nothing able to release it.
-        #
-        # AND IT NEEDS A RELEASE CONDITION. Identity alone has none: on a
-        # 2-account fleet the filter removes the only candidate, and
-        # `lastSwitchFrom` is rewritten ONLY by a successful switch — the very
-        # switch it prevents. Measured, reached by one ordinary proactive move
-        # and no seeded state: the peer resets to 0%, the active burns to 97%,
-        # and 20 ticks / 10h answer "no-candidates". Persisted, so it survives
-        # a restart and a week of wall clock. The engine then escapes only at a
-        # hard 100% — the proactive feature off, on the fleet size that has
-        # nowhere else to go.
-        #
-        # Released by the SAME ratio the anti-flap margin uses. The filter
-        # exists to stop a flip undoing the move before it; a peer that now
-        # beats us by 2x is not that flip, it is a move the outbound leg would
-        # have made on its own merits. One-way stays one-way: the margin is
-        # what makes it so, and re-using it keeps the release from becoming a
-        # second, looser threshold that has to be reasoned about separately.
-        # NOT REMOVED FROM THE LIST — barred from being CHOSEN. Removing it
-        # made eight downstream consumers believe the account does not exist:
-        # `truly_exhausted` (a peer holding 15 points produced
-        # AllExhaustedEvent, a macOS notification and a critical TUI row),
-        # `not oauth_candidates` -> "no candidates at all" with a stretched
-        # poll interval, `_every_account_above_threshold` (a hidden
-        # below-threshold peer flipped `all_above` and switched the whole
-        # ranking axis), `best_candidate_headroom`, and `any_known` ->
-        # "no candidate has readable usage", which was false.
-        #
-        # The filter's job is "do not go back to the account we just left".
-        # That is a statement about the CHOICE, and it belongs where the
-        # choice is made — `_rank_candidates` — not in the census of what
-        # exists. Measured before this move: disabling the filter entirely
-        # left the full suite green, because both its tests only exercised
-        # the released branch.
-        no_return = self._no_return_account(
-            trigger, state, headroom, active_headroom, oauth_candidates
-        )
+        # The no-return bar itself lives in `_rank` below: it is a statement
+        # about the CHOICE, so it belongs where the choice is made rather than
+        # in this census of what exists. See `_no_return_account` for the
+        # incident, the scoping, and the release.
         api_key_candidates = (
             [n for n in candidates if self.switcher.account_kind_for(n) == "api_key"]
             if settings.include_api_key_accounts
@@ -1116,21 +1060,61 @@ class AutoSwitchEngine:
         consume_first = settings.strategy == "consume-first"
 
         def _rank(**kw):
-            """Rank with the no-return bar, and WITHOUT it if that empties.
+            """Rank with the no-return bar, and WITHOUT it if that empties AND
+            the barred account is a different proposition from the one we left.
 
-            The bar has no release of its own — `lastSwitchFrom` is rewritten
-            only by a successful switch — so a bar that leaves nothing is
-            permanent, not anti-flap. Two predicates that tried to predict
-            emptiness both landed a gate short of the loop (see
-            `_no_return_account`), so the question is put to the ranking
-            itself. Exact by construction, and it cannot fall behind the gates
-            because it is not a second copy of them.
+            Emptiness alone cannot be the release. On two accounts there is
+            exactly one candidate, so barring it ALWAYS empties the list —
+            measured, sweeping active x barred headroom x both reset shapes,
+            `n=2 barred-rank EMPTY=320 NONEMPTY=0`. An emptiness-only release
+            therefore fires every tick and the bar is inert at the fleet size
+            the flap was reported on: pcts 92/92, resets 500h/400h, 60 ticks
+            gave `[1, 2, 1, 2]` with the bar on and the identical `[1, 2, 1, 2]`
+            with `lastSwitchFrom` popped every tick.
+
+            "BARRING LEAVES NOTHING" AND "WE ARE FLAPPING" ARE DIFFERENT
+            STATES, and at n=2 they are always the same state — which is how
+            one swallowed the other. The ranking cannot separate them: it sees
+            only the present, and both look like an empty list. What separates
+            them is WHY the ranking flipped. Traced at each leg of that walk:
+
+                t8   1->2   left 1 holding 4.0 pts, 500h out
+                t20  2->1   account 1 still 4.0 pts, still 500h out
+                t22  1->2   account 2 still 2.0 pts, still 400h out
+
+            Every return won because the ACTIVE burned down, never because the
+            target recovered. So the release asks the one question the ranking
+            cannot: is the account we left better than when we left it?
+
+            ON BOTH AXES THE RANKING USES, and with the margins it already
+            uses — ``SPENT_HEADROOM_PCT`` of headroom (below that an edge is
+            under two poll intervals of work) or ``RECOVERY_HYSTERESIS_S``
+            sooner. An account's headroom rises only when a window rolls over
+            and its binding reset only moves nearer when a nearer window
+            starts binding, so both are real events rather than the boundary
+            crossings burn manufactures for free.
+
+            Emptiness still decides whether to ASK. Where the bar leaves a
+            real alternative it simply applies, so a fleet with somewhere else
+            to go is untouched by any of this.
 
             Cheap: the retry runs only when the barred list came back empty,
             which is the tick that was about to do nothing anyway.
             """
+            # Recomputed per snapshot, never once per tick: the consume-first
+            # two-phase commit replaces `headroom` and `active_headroom` and
+            # re-ranks, and the ratio release consumes exactly those two
+            # values. Computed once, the bar answered from a snapshot the
+            # ranking had already thrown away — `left=20 active=30` bars,
+            # `left=90 active=10` releases, and phase 2 is where that flips.
+            recovered = self._left_account_recovered(
+                state, kw["usage"], kw["headroom"], kw["now"]
+            )
+            no_return = self._no_return_account(
+                trigger, state, kw["headroom"], kw["active_headroom"], recovered
+            )
             ranked = self._rank_candidates(no_return=no_return, **kw)
-            if no_return is not None and not ranked[0]:
+            if no_return is not None and not ranked[0] and recovered:
                 unbarred = self._rank_candidates(no_return=None, **kw)
                 if unbarred[0]:
                     return unbarred
@@ -1263,6 +1247,13 @@ class AutoSwitchEngine:
             return TickOutcome.BLOCKED
 
         # -- freshen + switch ----------------------------------------------
+        # The departure snapshot of the account we are leaving, taken from the
+        # SAME `usage`/`headroom` the ranking just decided on — for
+        # consume-first that is the phase-2 refetch, not the stale one.
+        left_snapshot = (
+            active_headroom,
+            _binding_recovery_ts(usage.get(current), self._models, self.clock()),
+        )
         transient_failure = False
         for num in ordered:
             email = self.switcher.account_email(num)
@@ -1288,7 +1279,7 @@ class AutoSwitchEngine:
             if self.dry_run:
                 # Dry-run stops at the decision: no token refresh, no
                 # quarantine writes — freshening is a mutation.
-                return self._perform(num, email, trigger)
+                return self._perform(num, email, trigger, left_snapshot)
             status = self._freshen_target(num, email)
             if status == "identity-conflict":
                 # The slot's credential is alive but belongs to a different
@@ -1305,7 +1296,7 @@ class AutoSwitchEngine:
                 continue
             if status == "skip-live-session":
                 continue
-            return self._perform(num, email, trigger)
+            return self._perform(num, email, trigger, left_snapshot)
 
         if transient_failure:
             self._emit(
@@ -1324,7 +1315,7 @@ class AutoSwitchEngine:
         state: dict,
         headroom: dict[str, float | None],
         active_headroom: float | None,
-        oauth_candidates: list[str],
+        recovered: bool,
     ) -> str | None:
         """The account this engine most recently left, while it is still barred.
 
@@ -1342,7 +1333,15 @@ class AutoSwitchEngine:
 
         RELEASED when the account we left now beats us by the same ratio the
         anti-flap margin uses: that is not the flip this bars, it is a move the
-        outbound leg would have made on its own merits.
+        outbound leg would have made on its own merits — BUT ONLY IF IT HAS
+        ACTUALLY RECOVERED. The ratio compares against the ACTIVE, and the
+        active burns, so ungated it comes true on a target that has done
+        nothing. Measured on the cited walk, the barred account held 4.0 pts at
+        departure and 4.0 pts at every return; the ratio fired purely because
+        the active fell to 2.0, which is the flap arriving through the release
+        instead of through the ranking. `recovered` is that gate, computed once
+        per snapshot by `_left_account_recovered` and shared with the
+        leaves-nothing retry in `_rank` so the two cannot disagree.
 
         THE LEAVES-NOTHING RELEASE IS NOT HERE. It used to be, and it was
         rewritten twice for the same reason both times: this function cannot
@@ -1362,11 +1361,18 @@ class AutoSwitchEngine:
         10h, active 2 pts / 500h out, third 1 pt — 30 ticks all BLOCKED, and
         the same fleet with `lastSwitchFrom` popped switches on the first.
 
-        `_tick_inner` now ASKS the ranking instead: it ranks with the bar, and
+        `_rank` now ASKS the ranking instead: it ranks with the bar, and
         re-ranks without it when the result is empty. That is exact by
         construction, covers the recovery axis this predicate never could, and
         cannot be one gate behind because it is not a separate copy of the
         gates.
+
+        EMPTINESS ALONE IS NOT THE RELEASE, though — see `_rank`. At n=2 the
+        barred ranking is always empty, so an emptiness-only retry is a no-op
+        at exactly the fleet size the flap was reported on. Both the retry and
+        the ratio above are gated on `recovered`, which is the one question the
+        ranking cannot answer: is this a different account from the one we
+        left, or only a different active?
         """
         came_from = state.get("lastSwitchFrom")
         if trigger not in ("proactive", "consume-first") or came_from is None:
@@ -1376,6 +1382,8 @@ class AutoSwitchEngine:
         # account that is not in it bars nothing. The check was a no-op and
         # nothing killed it under mutation.
         barred = str(came_from)
+        if not recovered:
+            return barred        # the ratio below burns true on its own; see above
         left_headroom = headroom.get(barred)
         if (
             left_headroom is not None
@@ -1384,6 +1392,70 @@ class AutoSwitchEngine:
         ):
             return None                      # beats us outright; not a flip
         return barred
+
+    def _left_account_recovered(
+        self,
+        state: dict,
+        usage: dict[str, dict | str | None],
+        headroom: dict[str, float | None],
+        now: float,
+    ) -> bool:
+        """Is the account we left a better proposition than when we left it?
+
+        This is the release the bar needs and the ranking cannot supply. A bar
+        that leaves nothing is a stall, but "leaves nothing" is also what every
+        flap looks like on two accounts, so lifting on emptiness alone lifts
+        always. The distinction is not in the present state — it is between the
+        present and the moment of departure, which is why `_perform` records
+        that moment (`leftHeadroom` / `leftRecoveryAt`) alongside
+        `lastSwitchFrom`.
+
+        Measured on the walk this guard exists for, the barred account was
+        IDENTICAL at every return — same headroom, same reset — and only the
+        active had changed. That is the flap: the ranking flipped underneath a
+        target that did nothing.
+
+        Two axes, matching the ranking's two, each with the margin that axis
+        already uses:
+
+          headroom   `+SPENT_HEADROOM_PCT` — below that an edge is under two
+                     poll intervals, the same reason the spent band exists.
+          recovery   `-RECOVERY_HYSTERESIS_S` — the same margin the recovery
+                     axis ranks by one gate later.
+
+        Burn cannot manufacture either: headroom rises only when a window rolls
+        over, and the binding reset moves nearer only when a nearer window
+        starts binding.
+
+        NO SNAPSHOT MEANS RELEASE. State written before this field existed, or
+        by a switch that never recorded one, carries no evidence either way —
+        and of the two failure modes the permanent proactive lockout is the
+        worse one, because it is persisted and survives a restart and a week of
+        wall clock. Absence of evidence releases.
+        """
+        came_from = state.get("lastSwitchFrom")
+        if came_from is None:
+            return True
+        barred = str(came_from)
+        left_headroom = state.get("leftHeadroom")
+        left_recovery = state.get("leftRecoveryAt")
+        if left_headroom is None and left_recovery is None:
+            return True
+        h = headroom.get(barred)
+        if (
+            isinstance(left_headroom, (int, float))
+            and h is not None
+            and h >= left_headroom + SPENT_HEADROOM_PCT
+        ):
+            return True
+        # `None` is the JSON-safe spelling of "unknown or already past", which
+        # `_binding_recovery_ts` returns as `inf`: an account nobody can
+        # schedule around. Moving off it onto a real reset IS the improvement.
+        was = left_recovery if isinstance(left_recovery, (int, float)) else float("inf")
+        return (
+            _binding_recovery_ts(usage.get(barred), self._models, now)
+            < was - RECOVERY_HYSTERESIS_S
+        )
 
     def _rank_candidates(
         self,
@@ -1729,7 +1801,13 @@ class AutoSwitchEngine:
         headroom = _headroom_by_account(usage, self._models)
         return entries, usage, headroom
 
-    def _perform(self, number: str, email: str, trigger: str) -> TickOutcome:
+    def _perform(
+        self,
+        number: str,
+        email: str,
+        trigger: str,
+        left: tuple[float | None, float],
+    ) -> TickOutcome:
         if self.dry_run:
             current = self.switcher.current_account_number()
             current_email = self.switcher.account_email(current) if current else ""
@@ -1768,9 +1846,15 @@ class AutoSwitchEngine:
             state["schemaVersion"] = STATE_SCHEMA_VERSION
             state["lastSwitchAt"] = self.clock()
             state["lastSwitchTo"] = number
-            # WHERE we came from, so the next tick can refuse to undo this.
-            # See the filter in `_tick_inner` for why.
+            # WHERE we came from, so the next tick can refuse to undo this,
+            # and WHAT IT LOOKED LIKE, so that refusal has a release that burn
+            # cannot fake. See `_left_account_recovered` for why the present
+            # state alone cannot supply one. `inf` is stored as null: it is not
+            # portable JSON, and every other reader of this file would have to
+            # learn about it.
             state["lastSwitchFrom"] = (result.get("from") or {}).get("number")
+            state["leftHeadroom"], recovery = left
+            state["leftRecoveryAt"] = None if recovery == float("inf") else recovery
             atomic_write_json(self.state_path, state)
 
         self._emit(

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1053,22 +1053,25 @@ class AutoSwitchEngine:
         # have made on its own merits. One-way stays one-way: the margin is
         # what makes it so, and re-using it keeps the release from becoming a
         # second, looser threshold that has to be reasoned about separately.
-        came_from = state.get("lastSwitchFrom")
-        if (
-            trigger in ("proactive", "consume-first")
-            and came_from is not None
-            and str(came_from) in oauth_candidates
-        ):
-            left_headroom = headroom.get(str(came_from))
-            released = (
-                left_headroom is not None
-                and active_headroom is not None
-                and left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO
-            )
-            if not released:
-                oauth_candidates = [
-                    n for n in oauth_candidates if n != str(came_from)
-                ]
+        # NOT REMOVED FROM THE LIST — barred from being CHOSEN. Removing it
+        # made eight downstream consumers believe the account does not exist:
+        # `truly_exhausted` (a peer holding 15 points produced
+        # AllExhaustedEvent, a macOS notification and a critical TUI row),
+        # `not oauth_candidates` -> "no candidates at all" with a stretched
+        # poll interval, `_every_account_above_threshold` (a hidden
+        # below-threshold peer flipped `all_above` and switched the whole
+        # ranking axis), `best_candidate_headroom`, and `any_known` ->
+        # "no candidate has readable usage", which was false.
+        #
+        # The filter's job is "do not go back to the account we just left".
+        # That is a statement about the CHOICE, and it belongs where the
+        # choice is made — `_rank_candidates` — not in the census of what
+        # exists. Measured before this move: disabling the filter entirely
+        # left the full suite green, because both its tests only exercised
+        # the released branch.
+        no_return = self._no_return_account(
+            trigger, state, headroom, active_headroom, oauth_candidates
+        )
         api_key_candidates = (
             [n for n in candidates if self.switcher.account_kind_for(n) == "api_key"]
             if settings.include_api_key_accounts
@@ -1109,6 +1112,7 @@ class AutoSwitchEngine:
             trigger=trigger,
             consume_first=consume_first,
             oauth_candidates=oauth_candidates,
+            no_return=no_return,
             usage=usage,
             headroom=headroom,
             current=current,
@@ -1139,6 +1143,7 @@ class AutoSwitchEngine:
                 trigger=trigger,
                 consume_first=consume_first,
                 oauth_candidates=oauth_candidates,
+                no_return=no_return,
                 usage=usage,
                 headroom=headroom,
                 current=current,
@@ -1287,12 +1292,67 @@ class AutoSwitchEngine:
         self._emit(NoSwitchEvent(reason="no-viable-target"))
         return TickOutcome.BLOCKED
 
+    def _no_return_account(
+        self,
+        trigger: str,
+        state: dict,
+        headroom: dict[str, float | None],
+        active_headroom: float | None,
+        oauth_candidates: list[str],
+    ) -> str | None:
+        """The account this engine most recently left, while it is still barred.
+
+        NEVER UNDO THE PREVIOUS MOVE. Each anti-flap gate is one-way on its own
+        axis, but the axis is a property of the pair's STATE and burn changes
+        that state: the ratio gate is relative (`h >= active x 2`) and the
+        spent gate absolute (`active <= 3.0`), so a burning pair crosses the
+        boundary repeatedly and each crossing re-opens a move. Measured, both
+        resets past the horizon, only the active burning: `[1, 2, 1, 2]` where
+        base makes one move.
+
+        SCOPED like every sibling gate — `at-limit` and `failover` skip the
+        anti-flap gates by design. Unscoped this stranded a 2-account fleet on
+        an exhausted active with the peer at 0%.
+
+        RELEASED when the account we left now beats us by the same ratio the
+        anti-flap margin uses: that is not the flip this bars, it is a move the
+        outbound leg would have made on its own merits.
+
+        And released when the bar would leave NOTHING to choose. Identity has
+        no release condition of its own — `lastSwitchFrom` is rewritten only by
+        a successful switch, the one it prevents — so on a 2-account fleet it
+        was permanent: measured, one ordinary proactive move then 20 ticks of
+        `no-candidates` with the peer at 0%, surviving a restart. The ratio
+        release does not cover it, because `left >= active x 2` is
+        unsatisfiable for any active headroom above 50 and consume-first fires
+        exactly there: measured, active 70 pts against a peer at 100 pts,
+        locked out for 10h and still locked after seven days of wall clock.
+        A bar that leaves the engine nothing is not anti-flap, it is a stall.
+        """
+        came_from = state.get("lastSwitchFrom")
+        if trigger not in ("proactive", "consume-first") or came_from is None:
+            return None
+        barred = str(came_from)
+        if barred not in oauth_candidates:
+            return None
+        left_headroom = headroom.get(barred)
+        if (
+            left_headroom is not None
+            and active_headroom is not None
+            and left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO
+        ):
+            return None                      # beats us outright; not a flip
+        if all(n == barred for n in oauth_candidates):
+            return None                      # barring it leaves nothing
+        return barred
+
     def _rank_candidates(
         self,
         *,
         trigger: str,
         consume_first: bool,
         oauth_candidates: list[str],
+        no_return: str | None,
         usage: dict[str, dict | str | None],
         headroom: dict[str, float | None],
         current: str,
@@ -1369,9 +1429,11 @@ class AutoSwitchEngine:
             h = headroom.get(num)
             if h is None:
                 continue
-            any_known = True
+            any_known = True          # it EXISTS and is readable either way
             if h <= 0:
                 continue  # itself at its limit — never a target
+            if num == no_return:
+                continue  # the account we just left; see _no_return_account
             reset_ts = (
                 _seven_day_reset_ts(usage.get(num), now) if consume_first else None
             )

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -117,22 +117,34 @@ HORIZON_HEADROOM_RATIO = 2.0
 #     base       move   move   move   move   move
 #     0457cb0    REF    REF    REF    REF    move
 #     db25990    move   move   move   move   move
-#     here       move   REF    REF    REF    move
+#     before     move   REF    REF    REF    move
+#     here       move   move   move   move   move
 #
 # The two bands trade against each other and their widths sum to a constant
 # (`active x HORIZON_HEADROOM_RATIO - SPENT_HEADROOM_PCT`), so no value of this
 # ratio removes both: 1.0 empties this band and re-arms the veto the filter
 # exists to stop, 2.0 does the reverse. Measured, not argued.
 #
-# Two fixes were tried and BOTH measured worse than shipping the residue.
-# Making the floor absolute (`> SPENT_HEADROOM_PCT`, fleet-wide rather than
-# relative) leaves the band at 2 of 5 points AND breaks
-# `test_an_unchoosable_peer_does_not_veto_the_reset_ranking`. Dropping the
-# filter entirely returns to `db25990`, which is the veto this PR fixed.
+# THAT ALGEBRA BOUNDS THE CONSTANT, NOT THE RANKING, and an earlier version of
+# this comment confused the two — it told the next reader the residue needed a
+# redesign. It did not. The fix is the fallback in `_rank_candidates`: drop the
+# floor from `best_candidate_headroom` so the worth-having question stops
+# keying on the active account's own headroom, and re-admit margin failures
+# through a one-way list used only when nothing else qualifies. Measured, same
+# scenario, 0.05 steps across [3.00, 10.00]:
 #
-# The real fix decouples the two axes rather than retuning a constant, and that
-# is a redesign of the ranking rather than a bound on it. Recorded here so the
-# next reader starts from the measurement instead of the constant.
+#     here, before   42 refusals of 141, band [3.90, 5.95]
+#     here, now       0 refusals of 141
+#
+# with the suite at 1717 passed and every horizon protection intact.
+#
+# Two OTHER fixes were tried and both measured worse. Making the floor absolute
+# (`> SPENT_HEADROOM_PCT`, fleet-wide rather than relative) refuses 4 of the 5
+# sampled points — no narrower than the band it replaces — AND breaks
+# `test_an_unchoosable_peer_does_not_veto_the_reset_ranking`. Dropping the
+# filter with no fallback gives `0457cb0`'s row (REF REF REF REF move), which
+# re-arms that veto. The fallback is exactly what separates the working fix
+# from that one.
 WORTH_HAVING_RATIO = 1.3
 
 # Below this an account is spent, and headroom comparisons between two spent
@@ -141,6 +153,7 @@ WORTH_HAVING_RATIO = 1.3
 # sit where quota returns first, however far out — rather than parking on
 # whichever account we happen to hold.
 SPENT_HEADROOM_PCT = 3.0
+
 
 def _recovery_is_useful(
     candidate_recovery_ts: float,
@@ -200,10 +213,11 @@ def _recovery_is_useful(
     The #202 case oscillated on the original code too — its test ticks once,
     so it only ever observed the outbound leg.
 
-    KNOWN RESIDUE: the step between the two axes is not monotone (2/2/3.0 takes
-    the soonest reset, 2/2/3.5 parks). The band is 0.5 points wide at the
-    default constants and both outcomes keep a working account. Every fix tried
-    re-armed the days-away trade this horizon exists to forbid.
+    The step between the two axes used to be non-monotone — adding headroom to
+    a peer flipped a move into a refusal, 42 refusals across a 0.05-step sweep.
+    That was a property of `best_candidate_headroom`'s ratio floor, not of this
+    predicate: the floor is gone and margin failures are re-admitted through a
+    one-way fallback, so the sweep now refuses nowhere. See WORTH_HAVING_RATIO.
     """
     if (
         active_headroom <= SPENT_HEADROOM_PCT
@@ -1296,16 +1310,23 @@ class AutoSwitchEngine:
         # blocked. The band is (SPENT_HEADROOM_PCT, active x RATIO], up to 3
         # points wide at the defaults.
         #
-        # Scoped by WORTH_HAVING_RATIO, not the anti-flap margin. Using the
-        # margin here excluded peers that plainly have quota and emptied the
-        # max, and an empty max reads as "nothing is worth having" — the exact
-        # opposite of what a 5.99-point peer means. See the constant.
-        _ratio_floor = (active_headroom or 0.0) * WORTH_HAVING_RATIO
+        # The headrooms the ranking may actually choose between: every
+        # candidate whose headroom is KNOWN. An unknown one is not evidence
+        # that somebody has quota left — the loop skips it a few lines down
+        # for exactly that reason — so it must not veto the spent check
+        # either. Measured: one sentinel row (expired token, locked keychain)
+        # made `all(...)` False forever, and three accounts at 99% days out
+        # left the engine parked on the one resetting LAST.
+        #
+        # Unfiltered. A floor scoped by WORTH_HAVING_RATIO used to sit here,
+        # which made the worth-having question key on the ACTIVE account's own
+        # headroom and inverted monotonicity across a 2-point band. The
+        # margin-failure fallback below is what lets it go. See the constant.
         best_candidate_headroom = max(
             (
                 h
                 for h in (headroom.get(n) for n in oauth_candidates)
-                if h is not None and h >= _ratio_floor
+                if h is not None
             ),
             default=0.0,
         )
@@ -1314,15 +1335,9 @@ class AutoSwitchEngine:
             if all_above
             else 0.0  # unread unless all_above; never a live sentinel
         )
-        # The headrooms the ranking may actually choose between: the active,
-        # plus every candidate whose headroom is KNOWN. An unknown one is not
-        # evidence that somebody has quota left — the loop skips it a few
-        # lines down for exactly that reason — so it must not veto the spent
-        # check either. Measured: one sentinel row (expired token, locked
-        # keychain) made `all(...)` False forever, and three accounts at 99%
-        # days out left the engine parked on the one resetting LAST.
 
         qualifying: list[tuple[tuple, str]] = []
+        fallback: list[tuple[tuple, str]] = []
         any_known = False
         for num in oauth_candidates:
             h = headroom.get(num)
@@ -1384,6 +1399,15 @@ class AutoSwitchEngine:
                         # in reverse. That takes a 4x relative burn instead of
                         # the one point a strictly-greater test would need.
                         if h < (active_headroom or 0.0) * HORIZON_HEADROOM_RATIO:
+                            if (
+                                (active_headroom or 0.0) <= SPENT_HEADROOM_PCT
+                                and h >= (active_headroom or 0.0)
+                                and recovery_ts
+                                < active_recovery_ts - RECOVERY_HYSTERESIS_S
+                            ):
+                                fallback.append(
+                                    ((0, recovery_ts, -h), num)
+                                )
                             continue
                 elif consume_first:
                     # Purely proactive on reset ordering: below the threshold,
@@ -1435,6 +1459,8 @@ class AutoSwitchEngine:
                 key = (-h,)
             qualifying.append((key, num))
         # Ascending by the strategy's key; list order (sequence order) breaks ties.
+        if not qualifying and fallback:
+            qualifying = fallback
         qualifying.sort(key=lambda t: t[0])
         return [num for _, num in qualifying], any_known, active_reset_ts
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1057,13 +1057,39 @@ class AutoSwitchEngine:
         # anti-flap gates by design. Unscoped this stranded a 2-account fleet
         # on an exhausted active with the peer at 0%, "no-candidates" every
         # tick, with nothing able to release it.
+        #
+        # AND IT NEEDS A RELEASE CONDITION. Identity alone has none: on a
+        # 2-account fleet the filter removes the only candidate, and
+        # `lastSwitchFrom` is rewritten ONLY by a successful switch — the very
+        # switch it prevents. Measured, reached by one ordinary proactive move
+        # and no seeded state: the peer resets to 0%, the active burns to 97%,
+        # and 20 ticks / 10h answer "no-candidates". Persisted, so it survives
+        # a restart and a week of wall clock. The engine then escapes only at a
+        # hard 100% — the proactive feature off, on the fleet size that has
+        # nowhere else to go.
+        #
+        # Released by the SAME ratio the anti-flap margin uses. The filter
+        # exists to stop a flip undoing the move before it; a peer that now
+        # beats us by 2x is not that flip, it is a move the outbound leg would
+        # have made on its own merits. One-way stays one-way: the margin is
+        # what makes it so, and re-using it keeps the release from becoming a
+        # second, looser threshold that has to be reasoned about separately.
         came_from = state.get("lastSwitchFrom")
         if (
             trigger in ("proactive", "consume-first")
             and came_from is not None
             and str(came_from) in oauth_candidates
         ):
-            oauth_candidates = [n for n in oauth_candidates if n != str(came_from)]
+            left_headroom = headroom.get(str(came_from))
+            released = (
+                left_headroom is not None
+                and active_headroom is not None
+                and left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO
+            )
+            if not released:
+                oauth_candidates = [
+                    n for n in oauth_candidates if n != str(came_from)
+                ]
         api_key_candidates = (
             [n for n in candidates if self.switcher.account_kind_for(n) == "api_key"]
             if settings.include_api_key_accounts

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -96,6 +96,19 @@ RECOVERY_HYSTERESIS_S = 300.0
 # 5-hour cycle, so same-day resets keep the recovery ranking.
 RECOVERY_HORIZON_S = 4 * 3600.0
 
+# Anti-flap margin for the headroom axis past RECOVERY_HORIZON_S, as a RATIO
+# rather than percentage points. The ordinary hysteresis_pct (10 points) is
+# unmeetable here by construction — everything is within a few points of its
+# limit — so requiring it would park the engine and let it ride into the wall.
+# Requiring strictly-more was the opposite error: one point is enough to move,
+# the target burns it back, and the engine ping-pongs (measured 2026-07-30,
+# four switches in 35 minutes, each buying one point and each costing a
+# credential rewrite). A ratio is the right unit in the endgame — with two
+# points left, what matters is how many TIMES more runway the target has — and
+# it makes the move one-way: the reverse leg would need the new active to fall
+# to a quarter of the headroom it just beat.
+HORIZON_HEADROOM_RATIO = 2.0
+
 # Adaptive scheduling: the baseline request volume is O(1) per tick — the
 # active account plus ONE due candidate (stalest data first) — instead of
 # every account in parallel, and the per-account cadence itself (movement,
@@ -1223,9 +1236,12 @@ class AutoSwitchEngine:
                         and recovery_ts >= active_recovery_ts - RECOVERY_HYSTERESIS_S
                     ):
                         continue
-                    if not recovery_useful and h <= (active_headroom or 0.0):
-                        # Headroom axis instead: only move to strictly more
-                        # quota than we hold, so this cannot flap either.
+                    if not recovery_useful and h < (
+                        (active_headroom or 0.0) * HORIZON_HEADROOM_RATIO
+                    ):
+                        # Headroom axis instead, with its own anti-flap margin:
+                        # a target must hold HORIZON_HEADROOM_RATIO times what
+                        # we do, so the reverse move can never qualify.
                         continue
                 elif consume_first:
                     # Purely proactive on reset ordering: below the threshold,

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -108,68 +108,39 @@ SPENT_HEADROOM_PCT = 3.0
 
 def _recovery_is_useful(
     candidate_recovery_ts: float,
-    active_recovery_ts: float,
     active_headroom: float,
     best_candidate_headroom: float,
-    threshold: float,
     now: float,
 ) -> bool:
-    """Rank THIS candidate by soonest reset, or by headroom?
+    """Rank THIS candidate by soonest reset, rather than by headroom?
 
-    One place, because four independent gates over two axes produce sixteen
-    combinations and a review found reachable holes in four of them. Each
-    clause below is a hole that was measured, not a hypothesis.
+    Two clauses, one place. Deciding it from four scattered gates left
+    reachable holes in four of the sixteen combinations.
 
-    Reset wins when:
+    Reset wins when everything worth having is spent — below
+    ``SPENT_HEADROOM_PCT`` a headroom edge is under two poll intervals, so the
+    only real question is which account returns first. Asked of the active and
+    the BEST candidate, not of every account: an unknown headroom is not
+    evidence of an empty one, and requiring all of them let a single sentinel
+    row veto the check for everybody.
 
-    * **Everything is spent.** Below ``SPENT_HEADROOM_PCT`` a headroom edge is
-      under ten minutes of work — less than two poll intervals — so comparing
-      two spent accounts compares noise, and the only real question is which
-      returns first. Asked of the active and the BEST candidate — "is there
-      anything worth having?" — not of every account. Requiring EVERY account
-      to be spent made the answer non-monotone in headroom (2/2/3.0 took the
-      soonest reset; improving one peer to 3.5 flipped the axis and parked on
-      the account resetting 59h later) and let one unknown headroom — a
-      sentinel row, a locked keychain — veto the check for everybody, which
-      parked three accounts at 99% on the one resetting LAST. The maximum
-      answers both: an unknown is not a maximum, and a peer improving can only
-      move the answer toward "keep the headroom".
-    * **This candidate is back soon.** Asked per candidate, not once on the
-      active: an active bound by its WEEKLY window sits days out while a
-      peer's five-hour window returns in minutes, and asking the active
-      refused that peer — the #202 case this is supposed to preserve.
+    It also wins when THIS candidate is back soon. Asked per candidate, not
+    once on the active: an active bound by its weekly window sits days out
+    while a peer's five-hour window returns in minutes.
 
-    Past the horizon we rank by headroom and, when no candidate can meet the
-    ratio, nobody qualifies — deliberately. An active holding materially more
-    quota than any peer can offer SHOULD keep the work; that is the whole
-    finding this horizon encodes. The one thing that must not happen is the
-    engine parking while a peer holds meaningfully more, and the ratio cannot
-    produce that: it is unreachable only when the active already holds more
-    than half of what the threshold permits, i.e. more than any candidate.
+    Past the horizon we rank by headroom, and when no candidate meets the ratio
+    nobody qualifies — an active holding more quota than any peer can offer
+    should keep the work.
 
-    KNOWN RESIDUE, deliberately left: inside the spent band the axis is the
-    reset, above it the ratio, and the step between them is not monotone —
-    2 / 2 / 3.0 switches to the soonest reset while 2 / 2 / 3.5 parks, because
-    3.5 leaves the spent band without meeting 2x. Every fix tried was worse:
-    ranking that band by reset re-armed the days-away trade for 9 / 10 / 10
-    and broke the return-leg flap guard. The band is 0.5 points wide at the
-    default constants and both outcomes keep a working account, so it is
-    recorded rather than papered over.
-
-    An UNKNOWN active recovery (``inf``, which also means "already elapsed")
-    deliberately does NOT keep the recovery axis. It used to, and that re-armed
-    the exact trade this horizon forbids: 9 points of headroom for a peer
-    resetting 50h out, whenever the active's ``resets_at`` was missing or
-    stale. No evidence a sooner reset helps is a reason to keep the headroom,
-    not to spend it.
+    KNOWN RESIDUE: the step between the two axes is not monotone (2/2/3.0 takes
+    the soonest reset, 2/2/3.5 parks). The band is 0.5 points wide at the
+    default constants and both outcomes keep a working account. Every fix tried
+    re-armed the days-away trade this horizon exists to forbid.
     """
-    if active_headroom <= SPENT_HEADROOM_PCT and best_candidate_headroom <= (
-        SPENT_HEADROOM_PCT
-    ):
-        return True
-    if candidate_recovery_ts - now <= RECOVERY_HORIZON_S:
-        return True
-    return False
+    return (
+        active_headroom <= SPENT_HEADROOM_PCT
+        and best_candidate_headroom <= SPENT_HEADROOM_PCT
+    ) or candidate_recovery_ts - now <= RECOVERY_HORIZON_S
 
 
 # Adaptive scheduling: the baseline request volume is O(1) per tick — the
@@ -1258,7 +1229,6 @@ class AutoSwitchEngine:
         # days out left the engine parked on the one resetting LAST.
 
         qualifying: list[tuple[tuple, str]] = []
-        axis_recovery: dict[str, bool] = {}  # per candidate, set in the loop
         any_known = False
         for num in oauth_candidates:
             h = headroom.get(num)
@@ -1297,15 +1267,14 @@ class AutoSwitchEngine:
                     # WHICH AXIS is decided per candidate, in one place — see
                     # _recovery_is_useful for the four holes that came from
                     # deciding it once, globally, from four scattered gates.
+                    # Set and read under the same `all_above and trigger`
+                    # condition, so it is always assigned before the key below.
                     by_recovery = _recovery_is_useful(
                         recovery_ts,
-                        active_recovery_ts,
                         active_headroom or 0.0,
                         best_candidate_headroom,
-                        settings.threshold,
                         now,
                     )
-                    axis_recovery[num] = by_recovery
                     if by_recovery:
                         # Hysteresis on the axis we actually rank by. It bounds
                         # the flap RATE rather than making a reverse move
@@ -1338,34 +1307,20 @@ class AutoSwitchEngine:
                     # qualifies; near-line pairs can't flap back).
                     if h - active_headroom < settings.hysteresis_pct:
                         continue
-            if axis_recovery.get(num) and trigger in ("proactive", "consume-first"):
-                # Soonest BINDING recovery first — the window actually holding
-                # this account back, not the weekly one. With everything in the
-                # 90s the only thing worth optimizing is how long until work can
-                # continue; headroom breaks ties, then sequence order.
+            if all_above and trigger in ("proactive", "consume-first"):
+                # Ranked on the axis its own gate decided, and TIERED so the two
+                # stay comparable: a candidate returning inside the horizon
+                # beats one that does not, whatever its headroom. Untiered, the
+                # two key shapes were compared elementwise — a raw headroom
+                # against an epoch timestamp — and headroom won on magnitude
+                # alone. Falling through to the weekly key instead split the
+                # filter and the sort across two axes, picking the candidate
+                # with LESS headroom whenever its weekly reset was sooner.
                 #
-                # Scoped to the SAME triggers as the gate above. Without the
-                # trigger clause this key also re-ranked at-limit and failover,
-                # which skip that gate deliberately: there the account with the
-                # most headroom must win, because we are escaping a dead or
-                # blocked active account rather than optimising a return time.
-                #
-                # TIER 0. The axis is per candidate, so the key must stay
-                # comparable across both: a candidate that returns inside the
-                # horizon beats one that does not, whatever its headroom, and
-                # ties are broken by how soon. Without the tier the two key
-                # SHAPES were compared elementwise — a raw headroom against an
-                # epoch timestamp — and the headroom candidate always won on
-                # magnitude alone.
-                key: tuple = (0, recovery_ts, -h)
-            elif all_above and trigger in ("proactive", "consume-first"):
-                # TIER 1: ranked on HEADROOM, because that is what its gate
-                # decided on. Falling through to the consume-first weekly key
-                # split the filter and the sort across two axes — the same
-                # mismatch the comment above records as a prior bug — and
-                # picked the candidate with LESS headroom whenever its weekly
-                # reset happened to be sooner.
-                key = (1, 0.0, -h)
+                # Scoped to the SAME triggers as the gate above: at-limit and
+                # failover skip that gate deliberately, because there we are
+                # escaping a dead account rather than optimising a return time.
+                key: tuple = (0, recovery_ts, -h) if by_recovery else (1, 0.0, -h)
             elif consume_first:
                 # Soonest weekly reset first (unknown resets sort last), most
                 # headroom breaks ties, then sequence order.

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import enum
 import json
 import logging
+import math
 import random
 import threading
 import time
@@ -1131,6 +1132,7 @@ class AutoSwitchEngine:
                     return unbarred
             return ranked
 
+        decided_now = self.clock()
         ordered, any_known, active_reset_ts = _rank(
             trigger=trigger,
             consume_first=consume_first,
@@ -1140,7 +1142,7 @@ class AutoSwitchEngine:
             current=current,
             active_headroom=active_headroom,
             settings=settings,
-            now=self.clock(),
+            now=decided_now,
         )
 
         if trigger == "consume-first" and ordered:
@@ -1161,6 +1163,7 @@ class AutoSwitchEngine:
             usage = {num: entry.decision_value() for num, entry in entries.items()}
             headroom = _headroom_by_account(usage, self._models)
             active_headroom = headroom.get(current)
+            decided_now = self.clock()
             ordered, any_known, active_reset_ts = _rank(
                 trigger=trigger,
                 consume_first=consume_first,
@@ -1170,7 +1173,7 @@ class AutoSwitchEngine:
                 current=current,
                 active_headroom=active_headroom,
                 settings=settings,
-                now=self.clock(),
+                now=decided_now,
             )
 
         if not ordered and api_key_candidates and trigger != "consume-first":
@@ -1263,7 +1266,7 @@ class AutoSwitchEngine:
         # consume-first that is the phase-2 refetch, not the stale one.
         left_snapshot = (
             active_headroom,
-            _binding_recovery_ts(usage.get(current), self._models, self.clock()),
+            _binding_recovery_ts(usage.get(current), self._models, decided_now),
         )
         transient_failure = False
         for num in ordered:
@@ -1327,7 +1330,7 @@ class AutoSwitchEngine:
         headroom: dict[str, float | None],
         active_headroom: float | None,
         recovered: bool,
-        settings: AutoSwitchSettings | None = None,
+        settings: AutoSwitchSettings,
     ) -> str | None:
         """The account this engine most recently left, while it is still barred.
 
@@ -1564,7 +1567,20 @@ class AutoSwitchEngine:
                 return True
             peer_recovery_ts = _binding_recovery_ts(usage.get(barred), self._models, now)
             active_recovery_ts = _binding_recovery_ts(usage.get(current), self._models, now)
-            return peer_recovery_ts < active_recovery_ts - RECOVERY_HYSTERESIS_S
+            # The active's recovery must be a REAL measurement, not merely
+            # "larger" -- `_binding_recovery_ts` returns `inf` for both
+            # "never resets" and "we do not know" (no windows, no
+            # `resets_at`, or a stale/past `resets_at`). Reading `inf` as
+            # "never" here made `peer < inf - HYST` true for ANY finite
+            # peer reset, releasing onto a peer arbitrarily far out on no
+            # evidence (R7 review, C-1). `math.isfinite` requires the
+            # active to have a genuine, known reset before the comparison
+            # even runs -- unknown holds, exactly like unreadable already
+            # does on the headroom axis (F6).
+            return (
+                math.isfinite(active_recovery_ts)
+                and peer_recovery_ts < active_recovery_ts - RECOVERY_HYSTERESIS_S
+            )
         # Dominance over the ACTIVE, only reached once a real baseline is
         # confirmed to exist above -- a peer that was already miles ahead of
         # the active at departure (moved for a DIFFERENT reason -- e.g.
@@ -1581,6 +1597,17 @@ class AutoSwitchEngine:
         # branch above uses when IT has no baseline to compare against
         # either, rather than silently treating "unreadable" as "no
         # dominance".
+        #
+        # DEFENSIVE, not currently outcome-changing (I-2, R7 review):
+        # measured exhaustively, `active_headroom=None` on this path closes
+        # BOTH of `_rank_candidates`'s gates before this leg is ever asked
+        # (`_every_account_above_threshold` is False on a None active, and
+        # the consume-first `active_reset_ts` gate is None too), so no
+        # fleet shape has been found where this branch changes a `tick()`
+        # outcome. Kept because the call IS reachable (confirmed via the
+        # phase-2 refetch) and a future change to those gates could make it
+        # live without anyone revisiting this function -- silently reading
+        # None as "no dominance" would then be exactly F6's original bug.
         if h is not None:
             if active_headroom is not None:
                 if h > active_headroom * HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT:

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -88,32 +88,22 @@ IDLE_HOLD_MAX_S = 30 * 60.0
 # it needs its own unit rather than a reused one.
 RECOVERY_HYSTERESIS_S = 300.0
 
-# Horizon past which "soonest recovery" stops being worth real headroom. The
-# escape above was measured on minutes-scale resets (#202: a peer back in 8
-# minutes). Days-scale is the opposite trade — measured live, active 91% /
-# 109h lost to 98% / 50h, and neither returns within the session, so the 9
-# points were the only resource that could still work. 4h covers a whole
-# 5-hour cycle, so same-day resets keep the recovery ranking.
+# Horizon past which a sooner reset stops being worth real headroom. The escape
+# above was measured on minutes-scale resets; days-scale is the opposite trade,
+# since neither account returns within the session. 4h covers a whole 5-hour
+# cycle, so same-day resets keep the recovery ranking.
 RECOVERY_HORIZON_S = 4 * 3600.0
 
-# Anti-flap margin for the headroom axis past RECOVERY_HORIZON_S, as a RATIO
-# rather than percentage points. Requiring strictly-more is no margin at all:
-# one point is enough to move, the target burns it back, and the engine
-# ping-pongs (measured 2026-07-30: four switches in 35 minutes, each buying one
-# point and each costing a credential rewrite). A ratio makes the move one-way
-# — the reverse leg would need the new active to fall to a quarter of the
-# headroom it just beat.
+# Anti-flap margin on the headroom axis, as a RATIO rather than percentage
+# points: strictly-more is no margin at all — one point moves the engine, the
+# target burns it back, and it ping-pongs. A ratio makes the move one-way.
 HORIZON_HEADROOM_RATIO = 2.0
 
-# Below this much headroom an account is spent for practical purposes, and
-# comparing headroom between two spent accounts compares noise: at the burn
-# rates measured on 2026-07-30 a one-point edge is under ten minutes of work,
-# less than two poll intervals. When EVERY candidate is down here the ranking
-# has to fall back to the reset — sit where the quota returns first, so the
-# reset finds us already on it — no matter how far out that reset is. Without
-# this, three accounts at 99% left the engine with no qualifying candidate and
-# it parked on whichever it happened to hold, including the one resetting
-# 59 hours after a peer.
+# Below this an account is spent, and headroom comparisons between two spent
+# accounts compare noise (a point is under ten minutes of work, less than two
+# poll intervals). When EVERY candidate is down here, rank by reset instead —
+# sit where quota returns first, however far out — rather than parking on
+# whichever account we happen to hold.
 SPENT_HEADROOM_PCT = 3.0
 
 # Adaptive scheduling: the baseline request volume is O(1) per tick — the
@@ -1186,15 +1176,12 @@ class AutoSwitchEngine:
             if all_above
             else 0.0  # unread unless all_above; never a live sentinel
         )
-        # all_spent is checked first: the horizon asks whether a sooner reset
-        # is worth REAL headroom, which only arises while real headroom exists.
-        # An UNKNOWN recovery is no evidence rather than a distant one, so it
-        # keeps the recovery axis. See SPENT_HEADROOM_PCT, RECOVERY_HORIZON_S.
-        all_spent = all_above and all(
-            h is not None and h <= SPENT_HEADROOM_PCT for h in headroom.values()
-        )
+        # The horizon asks whether a sooner reset is worth REAL headroom, so
+        # it only applies while real headroom exists — hence the spent check
+        # first. An UNKNOWN recovery is no evidence rather than a distant one,
+        # so it keeps the recovery axis.
         recovery_useful = all_above and (
-            all_spent
+            all(h is not None and h <= SPENT_HEADROOM_PCT for h in headroom.values())
             or active_recovery_ts == float("inf")
             or active_recovery_ts - now <= RECOVERY_HORIZON_S
         )

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -99,43 +99,19 @@ RECOVERY_HORIZON_S = 4 * 3600.0
 # target burns it back, and it ping-pongs. A ratio makes the move one-way.
 HORIZON_HEADROOM_RATIO = 2.0
 
-# "Is anything worth having?" — a DIFFERENT question from the anti-flap margin
-# above, and lower, because it is weaker: not "is this peer enough better to
-# justify a move?" but "does this peer have anything at all?"
+# The two anti-flap thresholds are both anchored to `active_headroom`, which
+# leaves a band where a peer is VISIBLE (the spent clause goes false, so the
+# reset axis switches off) yet UNCHOOSABLE (it misses the margin). Measured,
+# active 3.00 pts took a 0.10-pt peer over a 5.99-pt one, discarding 60x the
+# runway; and inside the band monotonicity inverts, so adding headroom flips a
+# move into a refusal.
 #
-# BOTH ARE ANCHORED TO `active_headroom`, and that is the defect neither number
-# can fix. They leave a gap where a peer is VISIBLE (the spent clause goes
-# false, so the reset axis switches off) yet UNCHOOSABLE (it misses the larger
-# margin) — and either end of the gap is a real misbehaviour. Below it, an
-# empty `max(..., default=0.0)` reads as "nothing is worth having" and ranking
-# falls to soonest reset: measured, active 3.00 pts took a 0.10-pt peer over a
-# 5.99-pt one, discarding 60x the runway. Inside it, monotonicity inverts —
-# adding headroom flips a move into a refusal. Measured, active 3.00 pts / 500h
-# against ONE peer better on BOTH axes:
-#
-#     peer pts   3.88   3.90   4.50   5.99   6.00
-#     base       move   move   move   move   move
-#     0457cb0    REF    REF    REF    REF    move
-#     db25990    move   move   move   move   move
-#     before     move   REF    REF    REF    move
-#     here       move   move   move   move   move
-#
-# The two bands trade against each other and their widths sum to a constant
-# (`active x HORIZON_HEADROOM_RATIO - SPENT_HEADROOM_PCT`), so no value of this
-# ratio removes both: 1.0 empties this band and re-arms the veto the filter
-# exists to stop, 2.0 does the reverse. Measured, not argued.
-#
-# That bounds the CONSTANT, not the ranking. The fix is elsewhere: drop the
-# floor from `best_candidate_headroom` and re-admit margin failures through a
-# one-way fallback used only when nothing else qualifies. Sweep across
-# [3.00, 10.00] at 0.05: 42 refusals before, 0 now.
-#
-# Two other fixes measured worse. An absolute floor (`> SPENT_HEADROOM_PCT`)
-# refuses 4 of the 5 sampled points and breaks
-# `test_an_unchoosable_peer_does_not_veto_the_reset_ranking`. Dropping the
-# filter with NO fallback gives `0457cb0`'s row, re-arming that veto — the
-# fallback is what separates the working fix from that one.
-WORTH_HAVING_RATIO = 1.3
+# No single constant removes both ends — the two band widths sum to
+# `active x HORIZON_HEADROOM_RATIO - SPENT_HEADROOM_PCT`, so shrinking one
+# grows the other. Measured, not argued. The fix is in the ranking instead:
+# `best_candidate_headroom` carries no floor, and margin failures are
+# re-admitted through a one-way fallback used only when nothing else
+# qualifies.
 
 # Below this an account is spent, and headroom comparisons between two spent
 # accounts compare noise (a point is under ten minutes of work, less than two
@@ -204,8 +180,11 @@ def _recovery_is_useful(
     so it only ever observed the outbound leg.
 
     The step between the two axes used to be non-monotone. That was a property
-    of `best_candidate_headroom`'s ratio floor, not of this predicate — the
-    floor is gone and the sweep now refuses nowhere. See WORTH_HAVING_RATIO.
+    of `best_candidate_headroom`'s ratio floor, not of this predicate. Swept
+    directly over the predicate — active 1..12 pts against a peer walked
+    0.5..40 at 0.05, four reset shapes — a strictly-improving peer never flips
+    a move into a refusal: 0 inversions. The one refusal left in
+    [3.00, 10.00] is at peer == active exactly, where the tie is the answer.
     """
     if (
         active_headroom <= SPENT_HEADROOM_PCT
@@ -1366,9 +1345,9 @@ class AutoSwitchEngine:
         # Every candidate whose headroom is KNOWN, unfiltered. An unknown one
         # is not evidence that somebody has quota left — measured, one
         # sentinel row (expired token, locked keychain) made `all(...)` False
-        # forever and parked the engine on the account resetting LAST. A
-        # WORTH_HAVING_RATIO floor used to sit here too and inverted
-        # monotonicity; the fallback below is what lets it go.
+        # forever and parked the engine on the account resetting LAST. A ratio
+        # floor used to sit here too and inverted monotonicity; the fallback
+        # below is what lets it go.
         best_candidate_headroom = max(
             (
                 h

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1053,14 +1053,10 @@ class AutoSwitchEngine:
         # releases the previous one. This bounds the direction, not the rate:
         # the cooldown already bounds the rate, and it had lapsed at every one
         # of the moves above (301s ticks against a 300s cooldown).
-        # SCOPED like every sibling gate. `at-limit` and `failover` skip the
-        # anti-flap gates by design — there we are escaping a dead account, not
-        # optimising a return time. Unscoped this stranded a 2-account fleet on
-        # an exhausted active with the peer at 0% quota, emitting
-        # "no-candidates" every tick with nothing to release it (the field is
-        # rewritten only by a successful switch, and the field is what prevents
-        # the switch), and on 3 accounts it raised a false AllExhaustedEvent
-        # that reaches the user as a notification and a critical TUI row.
+        # SCOPED like every sibling gate: `at-limit` and `failover` skip the
+        # anti-flap gates by design. Unscoped this stranded a 2-account fleet
+        # on an exhausted active with the peer at 0%, "no-candidates" every
+        # tick, with nothing able to release it.
         came_from = state.get("lastSwitchFrom")
         if (
             trigger in ("proactive", "consume-first")

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1114,9 +1114,15 @@ class AutoSwitchEngine:
                 kw["active_headroom"],
                 kw["settings"],
                 kw["now"],
+                kw["current"],
             )
             no_return = self._no_return_account(
-                trigger, state, kw["headroom"], kw["active_headroom"], recovered
+                trigger,
+                state,
+                kw["headroom"],
+                kw["active_headroom"],
+                recovered,
+                kw["settings"],
             )
             ranked = self._rank_candidates(no_return=no_return, **kw)
             if no_return is not None and not ranked[0] and recovered:
@@ -1321,6 +1327,7 @@ class AutoSwitchEngine:
         headroom: dict[str, float | None],
         active_headroom: float | None,
         recovered: bool,
+        settings: AutoSwitchSettings | None = None,
     ) -> str | None:
         """The account this engine most recently left, while it is still barred.
 
@@ -1390,12 +1397,19 @@ class AutoSwitchEngine:
         if not recovered:
             return barred        # the ratio below burns true on its own; see above
         left_headroom = headroom.get(barred)
-        if (
-            left_headroom is not None
-            and active_headroom is not None
-            and left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO
-        ):
-            return None                      # beats us outright; not a flip
+        if left_headroom is not None:
+            if active_headroom is not None:
+                if left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO:
+                    return None               # beats us outright; not a flip
+            elif (
+                settings is not None
+                and left_headroom > 100.0 - settings.threshold
+            ):
+                # F6 (round-6 review): an unreadable active must not be
+                # silently scored as "the peer does not beat it" -- same
+                # landing-eligible fallback `_left_account_recovered` uses
+                # when it, too, has no active to compare against.
+                return None
         return barred
 
     def _left_account_recovered(
@@ -1406,6 +1420,7 @@ class AutoSwitchEngine:
         active_headroom: float | None,
         settings: AutoSwitchSettings,
         now: float,
+        current: str | None = None,
     ) -> bool:
         """Is the account we left a better proposition than when we left it?
 
@@ -1430,26 +1445,36 @@ class AutoSwitchEngine:
         past the boundary this branch's own sibling test already sits on).
         A `(None, None)` snapshot means severity was genuinely unmeasured at
         departure — there is no `leftHeadroom` to diff against and never was
-        — so the only signal left that does not depend on the active's LIVE
-        state is whether the peer, right now, would itself be a healthy place
+        — so the two signals that do not depend on the active's LIVE state
+        are (1) whether the peer, right now, would itself be a healthy place
         to land: `h > 100 - settings.threshold`, the same "would the ranking
         accept this as a landing spot" test `_rank_candidates` already runs
         (`:1617`) on every candidate, reused rather than inventing a fresh
-        constant. It cannot tell "genuinely recovered" from "was already this
-        good" — there is nothing recorded to tell them apart — so R-A and R-B
-        collapse onto the same answer here. Measured which side that answer
-        should land on: MREL-sweeping this same leg for the ordinary path
-        (round 5 review, F3) showed an absolute floor is silently
-        reintroducible with a green suite, so this is not free of that risk
-        either — the difference is this constant is `settings.threshold`, not
-        a hardcoded number, so a user's OWN policy decides how conservative
+        constant; and (2), when the landing floor cannot answer, whether the
+        peer's own binding reset is meaningfully sooner than the active's
+        (C1, round-6 review). The landing floor is the exact complement of
+        `_every_account_above_threshold`, so it is UNSATISFIABLE whenever the
+        fleet is all-spent — the recovery leg is what keeps the hold from
+        becoming unconditional in exactly that regime. Neither leg can tell
+        "genuinely recovered" from "was already this good" — there is
+        nothing recorded to tell them apart — so R-A and R-B collapse onto
+        the same answer here. Measured which side the landing floor should
+        land on: MREL-sweeping this same leg for the ordinary path (round 5
+        review, F3) showed an absolute floor is silently reintroducible with
+        a green suite, so this is not free of that risk either — the
+        difference is this constant is `settings.threshold`, not a
+        hardcoded number, so a user's OWN policy decides how conservative
         the hold is, and it moves when they change it (pinned directly,
         below). Deliberately MORE conservative than the ordinary path below:
         a peer sitting at 4 points held through the whole walk that broke
         round 5's dominance leg, with no upper bound short of the peer
-        crossing the threshold itself. Bounded, not permanent — at-limit
-        still escapes untouched (`_no_return_account` scopes this trigger
-        out entirely), so the worst case is one bounded hold, not a lockout.
+        crossing the threshold itself OR its binding reset pulling
+        meaningfully ahead of the active's. Bounded, not permanent —
+        at-limit still escapes untouched (`_no_return_account` scopes this
+        trigger out entirely), and the recovery leg means the bound is no
+        longer just "the active reaches its own hard limit" (round-6
+        review, C1/M4): a peer that resets first releases the hold on its
+        own schedule, without the active ever needing to burn down to it.
 
         THE ORDINARY PATH HAS A REAL BASELINE (`leftHeadroom` is a number,
         not null), so it gets three legs, checked in this order, each with
@@ -1496,6 +1521,11 @@ class AutoSwitchEngine:
         """
         came_from = state.get("lastSwitchFrom")
         if came_from is None:
+            # M2 (round-6 review): this return value is unreachable through
+            # `_no_return_account`, the only caller -- it returns `None` at
+            # its own `came_from is None` check before `recovered` is ever
+            # read. Kept `True` (not load-bearing) so a future direct caller
+            # gets "no evidence, release" rather than a silent hold.
             return True
         barred = str(came_from)
         if "leftHeadroom" not in state:
@@ -1507,21 +1537,56 @@ class AutoSwitchEngine:
             # Failover: real departure, severity unmeasured at the time --
             # not absence of evidence, and there is no baseline to diff
             # against (that is exactly what "unmeasured" means), so this
-            # cannot use the active at all -- see docstring for why that is
-            # what round 5 got wrong and the walk that proved it.
-            return h is not None and h > 100.0 - settings.threshold
+            # cannot use the active's HEADROOM at all -- see docstring for
+            # why that is what round 5 got wrong and the walk that proved
+            # it. Two legs, both read-only against CURRENT state (no
+            # departure baseline exists to diff against):
+            #
+            #   landing   `h > 100 - settings.threshold` -- would the
+            #             ranking accept this peer as a landing spot right
+            #             now (`_rank_candidates`, :1636)?
+            #   recovery  the peer's binding reset is meaningfully sooner
+            #             than the ACTIVE's binding reset -- the same axis
+            #             `_recovery_is_useful` switches to once headroom
+            #             stops being informative. Needed because `landing`
+            #             is the exact complement of `_every_account_above_
+            #             threshold` (C1, round-6 review): whenever the
+            #             fleet is all-spent, `landing` is unsatisfiable by
+            #             construction, no matter how soon the peer's own
+            #             window resets, and that regime is precisely where
+            #             the recovery axis is the one the engine trusts.
+            #
+            # Burn cannot fake the recovery leg: a reset moves nearer only
+            # when a nearer window starts binding, never as a side effect
+            # of the active spending down (round 5's failure mode, guarded
+            # against directly by `MF-round5` in the mutation table).
+            if h is not None and h > 100.0 - settings.threshold:
+                return True
+            peer_recovery_ts = _binding_recovery_ts(usage.get(barred), self._models, now)
+            active_recovery_ts = _binding_recovery_ts(usage.get(current), self._models, now)
+            return peer_recovery_ts < active_recovery_ts - RECOVERY_HYSTERESIS_S
         # Dominance over the ACTIVE, only reached once a real baseline is
         # confirmed to exist above -- a peer that was already miles ahead of
         # the active at departure (moved for a DIFFERENT reason -- e.g.
         # consume-first's reset ordering, not headroom) never "improves" on
         # its own baseline and would stall on self-improvement alone despite
         # dominating throughout.
-        if (
-            h is not None
-            and active_headroom is not None
-            and h > active_headroom * HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT
-        ):
-            return True
+        #
+        # `active_headroom is None` (F6, round-6 review) means "we could not
+        # read the active this tick" -- reachable through the consume-first
+        # two-phase commit, which reassigns `active_headroom` from a fresh
+        # refetch without re-classifying the trigger. That is a DIFFERENT
+        # state from "readable, but does not dominate" and must not answer
+        # the same way: fall back to the landing-eligible test the failover
+        # branch above uses when IT has no baseline to compare against
+        # either, rather than silently treating "unreadable" as "no
+        # dominance".
+        if h is not None:
+            if active_headroom is not None:
+                if h > active_headroom * HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT:
+                    return True
+            elif h > 100.0 - settings.threshold:
+                return True
         if (
             isinstance(left_headroom, (int, float))
             and h is not None

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3965,6 +3965,54 @@ class TestHorizonAxisDoesNotFlap:
             "one proactive move disabled proactive switching permanently."
         )
 
+    def test_an_ordinary_departure_does_not_stall_on_a_weekly_bound_peer(
+        self, temp_home
+    ):
+        """I3: the anti-flap snapshot stalls ORDINARY departures too, not
+        just failover, whenever the barred peer is weekly-bound.
+
+        Same root as C1 (a release keyed away from the ACTIVE), reached
+        without any failover: an ordinary consume-first departure records
+        `leftHeadroom`/`leftRecoveryAt`, and `_left_account_recovered`'s
+        headroom leg (`h >= left_headroom + SPENT_HEADROOM_PCT`) can only
+        rise when the barred peer's OWN headroom improves. A peer whose
+        headroom is pinned by 7-day utilization (5-hour rollovers do not
+        raise it) never improves, and its `resets_at` is a fixed absolute
+        that never creeps nearer, so the recovery leg cannot fire either —
+        both legs are permanently unsatisfiable even though the peer is
+        already 35x better than the active.
+
+        Peer 1's reset (20 days out) stays sooner than active account 2's
+        (400 days out) throughout, so the ordinary consume-first
+        reset-ordering gate does not exclude it either; only the anti-flap
+        snapshot does.
+        """
+        h = EngineHarness(temp_home, strategy="consume-first")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage7(30, 30, self._days_out(h, 20)),   # 70 pts, resets in 20d
+            "2": _usage7(50, 50, self._days_out(h, 10)),   # 50 pts, resets SOONER
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(301.0)
+
+        outcomes = []
+        for active_pct in (50, 80, 90, 95, 98, 99.5, 100):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage7(30, 30, self._days_out(h, 20)),   # frozen, 70 pts
+                "2": _usage7(active_pct, active_pct, self._days_out(h, 400)),
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED in outcomes[:-1], (
+            f"{[o.name for o in outcomes]} — peer 1 held 70 points the whole "
+            "time, far ahead of the active, and the engine only returned "
+            "once the active hit a hard 100%"
+        )
+
     def test_a_filtered_candidate_does_not_forge_an_all_exhausted_claim(
         self, temp_home
     ):
@@ -4703,14 +4751,14 @@ class TestHorizonAxisDoesNotFlap:
         state = {"lastSwitchFrom": "2"}  # pre-upgrade: keys genuinely absent
 
         assert harness.engine._left_account_recovered(
-            state, {"2": _usage(96)}, {"2": 4.0}, harness.clock()
+            state, {"2": _usage(96)}, {"2": 4.0}, 2.0, harness.clock()
         ) is True, (
             "a pre-upgrade record (no snapshot) must release even when the "
             "barred account is currently poor (4 pts) — absence of evidence "
             "is not the same state as a measured-unmeasurable failover"
         )
         assert harness.engine._left_account_recovered(
-            state, {"2": None}, {"2": None}, harness.clock()
+            state, {"2": None}, {"2": None}, 2.0, harness.clock()
         ) is True, (
             "a pre-upgrade record (no snapshot) must release even when the "
             "barred account is currently unreadable — absence of evidence "
@@ -4875,6 +4923,60 @@ class TestHorizonAxisDoesNotFlap:
             "below the threshold. The engine stayed put: a permanent "
             "proactive lockout, not the bounded hold this predicate should "
             "produce."
+        )
+
+    def test_a_failover_departure_releases_a_healthy_but_not_near_full_peer(
+        self, temp_home
+    ):
+        """`(None, None)` must release a HEALTHY peer, not just a near-full one.
+
+        `test_a_failover_departure_releases_once_the_peer_is_readable_again`
+        only proves the bar is not PERMANENT — it drives the peer to a full
+        100.0, which also clears the (unfixed) absolute `>= 97.0` floor. That
+        floor makes any peer that has spent more than 3% of its weekly window
+        unreachable: a peer sitting on a perfectly healthy 70 points, with the
+        active burnt down to 2, is held exactly as hard as one on 4 points —
+        the two states this predicate exists to tell apart collapse onto the
+        same answer. C1.
+
+        Reached with a real failover, same setup as the sibling tests, then
+        the peer comes back READABLE at 70 points (well under the 97 floor,
+        well over the 4-point flap the bar must still catch) while the active
+        burns to 2.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = None
+        for _ in range(3):  # unhealthy_ticks default is 3
+            outcome = h.tick_with_usage({
+                "1": None,                              # unreadable -> failover
+                "2": _usage(4, self._days_out(h, 400)),
+            })
+            h.clock.advance(60.0)
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        state = h.engine._read_state()
+        assert state.get("leftHeadroom") is None and state.get(
+            "leftRecoveryAt"
+        ) is None, "premise: a failover snapshot, keys present, values null"
+
+        h.clock.advance(301.0)
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(30, self._days_out(h, 10)),   # READABLE, 70 pts
+                "2": _usage(98, self._days_out(h, 400)),  # active burnt to 2 pts
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"{[o.name for o in outcomes]} — peer 1 is READABLE at 70 points, "
+            "35x the active's 2 points, and the engine never returned. The "
+            "release floor is absolute (h >= 97), so any peer past 3% of its "
+            "weekly window is held until the active hits its own limit."
         )
 
     def test_a_failover_hold_still_escapes_at_limit(self, temp_home):

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -4735,6 +4735,65 @@ class TestHorizonAxisDoesNotFlap:
             "proactive tick"
         )
 
+    def test_a_failover_hold_still_escapes_at_limit(self, temp_home):
+        """The failover hold blocks the PROACTIVE return, not every return.
+
+        `_no_return_account` scopes at-limit and failover out of the bar by
+        design (`if trigger not in ("proactive", "consume-first"): return
+        None`) — a failover-installed hold hard-blocks the proactive path via
+        `_left_account_recovered`'s unconditional `return False`, but that
+        predicate is never even consulted on the at-limit path. Without this
+        test, a permanent-forever hold (e.g. accidentally deleting the
+        trigger scope check, or a future refactor routing at-limit through
+        the same predicate) would pass every other test in this class and
+        strand the engine on an exhausted account with a healthy peer sitting
+        right there.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = None
+        for _ in range(3):  # unhealthy_ticks default is 3
+            outcome = h.tick_with_usage({
+                "1": None,                              # unreadable -> failover
+                "2": _usage(4, self._days_out(h, 400)),
+            })
+            h.clock.advance(60.0)
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        state = h.engine._read_state()
+        assert "leftHeadroom" in state, (
+            "premise: _perform writes the keys unconditionally even on failover"
+        )
+        assert state.get("leftHeadroom") is None
+        assert state.get("leftRecoveryAt") is None
+
+        h.clock.advance(301.0)
+        outcomes = []
+        for _ in range(3):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(96, self._days_out(h, 500)),   # frozen, 4 pts
+                "2": _usage(98, self._days_out(h, 400)),   # active, burnt to 2 pts
+            }))
+            h.clock.advance(301.0)
+        assert TickOutcome.SWITCHED not in outcomes, (
+            f"{[o.name for o in outcomes]} — premise broken: the failover "
+            "hold should still be blocking the proactive return here"
+        )
+
+        outcome = h.tick_with_usage({
+            "1": _usage(0, self._days_out(h, 500)),     # barred, but FULL quota
+            "2": _usage(100, self._days_out(h, 400)),   # active, exhausted -> at-limit
+        })
+        assert outcome is TickOutcome.SWITCHED, (
+            "the failover hold blocked an at-limit escape onto a healthy peer "
+            "— that is a permanent lockout, not the bounded hold this "
+            "predicate is supposed to produce"
+        )
+        assert h.active_number() == 1
+
     def test_the_release_fires_when_the_barred_account_recovered(
         self, temp_home
     ):

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3337,6 +3337,80 @@ class TestRecoveryHorizon:
             "traded 9 points of headroom for 2 on a reset nobody reaches today"
         )
 
+    def test_an_unreadable_peer_does_not_veto_the_spent_check(
+        self, temp_home
+    ):
+        """The spent check ranks the CANDIDATES, not every account in `usage`.
+
+        `headroom` is keyed off `usage`, which carries a row for accounts the
+        loop can never pick — a sentinel (unreadable credential, keychain
+        locked) yields `None` headroom. Testing `headroom.values()` let one
+        such row make `all(...)` False forever, so the spent escape could not
+        fire: measured, three accounts at 99% days out and the engine parked
+        on the one resetting LAST. That is the bug SPENT_HEADROOM_PCT exists
+        to prevent, reintroduced through the iteration set.
+        """
+        h = EngineHarness(temp_home)
+        for n, e in ((1, "a@example.com"), (2, "b@example.com"),
+                     (3, "c@example.com"), (4, "d@example.com")):
+            h.seed(n, e)
+        h.make_live("a@example.com", 1)
+
+        outcome = h.tick_with_usage({
+            "1": _usage(99, self._at(h, 109 * 3600)),  # active, resets LAST
+            "2": _usage(99, self._at(h, 80 * 3600)),
+            "3": _usage(99, self._at(h, 50 * 3600)),   # soonest
+            "4": USAGE_TOKEN_EXPIRED,                  # sentinel: headroom None
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3, (
+            "an unreadable peer vetoed the spent check and parked the engine "
+            "on the account resetting last"
+        )
+
+    def test_a_weekly_bound_active_does_not_refuse_a_peer_back_in_minutes(
+        self, harness
+    ):
+        """The horizon is asked PER CANDIDATE, not once on the active.
+
+        An active bound by its WEEKLY window sits days out while a peer's
+        five-hour window returns in minutes. Asking the active refused that
+        peer — the #202 case this horizon is supposed to preserve. The
+        existing tests never caught it because they populate only a 5h
+        window, so the active's reset and the candidates' always moved
+        together.
+        """
+        outcome = harness.tick_with_usage({
+            # active: 5h fine, WEEKLY at 96% resetting 109h out — days.
+            "1": _usage7(10, 96, self._at(harness, 109 * 3600)),
+            # peer: binding 5h window back in 8 minutes.
+            "2": _usage(98, self._at(harness, 480)),
+            "3": _usage(99, self._at(harness, 90 * 3600)),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2, (
+            "refused a peer returning in 8 minutes because the ACTIVE was "
+            "weekly-bound"
+        )
+
+    def test_an_unknown_active_reset_keeps_the_headroom(self, harness):
+        """`inf` means unknown OR already elapsed — not 'rank by reset'.
+
+        It used to keep the recovery axis, which re-armed the exact trade the
+        horizon forbids: measured, an active with 9 points and no `resets_at`
+        moved to a peer with 1 point resetting 50h out. No evidence that a
+        sooner reset helps is a reason to keep the headroom, not spend it.
+        """
+        outcome = harness.tick_with_usage({
+            "1": _usage(91),                                # active, no reset
+            "2": _usage(98, self._at(harness, 80 * 3600)),
+            "3": _usage(99, self._at(harness, 50 * 3600)),  # soonest, 1 left
+        })
+        assert harness.active_number() == 1, (
+            "traded 9 points for 1 because the active's reset was unknown"
+        )
+        assert outcome is not TickOutcome.SWITCHED
+
     def test_a_peer_with_real_headroom_still_wins_past_the_horizon(self, harness):
         """Falling back to headroom is not "never move": a peer holding
         materially more quota is still the right landing, days-away or not."""

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -4322,14 +4322,14 @@ class TestHorizonAxisDoesNotFlap:
         for trigger in ("at-limit", "failover"):
             for active in (10.0, None):
                 assert harness.engine._no_return_account(
-                    trigger, state, headroom, active, ["1", "3"]
+                    trigger, state, headroom, active, ["1", "3"], harness.settings
                 ) is None, (
                     f"trigger={trigger} active_headroom={active} barred the "
                     "account we left; an escape must reach every candidate"
                 )
         # The control: the SAME state bars on a proactive tick.
         assert harness.engine._no_return_account(
-            "proactive", state, headroom, 10.0, ["1", "3"]
+            "proactive", state, headroom, 10.0, ["1", "3"], harness.settings
         ) == "1", "premise: these inputs are barred when the trigger allows it"
 
     def test_the_bar_actually_removes_the_account_from_the_ranking(
@@ -4489,7 +4489,7 @@ class TestHorizonAxisDoesNotFlap:
         state = {"lastSwitchFrom": 1}
         headroom = {"2": 10.0, "3": 40.0}       # slot 1 unreadable — absent
         assert harness.engine._no_return_account(
-            "proactive", state, headroom, 10.0, ["1", "3"]
+            "proactive", state, headroom, 10.0, ["1", "3"], harness.settings
         ) == "1", (
             "an unreadable barred account must still bar — unknown headroom "
             "is not evidence it beats us"
@@ -5474,6 +5474,130 @@ class TestHorizonAxisDoesNotFlap:
             "however soon the peer returns"
         )
 
+    def test_c1_recovery_leg_requires_the_actives_reset_to_be_known_not_merely_absent(
+        self, temp_home
+    ):
+        """R7 review C-1: `_binding_recovery_ts` returns `inf` for FIVE
+        states, only two of which mean "never" (unreadable, token-expired
+        sentinel) -- unknown resets_at and a stale/past resets_at both also
+        return `inf` but mean "we do not know", not "never". The old
+        predicate `peer < active - HYST` treats all of them alike, so an
+        active whose `resets_at` is simply unreported reads as WORSE than a
+        peer that is finite but arbitrarily far out (400h), and the bar
+        releases onto it on no evidence at all.
+
+        Same failover setup as the sibling C1 tests above (peer barred at
+        departure, active burns down), then a single tick with three
+        variants of the active's reset -- only the active's `resets_at`
+        differs across rows:
+
+            active reset UNREPORTED  -> must BLOCK (hold: unknown != never)
+            active resets in 500h    -> must SWITCH (intended release, C1)
+            active resets in 10min   -> must BLOCK (guard still works)
+        """
+        cases = [
+            (
+                "active reset UNREPORTED (no resets_at)",
+                lambda h: _usage(98.0),
+                TickOutcome.BLOCKED,
+                2,
+            ),
+            (
+                "CONTROL active resets in 500h (finite, still later than peer)",
+                lambda h: _usage(98.0, self._days_out(h, 500)),
+                TickOutcome.SWITCHED,
+                1,
+            ),
+            (
+                "CONTROL active resets in 10min (finite, sooner than peer)",
+                lambda h: _usage(98.0, self._at(h, 600)),
+                TickOutcome.BLOCKED,
+                2,
+            ),
+        ]
+        for label, active_row, expected_outcome, expected_active in cases:
+            h = EngineHarness(temp_home)
+            h.seed(1, "a@example.com")
+            h.seed(2, "b@example.com")
+            h.make_live("a@example.com", 1)
+
+            outcome = None
+            for _ in range(3):  # unhealthy_ticks default is 3
+                outcome = h.tick_with_usage({
+                    "1": None,                              # unreadable -> failover
+                    "2": _usage(4, self._at(h, 400 * 3600)),
+                })
+                h.clock.advance(60.0)
+            assert outcome is TickOutcome.SWITCHED
+            assert h.active_number() == 2
+
+            h.clock.advance(301.0)
+            out = h.tick_with_usage({
+                "1": _usage(97.5, self._at(h, 400 * 3600)),  # barred peer, 400h out
+                "2": active_row(h),                            # active
+            })
+            assert out is expected_outcome and h.active_number() == expected_active, (
+                f"{label}: got {out.name}/active={h.active_number()}, want "
+                f"{expected_outcome.name}/active={expected_active}"
+            )
+
+    def test_i3_left_snapshot_uses_the_ranking_now_not_a_fresh_clock_read(
+        self, temp_home
+    ):
+        """R7 review I-3: `left_snapshot` used to re-read `self.clock()`
+        AFTER the ranking had already decided on a `now`, instead of reusing
+        that same value. On a fake, non-advancing clock the two reads are
+        identical, so no existing test could see the difference -- on a real
+        wall clock any elapsed time between the two reads (however small) can
+        tip a reset that was still in the future at ranking time into the
+        past by the second read, turning a real `leftRecoveryAt` into `null`.
+
+        Drives that divergence directly with a scripted clock: the value
+        returned to the ranking's `now=self.clock()` sits BEFORE the active's
+        binding reset; the value that a SECOND, independent `self.clock()`
+        call would see (what the old code did) sits AFTER it. The recorded
+        `leftRecoveryAt` must reflect the ranking-time read.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        ranking_now = 1_000_000.0
+        reset_at = self._iso_at(ranking_now + 100.0)   # future at ranking_now
+        stale_reread = ranking_now + 200.0             # past reset_at
+
+        # Enough values for the OLD code's clock() call order (pre-tick
+        # check, ranking now, left_snapshot re-read, freshen expiry check,
+        # _perform's lastSwitchAt) with a couple of spares so neither code
+        # path can exhaust the sequence.
+        clock_values = iter([
+            ranking_now, ranking_now, stale_reread,
+            stale_reread, stale_reread, stale_reread,
+        ])
+        with patch.object(h.engine, "clock", side_effect=lambda: next(clock_values)):
+            outcome = h.tick_with_usage({
+                "1": _usage(95, reset_at),
+                "2": _usage(10),
+            })
+        assert outcome is TickOutcome.SWITCHED
+        state = h.engine._read_state()
+        assert state.get("leftRecoveryAt") == ranking_now + 100.0, (
+            f"leftRecoveryAt={state.get('leftRecoveryAt')!r} -- a SECOND, "
+            "independent clock() read after the ranking already decided "
+            "would see the reset as already past and record None; the "
+            "snapshot must use the value the ranking itself decided on"
+        )
+
+    def _iso_at(self, epoch_seconds):
+        from datetime import datetime, timezone
+
+        return (
+            datetime.fromtimestamp(epoch_seconds, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
     def test_the_all_spent_stall_above_is_the_floor_not_the_fleet(
         self, temp_home
     ):
@@ -5983,7 +6107,7 @@ class TestAcceptance204eR1toR7:
         for active in (0.0, None):
             for recovered in (True, False):
                 assert harness.engine._no_return_account(
-                    "at-limit", state, headroom, active, recovered
+                    "at-limit", state, headroom, active, recovered, harness.settings
                 ) is None, (
                     "at-limit must escape the bar regardless of "
                     "active_headroom or the recovered predicate's answer"

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3664,6 +3664,35 @@ class TestHorizonAxisDoesNotFlap:
         )
         assert outcome is not TickOutcome.SWITCHED
 
+    def test_past_the_horizon_headroom_decides_before_the_reset(self, harness):
+        """Tier 1 is `(1, -h, recovery_ts)` — headroom leads, reset breaks ties.
+
+        Past the horizon the reset is days out either way, so it cannot be the
+        thing that decides; the headroom is the only resource that still does
+        work this session. The reset stays in the key so two equal-headroom
+        peers do not tie into sequence order.
+
+        Nothing pinned the ORDER: swapping to `(1, recovery_ts, -h)` left the
+        whole suite green. The one test that touches the tier uses EQUAL
+        headroom (92/92), where both orderings agree — it kills the
+        hard-coded-`0.0` mutant and not this one.
+
+        Sweep over 23328 three-account shapes: 2040 change answer. The shape
+        below is one, and the trade the reset-first key makes is 2 points of
+        headroom for a reset 10 hours sooner, on a pair that both return
+        within a day.
+        """
+        outcome = harness.tick_with_usage({
+            "1": _usage(99, self._days_out(harness, 20)),     # active, 1 left
+            "2": _usage(98, self._days_out(harness, 10)),     # 2 left, sooner
+            "3": _usage(96, self._days_out(harness, 20)),     # 4 left
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3, (
+            f"landed on {harness.active_number()} — the reset outranked twice "
+            "the headroom, past a horizon where neither reset is near"
+        )
+
     def test_a_burn_walk_settles_instead_of_oscillating(self, harness):
         """A-B-A under burn is the fleet changing regime, not a gate leaking.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3630,6 +3630,40 @@ class TestHorizonAxisDoesNotFlap:
             "the guard belonging to the OTHER leg's axis"
         )
 
+    def test_the_spent_fallback_needs_a_meaningfully_sooner_reset(self, harness):
+        """The fallback is bounded by the SAME hysteresis the recovery axis uses.
+
+        Its other two guards are pinned by the tests above (dropping the spent
+        gate reddens `test_one_point_of_headroom_does_not_move` and
+        `test_the_return_leg_is_blocked_too`; dropping `h >= active` reddens
+        `test_a_peer_worth_having_is_not_filtered_out_of_the_worth_having_check`).
+        The margin was the one nothing killed — measured, replacing
+        `< active_recovery_ts - RECOVERY_HYSTERESIS_S` with a bare
+        `< active_recovery_ts` left all 168 tests in this file green.
+
+        Exhaustive 2- and 3-account sweep over headroom x reset, 16200 shapes:
+        exactly 42 change answer, all of the shape below.
+
+            acct 1   2.5 points, reset 500.02h out   (active)
+            acct 2   4.0 points, reset 500.00h out   (72s sooner)
+
+            with the margin     no move, both legs
+            without it          active=1 moves to 2; active=2 holds
+
+        One-way, so not a flap — a credential rewrite bought with 72 seconds
+        of earlier return, on a pair that both come back in three weeks. The
+        margin is what makes "sooner" mean sooner enough to be worth the write.
+        """
+        outcome = harness.tick_with_usage({
+            "1": _usage(97.5, self._days_out(harness, 500.02)),  # active, 2.5 left
+            "2": _usage(96.0, self._days_out(harness, 500.0)),   # 4 left, 72s sooner
+        })
+        assert harness.active_number() == 1, (
+            "moved for a 72-second-sooner reset three weeks out — inside "
+            "RECOVERY_HYSTERESIS_S, which is what bounds the write rate"
+        )
+        assert outcome is not TickOutcome.SWITCHED
+
     def test_a_materially_better_peer_still_wins(self, harness):
         """The escape must survive: 2 points left against 10 is a real move."""
         outcome = harness.tick_with_usage({

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3664,6 +3664,63 @@ class TestHorizonAxisDoesNotFlap:
         )
         assert outcome is not TickOutcome.SWITCHED
 
+    def test_the_fallback_never_outranks_a_real_qualifier(self, harness):
+        """It runs only when nothing else qualifies, and the key is why.
+
+        The fallback's key is tier 0; every ordinary candidate is tier 1. So
+        if a fallback entry ever reached the same list as a qualifier it would
+        sort FIRST regardless of headroom. `qualifying or fallback` is the
+        only thing preventing that, and nothing tested it — measured,
+        replacing it with `qualifying + fallback` left the suite green while
+        flipping this scenario 0/3 -> 3/3 in the fallback's favour.
+
+        Active is spent (3 pts). One peer qualifies outright on headroom; one
+        margin-failure peer resets sooner. The qualifier must win.
+        """
+        outcome = harness.tick_with_usage({
+            "1": _usage(97, self._days_out(harness, 500)),   # active, 3 left
+            "2": _usage(94, self._days_out(harness, 400)),   # 6 left: qualifies
+            "3": _usage(96.4, self._days_out(harness, 100)), # 3.6 left, sooner
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2, (
+            f"landed on {harness.active_number()} — the tier-0 fallback key "
+            "outranked a candidate with twice the headroom"
+        )
+
+    def test_the_fallback_ranks_by_reset_not_by_headroom(self, harness):
+        """`(0, recovery_ts, -h)` — the reset leads, and that is deliberate.
+
+        Every account in the fallback is spent, and below SPENT_HEADROOM_PCT a
+        headroom edge is under two poll intervals of work. The only real
+        question is which account can work again first, which is the same
+        judgement `_recovery_is_useful` makes one gate earlier.
+
+        Nothing tested it: swapping to `(0, -h, recovery_ts)` left the suite
+        green. Exhaustive sweep over 42336 three-account shapes, 558 change
+        answer, all this shape —
+
+            active 2.0 pts / 300h
+            acct 2  2.0 pts /  10h   (spent, back soonest)
+            acct 3  3.1 pts /  50h   (a point more, back 40h later)
+
+            reset key      -> 2 first
+            headroom key   -> 3 first
+
+        Taking acct 3 buys 1.1 points, worth minutes, at the cost of 40 hours
+        of waiting.
+        """
+        outcome = harness.tick_with_usage({
+            "1": _usage(98, self._days_out(harness, 300)),    # active, 2 left
+            "2": _usage(98, self._days_out(harness, 10)),     # 2 left, soonest
+            "3": _usage(96.9, self._days_out(harness, 50)),   # 3.1 left, later
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2, (
+            f"landed on {harness.active_number()} — took a point of spent "
+            "headroom over a reset 40 hours sooner"
+        )
+
     def test_a_materially_better_peer_still_wins(self, harness):
         """The escape must survive: 2 points left against 10 is a real move."""
         outcome = harness.tick_with_usage({

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3463,6 +3463,47 @@ class TestTheHorizonDoesNotDiscardWhatItAlreadyKnows:
             "equal headroom, and the 5h reset lost to the 500h one on slot order"
         )
 
+    def test_a_peer_worth_having_is_not_filtered_out_of_the_worth_having_check(
+        self, harness
+    ):
+        """The floor must not exclude a peer that plainly has quota.
+
+        `best_candidate_headroom` was scoped by
+        `active_headroom x HORIZON_HEADROOM_RATIO` — but that constant is an
+        ANTI-FLAP MARGIN, not a "worth having" cutoff. A peer at
+        2x-minus-epsilon the active's headroom is very much worth having; it
+        merely fails this tick's margin.
+
+        With every candidate below the floor, `default=0.0` makes
+        `best_candidate_headroom` 0.0, which SATISFIES the spent clause — so
+        the clause fires for everybody, the horizon check is never reached, and
+        ranking falls to soonest reset regardless of headroom. The engine then
+        takes a nearly-empty account over one holding 60x more:
+
+            active   3.00 pts, 500h     peerA 5.99 pts, 400h
+            peerB    0.10 pts, 200h  <- chosen
+
+        Three-way: base 9f35426 also lands on peerB, but 0457cb0 (this PR
+        before the veto-scope fix) holds the active. So the fix reintroduced
+        base's answer in a band the commit before it had already made safe.
+
+        Asserted as "does not take the nearly-empty account". Whether it takes
+        peerA or holds is the ANTI-FLAP margin's call, and at 5.99 against a
+        6.00 margin holding is correct — that is a separate question from
+        whether peerA counts as quota existing, which is what this pins.
+        """
+        out = harness.tick_with_usage({
+            "1": _usage(97.00, self._at(harness, 500 * 3600)),  # active, 3.00
+            "2": _usage(94.01, self._at(harness, 400 * 3600)),  # 5.99
+            "3": _usage(99.90, self._at(harness, 200 * 3600)),  # 0.10
+        })
+        assert harness.active_number() != 3, (
+            "took the 0.10-point account over one holding 5.99 — the floor "
+            "excluded the peer that made the spent clause false, and an empty "
+            "max reads as 'nothing is worth having'"
+        )
+        assert out is not TickOutcome.SWITCHED or harness.active_number() == 2
+
     def test_an_unchoosable_peer_does_not_veto_the_reset_ranking(self, harness):
         """``best_candidate_headroom`` counted a candidate the ranking cannot pick.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -4735,6 +4735,110 @@ class TestHorizonAxisDoesNotFlap:
             "proactive tick"
         )
 
+    def test_a_failover_departure_still_unreadable_does_not_crash_or_release(
+        self, temp_home
+    ):
+        """The barred peer staying unreadable after a failover must hold cleanly.
+
+        `_left_account_recovered`'s `(None, None)` branch reads the barred
+        account's CURRENT headroom to tell "still unmeasurable" from
+        "measurable again". `headroom.get(barred)` is `None` when the peer is
+        still unreadable, and a comparison against that (`None >= 97.0`)
+        raises `TypeError` in Python 3 rather than silently doing the wrong
+        thing — so a guard that drops the `is not None` check is not a subtle
+        release-too-early bug, it is a crash on every tick this shape
+        produces. Guard against both: no exception, and no release on
+        no-evidence-either-way.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = None
+        for _ in range(3):  # unhealthy_ticks default is 3
+            outcome = h.tick_with_usage({
+                "1": None,                              # unreadable -> failover
+                "2": _usage(4, self._days_out(h, 400)),
+            })
+            h.clock.advance(60.0)
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+        h.clock.advance(301.0)
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                "1": None,                                    # still unreadable
+                "2": _usage(98, self._days_out(h, 400)),       # active, burnt down
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.ERROR not in outcomes, (
+            f"{[o.name for o in outcomes]} — comparing the barred peer's "
+            "unreadable (`None`) headroom against the release threshold must "
+            "not raise; a bare `h >= ...` with no `is not None` guard does"
+        )
+        assert TickOutcome.SWITCHED not in outcomes, (
+            f"{[o.name for o in outcomes]} — the barred peer never became "
+            "readable; that is 'still unmeasurable', not a recovery"
+        )
+
+    def test_a_failover_departure_releases_once_the_peer_is_readable_again(
+        self, temp_home
+    ):
+        """`(None, None)` must not be a PERMANENT lockout once the peer heals.
+
+        The sibling test above holds the bar while the failed-over peer is
+        STILL unreadable or still poor — correct, and the flap 0b369e0 fixed.
+        But `_left_account_recovered`'s original fix (`return False`
+        unconditionally on `(None, None)`) held it forever: nothing in that
+        branch ever looked at the peer's CURRENT state, so a peer that went
+        unreadable -> readable at full quota with a near reset could never
+        release the proactive/consume-first bar. On a 2-account fleet there
+        is no third account to switch to, so that is a permanent proactive
+        lockout, not anti-flap.
+
+        Same failover setup as the sibling test, but this time account 1
+        comes back READABLE at full quota with a near reset while the active
+        burns below the threshold — a real change of state, not a flap.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = None
+        for _ in range(3):  # unhealthy_ticks default is 3
+            outcome = h.tick_with_usage({
+                "1": None,                              # unreadable -> failover
+                "2": _usage(4, self._days_out(h, 400)),
+            })
+            h.clock.advance(60.0)
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        state = h.engine._read_state()
+        assert state.get("leftHeadroom") is None and state.get(
+            "leftRecoveryAt"
+        ) is None, "premise: a failover snapshot, keys present, values null"
+
+        h.clock.advance(301.0)
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(0, self._days_out(h, 10)),    # READABLE, full, near reset
+                "2": _usage(95, self._days_out(h, 400)),  # active below threshold
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"{[o.name for o in outcomes]} — peer 1 went unreadable -> "
+            "readable at full quota with a near reset while the active fell "
+            "below the threshold. The engine stayed put: a permanent "
+            "proactive lockout, not the bounded hold this predicate should "
+            "produce."
+        )
+
     def test_a_failover_hold_still_escapes_at_limit(self, temp_home):
         """The failover hold blocks the PROACTIVE return, not every return.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3184,6 +3184,181 @@ class TestConsumeFirstStrategy:
         assert sw.trigger == "at-limit"
 
 
+class TestConsumeFirstDepartureRecordsItsOwnTrigger:
+    """R8 review I-B: a `consume-first` departure's phase-2 refetch can write
+    `(leftHeadroom, leftRecoveryAt) = (None, None)` -- the exact snapshot
+    shape a `failover` departure writes -- whenever the refetched active row
+    has a `pct` but is otherwise unmeasurable in the SAME tick its weekly
+    reset is known (`account_headroom` needs a numeric `pct`;
+    `_seven_day_reset_ts` needs only `resets_at` -- one row can satisfy one
+    and not the other, exactly what the normalizer emits for
+    `utilization: null`). `_left_account_recovered` then infers the trigger
+    from the two nulls and runs the FAILOVER legs (landing floor + recovery)
+    on what was really an ORDINARY departure (dominance + self-improvement +
+    recovery) -- and the two branches disagree.
+
+    Fleet: barred peer 11 pts, active 5 pts, no resets anywhere. Failover's
+    landing floor (`h > 100 - threshold` = 10) releases at 11. Ordinary's
+    dominance ratio (`h > active*2+3` = 13) does not, self-improvement has
+    no baseline to diff against (`leftHeadroom` genuinely unmeasured), and
+    the recovery leg is inf-vs-inf. The two branches give OPPOSITE answers
+    on the identical (None, None) snapshot -- only which trigger produced it
+    tells them apart, and that is exactly the bit `leftTrigger` records.
+    """
+
+    def test_the_null_snapshot_answers_differently_by_recorded_trigger(self):
+        from claude_swap.autoswitch import AutoSwitchEngine
+        from claude_swap.settings import AutoSwitchSettings
+
+        class Fake(AutoSwitchEngine):
+            def __init__(self):
+                self._models = ()
+
+        e = Fake()
+        settings = AutoSwitchSettings()
+        now = 1_000_000.0
+        usage = {"1": _usage(89.0), "2": _usage(95.0)}   # peer 11 pts, active 5 pts
+        headroom = {"1": 11.0}
+
+        failover_state = {
+            "lastSwitchFrom": "1",
+            "leftHeadroom": None,
+            "leftRecoveryAt": None,
+            "leftTrigger": "failover",
+        }
+        consume_first_state = {
+            "lastSwitchFrom": "1",
+            "leftHeadroom": None,
+            "leftRecoveryAt": None,
+            "leftTrigger": "consume-first",
+        }
+
+        failover_recovered = e._left_account_recovered(
+            failover_state, usage, headroom, 5.0, settings, now, "2"
+        )
+        ordinary_recovered = e._left_account_recovered(
+            consume_first_state, usage, headroom, 5.0, settings, now, "2"
+        )
+        assert failover_recovered is True, (
+            "a real failover departure's landing floor (h > 10) releases "
+            "on an 11-point peer with no baseline to diff against"
+        )
+        assert ordinary_recovered is False, (
+            "a consume-first departure's dominance leg (h > active*2+3=13) "
+            "does not clear at 11 points, and there is no leftHeadroom "
+            "baseline to self-improve against -- must hold, not borrow the "
+            "failover branch's more permissive landing floor"
+        )
+
+    def test_pre_upgrade_null_snapshot_without_leftTrigger_still_infers_failover(
+        self,
+    ):
+        """Backward compatibility: a record written before `leftTrigger`
+        existed has no such key. Must fall back to the old two-null
+        inference (failover) rather than crash or silently misclassify."""
+        from claude_swap.autoswitch import AutoSwitchEngine
+        from claude_swap.settings import AutoSwitchSettings
+
+        class Fake(AutoSwitchEngine):
+            def __init__(self):
+                self._models = ()
+
+        e = Fake()
+        settings = AutoSwitchSettings()
+        now = 1_000_000.0
+        usage = {"1": _usage(89.0), "2": _usage(95.0)}
+        headroom = {"1": 11.0}
+        legacy_state = {
+            "lastSwitchFrom": "1",
+            "leftHeadroom": None,
+            "leftRecoveryAt": None,
+            # no "leftTrigger" key
+        }
+        recovered = e._left_account_recovered(
+            legacy_state, usage, headroom, 5.0, settings, now, "2"
+        )
+        assert recovered is True, (
+            "no leftTrigger recorded -> fall back to the pre-I-B inference "
+            "(both null -> failover), same as before this fix"
+        )
+
+    def test_a_legacy_record_with_a_real_leftHeadroom_is_never_forced_through_the_failover_legs(
+        self,
+    ):
+        """The fallback must only trigger on the OLD (None, None) shape, not
+        unconditionally. A legacy record (no `leftTrigger`) with a REAL
+        `leftHeadroom` is unambiguous -- it is an ordinary-path departure by
+        construction (only `_perform`'s (None, None) write for failover ever
+        leaves both null) -- and must still take the ordinary legs, not the
+        more permissive failover landing floor, regardless of whether some
+        future change makes the failover branch unconditional."""
+        from claude_swap.autoswitch import AutoSwitchEngine
+        from claude_swap.settings import AutoSwitchSettings
+
+        class Fake(AutoSwitchEngine):
+            def __init__(self):
+                self._models = ()
+
+        e = Fake()
+        settings = AutoSwitchSettings()
+        now = 1_000_000.0
+        usage = {"1": _usage(89.0), "2": _usage(95.0)}  # peer 11 pts, active 5 pts
+        headroom = {"1": 11.0}
+        legacy_state_real_headroom = {
+            "lastSwitchFrom": "1",
+            "leftHeadroom": 10.0,
+            "leftRecoveryAt": None,
+            # no "leftTrigger" key
+        }
+        recovered = e._left_account_recovered(
+            legacy_state_real_headroom, usage, headroom, 5.0, settings, now, "2"
+        )
+        assert recovered is False, (
+            "leftHeadroom=10.0 is a real (non-null) baseline, so this is "
+            "unambiguously an ORDINARY departure -- the failover landing "
+            "floor (h > 10, which 11 clears) must NOT decide this; the "
+            "ordinary legs (dominance h > active*2+3=13, self-improvement "
+            "h >= left+3=13) both fail at h=11 and must hold"
+        )
+
+    def test_end_to_end_consume_first_departure_records_its_own_trigger(
+        self, temp_home
+    ):
+        """Drive a real consume-first departure through `_perform` and read
+        the persisted state back: `leftTrigger` must be `"consume-first"`,
+        not silently absent."""
+        h = EngineHarness(temp_home, strategy="consume-first")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        out = h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATER),
+            "2": _usage7(10, 10, _R_SOON),
+        })
+        assert out is TickOutcome.SWITCHED
+        state = h.engine._read_state()
+        assert state.get("leftTrigger") == "consume-first", (
+            f"expected leftTrigger='consume-first', got {state.get('leftTrigger')!r}"
+        )
+
+    def test_end_to_end_failover_departure_records_its_own_trigger(
+        self, temp_home
+    ):
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        out = None
+        for _ in range(3):
+            out = h.tick_with_usage({"1": None, "2": _usage(4)})
+            h.clock.advance(60.0)
+        assert out is TickOutcome.SWITCHED
+        state = h.engine._read_state()
+        assert state.get("leftTrigger") == "failover", (
+            f"expected leftTrigger='failover', got {state.get('leftTrigger')!r}"
+        )
+
+
 class TestEveryAccountAboveThreshold:
     """With nothing below the threshold, go to whatever comes back soonest.
 
@@ -5535,6 +5710,89 @@ class TestHorizonAxisDoesNotFlap:
             out = h.tick_with_usage({
                 "1": _usage(97.5, self._at(h, 400 * 3600)),  # barred peer, 400h out
                 "2": active_row(h),                            # active
+            })
+            assert out is expected_outcome and h.active_number() == expected_active, (
+                f"{label}: got {out.name}/active={h.active_number()}, want "
+                f"{expected_outcome.name}/active={expected_active}"
+            )
+
+    def test_r8_isfinite_guard_must_not_hold_when_a_near_peer_is_available(
+        self, temp_home
+    ):
+        """R8 review I-A: `math.isfinite(active_recovery_ts)` (C-1, R7) reads
+        ALL FIVE `inf` states as "unknown, hold" -- but two of them are
+        ordinary API shapes for an active that is plainly alive and burning:
+        no `resets_at` reported, or a `resets_at` already elapsed. On those
+        the bar now sits on a near-spent active even when the peer is back
+        within `RECOVERY_HORIZON_S` -- the same PR's own constant for "near
+        enough to matter".
+
+        Same failover setup as the sibling C1 tests (peer barred at
+        departure, active burns down), then a single tick with four
+        variants -- only the ACTIVE's `resets_at` (and, for NEG, the peer's)
+        differs across rows:
+
+            POS   active reset 400h out, peer back in ~50min  -> SWITCHED
+            NEG   active reset 400h out, peer only 60s sooner -> BLOCKED
+            DMG-a active reset UNREPORTED, peer back in ~50min-> SWITCHED
+            DMG-b active reset in the PAST, peer back in ~50min-> SWITCHED
+
+        POS/NEG must already pass unfixed -- they pin the guard's intended
+        behaviour (both controls invariant, per the review's damage table).
+        DMG-a/DMG-b fail against 5c69ad2 because `isfinite` reads the
+        active's `inf` as "unknown" and holds even though the peer is
+        inside the horizon.
+        """
+        cases = [
+            (
+                "POS active reset 400h out, peer ~50min out",
+                lambda h: _usage(98.0, self._at(h, 400 * 3600)),
+                lambda h: self._at(h, 3000.0),
+                TickOutcome.SWITCHED,
+                1,
+            ),
+            (
+                "NEG active reset 400h out, peer only 60s sooner",
+                lambda h: _usage(98.0, self._at(h, 400 * 3600)),
+                lambda h: self._at(h, 400 * 3600 - 60.0),
+                TickOutcome.BLOCKED,
+                2,
+            ),
+            (
+                "DMG-a active NO resets_at, peer ~50min out",
+                lambda h: _usage(98.0),
+                lambda h: self._at(h, 3000.0),
+                TickOutcome.SWITCHED,
+                1,
+            ),
+            (
+                "DMG-b active reset in PAST, peer ~50min out",
+                lambda h: _usage(98.0, self._at(h, -3600.0)),
+                lambda h: self._at(h, 3000.0),
+                TickOutcome.SWITCHED,
+                1,
+            ),
+        ]
+        for label, active_row, peer_reset, expected_outcome, expected_active in cases:
+            h = EngineHarness(temp_home)
+            h.seed(1, "a@example.com")
+            h.seed(2, "b@example.com")
+            h.make_live("a@example.com", 1)
+
+            outcome = None
+            for _ in range(3):  # unhealthy_ticks default is 3
+                outcome = h.tick_with_usage({
+                    "1": None,                              # unreadable -> failover
+                    "2": _usage(4, self._at(h, 400 * 3600)),
+                })
+                h.clock.advance(60.0)
+            assert outcome is TickOutcome.SWITCHED
+            assert h.active_number() == 2
+
+            h.clock.advance(301.0)
+            out = h.tick_with_usage({
+                "1": _usage(96.0, peer_reset(h)),  # barred peer, 4 pts (below floor)
+                "2": active_row(h),                # active, 2 pts
             })
             assert out is expected_outcome and h.active_number() == expected_active, (
                 f"{label}: got {out.name}/active={h.active_number()}, want "

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3296,6 +3296,69 @@ class TestEveryAccountAboveThreshold:
         assert sw.trigger == "at-limit"
 
 
+class TestRecoveryHorizon:
+    """The recovery escape must not spend real headroom on a distant reset.
+
+    #202 introduced "when everything is above the threshold, go where quota
+    returns first". Its evidence was minutes-scale — the measured case had a
+    peer whose 5-hour window reset in 8 minutes, and trading 9 points of
+    headroom for an 8-minute wait is obviously right.
+
+    The rule shipped with no horizon bound, so it applies identically when
+    every reset is DAYS away. Measured live: active 91% (7d resets in 109h),
+    peers 94%/80h and 98%/50h. The engine moved from 9 points of headroom to
+    2 — but nothing comes back today either way, so those 9 points were the
+    only resource that could still do work. The user switched back by hand.
+
+    Past HORIZON, ranking returns to headroom: when no candidate can resume
+    within a working session, "soonest" stops being a benefit worth paying
+    for and how much quota is left is what decides whether work continues.
+    """
+
+    def _at(self, harness, seconds: float) -> str:
+        from datetime import datetime, timezone
+
+        return (
+            datetime.fromtimestamp(harness.clock.now + seconds, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    def test_a_minutes_away_reset_still_wins(self, harness):
+        """The #202 design case is unchanged: an 8-minute wait is worth 9
+        points of headroom."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(91, self._at(harness, 7200)),   # active, 9 left, back in 2h
+            "2": _usage(94, self._at(harness, 1800)),
+            "3": _usage(98, self._at(harness, 480)),    # back in 8 minutes
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3
+
+    def test_a_days_away_reset_does_not_buy_headroom(self, harness):
+        """The measured live shape. Every reset is days out, so ranking falls
+        back to headroom and the account with 9 points left keeps the work."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(91, self._at(harness, 109 * 3600)),  # active, 9 left
+            "2": _usage(94, self._at(harness, 80 * 3600)),
+            "3": _usage(98, self._at(harness, 50 * 3600)),   # 2 left, soonest
+        })
+        assert harness.active_number() == 1, (
+            "traded 9 points of headroom for 2 on a reset nobody reaches today"
+        )
+
+    def test_a_peer_with_real_headroom_still_wins_past_the_horizon(self, harness):
+        """Falling back to headroom is not "never move": a peer holding
+        materially more quota is still the right landing, days-away or not."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(97, self._at(harness, 50 * 3600)),   # active, 3 left
+            "2": _usage(91, self._at(harness, 109 * 3600)),  # 9 left
+            "3": _usage(98, self._at(harness, 60 * 3600)),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2
+
+
 class TestReviewFindings202:
     """Three defects found reviewing #202, each reproduced before fixing.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3430,6 +3430,75 @@ class TestHorizonAxisDoesNotFlap:
         assert harness.active_number() == 3
 
 
+class TestAllSpentGoesToTheSoonestReset:
+    """When every account is spent, sit where the quota comes back first.
+
+    Headroom decides while there is headroom worth comparing. Once everyone is
+    down to a point or two, headroom says nothing — a one-point edge is under
+    ten minutes of work at the burn rates measured on 2026-07-30 — and the only
+    thing that still matters is who returns first, so the reset finds us
+    already on it.
+
+    The horizon rule alone got this wrong: past four hours it always ranked by
+    headroom, so three accounts at 99% had no qualifying candidate and the
+    engine parked on whichever one it happened to be on — including the one
+    resetting LAST, 109h out against a peer 50h out.
+    """
+
+    def _at(self, harness, seconds: float) -> str:
+        from datetime import datetime, timezone
+
+        return (
+            datetime.fromtimestamp(harness.clock.now + seconds, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    def test_all_spent_moves_to_the_soonest_reset(self, harness):
+        """The reported shape: 99/99/99, days out, active resets last."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(99, self._at(harness, 109 * 3600)),  # active, LAST
+            "2": _usage(99, self._at(harness, 80 * 3600)),
+            "3": _usage(99, self._at(harness, 50 * 3600)),   # SOONEST
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3, (
+            "parked on the account that returns last while a peer comes back "
+            "59h sooner"
+        )
+
+    def test_already_on_the_soonest_stays_put(self, harness):
+        """No move when we are already where the quota returns first."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(99, self._at(harness, 50 * 3600)),   # active, SOONEST
+            "2": _usage(99, self._at(harness, 80 * 3600)),
+            "3": _usage(99, self._at(harness, 109 * 3600)),
+        })
+        assert outcome is not TickOutcome.SWITCHED
+        assert harness.active_number() == 1
+
+    def test_real_headroom_still_beats_a_sooner_reset(self, harness):
+        """Above the spent band the headroom axis still rules: a peer holding
+        ten points wins even though a spent one resets sooner."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(98, self._at(harness, 109 * 3600)),  # active, 2 left
+            "2": _usage(90, self._at(harness, 80 * 3600)),   # 10 left
+            "3": _usage(99, self._at(harness, 50 * 3600)),   # 1 left, soonest
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2
+
+    def test_the_flap_guard_survives_in_the_spent_band(self, harness):
+        """Ranking by reset must not reintroduce ping-pong: an account whose
+        reset is barely sooner does not qualify."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(99, self._at(harness, 50 * 3600)),        # active
+            "2": _usage(99, self._at(harness, 50 * 3600 - 60)),   # 60s sooner
+            "3": _usage(99, self._at(harness, 80 * 3600)),
+        })
+        assert outcome is not TickOutcome.SWITCHED
+
+
 class TestReviewFindings202:
     """Three defects found reviewing #202, each reproduced before fixing.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3845,8 +3845,17 @@ class TestHorizonAxisDoesNotFlap:
         stops only because both accounts hit the 99.95 burn cap, so the fourth
         move is not a transient.
 
-        Refusing the account we most recently left bounds it: the axis may
-        still flip, but a flip cannot undo the move before it.
+        Refusing the account we most recently left bounds it — but identity
+        alone has no release, and on a 2-account fleet that is a permanent
+        proactive lockout (see the sibling test). Released by the same ratio
+        the anti-flap margin uses, the walk is still BOUNDED: measured over
+        24 / 120 / 400 ticks, [1,2,1] then [1,2,1,2] and no further, because
+        each return has to clear 2x and burn makes that harder every time.
+
+        So this asserts a BOUND, not zero returns. Zero was a property of the
+        release-less filter, and that property is what made the lockout
+        permanent. A walk that ends is the real requirement; the live incident
+        this class documents was four moves in 35 minutes and still climbing.
         """
         pct = {"1": 92.0, "2": 92.0}
         seen = []
@@ -3861,13 +3870,95 @@ class TestHorizonAxisDoesNotFlap:
             harness.clock.advance(301.0)
 
         moves = [n for i, n in enumerate(seen) if i == 0 or n != seen[i - 1]]
-        returns = [
-            moves[i + 1] for i in range(len(moves) - 1)
-            if moves[i + 1] in moves[:i + 1]
-        ]
-        assert returns == [], (
-            f"move sequence {moves} — the walk returned to an account it had "
-            "already left, so the axis flip undid the move before it"
+        assert len(moves) <= 4, (
+            f"move sequence {moves} — the walk did not settle. Without the "
+            "ratio release it is unbounded; with it, 120 and 400 ticks both "
+            "measure the same four moves."
+        )
+
+    def test_a_proactive_move_does_not_lock_out_the_next_one(self, harness):
+        """The no-return filter has no release condition on a 2-account fleet.
+
+        `lastSwitchFrom` is written only by a SUCCESSFUL switch, and on two
+        accounts the filter removes the only candidate — so the switch that
+        would rewrite it can never happen. Self-perpetuating, and persisted:
+        it survives a restart and a week of wall clock.
+
+        Reached by ONE ordinary proactive move, no seeded state. After it, the
+        peer resets to full and the active keeps burning; every proactive tick
+        answers "no-candidates" while a 0% account sits there. The engine
+        escapes only at a hard 100%, which is the feature turned off — the
+        user hits the limit they were supposed to be switched away from.
+
+        Asserts on the SWITCH, not on the state field: the field being clear
+        proves nothing about whether a move can happen, and the scoped filter
+        deliberately leaves the field set on the at-limit path.
+        """
+        assert harness.tick_with_usage({
+            "1": _usage(92, self._days_out(harness, 500)),
+            "2": _usage(10, self._days_out(harness, 400)),
+        }) is TickOutcome.SWITCHED
+        assert harness.active_number() == 2
+        harness.clock.advance(301.0)
+
+        # The account we left is now fully reset; the new active burns on.
+        outcomes = []
+        for _ in range(20):
+            outcomes.append(harness.tick_with_usage({
+                "1": _usage(0, self._days_out(harness, 400)),
+                "2": _usage(97, self._days_out(harness, 500)),
+            }))
+            harness.clock.advance(1801.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"20 ticks / 10h of outcomes {[o.name for o in outcomes]} — the "
+            "peer was at 0% the whole time and the active burned to 97%. The "
+            "one proactive move disabled proactive switching permanently."
+        )
+
+    def test_a_filtered_candidate_does_not_forge_an_all_exhausted_claim(
+        self, temp_home
+    ):
+        """The filter runs BEFORE `truly_exhausted`, so it hides the evidence.
+
+        A healthy peer removed from `oauth_candidates` cannot make the `all()`
+        False, and the engine then claims every account is exhausted. The user
+        gets a macOS notification and a critical TUI row while that peer sits
+        at 0%, and `_blocked_wait_long` stretches the poll interval, so the
+        recovery it is wrong about arrives slower too.
+
+        Needs a genuinely spent THIRD account: with only the filtered peer the
+        list goes empty and the tick exits at `no-candidates` first — measured,
+        3 ticks of `no-candidates` and no event. The false claim needs the
+        remaining candidates to be real and all spent, which is the shape a
+        user on three accounts actually hits.
+
+        Reached on the proactive path, which the at-limit escape test does not
+        cover. Asserts on the EVENT the user sees, not on the candidate list.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(92, self._days_out(h, 500)),
+            "2": _usage(10, self._days_out(h, 400)),
+            "3": _usage(100, self._days_out(h, 300)),
+        }) is TickOutcome.SWITCHED
+        h.clock.advance(301.0)
+
+        h.events.clear()
+        h.tick_with_usage({
+            "1": _usage(0, self._days_out(h, 400)),    # the one we left: FULL
+            "2": _usage(97, self._days_out(h, 500)),
+            "3": _usage(100, self._days_out(h, 300)),  # genuinely spent
+        })
+        assert not any(isinstance(e, AllExhaustedEvent) for e in h.events), (
+            f"events {[type(e).__name__ for e in h.events]} — account 1 is at "
+            "0%; the fleet is not exhausted, the filter hid the one peer that "
+            "disproves it"
         )
 
     def test_the_fallback_never_outranks_a_real_qualifier(self, harness):
@@ -4148,3 +4239,5 @@ class TestReviewFindings202:
         )
         sw = next(e for e in harness.events if isinstance(e, SwitchEvent))
         assert sw.trigger == "at-limit"
+
+

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -16,6 +16,7 @@ from claude_swap.autoswitch import (
     IDLE_HOLD_MAX_S,
     NO_RESET_FALLBACK_S,
     RECOVERY_HORIZON_S,
+    SPENT_HEADROOM_PCT,
     AllExhaustedEvent,
     AutoSwitchEngine,
     ConfigWarningEvent,
@@ -4129,6 +4130,17 @@ class TestHorizonAxisDoesNotFlap:
         (400 days out) throughout, so the ordinary consume-first
         reset-ordering gate does not exclude it either; only the anti-flap
         snapshot does.
+
+        DISCRIMINATES RELATIONAL FROM ABSOLUTE (F3, round-5 review): the
+        first tick below (active_pct=50, active_headroom=50.0) is chosen so
+        that ANY absolute floor at or below 70 — the exact defect class round
+        4b shipped, and the round-5 review found this test could not tell
+        apart from a relational fix — would release the peer immediately
+        (70 clears a `>= floor<=70` bar outright), while the relational fix
+        needs `70 > 50 x 2 + 3 = 103`, which is false, so it must still hold
+        at that first tick. Only once the active has burned enough for the
+        RATIO against it (not the peer's own absolute value) to clear does
+        the release fire.
         """
         h = EngineHarness(temp_home, strategy="consume-first")
         h.seed(1, "a@example.com")
@@ -4150,6 +4162,11 @@ class TestHorizonAxisDoesNotFlap:
             }))
             h.clock.advance(301.0)
 
+        assert outcomes[0] is not TickOutcome.SWITCHED, (
+            f"{[o.name for o in outcomes]} — the very first tick (active at "
+            "50%, ratio only 1.4x) already switched. An absolute floor <= 70 "
+            "would fire here immediately; the relational fix must not."
+        )
         assert TickOutcome.SWITCHED in outcomes[:-1], (
             f"{[o.name for o in outcomes]} — peer 1 held 70 points the whole "
             "time, far ahead of the active, and the engine only returned "
@@ -4658,6 +4675,62 @@ class TestHorizonAxisDoesNotFlap:
         Both legs of the test below are the flap shape: the barred account is
         no better than we left it on either axis. The bar must hold even
         though the ranking is empty and the tick therefore does nothing.
+
+        WALKED PAST THE OLD BOUNDARY (F5, round-5 review): the pre-fix
+        dominance leg was a bare `h > active x RATIO`, which held only up to
+        and including ratio exactly 2.00 (`active=2.0` pts) and opened on the
+        very next cell (`active=1.8`) — round 5's own defect, the exact shape
+        the review measured. The fixed leg adds a flat `+SPENT_HEADROOM_PCT`
+        on top of the ratio, so the boundary against this same 4.0-pt frozen
+        peer moves from `active=2.0` to `active=0.5` — the walk below covers
+        every cell in between, well past where round 5 opened.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(96, self._days_out(h, 500)),   # 4 pts
+            "2": _usage(92, self._days_out(h, 400)),   # 8 pts
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(3612.0)
+
+        outcomes = []
+        # 98 (2.0 pts, the old exact boundary) through 99.5 (0.5 pts, the new
+        # boundary's last holding cell) — well past where round 5's bare
+        # ratio opened at 1.8 pts.
+        for active_pct in (98.0, 98.2, 98.4, 99.0, 99.5):
+            outcomes.append(h.tick_with_usage({
+                # unchanged since we left it: same headroom, same reset
+                "1": _usage(96, self._days_out(h, 500)),
+                "2": _usage(active_pct, self._days_out(h, 400)),   # active, burnt down
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED not in outcomes, (
+            f"{[o.name for o in outcomes]} — the engine went back to an "
+            "account that is exactly as we left it. The ranking flipped "
+            "because the active burned, not because the target recovered; "
+            "that is the flap this bar exists for."
+        )
+
+    def test_the_release_fires_on_this_same_fleet_once_the_peer_actually_improves(
+        self, temp_home
+    ):
+        """The release partner for the hold above (F5): SAME fleet, PEER moves.
+
+        The sibling test proves the bar holds no matter how far the active
+        burns while the peer is frozen. Without this partner, an
+        over-conservative predicate that never releases at all — the
+        permanent 2-account lockout this branch has already fixed twice —
+        would also pass that test, since "never SWITCHED" is satisfied
+        trivially by "never releases anything, ever". This uses the exact
+        same departure (1 at 4.0 pts / 500h, 2 at 8.0 pts / 400h) and then
+        lets account 1 recover to full quota while the active sits at the
+        SAME 98% the sibling test holds at — the only variable that changes
+        is the peer.
         """
         h = EngineHarness(temp_home)
         h.seed(1, "a@example.com")
@@ -4674,17 +4747,16 @@ class TestHorizonAxisDoesNotFlap:
         outcomes = []
         for _ in range(10):
             outcomes.append(h.tick_with_usage({
-                # unchanged since we left it: same headroom, same reset
-                "1": _usage(96, self._days_out(h, 500)),
-                "2": _usage(98, self._days_out(h, 400)),   # active, burnt down
+                "1": _usage(0, self._days_out(h, 500)),    # RECOVERED: reset to full
+                "2": _usage(98, self._days_out(h, 400)),   # active, same 98% as the hold
             }))
             h.clock.advance(301.0)
 
-        assert TickOutcome.SWITCHED not in outcomes, (
-            f"{[o.name for o in outcomes]} — the engine went back to an "
-            "account that is exactly as we left it. The ranking flipped "
-            "because the active burned, not because the target recovered; "
-            "that is the flap this bar exists for."
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"{[o.name for o in outcomes]} — account 1 reset to full quota, "
+            "the peer's own state, and the engine never returned; a bar that "
+            "never releases at any active burn is the permanent lockout, not "
+            "anti-flap"
         )
 
     def test_a_departure_at_full_quota_is_immediately_eligible(self, temp_home):
@@ -4731,6 +4803,42 @@ class TestHorizonAxisDoesNotFlap:
             f"{[o.name for o in outcomes]} — account 1 never dropped below a "
             "full 100.0 points and is the only peer; refusing it is the "
             "unsatisfiable-above-97 lockout, not anti-flap"
+        )
+
+    def test_the_clamp_stays_load_bearing_when_dominance_does_not_fire(
+        self, harness
+    ):
+        """F4 (round-5 review): dominance must not shadow the `min(...,100.0)`
+        clamp — the round-4a shape recurring, a new leg silently disarming an
+        existing guard's killer.
+
+        The sibling test above (`test_a_departure_at_full_quota_is_
+        immediately_eligible`) uses active=10, where dominance ALSO fires
+        (`100 > 10*2+3`), so mutating away the clamp there is invisible: the
+        dominance leg answers True regardless of the clamp. Isolate the
+        clamp with an active_headroom chosen so dominance is FALSE
+        (`100 > 60*2+3=123` is false) while the clamp (`100 >= min(98+3,
+        100)`) is still True — exactly the shape the round-5 review measured
+        (left=98 / peer=100 / active=60) as flipping between clamp on/off.
+        """
+        state = {"lastSwitchFrom": "1", "leftHeadroom": 98.0, "leftRecoveryAt": None}
+        recovered = harness.engine._left_account_recovered(
+            state,
+            {"1": _usage(0)},
+            {"1": 100.0},
+            60.0,
+            harness.settings,
+            harness.clock(),
+        )
+        assert recovered is True, (
+            "the clamp must still release a departure recorded at a near-full "
+            "leftHeadroom even where dominance over the active does not fire"
+        )
+        # Control: without the clamp (`h >= left_headroom + SPENT_HEADROOM_PCT`
+        # unclamped -> `h >= 101.0`), 100.0 fails and this would be False —
+        # confirms the clamp, not some other leg, is what makes it True.
+        assert not (100.0 >= 98.0 + SPENT_HEADROOM_PCT), (
+            "premise: the unclamped threshold is unsatisfiable at h=100.0"
         )
 
     def test_a_reset_that_crept_nearer_is_not_a_recovery(self, temp_home):
@@ -4894,14 +5002,14 @@ class TestHorizonAxisDoesNotFlap:
         state = {"lastSwitchFrom": "2"}  # pre-upgrade: keys genuinely absent
 
         assert harness.engine._left_account_recovered(
-            state, {"2": _usage(96)}, {"2": 4.0}, 2.0, harness.clock()
+            state, {"2": _usage(96)}, {"2": 4.0}, 2.0, harness.settings, harness.clock()
         ) is True, (
             "a pre-upgrade record (no snapshot) must release even when the "
             "barred account is currently poor (4 pts) — absence of evidence "
             "is not the same state as a measured-unmeasurable failover"
         )
         assert harness.engine._left_account_recovered(
-            state, {"2": None}, {"2": None}, 2.0, harness.clock()
+            state, {"2": None}, {"2": None}, 2.0, harness.settings, harness.clock()
         ) is True, (
             "a pre-upgrade record (no snapshot) must release even when the "
             "barred account is currently unreadable — absence of evidence "
@@ -4910,6 +5018,9 @@ class TestHorizonAxisDoesNotFlap:
 
     def test_a_failover_departure_does_not_disarm_the_bar(self, temp_home):
         """`(None, None)` from a failover must not read the same as `absent`.
+
+        R2 of the round-5 acceptance matrix: failover, peer FROZEN, active
+        burning -> HOLD.
 
         `_perform` writes `leftHeadroom`/`leftRecoveryAt` unconditionally on
         every trigger, including `failover`, where `active_headroom` is None
@@ -4922,10 +5033,19 @@ class TestHorizonAxisDoesNotFlap:
 
         Reached with a real failover (active usage unreadable for
         `unhealthy_ticks` ticks), then the classic flap shape: the barred
-        account frozen at 4 pts, the new active burning from 4 to 2 pts —
-        the same shape `test_the_release_needs_the_barred_account_to_have_improved`
-        uses for a PROACTIVE departure, which correctly holds. A failover
-        departure must hold the same way, not disarm on the very next tick.
+        account frozen at 4 pts, the new active burning from 4 pts down past
+        the exact boundary (98.2%) round 5's dominance leg opened at —
+        `4.0 > 1.8 x 2` — walked further still, to a bare sliver (99.9%,
+        0.1 pts). The round-5 defect switched back to the frozen peer at
+        98.2%, measured on this exact fleet (round-5 review F1/F2). This
+        leaves the ORDINARY-path shape (`test_the_release_needs_the_barred_
+        account_to_have_improved`) as the sibling proving the general
+        dominance leg's own margin separately; this one is failover-only,
+        which never reads `leftHeadroom`/`leftRecoveryAt` at all, so it also
+        discriminates a relational fix from an absolute one: mutate the
+        failover leg to a bare `h >= 4.0` (the peer's own constant value) and
+        every tick below flips to SWITCHED, because that mutant no longer
+        reads the active at all.
         """
         h = EngineHarness(temp_home)
         h.seed(1, "a@example.com")
@@ -4951,17 +5071,20 @@ class TestHorizonAxisDoesNotFlap:
 
         h.clock.advance(301.0)
         outcomes = []
-        for _ in range(10):
+        # 98.0 (2.0 pts, the old boundary), 98.2 (1.8 pts, round 5's exact
+        # kill shot), then further still down to a bare sliver — the peer
+        # never moves, so nothing on this walk is evidence it improved.
+        for active_pct in (98.0, 98.2, 98.4, 99.0, 99.5, 99.9):
             outcomes.append(h.tick_with_usage({
                 "1": _usage(96, frozen1),                     # frozen, 4 pts
-                "2": _usage(98, self._days_out(h, 400)),       # active, burnt to 2 pts
+                "2": _usage(active_pct, self._days_out(h, 400)),
             }))
             h.clock.advance(301.0)
 
         assert TickOutcome.SWITCHED not in outcomes, (
             f"{[o.name for o in outcomes]} — a failover departure was treated "
-            "as 'no evidence, release', undoing the failover on the very next "
-            "proactive tick"
+            "as 'no evidence, release', undoing the failover once the active "
+            "burned far enough, however far — the peer never changed"
         )
 
     def test_a_failover_departure_still_unreadable_does_not_crash_or_release(
@@ -5075,17 +5198,31 @@ class TestHorizonAxisDoesNotFlap:
 
         `test_a_failover_departure_releases_once_the_peer_is_readable_again`
         only proves the bar is not PERMANENT — it drives the peer to a full
-        100.0, which also clears the (unfixed) absolute `>= 97.0` floor. That
-        floor makes any peer that has spent more than 3% of its weekly window
-        unreachable: a peer sitting on a perfectly healthy 70 points, with the
-        active burnt down to 2, is held exactly as hard as one on 4 points —
-        the two states this predicate exists to tell apart collapse onto the
-        same answer. C1.
+        100.0, which also clears a fixed near-100 floor. C1's original bug was
+        an absolute `>= 97.0` floor, unreachable for any peer that had spent
+        more than 3% of its weekly window.
+
+        THIS IS DELIBERATELY NOT RELATIONAL TO THE ACTIVE (round-5 correction):
+        round 5's fix made this branch dominance-vs-active, and that is
+        exactly what broke `test_a_failover_departure_does_not_disarm_the_bar`
+        — a `(None, None)` snapshot has no recorded baseline for either
+        headroom or recovery, so there is nothing to diff the ACTIVE's burn
+        away from; any leg that reads the active here reproduces the flap the
+        moment the active burns far enough, however far. What this branch
+        uses instead is `h > 100 - settings.threshold`: the same "would the
+        ranking accept this as a landing spot" test every candidate already
+        passes (`:1617`), so the floor is the user's OWN policy rather than a
+        hardcoded constant, and it moves when they change it. It genuinely
+        cannot tell "the peer just recovered" from "the peer was always this
+        good" — there is nothing recorded to tell them apart on a failover
+        departure — so both land on RELEASE, which is the documented,
+        measurement-backed choice (see `_left_account_recovered`'s docstring)
+        for a case R-A and R-B cannot be separated in.
 
         Reached with a real failover, same setup as the sibling tests, then
-        the peer comes back READABLE at 70 points (well under the 97 floor,
-        well over the 4-point flap the bar must still catch) while the active
-        burns to 2.
+        the peer comes back READABLE at 70 points (well over the default
+        threshold-derived floor of 10, well over the 4-point flap the bar
+        must still catch) while the active burns to 2.
         """
         h = EngineHarness(temp_home)
         h.seed(1, "a@example.com")
@@ -5398,6 +5535,202 @@ class TestHorizonAxisDoesNotFlap:
         })
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 3
+
+
+class TestAcceptance204eR1toR7:
+    """Task 204e's acceptance matrix, one test per line.
+
+    R1  failover, peer readable and dominant AND CHANGED     -> RELEASE
+    R2  failover, peer FROZEN, active burning                -> HOLD    (F1)
+    R3  failover, peer still poor                            -> HOLD
+    R4  failover, peer still unreadable                      -> HOLD
+    R5  ordinary departure, weekly-bound peer that recovered -> RELEASE
+    R6  pre-upgrade record (keys absent)                     -> RELEASE
+    R7  at-limit escape                                      -> works
+
+    Some of these are also proven end-to-end elsewhere in this file
+    (`test_a_failover_departure_does_not_disarm_the_bar` is R2 through a real
+    tick loop, `test_a_switch_that_recorded_no_snapshot_still_releases` is
+    R6, `test_a_failover_hold_still_escapes_at_limit` is R7); this class
+    drives `_left_account_recovered` directly so each line of the matrix is
+    checkable in isolation, against the exact state shape that line names,
+    without a multi-tick walk's other gates (cooldown, ranking, hysteresis)
+    able to hide a wrong answer.
+    """
+
+    def _at(self, harness, seconds: float) -> str:
+        from datetime import datetime, timezone
+
+        return (
+            datetime.fromtimestamp(harness.clock.now + seconds, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    def test_r1_failover_peer_readable_dominant_and_changed_releases(
+        self, harness
+    ):
+        """R1: a failover snapshot, peer now readable and clearly healthy.
+
+        h=15: past the threshold-derived floor (`100 - 90 = 10`) but under
+        20 and 50 — chosen so an absolute floor of 20 or 50 (MRELF-a/b in
+        the mutation sweep) would give the WRONG answer (False) here, while
+        the threshold-derived floor correctly releases. A peer at 70, past
+        every plausible floor, would not tell the two apart.
+        """
+        state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
+        assert harness.engine._left_account_recovered(
+            state, {"2": _usage(85)}, {"2": 15.0}, 2.0, harness.settings, harness.clock()
+        ) is True, (
+            "a failover departure with the peer now readable at 15 points "
+            "(past the threshold-derived floor of 10, under any floor of "
+            "20 or 50) must release"
+        )
+
+    def test_r1_floor_moves_with_the_users_threshold(self, temp_home):
+        """The failover floor is `settings.threshold`-derived, not a fixed 10.
+
+        At the default threshold (90) the floor happens to be exactly 10,
+        indistinguishable from a hardcoded `h >= 10.0` (MRELF-c in the
+        mutation sweep survived for exactly this reason). The property this
+        branch actually claims is that the floor is the USER'S policy, so it
+        must move when `settings.threshold` does: the SAME peer, held fixed
+        at 35 points, must hold under a threshold whose floor sits above 35
+        and release under one whose floor sits below it.
+        """
+        h_low = EngineHarness(temp_home, threshold=60.0)   # floor = 100-60 = 40
+        h_low.seed(1, "a@example.com")
+        h_low.seed(2, "b@example.com")
+        h_low.make_live("a@example.com", 1)
+        state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
+        assert h_low.engine._left_account_recovered(
+            state, {"2": _usage(65)}, {"2": 35.0}, 2.0, h_low.settings, h_low.clock()
+        ) is False, (
+            "threshold=60 -> floor=40; a peer at 35 points is BELOW that "
+            "floor and must hold"
+        )
+
+        h_high = EngineHarness(temp_home, threshold=71.0)  # floor = 100-71 = 29
+        h_high.seed(1, "a@example.com")
+        h_high.seed(2, "b@example.com")
+        h_high.make_live("a@example.com", 1)
+        assert h_high.engine._left_account_recovered(
+            state, {"2": _usage(65)}, {"2": 35.0}, 2.0, h_high.settings, h_high.clock()
+        ) is True, (
+            "the SAME peer at 35 points, only `settings.threshold` changed "
+            "(71 -> floor 29) — a hardcoded absolute floor would answer the "
+            "same both times; this must flip, proving the floor is the "
+            "user's own policy, not a fixed constant"
+        )
+
+    def test_r2_failover_peer_frozen_active_burning_holds(self, temp_home):
+        """R2 (F1): a failover snapshot, peer frozen, only the active moves.
+
+        End-to-end walk, not a direct predicate call: this is the exact shape
+        round 5 shipped broken, so it is worth proving through the real tick
+        loop rather than only the unit. See `test_a_failover_departure_does_
+        not_disarm_the_bar` for the longer walk this is a focused version of.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = None
+        for _ in range(3):
+            outcome = h.tick_with_usage({
+                "1": None,
+                "2": _usage(4, self._at(h, 400 * 3600)),
+            })
+            h.clock.advance(60.0)
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+        h.clock.advance(301.0)
+        outcome = h.tick_with_usage({
+            "1": _usage(96, self._at(h, 500 * 3600)),   # frozen, 4 pts, below floor
+            "2": _usage(98.2, self._at(h, 400 * 3600)),  # active burnt, round 5's kill shot
+        })
+        assert outcome is not TickOutcome.SWITCHED, (
+            "the peer never changed and is well under the threshold-derived "
+            "floor; burning the active alone must not release a failover hold"
+        )
+
+    def test_r3_failover_peer_still_poor_holds(self, harness):
+        """R3: a failover snapshot, peer readable but genuinely poor."""
+        state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
+        # 5.0 < 100 - 90 = 10, the threshold-derived floor: readable, but poor.
+        assert harness.engine._left_account_recovered(
+            state, {"2": _usage(95)}, {"2": 5.0}, 2.0, harness.settings, harness.clock()
+        ) is False, (
+            "a failover departure with the peer readable but under the "
+            "floor must hold — readable is not the same as recovered"
+        )
+
+    def test_r4_failover_peer_still_unreadable_holds(self, harness):
+        """R4: a failover snapshot, peer still unreadable."""
+        state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
+        assert harness.engine._left_account_recovered(
+            state, {"2": None}, {"2": None}, 2.0, harness.settings, harness.clock()
+        ) is False, (
+            "a failover departure with the peer still unreadable must hold; "
+            "unknown is not evidence of recovery"
+        )
+
+    def test_r5_ordinary_departure_weekly_bound_peer_that_recovered_releases(
+        self, harness
+    ):
+        """R5: a real (non-failover) baseline, and the peer's WEEKLY window
+        actually rolled over — genuine recovery on the recovery axis, which
+        the headroom axis (pinned by 7-day utilization) cannot see at all.
+        """
+        state = {
+            "lastSwitchFrom": "2",
+            "leftHeadroom": 4.0,
+            "leftRecoveryAt": harness.clock.now + 3600.0,  # was back in 1h
+        }
+        # Same 4.0 pts as departure (headroom leg cannot fire), but the
+        # binding reset is now well past the old one plus the hysteresis
+        # margin — a real recovery event, not drift.
+        assert harness.engine._left_account_recovered(
+            state,
+            {"2": _usage(96, self._at(harness, 60.0))},  # now back in 1 MINUTE
+            {"2": 4.0},
+            8.0,
+            harness.settings,
+            harness.clock(),
+        ) is True, (
+            "the peer's weekly-bound reset moved meaningfully nearer, which "
+            "is a real recovery event the headroom leg cannot see"
+        )
+
+    def test_r6_pre_upgrade_record_keys_absent_releases(self, harness):
+        """R6: state written before the snapshot fields existed."""
+        state = {"lastSwitchFrom": "2"}  # no leftHeadroom / leftRecoveryAt key
+        assert harness.engine._left_account_recovered(
+            state, {"2": _usage(96)}, {"2": 4.0}, 2.0, harness.settings, harness.clock()
+        ) is True, (
+            "absence of the snapshot fields (a pre-upgrade record) carries "
+            "no evidence either way and must release, not hold forever"
+        )
+
+    def test_r7_at_limit_escape_still_works(self, harness):
+        """R7: at-limit skips this predicate's bar entirely by trigger scope.
+
+        `_no_return_account` (not `_left_account_recovered`) is what gates
+        at-limit/failover out; this confirms the fix did not touch that
+        scoping. See `test_a_failover_hold_still_escapes_at_limit` for the
+        longer end-to-end version through a real failover-then-at-limit walk.
+        """
+        state = {"lastSwitchFrom": "2"}
+        headroom = {"1": 0.0, "2": 100.0}
+        for active in (0.0, None):
+            assert harness.engine._no_return_account(
+                "at-limit", state, headroom, active, ["1", "2"]
+            ) is None, (
+                "at-limit must escape the bar regardless of active_headroom "
+                "or the recovered predicate's answer"
+            )
 
 
 class TestAllSpentGoesToTheSoonestReset:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3299,20 +3299,10 @@ class TestEveryAccountAboveThreshold:
 class TestRecoveryHorizon:
     """The recovery escape must not spend real headroom on a distant reset.
 
-    #202 introduced "when everything is above the threshold, go where quota
-    returns first". Its evidence was minutes-scale — the measured case had a
-    peer whose 5-hour window reset in 8 minutes, and trading 9 points of
-    headroom for an 8-minute wait is obviously right.
-
-    The rule shipped with no horizon bound, so it applies identically when
-    every reset is DAYS away. Measured live: active 91% (7d resets in 109h),
-    peers 94%/80h and 98%/50h. The engine moved from 9 points of headroom to
-    2 — but nothing comes back today either way, so those 9 points were the
-    only resource that could still do work. The user switched back by hand.
-
-    Past HORIZON, ranking returns to headroom: when no candidate can resume
-    within a working session, "soonest" stops being a benefit worth paying
-    for and how much quota is left is what decides whether work continues.
+    #202's rule ("go where quota returns first") was measured on minutes-scale
+    resets and shipped with no upper bound, so it applied identically days
+    out — measured live, 9 points of headroom traded for 2 on a reset nobody
+    reaches today. Past the horizon, ranking returns to headroom.
     """
 
     def _at(self, harness, seconds: float) -> str:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3510,7 +3510,7 @@ class TestEscapeBeforeTheLimitLands:
 
     What actually happened in the 18:50 observation that prompted this: the
     only peers were 99% (one point) and 100% (never a target), so there was
-    nowhere better and holding was correct. `all_spent` already covers that
+    nowhere better and holding was correct. The spent check already covers that
     case by ranking on the soonest reset.
 
     Kept as a regression pin: moving the at-limit trigger earlier looks

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -88,10 +88,9 @@ class EngineHarness:
         # superset of patching $XDG_DATA_HOME alone: a developer/CI with
         # XDG_DATA_HOME exported would have every EngineHarness's XDG branch
         # resolve to that ONE ambient value regardless of Path.home(),
-        # aliasing all harnesses in the process onto one store (round-10
-        # review, I-1). Keep BOTH patches — neither mechanism dominates the
-        # other, and each covers the platforms/environments where the other
-        # is silent.
+        # aliasing all harnesses in the process onto one store. Keep BOTH
+        # patches — neither mechanism dominates the other, and each covers
+        # the platforms/environments where the other is silent.
         with (
             patch("pathlib.Path.home", return_value=self.temp_home),
             patch.dict(
@@ -200,19 +199,19 @@ class TestEngineHarnessIsolation:
     exists for (see its docstring): two harnesses built against the SAME
     `temp_home` must not resolve to the same store.
 
-    I2 (round-8 review): the prior form of this guard had no test that could
-    kill it — reverting the scoping left the full suite green (round-7's
-    `test_a_non_429_recorded_through_record_does_not_take_the_margin` no
+    The prior form of this guard had no test that could kill it — reverting
+    the scoping left the full suite green
+    (`test_a_non_429_recorded_through_record_does_not_take_the_margin` no
     longer depends on it; that test's premise now stands on its own
     `record()` call). Without a test, a future cleanup could delete the
     isolation silently, and the next multi-harness test would alias two
     accounts' stores into one without any assertion noticing.
 
-    I2 (round-9 review): round-8's fix scoped isolation on `$XDG_DATA_HOME`,
-    which `get_backup_root()` only consults on LINUX/WSL (paths.py:101) — so
+    An earlier fix scoped isolation on `$XDG_DATA_HOME`, which
+    `get_backup_root()` only consults on LINUX/WSL (paths.py:101) — so
     the guard's OWN skipif, added because the mechanism is genuinely absent
-    off Linux, also left the guard itself untested there (S2 mutation:
-    skip forced + scoping reverted, full suite SURVIVED). The aliasing it
+    off Linux, also left the guard itself untested there (measured: skip
+    forced + scoping reverted, full suite SURVIVED). The aliasing it
     guards against is real off Linux (direct probe: two harnesses on
     distinct subtrees collapsed to one store under the legacy
     ~/.claude-swap-backup path, and h1's seeded account silently became
@@ -275,9 +274,9 @@ class TestEngineHarnessIsolation:
     def test_two_harnesses_with_xdg_data_home_set_get_distinct_stores(
         self, temp_home, monkeypatch
     ):
-        """I-1 (round-10 review): round 9's `Path.home()` rescoping is NOT a
-        superset of round 8's `$XDG_DATA_HOME` scoping. `get_backup_root()`
-        gives `$XDG_DATA_HOME` precedence over `Path.home()` on Linux/WSL
+        """The `Path.home()` patch is NOT a superset of the
+        `$XDG_DATA_HOME` one. `get_backup_root()` gives `$XDG_DATA_HOME`
+        precedence over `Path.home()` on Linux/WSL
         (paths.py:101-107) -- so a developer/CI with `XDG_DATA_HOME` exported
         still gets two harnesses colliding on ONE store, even though each
         harness's `Path.home()` differs. The prior test above cannot see this
@@ -963,8 +962,7 @@ class TestAdaptiveScheduler:
         Retry-After for ANY HTTPError code, not just 429, and the usage
         endpoint sits behind Cloudflare, which routinely emits Retry-After on
         503s. A `503 Retry-After: 86400` parked a row 24h with no bound at
-        all — reproduced end-to-end, see the Blocker in review round 5 of PR
-        #197.
+        all — reproduced end-to-end (PR #197).
 
         A LATER FIX bounded it at `RETRY_AFTER_FLOOR_CAP_S` (4500) —
         reasoning "one ceiling for how long any ask can park a row" — but
@@ -972,8 +970,8 @@ class TestAdaptiveScheduler:
         non-429 row unknown once `TRUST_MAX_AGE_S` (3600) elapses past the
         last success, so a non-429 ask between 3600 and 4500 parked the row
         past its own trust for up to 900s (a regression against
-        upstream/main introduced by this PR, round 6 Blocker). The bound is
-        now `TRUST_MAX_AGE_S`, the ceiling this arm's trust actually uses.
+        upstream/main introduced by this PR). The bound is now
+        `TRUST_MAX_AGE_S`, the ceiling this arm's trust actually uses.
 
         Asks below the ceiling are asserted with `==`, not `<=`, so a
         reintroduced blanket clamp to something shorter still fails this
@@ -1143,9 +1141,9 @@ class TestAdaptiveScheduler:
         release either way (see
         `test_a_429_wait_is_the_deadline_plus_the_margin`) — while landing on
         the deadline re-blocks 20 of 35 times for a fresh hour (re-measured
-        2026-08-03, round 8; of 35, not 38 raw gaps — 3 are negative, not a
-        uniform mechanism (per-gap detail in the RETRY_AFTER_MARGIN_S
-        comment), excluded from both numerator and denominator).
+        2026-08-03; of 35, not 38 raw gaps — 3 are negative, not a uniform
+        mechanism (per-gap detail in the RETRY_AFTER_MARGIN_S comment),
+        excluded from both numerator and denominator).
 
         So the wait stays deadline + margin whatever the scoped window says.
         What the scoped window still decides is whether the row SERVES its
@@ -1279,8 +1277,8 @@ class TestAdaptiveScheduler:
 
         RETRY_AFTER_MARGIN_S is 900 because 20 of 35 measured lapses
         re-blocked at +2s..+887s past their own deadline (re-measured
-        2026-08-03, round 8; "of 35" not "of 38": 3 of the 38 raw gaps are
-        negative — not a uniform mechanism (per-gap detail in the
+        2026-08-03; "of 35" not "of 38": 3 of the 38 raw gaps are negative
+        — not a uniform mechanism (per-gap detail in the
         RETRY_AFTER_MARGIN_S comment) — excluded from both numerator and
         denominator), each earning a fresh hour. So `(deadline, deadline +
         900)` — the MEASURED band, a literal, independent of whatever
@@ -1391,8 +1389,8 @@ class TestAdaptiveScheduler:
 
         Drives a REAL success through `record()` first, so `last_good` and
         `fetched_at` actually exist and are decision-trusted before the 503.
-        The round-3/round-4 defect this test previously carried recorded
-        neither (`last_good=None, fetched_at=None`) and asserted a trust
+        The defect this test previously carried recorded neither
+        (`last_good=None, fetched_at=None`) and asserted a trust
         relationship that was never exercised — masked by `EngineHarness`
         instances sharing one store (see its docstring), which supplied a
         `lastGood` left behind by an earlier test in the same file even with
@@ -1403,9 +1401,9 @@ class TestAdaptiveScheduler:
         The ask is chosen strictly between `TRUST_MAX_AGE_S` (3600) and
         `RETRY_AFTER_FLOOR_CAP_S` (4500). Above `TRUST_MAX_AGE_S`, the
         correct non-429 wiring clips the wait to `TRUST_MAX_AGE_S` (its own
-        trust ceiling, so a non-429 park never outlasts it — see the round-6
-        Blocker). The buggy wiring (defaulting to `rate_limited=True`) takes
-        the 429-only margin instead: `min(ask + 900, RETRY_AFTER_FLOOR_CAP_S)`
+        trust ceiling, so a non-429 park never outlasts it). The buggy
+        wiring (defaulting to `rate_limited=True`) takes the 429-only margin
+        instead: `min(ask + 900, RETRY_AFTER_FLOOR_CAP_S)`
         = 4500 for any ask at or above 3600. The two provably disagree (3600
         vs 4500) for any ask in this range. `_classify_usage_error` parses
         Retry-After for ANY HTTPError code, so a 503 carrying this Retry-After
@@ -3185,8 +3183,8 @@ class TestConsumeFirstStrategy:
 
 
 class TestConsumeFirstDepartureRecordsItsOwnTrigger:
-    """R8 review I-B: a `consume-first` departure's phase-2 refetch can write
-    `(leftHeadroom, leftRecoveryAt) = (None, None)` -- the exact snapshot
+    """A `consume-first` departure's phase-2 refetch can write
+    `(leftHeadroom, leftRecoveryAt) = (None, None)`, the exact snapshot
     shape a `failover` departure writes -- whenever the refetched active row
     has a `pct` but is otherwise unmeasurable in the SAME tick its weekly
     reset is known (`account_headroom` needs a numeric `pct`;
@@ -3510,7 +3508,7 @@ class TestEveryAccountAboveThreshold:
 
 
 class TestRecoveryIsUsefulEitherClause:
-    """I1: the `or active_recovery_ts` leg of `_recovery_is_useful` had no
+    """The `or active_recovery_ts` leg of `_recovery_is_useful` had no
     killer in the full suite, even through `tick()`.
 
     `test_a_pair_straddling_the_horizon_does_not_ping_pong` (the branch's own
@@ -3628,8 +3626,8 @@ class TestRecoveryHorizon:
     def test_an_unreadable_peer_does_not_forge_headroom_for_the_spent_check(
         self, temp_home
     ):
-        """I2: counting an unreadable candidate's headroom as 100.0 instead
-        of excluding it turns the all-spent gate off for the whole fleet.
+        """Counting an unreadable candidate's headroom as 100.0 instead of
+        excluding it turns the all-spent gate off for the whole fleet.
 
         `best_candidate_headroom` filters `None` (unreadable) rows out of the
         max — the sibling test above proves exclusion doesn't VETO the check.
@@ -3894,7 +3892,7 @@ class TestHorizonAxisDoesNotFlap:
     def test_a_fixed_reset_crosses_into_the_horizon_as_the_clock_advances(
         self, harness
     ):
-        """I4: `_days_out` must return a FIXED absolute instant, not
+        """`_days_out` must return a FIXED absolute instant, not
         "N hours from whenever this is called."
 
         Both accounts start above the threshold (`all_above`), the peer's
@@ -4287,11 +4285,12 @@ class TestHorizonAxisDoesNotFlap:
     def test_an_ordinary_departure_does_not_stall_on_a_weekly_bound_peer(
         self, temp_home
     ):
-        """I3: the anti-flap snapshot stalls ORDINARY departures too, not
+        """The anti-flap snapshot stalls ORDINARY departures too, not
         just failover, whenever the barred peer is weekly-bound.
 
-        Same root as C1 (a release keyed away from the ACTIVE), reached
-        without any failover: an ordinary consume-first departure records
+        Same root as the failover recovery leg (a release keyed away from
+        the ACTIVE), reached without any failover: an ordinary consume-first
+        departure records
         `leftHeadroom`/`leftRecoveryAt`, and `_left_account_recovered`'s
         headroom leg (`h >= left_headroom + SPENT_HEADROOM_PCT`) can only
         rise when the barred peer's OWN headroom improves. A peer whose
@@ -4306,12 +4305,12 @@ class TestHorizonAxisDoesNotFlap:
         reset-ordering gate does not exclude it either; only the anti-flap
         snapshot does.
 
-        DISCRIMINATES RELATIONAL FROM ABSOLUTE (F3, round-5 review): the
-        first tick below (active_pct=50, active_headroom=50.0) is chosen so
-        that ANY absolute floor at or below 70 — the exact defect class round
-        4b shipped, and the round-5 review found this test could not tell
-        apart from a relational fix — would release the peer immediately
-        (70 clears a `>= floor<=70` bar outright), while the relational fix
+        DISCRIMINATES RELATIONAL FROM ABSOLUTE: the first tick below
+        (active_pct=50, active_headroom=50.0) is chosen so that ANY absolute
+        floor at or below 70 — the defect class an earlier cut shipped,
+        which this test could not tell apart from a relational fix — would
+        release the peer immediately (70 clears a `>= floor<=70` bar
+        outright), while the relational fix
         needs `70 > 50 x 2 + 3 = 103`, which is false, so it must still hold
         at that first tick. Only once the active has burned enough for the
         RATIO against it (not the peer's own absolute value) to clear does
@@ -4506,6 +4505,109 @@ class TestHorizonAxisDoesNotFlap:
         assert harness.engine._no_return_account(
             "proactive", state, headroom, 10.0, ["1", "3"], harness.settings
         ) == "1", "premise: these inputs are barred when the trigger allows it"
+
+    @pytest.mark.parametrize(
+        "landed,live,expect",
+        [
+            ("2", 2, "3"),   # the engine is still standing where it landed
+            ("2", 3, "1"),   # the user moved 2 -> 3 by hand
+            (2, 2, "3"),     # same pair, `lastSwitchTo` recorded as an int
+            (2, 3, "1"),
+            (None, 3, "3"),  # pre-upgrade record: no `lastSwitchTo` at all
+        ],
+    )
+    def test_the_bar_only_holds_while_the_engine_is_where_it_landed(
+        self, temp_home, landed, live, expect
+    ):
+        """A MANUAL switch away from the landing undoes the move the bar guards.
+
+        The bar refuses to undo THIS ENGINE'S own last move. Once the user
+        switches by hand the engine is no longer sitting where it put itself
+        and that move is already undone, so barring where it came FROM
+        protects nothing — it just withholds the fleet's best account.
+        Reproduced: engine 1 -> 2, user 2 -> 3 by hand, account 1 still
+        barred while it is the soonest account back, so the engine holds an
+        active that returns an hour later until the at-limit escape.
+
+        NO RELEASE LEG COVERS IT. `_no_return_account` returns the barred
+        account as soon as `recovered` is False, before its ratio leg is
+        read, and the leaves-nothing retry in `_rank` is gated on the same
+        `recovered`. Account 1 is 1 point here against 8 at departure and its
+        binding reset is the SAME absolute instant, so nothing on any axis
+        says it improved — measured, and that is what makes the hold
+        permanent rather than momentary.
+
+        THROUGH `tick()`, NOT THE PREDICATE: `current` has to be threaded
+        from the call site into `_no_return_account`, and this module has
+        already shipped a bar whose unit was pinned while its wiring was not
+        (see `test_the_bar_reaches_the_ranking_through_tick`). Measured here:
+        dropping `kw["current"]` at the call site leaves a direct-call test
+        of the gate entirely green.
+
+        TYPES DIFFER ACROSS THE COMPARISON: `lastSwitchTo` is written from
+        `_perform`'s `number: str` while `lastSwitchFrom` comes from
+        `account_ref(number: int | None, ...)`. The `landed=2` / `live=2` row
+        is the one a bare `==` fails — `2 != "2"` releases a bar that must
+        hold — so the row asserting the HOLD is what pins the normalisation.
+
+        ABSENT `lastSwitchTo` KEEPS THE BAR: a record written before the key
+        existed cannot prove the engine moved away, and this module treats
+        every other missing field the same conservative way. Letting absence
+        disarm would silently drop the anti-flap bound for one upgrade cycle
+        — the last row, whose engine stays put exactly like the on-landing
+        rows.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        # Fixed absolute instants: account 1's reset must be the SAME instant
+        # at departure and on the deciding tick, or the recovery leg reads a
+        # reset creeping nearer as a genuine improvement and releases.
+        back = {n: self._at(h, secs) for n, secs in
+                (("1", 1800.0), ("2", 7200.0), ("3", 3600.0))}
+
+        assert h.tick_with_usage({
+            "1": _usage(92, back["1"]),    # 8 pts: the departure baseline
+            "2": _usage(10, back["2"]),
+            "3": _usage(92, back["3"]),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        state = h.engine._read_state()
+        assert state["lastSwitchFrom"] == 1 and state["lastSwitchTo"] == "2", (
+            f"premise: production writes an int `from` and a str `to` — got "
+            f"{state.get('lastSwitchFrom')!r} / {state.get('lastSwitchTo')!r}"
+        )
+        h.engine._mutate_state(
+            lambda st: st.pop("lastSwitchTo", None) if landed is None
+            else st.__setitem__("lastSwitchTo", landed)
+        )
+        if live != 2:
+            h.make_live("c@example.com", 3)   # the user switches BY HAND
+        assert h.switcher.current_account_number() == str(live), (
+            "premise: the live login is where this row says it is"
+        )
+        h.clock.advance(301.0)
+
+        # Everything spent, so the ranking is on the recovery axis, where the
+        # bar can change an answer at all. Account 1 is back soonest and is
+        # WORSE than at departure (1 point against 8, same reset instant), so
+        # no release leg can fire on its own.
+        h.tick_with_usage({
+            "1": _usage(99, back["1"]),   # barred; back in 30 min
+            "2": _usage(99, back["2"]),   # back in 2h
+            "3": _usage(99, back["3"]),   # back in 1h
+        })
+        # The LIVE login, not `activeAccountNumber`: a hand switch moves the
+        # former and not the latter, which is the whole premise of this test.
+        assert h.switcher.current_account_number() == expect, (
+            f"lastSwitchTo={landed!r} live={live}: ended up on "
+            f"{h.switcher.current_account_number()}, want {expect}. The bar "
+            "must apply only while the engine is still standing on the "
+            "account it switched to; a hand switch away undoes the move it "
+            "guards"
+        )
 
     def test_the_bar_actually_removes_the_account_from_the_ranking(
         self, harness
@@ -4851,14 +4953,14 @@ class TestHorizonAxisDoesNotFlap:
         no better than we left it on either axis. The bar must hold even
         though the ranking is empty and the tick therefore does nothing.
 
-        WALKED PAST THE OLD BOUNDARY (F5, round-5 review): the pre-fix
-        dominance leg was a bare `h > active x RATIO`, which held only up to
-        and including ratio exactly 2.00 (`active=2.0` pts) and opened on the
-        very next cell (`active=1.8`) — round 5's own defect, the exact shape
-        the review measured. The fixed leg adds a flat `+SPENT_HEADROOM_PCT`
-        on top of the ratio, so the boundary against this same 4.0-pt frozen
+        WALKED PAST THE OLD BOUNDARY: the pre-fix dominance leg was a bare
+        `h > active x RATIO`, which held only up to and including ratio
+        exactly 2.00 (`active=2.0` pts) and opened on the very next cell
+        (`active=1.8`) — measured, on this fleet. The fixed leg adds a flat
+        `+SPENT_HEADROOM_PCT` on top of the ratio, so the boundary against
+        this same 4.0-pt frozen
         peer moves from `active=2.0` to `active=0.5` — the walk below covers
-        every cell in between, well past where round 5 opened.
+        every cell in between, well past where the bare ratio opened.
         """
         h = EngineHarness(temp_home)
         h.seed(1, "a@example.com")
@@ -4874,8 +4976,8 @@ class TestHorizonAxisDoesNotFlap:
 
         outcomes = []
         # 98 (2.0 pts, the old exact boundary) through 99.5 (0.5 pts, the new
-        # boundary's last holding cell) — well past where round 5's bare
-        # ratio opened at 1.8 pts.
+        # boundary's last holding cell) — well past where the bare ratio
+        # opened, at 1.8 pts.
         for active_pct in (98.0, 98.2, 98.4, 99.0, 99.5):
             outcomes.append(h.tick_with_usage({
                 # unchanged since we left it: same headroom, same reset
@@ -4894,7 +4996,7 @@ class TestHorizonAxisDoesNotFlap:
     def test_the_release_fires_on_this_same_fleet_once_the_peer_actually_improves(
         self, temp_home
     ):
-        """The release partner for the hold above (F5): SAME fleet, PEER moves.
+        """The release partner for the hold above: SAME fleet, PEER moves.
 
         The sibling test proves the bar holds no matter how far the active
         burns while the peer is frozen. Without this partner, an
@@ -4983,9 +5085,9 @@ class TestHorizonAxisDoesNotFlap:
     def test_the_clamp_stays_load_bearing_when_dominance_does_not_fire(
         self, harness
     ):
-        """F4 (round-5 review): dominance must not shadow the `min(...,100.0)`
-        clamp — the round-4a shape recurring, a new leg silently disarming an
-        existing guard's killer.
+        """Dominance must not shadow the `min(..., 100.0)` clamp — a new
+        leg silently disarming an existing guard's killer, a shape this
+        module has hit before.
 
         The sibling test above (`test_a_departure_at_full_quota_is_
         immediately_eligible`) uses active=10, where dominance ALSO fires
@@ -4993,8 +5095,8 @@ class TestHorizonAxisDoesNotFlap:
         dominance leg answers True regardless of the clamp. Isolate the
         clamp with an active_headroom chosen so dominance is FALSE
         (`100 > 60*2+3=123` is false) while the clamp (`100 >= min(98+3,
-        100)`) is still True — exactly the shape the round-5 review measured
-        (left=98 / peer=100 / active=60) as flipping between clamp on/off.
+        100)`) is still True — exactly the shape measured (left=98 /
+        peer=100 / active=60) as flipping between clamp on/off.
         """
         state = {"lastSwitchFrom": "1", "leftHeadroom": 98.0, "leftRecoveryAt": None}
         recovered = harness.engine._left_account_recovered(
@@ -5019,8 +5121,8 @@ class TestHorizonAxisDoesNotFlap:
     def test_the_dominance_leg_does_not_silently_read_an_unreadable_active_as_no_dominance(
         self, harness
     ):
-        """F6 (round-6 review): `active_headroom is None` must not collapse
-        onto the same answer as "the peer genuinely does not dominate".
+        """`active_headroom is None` must not collapse onto the same
+        answer as "the peer genuinely does not dominate".
 
         The consume-first two-phase commit reassigns `active_headroom` from
         an escalated refetch WITHOUT re-classifying the trigger
@@ -5031,9 +5133,9 @@ class TestHorizonAxisDoesNotFlap:
         not None` guard silently turned "cannot compare" into "does not
         dominate", identical to a peer that genuinely fails the ratio test.
 
-        Same peer (frozen at 40 pts, well past the round-5e `+SPENT_
-        HEADROOM_PCT` margin at any active this small) with only the
-        active's readability changed:
+        Same peer (frozen at 40 pts, well past the `+SPENT_HEADROOM_PCT`
+        margin at any active this small) with only the active's readability
+        changed:
 
             active_headroom=2.0   (readable)   -> True
             active_headroom=None  (unreadable) -> must ALSO be True
@@ -5061,7 +5163,7 @@ class TestHorizonAxisDoesNotFlap:
     def test_no_return_account_does_not_re_bar_an_already_recovered_peer_when_the_active_is_unreadable(
         self, harness
     ):
-        """F6, measured directly against `_no_return_account`: with `recovered`
+        """Measured directly against `_no_return_account`: with `recovered`
         already established True, the function's OWN ratio leg has the same
         `active_headroom is None` ambiguity as the predicate that feeds it --
         an unreadable active must not re-impose the bar on a peer already
@@ -5095,14 +5197,14 @@ class TestHorizonAxisDoesNotFlap:
     def test_the_all_spent_recovery_leg_carries_its_own_hysteresis(
         self, temp_home
     ):
-        """MC1-nohyst: the new failover recovery leg (C1) needs a margin too.
+        """The failover recovery leg needs a margin too.
 
         Without `RECOVERY_HYSTERESIS_S`, any reset that drifts a second
         nearer than the active's reads as "the barred peer recovered" --
         the same drift-is-not-recovery hole the ordinary path's recovery
         leg already guards against (`test_a_reset_that_crept_nearer_is_not_
-        a_recovery`), but on the failover leg added for C1. Both accounts
-        sit inside the all-spent band (peer 5 pts, active 2 pts, threshold
+        a_recovery`), but on the failover leg. Both accounts sit inside the
+        all-spent band (peer 5 pts, active 2 pts, threshold
         90 -> floor 10) so the landing leg cannot fire and only the
         recovery leg decides; the peer's reset is 60s sooner than the
         active's, well inside the 300s margin, so this must NOT release.
@@ -5128,9 +5230,8 @@ class TestHorizonAxisDoesNotFlap:
     def test_the_dominance_fallback_does_not_fire_below_its_own_floor(
         self, harness
     ):
-        """MF6a-always: the F6 fallback (unreadable active) still has a
-        floor -- it is not an unconditional release once the active goes
-        unreadable.
+        """The unreadable-active fallback still has a floor -- it is not an
+        unconditional release once the active goes unreadable.
 
         Ordinary-path snapshot (`leftHeadroom` a real baseline), active
         unreadable, and the peer currently BELOW the landing floor
@@ -5146,16 +5247,16 @@ class TestHorizonAxisDoesNotFlap:
         )
         assert recovered is False, (
             "the peer is unreadable-active-fallback-eligible in shape only -- "
-            "at 5 pts it is BELOW the landing floor (10), so the F6 fallback "
+            "at 5 pts it is BELOW the landing floor (10), so the fallback "
             "must not release it just because the active went unreadable"
         )
 
     def test_no_return_accounts_unreadable_active_fallback_has_a_floor_too(
         self, harness
     ):
-        """MF6b-always: `_no_return_account`'s own F6 fallback leg needs the
-        same floor as the predicate that feeds it -- not an unconditional
-        release once the active is unreadable.
+        """`_no_return_account`'s own unreadable-active fallback leg needs
+        the same floor as the predicate that feeds it -- not an
+        unconditional release once the active is unreadable.
 
         `recovered=True` fixed (isolates this leg). Barred peer at 5 pts,
         active unreadable -- 5 is BELOW the landing floor (10 at the
@@ -5350,9 +5451,6 @@ class TestHorizonAxisDoesNotFlap:
     def test_a_failover_departure_does_not_disarm_the_bar(self, temp_home):
         """`(None, None)` from a failover must not read the same as `absent`.
 
-        R2 of the round-5 acceptance matrix: failover, peer FROZEN, active
-        burning -> HOLD.
-
         `_perform` writes `leftHeadroom`/`leftRecoveryAt` unconditionally on
         every trigger, including `failover`, where `active_headroom` is None
         (that is the definition of failover) and the recorded recovery is
@@ -5365,12 +5463,12 @@ class TestHorizonAxisDoesNotFlap:
         Reached with a real failover (active usage unreadable for
         `unhealthy_ticks` ticks), then the classic flap shape: the barred
         account frozen at 4 pts, the new active burning from 4 pts down past
-        the exact boundary (98.2%) round 5's dominance leg opened at —
+        the exact boundary (98.2%) a bare dominance leg opens at —
         `4.0 > 1.8 x 2` — walked further still, to a bare sliver (99.9%,
-        0.1 pts). The round-5 defect switched back to the frozen peer at
-        98.2%, measured on this exact fleet (round-5 review F1/F2). This
-        leaves the ORDINARY-path shape (`test_the_release_needs_the_barred_
-        account_to_have_improved`) as the sibling proving the general
+        0.1 pts). Measured on this exact fleet, the bare leg switched back
+        to the frozen peer at 98.2%. This leaves the ORDINARY-path shape
+        (`test_the_release_needs_the_barred_account_to_have_improved`) as
+        the sibling proving the general
         dominance leg's own margin separately; this one is failover-only,
         which never reads `leftHeadroom`/`leftRecoveryAt` at all, so it also
         discriminates a relational fix from an absolute one: mutate the
@@ -5402,8 +5500,8 @@ class TestHorizonAxisDoesNotFlap:
 
         h.clock.advance(301.0)
         outcomes = []
-        # 98.0 (2.0 pts, the old boundary), 98.2 (1.8 pts, round 5's exact
-        # kill shot), then further still down to a bare sliver — the peer
+        # 98.0 (2.0 pts, the old boundary), 98.2 (1.8 pts, where the bare
+        # leg opened), then further still down to a bare sliver — the peer
         # never moves, so nothing on this walk is evidence it improved.
         for active_pct in (98.0, 98.2, 98.4, 99.0, 99.5, 99.9):
             outcomes.append(h.tick_with_usage({
@@ -5529,13 +5627,13 @@ class TestHorizonAxisDoesNotFlap:
 
         `test_a_failover_departure_releases_once_the_peer_is_readable_again`
         only proves the bar is not PERMANENT — it drives the peer to a full
-        100.0, which also clears a fixed near-100 floor. C1's original bug was
-        an absolute `>= 97.0` floor, unreachable for any peer that had spent
-        more than 3% of its weekly window.
+        100.0, which also clears a fixed near-100 floor. The original bug
+        here was an absolute `>= 97.0` floor, unreachable for any peer that
+        had spent more than 3% of its weekly window.
 
-        THIS IS DELIBERATELY NOT RELATIONAL TO THE ACTIVE (round-5 correction):
-        round 5's fix made this branch dominance-vs-active, and that is
-        exactly what broke `test_a_failover_departure_does_not_disarm_the_bar`
+        THIS IS DELIBERATELY NOT RELATIONAL TO THE ACTIVE: making this
+        branch dominance-vs-active is exactly what broke
+        `test_a_failover_departure_does_not_disarm_the_bar`
         — a `(None, None)` snapshot has no recorded baseline for either
         headroom or recovery, so there is nothing to diff the ACTIVE's burn
         away from; any leg that reads the active here reproduces the flap the
@@ -5593,8 +5691,8 @@ class TestHorizonAxisDoesNotFlap:
     def test_a_failover_departure_releases_when_the_peer_resets_first_in_the_all_spent_regime(
         self, temp_home
     ):
-        """C1 (round-6 review): the failover floor is the exact complement of
-        all-spent, so a peer that resets first can never release the bar.
+        """The failover floor is the exact complement of all-spent, so a
+        peer that resets first can never release the bar.
 
         `_every_account_above_threshold` is True exactly when every account,
         active included, sits at or under `100 - threshold`. The failover
@@ -5649,11 +5747,11 @@ class TestHorizonAxisDoesNotFlap:
             "however soon the peer returns"
         )
 
-    def test_c1_recovery_leg_requires_the_actives_reset_to_be_known_not_merely_absent(
+    def test_the_recovery_leg_requires_the_actives_reset_to_be_known_not_merely_absent(
         self, temp_home
     ):
-        """R7 review C-1: `_binding_recovery_ts` returns `inf` for FIVE
-        states, only two of which mean "never" (unreadable, token-expired
+        """`_binding_recovery_ts` returns `inf` for FIVE states, only two
+        of which mean "never" (unreadable, token-expired
         sentinel) -- unknown resets_at and a stale/past resets_at both also
         return `inf` but mean "we do not know", not "never". The old
         predicate `peer < active - HYST` treats all of them alike, so an
@@ -5661,13 +5759,14 @@ class TestHorizonAxisDoesNotFlap:
         peer that is finite but arbitrarily far out (400h), and the bar
         releases onto it on no evidence at all.
 
-        Same failover setup as the sibling C1 tests above (peer barred at
-        departure, active burns down), then a single tick with three
+        Same failover setup as the sibling all-spent tests above (peer
+        barred at departure, active burns down), then a single tick with
+        three
         variants of the active's reset -- only the active's `resets_at`
         differs across rows:
 
             active reset UNREPORTED  -> must BLOCK (hold: unknown != never)
-            active resets in 500h    -> must SWITCH (intended release, C1)
+            active resets in 500h    -> must SWITCH (the intended release)
             active resets in 10min   -> must BLOCK (guard still works)
         """
         cases = [
@@ -5716,18 +5815,18 @@ class TestHorizonAxisDoesNotFlap:
                 f"{expected_outcome.name}/active={expected_active}"
             )
 
-    def test_r8_isfinite_guard_must_not_hold_when_a_near_peer_is_available(
+    def test_the_isfinite_guard_must_not_hold_when_a_near_peer_is_available(
         self, temp_home
     ):
-        """R8 review I-A: `math.isfinite(active_recovery_ts)` (C-1, R7) reads
-        ALL FIVE `inf` states as "unknown, hold" -- but two of them are
+        """`math.isfinite(active_recovery_ts)` reads ALL FIVE `inf` states
+        as "unknown, hold" -- but two of them are
         ordinary API shapes for an active that is plainly alive and burning:
         no `resets_at` reported, or a `resets_at` already elapsed. On those
         the bar now sits on a near-spent active even when the peer is back
         within `RECOVERY_HORIZON_S` -- the same PR's own constant for "near
         enough to matter".
 
-        Same failover setup as the sibling C1 tests (peer barred at
+        Same failover setup as the sibling all-spent tests (peer barred at
         departure, active burns down), then a single tick with four
         variants -- only the ACTIVE's `resets_at` (and, for NEG, the peer's)
         differs across rows:
@@ -5799,11 +5898,11 @@ class TestHorizonAxisDoesNotFlap:
                 f"{expected_outcome.name}/active={expected_active}"
             )
 
-    def test_i3_left_snapshot_uses_the_ranking_now_not_a_fresh_clock_read(
+    def test_left_snapshot_uses_the_ranking_now_not_a_fresh_clock_read(
         self, temp_home
     ):
-        """R7 review I-3: `left_snapshot` used to re-read `self.clock()`
-        AFTER the ranking had already decided on a `now`, instead of reusing
+        """`left_snapshot` used to re-read `self.clock()` AFTER the
+        ranking had already decided on a `now`, instead of reusing
         that same value. On a fake, non-advancing clock the two reads are
         identical, so no existing test could see the difference -- on a real
         wall clock any elapsed time between the two reads (however small) can
@@ -5880,7 +5979,7 @@ class TestHorizonAxisDoesNotFlap:
         assert h.active_number() == 2
 
         # Strip to the pre-upgrade shape: barred is named, no departure
-        # evidence recorded at all -- absence releases (R6), by design.
+        # evidence recorded at all -- absence releases, by design.
         h.engine._mutate_state(lambda st: st.pop("leftHeadroom", None))
         h.engine._mutate_state(lambda st: st.pop("leftRecoveryAt", None))
         assert "leftHeadroom" not in h.engine._read_state()
@@ -6175,23 +6274,25 @@ class TestHorizonAxisDoesNotFlap:
         assert harness.active_number() == 3
 
 
-class TestAcceptance204eR1toR7:
-    """Task 204e's acceptance matrix, one test per line.
+class TestTheReleasePredicateOneStateShapePerTest:
+    """Every state shape `_left_account_recovered` must answer for, one test
+    per shape.
 
-    R1  failover, peer readable and dominant AND CHANGED     -> RELEASE
-    R2  failover, peer FROZEN, active burning                -> HOLD    (F1)
-    R3  failover, peer still poor                            -> HOLD
-    R4  failover, peer still unreadable                      -> HOLD
-    R5  ordinary departure, weekly-bound peer that recovered -> RELEASE
-    R6  pre-upgrade record (keys absent)                     -> RELEASE
-    R7  at-limit escape                                      -> works
+    failover, peer readable and dominant AND CHANGED     -> RELEASE
+    failover, peer FROZEN, active burning                -> HOLD
+    failover, peer still poor                            -> HOLD
+    failover, peer still unreadable                      -> HOLD
+    ordinary departure, weekly-bound peer that recovered -> RELEASE
+    pre-upgrade record (keys absent)                     -> RELEASE
+    at-limit escape                                      -> works
 
     Some of these are also proven end-to-end elsewhere in this file
-    (`test_a_failover_departure_does_not_disarm_the_bar` is R2 through a real
-    tick loop, `test_a_switch_that_recorded_no_snapshot_still_releases` is
-    R6, `test_a_failover_hold_still_escapes_at_limit` is R7); this class
-    drives `_left_account_recovered` directly so each line of the matrix is
-    checkable in isolation, against the exact state shape that line names,
+    (`test_a_failover_departure_does_not_disarm_the_bar` is the frozen-peer
+    hold through a real tick loop,
+    `test_a_switch_that_recorded_no_snapshot_still_releases` the pre-upgrade
+    record, `test_a_failover_hold_still_escapes_at_limit` the at-limit
+    escape); this class drives `_left_account_recovered` directly so each
+    shape is checkable in isolation, against the exact state it names,
     without a multi-tick walk's other gates (cooldown, ranking, hysteresis)
     able to hide a wrong answer.
     """
@@ -6205,15 +6306,16 @@ class TestAcceptance204eR1toR7:
             .replace("+00:00", "Z")
         )
 
-    def test_r1_failover_peer_readable_dominant_and_changed_releases(
+    def test_failover_peer_readable_dominant_and_changed_releases(
         self, harness
     ):
-        """R1: a failover snapshot, peer now readable and clearly healthy.
+        """A failover snapshot, peer now readable and clearly healthy.
 
         h=15: past the threshold-derived floor (`100 - 90 = 10`) but under
-        20 and 50 — chosen so an absolute floor of 20 or 50 (MRELF-a/b in
-        the mutation sweep) would give the WRONG answer (False) here, while
-        the threshold-derived floor correctly releases. A peer at 70, past
+        20 and 50 — chosen so an absolute floor of 20 or 50 (both survived
+        the mutation sweep otherwise) would give the WRONG answer (False)
+        here, while the threshold-derived floor correctly releases. A peer
+        at 70, past
         every plausible floor, would not tell the two apart.
         """
         state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
@@ -6225,13 +6327,13 @@ class TestAcceptance204eR1toR7:
             "20 or 50) must release"
         )
 
-    def test_r1_floor_moves_with_the_users_threshold(self, temp_home):
+    def test_the_failover_floor_moves_with_the_users_threshold(self, temp_home):
         """The failover floor is `settings.threshold`-derived, not a fixed 10.
 
         At the default threshold (90) the floor happens to be exactly 10,
-        indistinguishable from a hardcoded `h >= 10.0` (MRELF-c in the
-        mutation sweep survived for exactly this reason). The property this
-        branch actually claims is that the floor is the USER'S policy, so it
+        indistinguishable from a hardcoded `h >= 10.0` (that mutation
+        survived for exactly this reason). The property this branch actually
+        claims is that the floor is the USER'S policy, so it
         must move when `settings.threshold` does: the SAME peer, held fixed
         at 35 points, must hold under a threshold whose floor sits above 35
         and release under one whose floor sits below it.
@@ -6261,13 +6363,14 @@ class TestAcceptance204eR1toR7:
             "user's own policy, not a fixed constant"
         )
 
-    def test_r2_failover_peer_frozen_active_burning_holds(self, temp_home):
-        """R2 (F1): a failover snapshot, peer frozen, only the active moves.
+    def test_failover_peer_frozen_active_burning_holds(self, temp_home):
+        """A failover snapshot, peer frozen, only the active moves.
 
-        End-to-end walk, not a direct predicate call: this is the exact shape
-        round 5 shipped broken, so it is worth proving through the real tick
-        loop rather than only the unit. See `test_a_failover_departure_does_
-        not_disarm_the_bar` for the longer walk this is a focused version of.
+        End-to-end walk, not a direct predicate call: this is the exact
+        shape an earlier cut shipped broken, so it is worth proving through
+        the real tick loop rather than only the unit. See
+        `test_a_failover_departure_does_not_disarm_the_bar` for the longer
+        walk this is a focused version of.
         """
         h = EngineHarness(temp_home)
         h.seed(1, "a@example.com")
@@ -6287,15 +6390,16 @@ class TestAcceptance204eR1toR7:
         h.clock.advance(301.0)
         outcome = h.tick_with_usage({
             "1": _usage(96, self._at(h, 500 * 3600)),   # frozen, 4 pts, below floor
-            "2": _usage(98.2, self._at(h, 400 * 3600)),  # active burnt, round 5's kill shot
+            # active burnt past the bare-ratio boundary
+            "2": _usage(98.2, self._at(h, 400 * 3600)),
         })
         assert outcome is not TickOutcome.SWITCHED, (
             "the peer never changed and is well under the threshold-derived "
             "floor; burning the active alone must not release a failover hold"
         )
 
-    def test_r3_failover_peer_still_poor_holds(self, harness):
-        """R3: a failover snapshot, peer readable but genuinely poor."""
+    def test_failover_peer_still_poor_holds(self, harness):
+        """A failover snapshot, peer readable but genuinely poor."""
         state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
         # 5.0 < 100 - 90 = 10, the threshold-derived floor: readable, but poor.
         assert harness.engine._left_account_recovered(
@@ -6305,8 +6409,8 @@ class TestAcceptance204eR1toR7:
             "floor must hold — readable is not the same as recovered"
         )
 
-    def test_r4_failover_peer_still_unreadable_holds(self, harness):
-        """R4: a failover snapshot, peer still unreadable."""
+    def test_failover_peer_still_unreadable_holds(self, harness):
+        """A failover snapshot, peer still unreadable."""
         state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
         assert harness.engine._left_account_recovered(
             state, {"2": None}, {"2": None}, 2.0, harness.settings, harness.clock()
@@ -6315,10 +6419,10 @@ class TestAcceptance204eR1toR7:
             "unknown is not evidence of recovery"
         )
 
-    def test_r5_ordinary_departure_weekly_bound_peer_that_recovered_releases(
+    def test_ordinary_departure_weekly_bound_peer_that_recovered_releases(
         self, harness
     ):
-        """R5: a real (non-failover) baseline, and the peer's WEEKLY window
+        """A real (non-failover) baseline, and the peer's WEEKLY window
         actually rolled over — genuine recovery on the recovery axis, which
         the headroom axis (pinned by 7-day utilization) cannot see at all.
         """
@@ -6342,8 +6446,8 @@ class TestAcceptance204eR1toR7:
             "is a real recovery event the headroom leg cannot see"
         )
 
-    def test_r6_pre_upgrade_record_keys_absent_releases(self, harness):
-        """R6: state written before the snapshot fields existed."""
+    def test_pre_upgrade_record_keys_absent_releases(self, harness):
+        """State written before the snapshot fields existed."""
         state = {"lastSwitchFrom": "2"}  # no leftHeadroom / leftRecoveryAt key
         assert harness.engine._left_account_recovered(
             state, {"2": _usage(96)}, {"2": 4.0}, 2.0, harness.settings, harness.clock()
@@ -6352,8 +6456,8 @@ class TestAcceptance204eR1toR7:
             "no evidence either way and must release, not hold forever"
         )
 
-    def test_r7_at_limit_escape_still_works(self, harness):
-        """R7: at-limit skips this predicate's bar entirely by trigger scope.
+    def test_at_limit_escape_still_works(self, harness):
+        """At-limit skips this predicate's bar entirely by trigger scope.
 
         `_no_return_account` (not `_left_account_recovered`) is what gates
         at-limit/failover out; this confirms the fix did not touch that

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -4841,6 +4841,162 @@ class TestHorizonAxisDoesNotFlap:
             "premise: the unclamped threshold is unsatisfiable at h=100.0"
         )
 
+    def test_the_dominance_leg_does_not_silently_read_an_unreadable_active_as_no_dominance(
+        self, harness
+    ):
+        """F6 (round-6 review): `active_headroom is None` must not collapse
+        onto the same answer as "the peer genuinely does not dominate".
+
+        The consume-first two-phase commit reassigns `active_headroom` from
+        an escalated refetch WITHOUT re-classifying the trigger
+        (`autoswitch.py:1152-1168`) -- so a phase-2 refetch that cannot read
+        the active reaches this predicate with `trigger in ("proactive",
+        "consume-first")` (in scope for the bar) and `active_headroom is
+        None`. Before the fix, the dominance leg's own `active_headroom is
+        not None` guard silently turned "cannot compare" into "does not
+        dominate", identical to a peer that genuinely fails the ratio test.
+
+        Same peer (frozen at 40 pts, well past the round-5e `+SPENT_
+        HEADROOM_PCT` margin at any active this small) with only the
+        active's readability changed:
+
+            active_headroom=2.0   (readable)   -> True
+            active_headroom=None  (unreadable) -> must ALSO be True
+
+        Measured pre-fix: readable gave True (`40 > 2*2+3`), unreadable gave
+        False -- same peer, same reality, opposite answers, purely from
+        losing the ability to read a THIRD account.
+        """
+        state = {"lastSwitchFrom": "2", "leftHeadroom": 40.0, "leftRecoveryAt": None}
+        usage = {"2": _usage(60.0)}  # peer frozen at 40 pts headroom
+        readable = harness.engine._left_account_recovered(
+            state, usage, {"2": 40.0}, 2.0, harness.settings, harness.clock(), "1",
+        )
+        unreadable = harness.engine._left_account_recovered(
+            state, usage, {"2": 40.0}, None, harness.settings, harness.clock(), "1",
+        )
+        assert readable is True, "premise: a readable, dominant active releases"
+        assert unreadable is True, (
+            f"readable={readable} unreadable={unreadable} -- the SAME peer, "
+            "unchanged, must not flip to HOLD purely because the active "
+            "became unreadable; that silently scores 'cannot read' the same "
+            "as 'does not dominate'"
+        )
+
+    def test_no_return_account_does_not_re_bar_an_already_recovered_peer_when_the_active_is_unreadable(
+        self, harness
+    ):
+        """F6, measured directly against `_no_return_account`: with `recovered`
+        already established True, the function's OWN ratio leg has the same
+        `active_headroom is None` ambiguity as the predicate that feeds it --
+        an unreadable active must not re-impose the bar on a peer already
+        judged recovered.
+
+        `recovered=True` is fixed on both calls (this isolates
+        `_no_return_account`'s own leg from the fix already applied to
+        `_left_account_recovered`). Same barred peer at 40 pts, dominating a
+        2-pt active by 20x -- readable releases (`None`); measured pre-fix
+        that unreadable stayed barred (`'2'`) for the identical peer, purely
+        because the second, redundant ratio check inside `_no_return_account`
+        could not confirm dominance without a readable active.
+        """
+        state = {"lastSwitchFrom": "2", "leftHeadroom": 40.0, "leftRecoveryAt": None}
+        headroom = {"2": 40.0}
+        for trigger in ("proactive", "consume-first"):
+            readable = harness.engine._no_return_account(
+                trigger, state, headroom, 2.0, recovered=True, settings=harness.settings
+            )
+            unreadable = harness.engine._no_return_account(
+                trigger, state, headroom, None, recovered=True, settings=harness.settings
+            )
+            assert readable is None, f"premise: {trigger} releases when readable"
+            assert unreadable is None, (
+                f"trigger={trigger} readable={readable!r} "
+                f"unreadable={unreadable!r} -- the same already-recovered peer "
+                "must not be re-barred purely because the active became "
+                "unreadable"
+            )
+
+    def test_the_all_spent_recovery_leg_carries_its_own_hysteresis(
+        self, temp_home
+    ):
+        """MC1-nohyst: the new failover recovery leg (C1) needs a margin too.
+
+        Without `RECOVERY_HYSTERESIS_S`, any reset that drifts a second
+        nearer than the active's reads as "the barred peer recovered" --
+        the same drift-is-not-recovery hole the ordinary path's recovery
+        leg already guards against (`test_a_reset_that_crept_nearer_is_not_
+        a_recovery`), but on the failover leg added for C1. Both accounts
+        sit inside the all-spent band (peer 5 pts, active 2 pts, threshold
+        90 -> floor 10) so the landing leg cannot fire and only the
+        recovery leg decides; the peer's reset is 60s sooner than the
+        active's, well inside the 300s margin, so this must NOT release.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        state = {"lastSwitchFrom": "1", "leftHeadroom": None, "leftRecoveryAt": None}
+        usage = {
+            "1": _usage(95.0, self._at(h, 3600.0)),        # 5 pts, back in 1h
+            "2": _usage(98.0, self._at(h, 3660.0)),        # 2 pts, back in 1h+60s
+        }
+        recovered = h.engine._left_account_recovered(
+            state, usage, {"1": 5.0}, 2.0, h.settings, h.clock(), "2",
+        )
+        assert recovered is False, (
+            "the peer's reset is only 60s sooner than the active's, well "
+            "inside RECOVERY_HYSTERESIS_S (300s) -- without the margin any "
+            "drift in resets_at releases the all-spent failover hold"
+        )
+
+    def test_the_dominance_fallback_does_not_fire_below_its_own_floor(
+        self, harness
+    ):
+        """MF6a-always: the F6 fallback (unreadable active) still has a
+        floor -- it is not an unconditional release once the active goes
+        unreadable.
+
+        Ordinary-path snapshot (`leftHeadroom` a real baseline), active
+        unreadable, and the peer currently BELOW the landing floor
+        (`h=5 < 100-90=10`). None of the other legs can fire either (peer
+        far under `left_headroom + SPENT_HEADROOM_PCT`, and no reset info
+        at all so the recovery leg's `inf < inf - 300` is false), so a
+        correct predicate holds.
+        """
+        state = {"lastSwitchFrom": "2", "leftHeadroom": 40.0, "leftRecoveryAt": None}
+        usage = {"2": _usage(95.0)}  # 5 pts, no resets_at at all
+        recovered = harness.engine._left_account_recovered(
+            state, usage, {"2": 5.0}, None, harness.settings, harness.clock(), "1",
+        )
+        assert recovered is False, (
+            "the peer is unreadable-active-fallback-eligible in shape only -- "
+            "at 5 pts it is BELOW the landing floor (10), so the F6 fallback "
+            "must not release it just because the active went unreadable"
+        )
+
+    def test_no_return_accounts_unreadable_active_fallback_has_a_floor_too(
+        self, harness
+    ):
+        """MF6b-always: `_no_return_account`'s own F6 fallback leg needs the
+        same floor as the predicate that feeds it -- not an unconditional
+        release once the active is unreadable.
+
+        `recovered=True` fixed (isolates this leg). Barred peer at 5 pts,
+        active unreadable -- 5 is BELOW the landing floor (10 at the
+        default threshold), so the bar must still apply.
+        """
+        state = {"lastSwitchFrom": "2"}
+        headroom = {"2": 5.0}
+        no_return = harness.engine._no_return_account(
+            "proactive", state, headroom, None, recovered=True,
+            settings=harness.settings,
+        )
+        assert no_return == "2", (
+            "the barred peer at 5 pts is below the landing floor (10); an "
+            "unreadable active must not unconditionally release it"
+        )
+
     def test_a_reset_that_crept_nearer_is_not_a_recovery(self, temp_home):
         """The recovery leg carries `RECOVERY_HYSTERESIS_S`, and it must.
 
@@ -5257,6 +5413,106 @@ class TestHorizonAxisDoesNotFlap:
             "35x the active's 2 points, and the engine never returned. The "
             "release floor is absolute (h >= 97), so any peer past 3% of its "
             "weekly window is held until the active hits its own limit."
+        )
+
+    def test_a_failover_departure_releases_when_the_peer_resets_first_in_the_all_spent_regime(
+        self, temp_home
+    ):
+        """C1 (round-6 review): the failover floor is the exact complement of
+        all-spent, so a peer that resets first can never release the bar.
+
+        `_every_account_above_threshold` is True exactly when every account,
+        active included, sits at or under `100 - threshold`. The failover
+        release floor at `_left_account_recovered` demands the barred peer
+        sit STRICTLY ABOVE `100 - threshold` -- the exact complement of the
+        same quantity. So whenever the fleet is all-spent, the floor cannot
+        be cleared by any measured headroom, independent of how soon the
+        peer's own binding window resets -- which is exactly the axis
+        `TestAllSpentGoesToTheSoonestReset` says should decide once headroom
+        stops being informative.
+
+        Same failover setup as the sibling tests above, but both accounts
+        now sit inside the all-spent band (peer 2.5 pts, active 2.0 pts --
+        both under the default floor of 10) and the peer's binding reset is
+        5 minutes away against the active's 400 hours out. See the sibling
+        test below for the snapshot-stripped control proving this exact
+        fleet is choosable, so a stall here is the floor, not the ranking.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = None
+        for _ in range(3):  # unhealthy_ticks default is 3
+            outcome = h.tick_with_usage({
+                "1": None,                              # unreadable -> failover
+                "2": _usage(4, self._at(h, 400 * 3600)),
+            })
+            h.clock.advance(60.0)
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        state = h.engine._read_state()
+        assert state.get("leftHeadroom") is None and state.get(
+            "leftRecoveryAt"
+        ) is None, "premise: a failover snapshot, keys present, values null"
+
+        h.clock.advance(301.0)
+        outcomes = []
+        for _ in range(8):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(97.5, self._at(h, 300.0)),      # 2.5 pts, 5 min out
+                "2": _usage(98.0, self._days_out(h, 400)),  # 2.0 pts, 400h out
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"{[o.name for o in outcomes]} -- peer 1 sits inside the "
+            "all-spent band at 2.5 pts and resets in 5 minutes against the "
+            "active's 2.0 pts / 400h out; the floor `h > 100 - threshold` is "
+            "the complement of all-spent so it can never release here "
+            "however soon the peer returns"
+        )
+
+    def test_the_all_spent_stall_above_is_the_floor_not_the_fleet(
+        self, temp_home
+    ):
+        """Control for the test above: strip the failover snapshot to the
+        pre-upgrade shape on the IDENTICAL fleet, and it switches on the very
+        next tick -- proving the stall above comes from the floor being the
+        complement of all-spent, not from the fleet having nowhere to go.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = None
+        for _ in range(3):
+            outcome = h.tick_with_usage({
+                "1": None,
+                "2": _usage(4, self._at(h, 400 * 3600)),
+            })
+            h.clock.advance(60.0)
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+        # Strip to the pre-upgrade shape: barred is named, no departure
+        # evidence recorded at all -- absence releases (R6), by design.
+        h.engine._mutate_state(lambda st: st.pop("leftHeadroom", None))
+        h.engine._mutate_state(lambda st: st.pop("leftRecoveryAt", None))
+        assert "leftHeadroom" not in h.engine._read_state()
+
+        h.clock.advance(301.0)
+        outcome = h.tick_with_usage({
+            "1": _usage(97.5, self._at(h, 300.0)),
+            "2": _usage(98.0, self._days_out(h, 400)),
+        })
+        assert outcome is TickOutcome.SWITCHED, (
+            "the identical fleet with no departure snapshot recorded "
+            "switches on the very next tick -- the fleet is choosable, so "
+            "the failover-shaped stall in the sibling test is the floor's "
+            "own construction, not a property of the ranking"
         )
 
     def test_a_failover_hold_still_escapes_at_limit(self, temp_home):
@@ -5725,12 +5981,13 @@ class TestAcceptance204eR1toR7:
         state = {"lastSwitchFrom": "2"}
         headroom = {"1": 0.0, "2": 100.0}
         for active in (0.0, None):
-            assert harness.engine._no_return_account(
-                "at-limit", state, headroom, active, ["1", "2"]
-            ) is None, (
-                "at-limit must escape the bar regardless of active_headroom "
-                "or the recovered predicate's answer"
-            )
+            for recovered in (True, False):
+                assert harness.engine._no_return_account(
+                    "at-limit", state, headroom, active, recovered
+                ) is None, (
+                    "at-limit must escape the bar regardless of "
+                    "active_headroom or the recovered predicate's answer"
+                )
 
 
 class TestAllSpentGoesToTheSoonestReset:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3423,6 +3423,79 @@ class TestRecoveryHorizon:
         assert harness.active_number() == 2
 
 
+class TestTheHorizonDoesNotDiscardWhatItAlreadyKnows:
+    """Two regressions from carrying the horizon into the ranking.
+
+    Both are cases where the PR had the right answer in hand and dropped it —
+    base 9f35426 gets them right, so neither is inherited.
+    """
+
+    def _at(self, harness, seconds: float) -> str:
+        from datetime import datetime, timezone
+
+        return (
+            datetime.fromtimestamp(harness.clock.now + seconds, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    def test_equal_headroom_past_the_horizon_takes_the_sooner_reset(self, harness):
+        """The tier-1 key hard-coded ``0.0`` where ``recovery_ts`` belongs.
+
+        Two peers with IDENTICAL headroom, both past the horizon, one returning
+        in 5h and one in 500h. With the second slot zeroed the tie falls
+        through to sequence order, so which account is chosen depends on which
+        slot number it happens to occupy:
+
+            near is acct 3  ->  base picks 3 (5h),  head picked 2 (500h)
+
+        `recovery_ts` is already computed at that point and is strictly better
+        than list order at zero cost. Headroom still outranks it — the tier
+        byte separates the two axes, and `-h` still comes first within tier 1.
+        """
+        out = harness.tick_with_usage({
+            "1": _usage(96, self._at(harness, 300 * 3600)),   # active, 4 pts
+            "2": _usage(92, self._at(harness, 500 * 3600)),   # 8 pts, LAST
+            "3": _usage(92, self._at(harness, 5 * 3600)),     # 8 pts, soonest
+        })
+        assert out is TickOutcome.SWITCHED
+        assert harness.active_number() == 3, (
+            "equal headroom, and the 5h reset lost to the 500h one on slot order"
+        )
+
+    def test_an_unchoosable_peer_does_not_veto_the_reset_ranking(self, harness):
+        """``best_candidate_headroom`` counted a candidate the ranking cannot pick.
+
+        The spent check asks "is anything worth having?" of the BEST candidate.
+        A peer holding 3.05 points is above ``SPENT_HEADROOM_PCT``, so the
+        answer is no for everybody — yet that peer cannot itself be chosen,
+        because 3.05 < 3.0 x HORIZON_HEADROOM_RATIO fails the ratio gate.
+        Nothing qualifies, and the engine parks on the account that returns
+        LAST:
+
+            active   3.00 pts, resets in 200h   <- stays here
+            peer     3.00 pts, resets in  10h   <- 190h sooner, refused
+            vetoer   3.05 pts, resets in 500h   <- unchoosable, decides
+
+        Measured against base: base switches at 3.05 and this branch blocks.
+        The veto band is (SPENT_HEADROOM_PCT, active x RATIO], up to 3 points
+        wide, so it is not an edge case in the endgame this code is for.
+
+        ``test_an_unreadable_peer_does_not_veto_the_spent_check`` pins the same
+        shape for an UNREADABLE peer; a readable one 0.05 points over the line
+        does the same damage.
+        """
+        out = harness.tick_with_usage({
+            "1": _usage(97.0, self._at(harness, 200 * 3600)),   # active, 3 pts
+            "2": _usage(97.0, self._at(harness, 10 * 3600)),    # 3 pts, sooner
+            "3": _usage(96.95, self._at(harness, 500 * 3600)),  # 3.05 pts
+        })
+        assert out is TickOutcome.SWITCHED
+        assert harness.active_number() == 2, (
+            "a peer that cannot be chosen vetoed the ranking for everyone"
+        )
+
+
 class TestHorizonAxisDoesNotFlap:
     """Past the horizon the headroom axis needs its own anti-flap margin.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3859,7 +3859,10 @@ class TestHorizonAxisDoesNotFlap:
         """
         pct = {"1": 92.0, "2": 92.0}
         seen = []
-        for _ in range(24):
+        # 60, not 24: the settling point moves with fleet size (measured 3 /
+        # 6 / 8 / 10 moves at n = 2 / 3 / 4 / 5) and 24 ticks caught this
+        # shape mid-walk.
+        for _ in range(60):
             harness.tick_with_usage({
                 "1": _usage(pct["1"], self._days_out(harness, 500)),
                 "2": _usage(pct["2"], self._days_out(harness, 400)),
@@ -3870,10 +3873,17 @@ class TestHorizonAxisDoesNotFlap:
             harness.clock.advance(301.0)
 
         moves = [n for i, n in enumerate(seen) if i == 0 or n != seen[i - 1]]
-        assert len(moves) <= 4, (
-            f"move sequence {moves} — the walk did not settle. Without the "
-            "ratio release it is unbounded; with it, 120 and 400 ticks both "
-            "measure the same four moves."
+        # SETTLING is the property, not a move count. `len(moves) <= 4` was
+        # true of this 2-account shape and false of every other: measured over
+        # 120 ticks with the fleet grown, 3 / 6 / 8 / 10 moves at n = 2 / 3 /
+        # 4 / 5 — the bar refuses only the ONE account left last, so a longer
+        # ring walks further before it comes back. All four settle.
+        #
+        # A count that holds for one fleet size reads as a bound and is not
+        # one. What the walk has to do is END.
+        assert len(set(seen[-8:])) == 1, (
+            f"move sequence {moves} — the walk was still moving in the last "
+            "eight ticks, so it does not settle at all"
         )
 
     def test_a_proactive_move_does_not_lock_out_the_next_one(self, harness):
@@ -4113,6 +4123,53 @@ class TestHorizonAxisDoesNotFlap:
         )
         assert list(barred) == [], (
             f"the bar did not remove account 1 from the ranking: {list(barred)}"
+        )
+
+    def test_the_bar_lifts_when_the_only_alternative_cannot_be_chosen(
+        self, temp_home
+    ):
+        """Existing is not the same as being an alternative.
+
+        The leaves-nothing release asked whether any OTHER account exists. A
+        third account that exists but can never qualify — at its limit, or with
+        unreadable headroom — answered yes while offering the ranking nothing,
+        so the release never fired and the n=2 stall simply moved to n>=3.
+
+        Measured before this, one ordinary proactive move and no seeded state:
+        30 ticks / 30h all BLOCKED with the active on 2 points and the barred
+        peer on 3, while the same fleet with the bar cleared switches on the
+        first tick.
+
+        THIRD ACCOUNT AT ITS LIMIT on purpose: with a healthy third the bar is
+        correct and the sibling tests cover it. The defect needs an alternative
+        that the ranking loop would skip anyway.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(92, self._days_out(h, 500)),
+            "2": _usage(10, self._days_out(h, 400)),
+            "3": _usage(100, self._days_out(h, 300)),
+        }) is TickOutcome.SWITCHED
+        h.clock.advance(301.0)
+
+        outcomes = []
+        for _ in range(30):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(97, self._days_out(h, 10)),    # barred, 3 pts
+                "2": _usage(98, self._days_out(h, 500)),   # active, 2 pts
+                "3": _usage(100, self._days_out(h, 300)),  # exists, spent
+            }))
+            h.clock.advance(3601.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"30 ticks of {[o.name for o in outcomes[:6]]}… — the only "
+            "choosable peer was barred and the third account is at its limit, "
+            "so the bar left the engine nothing"
         )
 
     def test_the_fallback_never_outranks_a_real_qualifier(self, harness):

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -2826,6 +2826,41 @@ class TestConsumeFirstStrategy:
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
 
+    def test_a_consume_first_target_must_still_be_healthy(self, temp_home):
+        """The threshold landing gate has no cover on the consume-first path.
+
+        `if (100.0 - h) >= settings.threshold and not all_above: continue` ->
+        `if False` survives the whole suite. On the `best` path the hysteresis
+        gate below masks it; consume-first has no headroom test at all — its
+        `elif` compares weekly resets only, so with the gate gone a 96%-used
+        account whose weekly window resets sooner is a valid target. Measured:
+
+            active 1: 60 pts (util 40%), weekly reset 500h
+            peer   2:  4 pts (util 96%), weekly reset  10h
+            ORIGINAL ranking=[]      tick -> NO_ACTION
+            MUTANT   ranking=['2']   tick -> SWITCHED to 2
+
+        Landing there re-triggers on the very next tick, which is the harm the
+        comment on that gate describes.
+
+        TWO accounts on purpose: a third healthy peer would win the sort and
+        hide the defect behind a correct answer.
+        """
+        h = EngineHarness(temp_home, strategy="consume-first")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(40, 40, _R_LATEST),   # active, 60 pts, resets LAST
+            "2": _usage7(96, 96, _R_SOON),     # 4 pts: sooner, but spent
+        })
+        assert outcome is not TickOutcome.SWITCHED, (
+            "consume-first moved onto an account at 96% utilization because "
+            "its weekly window resets sooner — it re-triggers next tick"
+        )
+        assert h.active_number() == 1
+
     def test_respects_cooldown(self, temp_home):
         h = self._harness(temp_home)  # default cooldown 300s
         h.tick_with_usage({
@@ -3752,9 +3787,8 @@ class TestHorizonAxisDoesNotFlap:
 
         Both legs are legitimate on the axis their own state selects: at the
         first the fleet still held real headroom, by the second every account
-        is spent, which is the regime the reset axis exists for. 21 of 576
-        burn walks make that transition; base makes 0 because it refuses the
-        outbound leg too.
+        is spent, which is the regime the reset axis exists for. Base never
+        makes that transition because it refuses the outbound leg too.
 
         Two candidate constraints were measured and BOTH changed the count by
         zero — requiring the fallback's candidate to be spent, and taking
@@ -4331,10 +4365,10 @@ class TestHorizonAxisDoesNotFlap:
     def test_the_bar_reaches_the_ranking_through_tick(self, temp_home):
         """The bar's production WIRING, which nothing pinned.
 
-        `_no_return_account` is computed in `_tick_inner` and threaded into
-        both `_rank_candidates` calls. Measured: replacing that computation
-        with `no_return = None` — the whole feature off in production — left
-        the FULL suite at 1732 passed. The only test of the bar's effect drives
+        `_no_return_account` is computed inside `_rank` and threaded into
+        `_rank_candidates`. Measured: replacing that computation with
+        `no_return = None` — the whole feature off in production — left the
+        full suite green. The only test of the bar's effect drives
         `_rank_candidates` directly and passes `no_return` by hand, so the unit
         was pinned and the integration was not: any refactor that drops the
         kwarg reverts the anti-flap bound silently.
@@ -4349,11 +4383,10 @@ class TestHorizonAxisDoesNotFlap:
         an answer at all. Past the horizon the release (`left >= active x
         RATIO` -> not barred) and the ranking gate (`h >= active x RATIO` ->
         qualifies) are the SAME inequality, so anything the bar could remove
-        the loop had already dropped: swept 18 headroom combinations, every one
-        `unbarred == barred`. Inside the horizon the ranking sorts by reset
-        time instead, the two stop agreeing, and the bar bites — 162 of the
-        swept combinations differ. Both peers are back within the hour here,
-        which is what puts the tick on that axis.
+        the loop had already dropped. Inside the horizon the ranking sorts by
+        reset time instead, the two stop agreeing, and the bar bites. Both
+        peers are back within the hour here, which is what puts the tick on
+        that axis.
 
         ONE fleet, ticked twice: `temp_home` is a single home and a second
         `EngineHarness` over it inherits the first run's roster, so the control
@@ -4399,6 +4432,346 @@ class TestHorizonAxisDoesNotFlap:
             "premise: unbarred, the account we left returns soonest and IS the "
             "pick — without this the assertion above would pass on a fleet "
             "where 3 wins for its own reasons"
+        )
+
+    def test_the_release_needs_the_barred_account_to_have_improved(
+        self, temp_home
+    ):
+        """An empty barred ranking is a reason to ASK, not a reason to release.
+
+        On two accounts the barred ranking is ALWAYS empty — barring the only
+        candidate necessarily empties the list — so a release keyed on
+        emptiness alone is a no-op at n=2, which is the fleet size the flap was
+        reported on. Measured on the emptiness-only release, sweeping active x
+        barred headroom x both reset shapes through `_rank_candidates(
+        no_return="1", oauth_candidates=["1"])`:
+
+            n=2 barred-rank EMPTY=320 NONEMPTY=0
+
+        So the retry fired every time and the bar never applied. The cited flap
+        reproduced unchanged: pcts 92/92, resets 500h/400h, 60 ticks gave
+        `[1, 2, 1, 2]` with the bar ON and `[1, 2, 1, 2]` with `lastSwitchFrom`
+        popped every tick — identical, and worse than base's single move.
+
+        WHAT SEPARATES THE TWO STATES is not the ranking, which only sees the
+        present. It is whether the barred account is a different proposition
+        from the one we left. At each leg of that walk it was not:
+
+            t8   1->2   left 1 holding 4.0 pts, 500h out
+            t20  2->1   account 1 holds 4.0 pts, 500h out   <- nothing changed
+            t22  1->2   account 2 holds 2.0 pts, 400h out   <- nothing changed
+
+        Every return won because the ACTIVE burned down, never because the
+        target recovered. That is the flap, exactly.
+
+        Both legs of the test below are the flap shape: the barred account is
+        no better than we left it on either axis. The bar must hold even
+        though the ranking is empty and the tick therefore does nothing.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(96, self._days_out(h, 500)),   # 4 pts
+            "2": _usage(92, self._days_out(h, 400)),   # 8 pts
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(3612.0)
+
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                # unchanged since we left it: same headroom, same reset
+                "1": _usage(96, self._days_out(h, 500)),
+                "2": _usage(98, self._days_out(h, 400)),   # active, burnt down
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED not in outcomes, (
+            f"{[o.name for o in outcomes]} — the engine went back to an "
+            "account that is exactly as we left it. The ranking flipped "
+            "because the active burned, not because the target recovered; "
+            "that is the flap this bar exists for."
+        )
+
+    def test_a_reset_that_crept_nearer_is_not_a_recovery(self, temp_home):
+        """The recovery leg carries `RECOVERY_HYSTERESIS_S`, and it must.
+
+        Without a margin (`< was - 0.0`) any reset that moved a second nearer
+        counts as the barred account "recovering", and a `resets_at` that
+        drifts — a refetch landing a slightly different estimate, or simply a
+        nearer window starting to bind — hands the flap a release for free.
+        That is the same shape as the ratio gate before it was gated: a
+        threshold burn crosses on its own.
+
+        Measured with the margin removed: the walk below returns to account 1
+        because its binding reset reads 60s nearer than the value recorded at
+        departure, while its headroom is unchanged.
+
+        `RECOVERY_HYSTERESIS_S` is the margin the recovery AXIS already ranks
+        by one gate later, so the release and the ranking agree about what
+        "meaningfully sooner" means rather than being two numbers to reason
+        about separately.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        depart = self._at(h, 500 * 3600)
+        assert h.tick_with_usage({
+            "1": _usage(96, depart),                    # 4 pts
+            "2": _usage(92, self._days_out(h, 400)),    # 8 pts
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(3612.0)
+
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                # same headroom as at departure; the reset crept 60s nearer,
+                # which is well inside RECOVERY_HYSTERESIS_S
+                "1": _usage(96, self._at(h, 500 * 3600 - 3612 - 60)),
+                "2": _usage(98, self._days_out(h, 400)),
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED not in outcomes, (
+            f"{[o.name for o in outcomes]} — a reset one minute nearer is not "
+            "the barred account recovering; without the margin any drift in "
+            "`resets_at` releases the bar"
+        )
+
+    def test_an_unschedulable_account_that_gained_a_reset_has_recovered(
+        self, temp_home
+    ):
+        """`inf` is the right departure value for an unknown reset, not zero.
+
+        `_binding_recovery_ts` returns `inf` for a binding window with no
+        usable `resets_at` — an account nobody can schedule around — and
+        `_perform` stores that as JSON `null`. Reading it back as `0.0` makes
+        the recovery leg unsatisfiable, because no real timestamp is below
+        `0 - RECOVERY_HYSTERESIS_S`, so an account that gained a reset while we
+        were away is refused forever on that axis.
+
+        That IS an improvement, and it is one the headroom leg cannot see: the
+        account below holds the same 4 points it had at departure, so only the
+        reset changed. Measured with the default flipped to `0.0`: 10 ticks
+        BLOCKED with the peer back in an hour.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(96),                            # 4 pts, NO reset known
+            "2": _usage(92, self._days_out(h, 400)),
+        }) is TickOutcome.SWITCHED
+        assert h.engine._read_state().get("leftRecoveryAt") is None, (
+            "premise: the departure reset was unknown and stored as null"
+        )
+        h.clock.advance(3612.0)
+
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                # SAME 4 points; only the reset is now known, and it is near
+                "1": _usage(96, self._at(h, 3600)),
+                "2": _usage(98, self._days_out(h, 400)),
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"{[o.name for o in outcomes]} — the barred account went from "
+            "unschedulable to back-in-an-hour, which the headroom leg cannot "
+            "see; reading the stored null as 0.0 makes that unreachable"
+        )
+
+    def test_a_switch_that_recorded_no_snapshot_still_releases(
+        self, temp_home
+    ):
+        """No departure snapshot means release, and that direction is chosen.
+
+        State written before `leftHeadroom`/`leftRecoveryAt` existed — an
+        upgrade in place, with the file persisted across restarts — names a
+        barred account and carries no evidence about it either way. The two
+        failure modes are not symmetric: barring on absent evidence is the
+        permanent proactive lockout this branch has already fixed twice, and it
+        survives a restart and a week of wall clock, while releasing costs at
+        most one extra move that the next switch then records properly.
+
+        Measured with the default flipped to `return False`: the shape below
+        answers BLOCKED for 20 ticks with a peer at full quota.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        # A pre-upgrade record: the bar is named, the snapshot is not there.
+        h.engine._mutate_state(lambda st: st.update({"lastSwitchFrom": "2"}))
+        h.engine._mutate_state(lambda st: st.pop("leftHeadroom", None))
+        h.engine._mutate_state(lambda st: st.pop("leftRecoveryAt", None))
+        assert "leftHeadroom" not in h.engine._read_state(), (
+            "premise: the state carries no departure snapshot"
+        )
+
+        outcomes = []
+        for _ in range(20):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(97, self._days_out(h, 500)),   # active, 3 pts
+                "2": _usage(0, self._days_out(h, 400)),    # barred, FULL quota
+            }))
+            h.clock.advance(1801.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"20 ticks of {[o.name for o in outcomes[:6]]}… — state written "
+            "before the snapshot field existed barred the only peer forever, "
+            "which is the persisted lockout, not anti-flap"
+        )
+
+    def test_the_release_fires_when_the_barred_account_recovered(
+        self, temp_home
+    ):
+        """The control: same fleet, same bar, the barred account IS better.
+
+        Without this the assertion above would pass on a bar that never
+        releases at all, which is the permanent 2-account lockout this branch
+        already fixed twice. Only account 1's numbers differ — it reset to full
+        quota — and that must move the engine on the recovery axis the
+        emptiness retry was reaching for.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(96, self._days_out(h, 500)),
+            "2": _usage(92, self._days_out(h, 400)),
+        }) is TickOutcome.SWITCHED
+        h.clock.advance(3612.0)
+
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(0, self._days_out(h, 500)),    # reset to FULL
+                "2": _usage(98, self._days_out(h, 400)),
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"{[o.name for o in outcomes]} — account 1 came back to full "
+            "quota and is the only peer; refusing it is the permanent "
+            "2-account lockout, not anti-flap"
+        )
+
+    def test_the_ratio_release_changes_where_the_engine_lands(self, temp_home):
+        """`left >= active x HORIZON_HEADROOM_RATIO` — worth 50 points, unpinned.
+
+        Measured: replacing the whole condition with `False` left the full
+        suite green. It is not equivalent. `test_the_bar_never_applies_to_an_
+        escape` deliberately uses 15 against 10 so the ratio CANNOT fire, and
+        every other bar test releases through the emptiness path instead, so
+        nothing observed the release doing its job.
+
+        End-to-end after a 1->2 move, active 2 on 10 pts, the barred 1 on 80,
+        a third peer on 30:
+
+            release ON   -> SWITCHED to account 1 (80 pts)
+            release OFF  -> SWITCHED to account 3 (30 pts)
+
+        Asserts the DESTINATION: the tick switches either way, so an outcome
+        assertion would pass with the release gone.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(92, self._days_out(h, 500)),
+            "2": _usage(10, self._days_out(h, 400)),
+            "3": _usage(70, self._days_out(h, 300)),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(301.0)
+
+        assert h.tick_with_usage({
+            "1": _usage(20, self._days_out(h, 500)),   # barred, 80 pts
+            "2": _usage(90, self._days_out(h, 400)),   # active, 10 pts
+            "3": _usage(70, self._days_out(h, 300)),   # peer, 30 pts
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 1, (
+            f"landed on {h.active_number()} — the account we left now holds "
+            "8x the active's headroom, which is a move the outbound leg would "
+            "have made on its own merits, not the flip the bar refuses"
+        )
+
+    def test_the_bar_is_recomputed_on_the_phase_two_snapshot(self, temp_home):
+        """Consume-first refetches, and the bar has to be re-asked.
+
+        The two-phase commit replaces `usage`, `headroom` and `active_headroom`
+        with an escalated refetch, then re-ranks — but the bar was computed
+        once, before phase 1, from the STALE snapshot. `_no_return_account`'s
+        ratio release consumes exactly the two values phase 2 replaces, so the
+        bar is decided on data the ranking has already thrown away:
+
+            no_return(stale: left=20, active=30) = '1'    (barred)
+            no_return(fresh: left=90, active=15) = None   (released)
+
+        Drives a real consume-first tick and swaps the snapshot underneath it:
+        phase A serves the stale numbers, the phase-2 escalation (the only
+        fetch that asks for every account) serves the fresh ones. On the fresh
+        numbers the account we left holds 6x the active's headroom and its
+        weekly window resets soonest, so it is the pick — unless the bar is
+        still answering from the stale snapshot, where it lost by well under
+        the ratio and stayed barred.
+        """
+        h = EngineHarness(temp_home, strategy="consume-first")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage7(20, 20, self._days_out(h, 500)),   # active, LAST
+            "2": _usage7(5, 5, self._days_out(h, 10)),      # SOONEST
+            "3": _usage7(5, 5, self._days_out(h, 400)),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(301.0)
+
+        stale = {
+            "1": _usage7(80, 80, self._days_out(h, 10)),    # left; 20 pts
+            "2": _usage7(70, 70, self._days_out(h, 500)),   # active; 30 pts
+            "3": _usage7(60, 60, self._days_out(h, 400)),   # 40 pts
+        }
+        fresh = {
+            "1": _usage7(10, 10, self._days_out(h, 10)),    # left; 90 pts NOW
+            "2": _usage7(85, 85, self._days_out(h, 500)),   # active; 15 pts
+            "3": _usage7(60, 60, self._days_out(h, 400)),   # 40 pts
+        }
+
+        def _serve(fetch=frozenset(), **kw):
+            # The phase-2 escalation is the only call that asks for the whole
+            # fleet; everything before it is the stale baseline.
+            snap = fresh if len(fetch) >= 3 else stale
+            return {n: _entry_for(v, h.clock.now) for n, v in snap.items()}
+
+        with patch.object(
+            h.switcher, "usage_entries_by_account", side_effect=_serve
+        ):
+            assert h.engine.tick() is TickOutcome.SWITCHED
+        assert h.active_number() == 1, (
+            f"landed on {h.active_number()} — on the FRESH snapshot the "
+            "account we left holds 6x the active's headroom and its weekly "
+            "window resets soonest, so the release fires; the bar was still "
+            "answering from the stale snapshot the ranking had replaced"
         )
 
     def test_the_fallback_never_outranks_a_real_qualifier(self, harness):
@@ -4536,6 +4909,44 @@ class TestAllSpentGoesToTheSoonestReset:
         })
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 2
+
+    def test_a_spent_fleet_takes_the_soonest_reset_over_the_most_headroom(
+        self, harness
+    ):
+        """`_recovery_is_useful`'s spent clause, as a whole, was unpinned.
+
+        Its two legs are individually killed
+        (`test_a_peer_with_real_headroom_still_wins_past_the_horizon`,
+        `test_an_unknown_active_reset_keeps_the_headroom`), but removing the
+        entire `if` — the clause's whole stated purpose — left the full suite
+        green. Reachable through `tick()`:
+
+            active 1: 0.5 pts, 300h out
+            peer   2: 0.5 pts, back in 10h
+            peer   3: 1.0 pt,  500h out
+
+            ORIGINAL -> SWITCHED to 2 (the 10h account)
+            MUTANT   -> SWITCHED to 3 (the 500h account)
+
+        Every account is under SPENT_HEADROOM_PCT, which is exactly the regime
+        the clause exists for: at half a point a headroom edge is minutes of
+        work, so the only real question is who returns first. Without the
+        clause the axis falls back to headroom, and one extra point buys a
+        490-hour wait.
+
+        Asserts the DESTINATION — both answers are a switch.
+        """
+        outcome = harness.tick_with_usage({
+            "1": _usage(99.5, self._at(harness, 300 * 3600)),  # active, 0.5 pt
+            "2": _usage(99.5, self._at(harness, 10 * 3600)),   # 0.5 pt, SOON
+            "3": _usage(99.0, self._at(harness, 500 * 3600)),  # 1.0 pt, LAST
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2, (
+            f"landed on {harness.active_number()} — every account is spent, "
+            "so half a point of extra headroom bought a 490-hour wait over an "
+            "account back in ten"
+        )
 
     def test_the_flap_guard_survives_in_the_spent_band(self, harness):
         """Ranking by reset must not reintroduce ping-pong: an account whose

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -4679,6 +4679,62 @@ class TestHorizonAxisDoesNotFlap:
             "which is the persisted lockout, not anti-flap"
         )
 
+    def test_a_failover_departure_does_not_disarm_the_bar(self, temp_home):
+        """`(None, None)` from a failover must not read the same as `absent`.
+
+        `_perform` writes `leftHeadroom`/`leftRecoveryAt` unconditionally on
+        every trigger, including `failover`, where `active_headroom` is None
+        (that is the definition of failover) and the recorded recovery is
+        `inf` -> stored as `null`. The resulting state —
+        `{"leftHeadroom": null, "leftRecoveryAt": null}`, KEYS PRESENT — is
+        byte-identical over JSON to a pre-upgrade record where the keys were
+        never written, and the old code read both with `state.get(...)`,
+        which cannot tell presence-with-null from absence.
+
+        Reached with a real failover (active usage unreadable for
+        `unhealthy_ticks` ticks), then the classic flap shape: the barred
+        account frozen at 4 pts, the new active burning from 4 to 2 pts —
+        the same shape `test_the_release_needs_the_barred_account_to_have_improved`
+        uses for a PROACTIVE departure, which correctly holds. A failover
+        departure must hold the same way, not disarm on the very next tick.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        frozen1 = self._days_out(h, 500)
+        outcome = None
+        for _ in range(3):  # unhealthy_ticks default is 3
+            outcome = h.tick_with_usage({
+                "1": None,                              # unreadable -> failover
+                "2": _usage(4, self._days_out(h, 400)),
+            })
+            h.clock.advance(60.0)
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        state = h.engine._read_state()
+        assert "leftHeadroom" in state, (
+            "premise: _perform writes the keys unconditionally even on failover"
+        )
+        assert state.get("leftHeadroom") is None
+        assert state.get("leftRecoveryAt") is None
+
+        h.clock.advance(301.0)
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(96, frozen1),                     # frozen, 4 pts
+                "2": _usage(98, self._days_out(h, 400)),       # active, burnt to 2 pts
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED not in outcomes, (
+            f"{[o.name for o in outcomes]} — a failover departure was treated "
+            "as 'no evidence, release', undoing the failover on the very next "
+            "proactive tick"
+        )
+
     def test_the_release_fires_when_the_barred_account_recovered(
         self, temp_home
     ):

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3732,12 +3732,64 @@ class TestHorizonAxisDoesNotFlap:
             harness.clock.advance(301.0)
 
         moves = [n for i, n in enumerate(seen) if i == 0 or n != seen[i - 1]]
-        assert len(moves) <= 3, (
+        assert len(moves) <= 2, (
             f"move sequence {moves} — a burn walk that keeps moving is a flap, "
             "whatever axis each leg took"
         )
         assert seen[-4:] == [seen[-1]] * 4, (
             f"active trace {seen} — the walk never settled"
+        )
+
+    def test_a_burn_walk_never_returns_to_what_it_left(self, harness):
+        """The axis can flip more than once, and nothing bounded how often.
+
+        A previous round measured A-B-A under burn and dismissed it: each leg
+        IS legitimate on the axis its own state selects, and base shows 0 only
+        because it refuses the outbound leg too. That reasoning holds. The
+        conclusion did not — it rested on the walk settling in at most three
+        moves, which is a property of the one shape that was measured.
+
+        Measured, only the active burning at 0.5 pts/tick, both resets past
+        the horizon, 24 ticks:
+
+            pcts (96,92) resets (20h, 80h)    moves [2, 1]        settles
+            pcts (92,92) resets (500h,400h)   moves [1, 2, 1, 2]  does not
+
+        Base on both: a single move. Traced at each leg of the second shape —
+
+            t8   1->2  headroom axis   active 4.0 / best 8.0
+            t20  2->1  headroom axis   active 2.0 / best 4.0
+            t22  1->2  recovery axis   active 3.0 / best 2.0
+
+        The ratio gate is RELATIVE (`h >= active x 2`) and the spent gate
+        ABSOLUTE (`active <= 3.0`), so burn walks the pair across the boundary
+        repeatedly and each crossing re-opens a move. Extending to 120 ticks
+        stops only because both accounts hit the 99.95 burn cap, so the fourth
+        move is not a transient.
+
+        Refusing the account we most recently left bounds it: the axis may
+        still flip, but a flip cannot undo the move before it.
+        """
+        pct = {"1": 92.0, "2": 92.0}
+        seen = []
+        for _ in range(24):
+            harness.tick_with_usage({
+                "1": _usage(pct["1"], self._days_out(harness, 500)),
+                "2": _usage(pct["2"], self._days_out(harness, 400)),
+            })
+            active = harness.active_number()
+            seen.append(active)
+            pct[str(active)] = min(99.95, pct[str(active)] + 0.5)
+            harness.clock.advance(301.0)
+
+        moves = [n for i, n in enumerate(seen) if i == 0 or n != seen[i - 1]]
+        returns = [
+            moves[i + 1] for i in range(len(moves) - 1)
+            if moves[i + 1] in moves[:i + 1]
+        ]
+        assert returns == [], (
+            f"move sequence {moves} — the walk returned to an account it had "
+            "already left, so the axis flip undid the move before it"
         )
 
     def test_the_fallback_never_outranks_a_real_qualifier(self, harness):

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3483,6 +3483,39 @@ class TestHorizonAxisDoesNotFlap:
         assert harness.active_number() == 1
         assert outcome is not TickOutcome.SWITCHED
 
+    def test_a_pair_straddling_the_horizon_does_not_ping_pong(self, harness):
+        """Each guard is one-way on ITS OWN axis — but the axis itself flips.
+
+        ``_recovery_is_useful`` reads the ACTIVE account's headroom and the
+        CANDIDATE's reset, and a switch swaps both operands. So a pair that
+        straddles the horizon takes the recovery gate going out and the
+        headroom gate coming back, and neither guard ever sees the other leg:
+
+            acct 1   8 points, reset 109h out   (past the horizon)
+            acct 2   3 points, reset 3.5h out   (inside it)
+
+            active=1 -> candidate 2 is inside  -> recovery axis  -> 3.5h < 109h
+            active=2 -> candidate 1 is outside -> headroom axis  -> 8 >= 3*2
+
+        Both legs qualify on frozen inputs, so the engine rewrites credentials
+        every cooldown until the sooner reset actually lands. Every other test
+        in this class ticks ONCE, which is why the pair went unseen.
+        """
+        r_far = self._days_out(harness, 109)
+        r_near = self._days_out(harness, 3.5)
+        seen = []
+        for _ in range(6):
+            harness.tick_with_usage({
+                "1": _usage(92, r_far),    # 8 points, returns days out
+                "2": _usage(97, r_near),   # 3 points, returns inside 4h
+            })
+            seen.append(harness.active_number())
+            harness.clock.advance(301.0)   # past the 300s cooldown
+        assert len(set(seen)) == 1, (
+            f"cross-axis oscillation: active trace {seen} — each leg passes "
+            "the guard belonging to the OTHER leg's axis"
+        )
+
     def test_a_materially_better_peer_still_wins(self, harness):
         """The escape must survive: 2 points left against 10 is a real move."""
         outcome = harness.tick_with_usage({

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -4496,6 +4496,52 @@ class TestHorizonAxisDoesNotFlap:
             "that is the flap this bar exists for."
         )
 
+    def test_a_departure_at_full_quota_is_immediately_eligible(self, temp_home):
+        """`left_headroom == 100.0` must not be a permanent lockout.
+
+        `h >= left_headroom + SPENT_HEADROOM_PCT` is `h >= 103.0` when the
+        departure was recorded at a full 100.0 points — unsatisfiable forever,
+        because `oauth.account_headroom` caps `h` at 100.0
+        (`100 - max(pct)`, and pct cannot go negative). consume-first departs
+        BELOW the threshold, so this is the routine case, not a corner one: a
+        fresh/full account handed off to a sooner-resetting peer records
+        exactly this.
+
+        The account below holds the SAME 100.0 points at every check (never
+        spent anything) and the SAME resets_at (no recovery-axis movement
+        either) — the only way this switches is if a departure at the cap is
+        treated as needing no recovery on the headroom axis.
+        """
+        h = EngineHarness(temp_home, strategy="consume-first", threshold=90.0)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage7(0.0, 0.0, self._days_out(h, 500)),
+            "2": _usage7(0.0, 0.0, self._days_out(h, 100)),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert h.engine._read_state().get("leftHeadroom") == 100.0, (
+            "premise: consume-first recorded a full-quota departure"
+        )
+        h.clock.advance(301.0)
+
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                # unchanged since departure on BOTH axes
+                "1": _usage7(0.0, 0.0, self._days_out(h, 500)),
+                "2": _usage7(90.0, 0.0, self._days_out(h, 100)),
+            }))
+            h.clock.advance(301.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"{[o.name for o in outcomes]} — account 1 never dropped below a "
+            "full 100.0 points and is the only peer; refusing it is the "
+            "unsatisfiable-above-97 lockout, not anti-flap"
+        )
+
     def test_a_reset_that_crept_nearer_is_not_a_recovery(self, temp_home):
         """The recovery leg carries `RECOVERY_HYSTERESIS_S`, and it must.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3349,6 +3349,87 @@ class TestRecoveryHorizon:
         assert harness.active_number() == 2
 
 
+class TestHorizonAxisDoesNotFlap:
+    """Past the horizon the headroom axis needs its own anti-flap margin.
+
+    The first cut required only *strictly more* headroom, which is no margin
+    at all: one point is enough to move, and the account we move to burns that
+    point back within a poll or two. Measured live on 2026-07-30, four switches
+    in 35 minutes, each buying one point and each costing a credential rewrite:
+
+        17:28  acct 1 (5% left) -> acct 2 (6%)
+        17:49  acct 2 (4% left) -> acct 1 (5%)
+        17:54  acct 1           -> acct 2
+        18:03  acct 2 (2% left) -> acct 1 (3%)
+
+    The ordinary path uses ``hysteresis_pct`` (10 points), but that is
+    unmeetable here by construction — everything is within a few points of its
+    limit, so requiring ten would park the engine and let it ride into the
+    wall, which is the failure #202 exists to prevent.
+
+    A RATIO is the right unit in the endgame: with two points left, what
+    matters is how many times more runway the target has, not how many points.
+    Requiring the target to hold ``HORIZON_HEADROOM_RATIO`` times the active
+    account's headroom makes the move one-way by construction — the reverse
+    would need the new active to fall to a quarter of what it just beat.
+    """
+
+    def _at(self, harness, seconds: float) -> str:
+        from datetime import datetime, timezone
+
+        return (
+            datetime.fromtimestamp(harness.clock.now + seconds, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    def _days_out(self, harness, hours):
+        return self._at(harness, hours * 3600)
+
+    def test_one_point_of_headroom_does_not_move(self, harness):
+        """The measured flap: 95% active against a 94% peer, both days out."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(95, self._days_out(harness, 109)),   # active, 5 left
+            "2": _usage(94, self._days_out(harness, 80)),    # 6 left
+            "3": _usage(99, self._days_out(harness, 50)),
+        })
+        assert harness.active_number() == 1, (
+            "moved for one point of headroom; the target burns it back and the "
+            "engine ping-pongs (measured: 4 switches in 35 minutes)"
+        )
+        assert outcome is not TickOutcome.SWITCHED
+
+    def test_the_return_leg_is_blocked_too(self, harness):
+        """Same shape with the roles reversed — symmetric, so neither leg runs."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(96, self._days_out(harness, 109)),   # active, 4 left
+            "2": _usage(95, self._days_out(harness, 80)),    # 5 left
+            "3": _usage(99, self._days_out(harness, 50)),
+        })
+        assert harness.active_number() == 1
+        assert outcome is not TickOutcome.SWITCHED
+
+    def test_a_materially_better_peer_still_wins(self, harness):
+        """The escape must survive: 2 points left against 10 is a real move."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(98, self._days_out(harness, 109)),   # active, 2 left
+            "2": _usage(90, self._days_out(harness, 80)),    # 10 left — 5x
+            "3": _usage(99, self._days_out(harness, 50)),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2
+
+    def test_a_minutes_away_reset_is_unaffected(self, harness):
+        """Inside the horizon the recovery axis still decides, ratio or not."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(91, self._at(harness, 7200)),
+            "2": _usage(94, self._at(harness, 1800)),
+            "3": _usage(98, self._at(harness, 480)),         # back in 8 min
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3
+
+
 class TestReviewFindings202:
     """Three defects found reviewing #202, each reproduced before fixing.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3664,6 +3664,51 @@ class TestHorizonAxisDoesNotFlap:
         )
         assert outcome is not TickOutcome.SWITCHED
 
+    def test_the_tier_byte_puts_a_returning_peer_ahead_of_a_distant_one(
+        self, harness
+    ):
+        """`(0, ...)` before `(1, ...)` — the tier prefix itself, not its tail.
+
+        Both existing tier tests compare candidates WITHIN one tier, so the
+        byte cancels and neither pins it. Collapsing it to a flat key left the
+        suite green.
+
+        A candidate returning inside the horizon beats one that does not,
+        whatever its headroom: acct 2 is nearly spent but works again in an
+        hour; acct 3 has nine points that never return this session.
+        """
+        outcome = harness.tick_with_usage({
+            "1": _usage(99, self._days_out(harness, 300)),    # active, 1 left
+            "2": _usage(98.5, self._days_out(harness, 1)),    # 1.5 left, back in 1h
+            "3": _usage(91, self._days_out(harness, 400)),    # 9 left, never
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2, (
+            f"landed on {harness.active_number()} — took headroom that never "
+            "returns over a peer that works again in an hour"
+        )
+
+    def test_the_fallback_breaks_a_reset_tie_by_headroom(self, harness):
+        """The fallback key's THIRD slot: `(0, recovery_ts, -h)`.
+
+        `test_the_fallback_ranks_by_reset_not_by_headroom` pins the second
+        slot (reset leads). The third was untested — `-h` to `h` left the suite
+        green. It needs an actual tie in `recovery_ts` AND both peers routed
+        through the fallback, which requires the active to sit exactly at
+        SPENT_HEADROOM_PCT so neither peer meets the ratio.
+        """
+        same = self._days_out(harness, 10)
+        outcome = harness.tick_with_usage({
+            "1": _usage(97, self._days_out(harness, 300)),   # active, 3.0 left
+            "2": _usage(97, same),                            # 3.00 left
+            "3": _usage(96.95, same),                         # 3.05 left
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 3, (
+            f"landed on {harness.active_number()} — at an equal reset the "
+            "fallback took the smaller headroom"
+        )
+
     def test_past_the_horizon_headroom_decides_before_the_reset(self, harness):
         """Tier 1 is `(1, -h, recovery_ts)` — headroom leads, reset breaks ties.
 
@@ -3739,6 +3784,39 @@ class TestHorizonAxisDoesNotFlap:
         assert seen[-4:] == [seen[-1]] * 4, (
             f"active trace {seen} — the walk never settled"
         )
+
+    def test_the_no_return_filter_does_not_block_the_at_limit_escape(
+        self, harness
+    ):
+        """Every sibling anti-flap gate is scoped to the proactive triggers.
+
+        `at-limit` and `failover` skip them by design — there we are escaping a
+        dead account, not optimising a return time. The no-return filter ran in
+        `_tick_inner` BEFORE the trigger is consulted, so it stripped the
+        candidate from those escapes too.
+
+        Measured, 2 accounts, the active exhausted and the peer at full quota:
+
+            base 9f35426   switches on tick 1
+            here           switches=0, "no-candidates" every tick, 720 ticks
+
+        Nothing releases it: `lastSwitchFrom` is only rewritten by a successful
+        switch, and the field is what prevents the switch. On a 3-account fleet
+        it also emits AllExhaustedEvent — a false claim that reaches the user
+        as a macOS notification and a critical TUI row while a peer sits at 0%.
+        """
+        harness.engine._mutate_state(
+            lambda st: st.__setitem__("lastSwitchFrom", "2")
+        )
+        outcome = harness.tick_with_usage({
+            "1": _usage(100),      # active, exhausted -> at-limit
+            "2": _usage(0),        # the account we left, now at full quota
+        })
+        assert outcome is TickOutcome.SWITCHED, (
+            "the at-limit escape was refused because we had left that account "
+            "once — the engine sits on an exhausted account with a peer at 0%"
+        )
+        assert harness.active_number() == 2
 
     def test_a_burn_walk_never_returns_to_what_it_left(self, harness):
         """The axis can flip more than once, and nothing bounded how often.

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3499,6 +3499,70 @@ class TestAllSpentGoesToTheSoonestReset:
         assert outcome is not TickOutcome.SWITCHED
 
 
+class TestEscapeBeforeTheLimitLands:
+    """At the brink the ordinary proactive path already leaves — verified.
+
+    I assumed ``at-limit`` firing only at exactly 0% meant an account rode to
+    100% before escaping, and set out to move the trigger a point earlier.
+    Measuring it refuted that: at 99% with a peer that has real headroom, the
+    engine switches on the ORDINARY proactive path, because 99% is above the
+    threshold and the peer clears the hysteresis margin easily.
+
+    What actually happened in the 18:50 observation that prompted this: the
+    only peers were 99% (one point) and 100% (never a target), so there was
+    nowhere better and holding was correct. `all_spent` already covers that
+    case by ranking on the soonest reset.
+
+    Kept as a regression pin: moving the at-limit trigger earlier looks
+    appealing and is wrong — it hijacks the recovery ranking (#202) and the
+    spent-band ranking, both of which belong to `proactive`.
+    """
+
+    def _at(self, harness, seconds: float) -> str:
+        from datetime import datetime, timezone
+
+        return (
+            datetime.fromtimestamp(harness.clock.now + seconds, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    def test_at_99_the_proactive_path_already_escapes(self, harness):
+        """No special trigger needed: 99% is over the threshold and a healthy
+        peer clears the margin."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(99, self._at(harness, 109 * 3600)),  # active, 1 left
+            "2": _usage(70, self._at(harness, 80 * 3600)),   # 30 left
+            "3": _usage(100, self._at(harness, 50 * 3600)),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() == 2
+        sw = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "proactive", (
+            "at-limit must stay bound to headroom <= 0: it skips the recovery "
+            "and spent-band rankings that proactive owns"
+        )
+
+    def test_at_99_with_only_spent_peers_it_holds(self, harness):
+        """The 18:50 shape: nowhere better, so staying is right. The spent-band
+        rule decides where to sit, not an early escape."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(99, self._at(harness, 109 * 3600)),
+            "2": _usage(100, self._at(harness, 80 * 3600)),
+            "3": _usage(100, self._at(harness, 50 * 3600)),
+        })
+        assert outcome is not TickOutcome.SWITCHED
+
+    def test_below_the_brink_the_ordinary_rules_still_decide(self, harness):
+        """A comfortable account is untouched: the hysteresis margin applies."""
+        outcome = harness.tick_with_usage({
+            "1": _usage(50, self._at(harness, 109 * 3600)),
+            "2": _usage(45, self._at(harness, 80 * 3600)),
+            "3": _usage(40, self._at(harness, 50 * 3600)),
+        })
+        assert outcome is not TickOutcome.SWITCHED
+
+
 class TestReviewFindings202:
     """Three defects found reviewing #202, each reproduced before fixing.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3847,10 +3847,14 @@ class TestHorizonAxisDoesNotFlap:
 
         Refusing the account we most recently left bounds it — but identity
         alone has no release, and on a 2-account fleet that is a permanent
-        proactive lockout (see the sibling test). Released by the same ratio
-        the anti-flap margin uses, the walk is still BOUNDED: measured over
-        24 / 120 / 400 ticks, [1,2,1] then [1,2,1,2] and no further, because
-        each return has to clear 2x and burn makes that harder every time.
+        proactive lockout (see the sibling test). Released by asking the
+        ranking, the walk is still BOUNDED: it ends, because each return has to
+        clear the margin and burn makes that harder every time.
+
+        A trace of the exact moves used to sit here. It has been re-taken three
+        times and come back different every time — the walk depends on the
+        release, and the release has changed in every round that quoted it. The
+        assertion is on SETTLING for the same reason.
 
         So this asserts a BOUND, not zero returns. Zero was a property of the
         release-less filter, and that property is what made the lockout
@@ -3859,8 +3863,8 @@ class TestHorizonAxisDoesNotFlap:
         """
         pct = {"1": 92.0, "2": 92.0}
         seen = []
-        # 60, not 24: the settling point moves with fleet size (measured 3 /
-        # 6 / 8 / 10 moves at n = 2 / 3 / 4 / 5) and 24 ticks caught this
+        # 60, not 24: the settling point moves with fleet size — a longer
+        # ring walks further before it comes back — and 24 ticks caught this
         # shape mid-walk.
         for _ in range(60):
             harness.tick_with_usage({
@@ -3874,13 +3878,14 @@ class TestHorizonAxisDoesNotFlap:
 
         moves = [n for i, n in enumerate(seen) if i == 0 or n != seen[i - 1]]
         # SETTLING is the property, not a move count. `len(moves) <= 4` was
-        # true of this 2-account shape and false of every other: measured over
-        # 120 ticks with the fleet grown, 3 / 6 / 8 / 10 moves at n = 2 / 3 /
-        # 4 / 5 — the bar refuses only the ONE account left last, so a longer
-        # ring walks further before it comes back. All four settle.
+        # true of this 2-account shape and false of every other — the bar
+        # refuses only the ONE account left last, so a longer ring walks
+        # further before it comes back, and every fleet size settles.
         #
-        # A count that holds for one fleet size reads as a bound and is not
-        # one. What the walk has to do is END.
+        # The per-size counts that used to be quoted here did not re-measure
+        # after the release changed. A count that holds for one fleet size and
+        # one release reads as a bound and is neither. What the walk has to do
+        # is END.
         assert len(set(seen[-8:])) == 1, (
             f"move sequence {moves} — the walk was still moving in the last "
             "eight ticks, so it does not settle at all"
@@ -4170,6 +4175,230 @@ class TestHorizonAxisDoesNotFlap:
             f"30 ticks of {[o.name for o in outcomes[:6]]}… — the only "
             "choosable peer was barred and the third account is at its limit, "
             "so the bar left the engine nothing"
+        )
+
+    def test_the_bar_lifts_for_an_alternative_the_ranking_would_reject(
+        self, temp_home
+    ):
+        """Not-at-its-limit is not the same as rankable.
+
+        The predicate above was `(headroom.get(n) or 0.0) > 0.0` — "has any
+        points left". That is only the FIRST of the gates a candidate must
+        clear: past the horizon it also needs `h >= active x HORIZON_HEADROOM_
+        RATIO`, or the spent fallback's `h >= active` with a meaningfully
+        sooner reset. A third account holding ONE point clears `> 0.0` and
+        clears nothing else, so the release stayed shut and the n>=3 stall the
+        release above was written for came straight back one point up.
+
+        Measured, one ordinary proactive move and no seeded state: barred peer
+        3.5 pts / back in 10h, active 2 pts / 500h out, third 1 pt — 30 ticks
+        all BLOCKED. The control below is the same fleet with `lastSwitchFrom`
+        popped and switches on the first tick, so the bar is the cause.
+
+        This is the third time this release has been fixed one step short of
+        the gate that actually decides (present -> not-at-limit -> rankable),
+        which is why the fix is no longer a predicate that PREDICTS the
+        ranking: `_tick_inner` now asks the ranking itself and re-ranks unbarred
+        when the bar empties the list.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(92, self._days_out(h, 500)),
+            "2": _usage(10, self._days_out(h, 400)),
+            "3": _usage(99, self._days_out(h, 300)),
+        }) is TickOutcome.SWITCHED
+        h.clock.advance(301.0)
+
+        outcomes = []
+        for _ in range(30):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(96.5, self._days_out(h, 10)),   # barred, 3.5 pts
+                "2": _usage(98, self._days_out(h, 500)),    # active, 2 pts
+                "3": _usage(99, self._days_out(h, 300)),    # 1 pt: > 0, unrankable
+            }))
+            h.clock.advance(3601.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"30 ticks of {[o.name for o in outcomes[:6]]}… — the third "
+            "account holds one point, which passes `> 0.0` and no ranking "
+            "gate, so the bar left the engine nothing"
+        )
+
+    def test_an_unreadable_barred_account_does_not_crash_the_tick(
+        self, harness
+    ):
+        """`headroom.get(barred)` is None when that slot's usage is unreadable.
+
+        The ratio release compares it against `active_headroom * RATIO`, so
+        without the None check the tick raises `TypeError: '>=' not supported
+        between instances of 'NoneType' and 'float'` — inside `_tick_inner`,
+        on an ordinary proactive tick, whenever the account we just left has
+        no readable usage. Measured: dropping `left_headroom is not None` left
+        the whole suite green, so nothing pinned it.
+
+        Asserts the CALL returns rather than the tick outcome: which account
+        wins is the ranking's business, and a crash is the defect.
+        """
+        state = {"lastSwitchFrom": 1}
+        headroom = {"2": 10.0, "3": 40.0}       # slot 1 unreadable — absent
+        assert harness.engine._no_return_account(
+            "proactive", state, headroom, 10.0, ["1", "3"]
+        ) == "1", (
+            "an unreadable barred account must still bar — unknown headroom "
+            "is not evidence it beats us"
+        )
+
+    def test_the_bar_lifts_for_a_peer_returning_inside_the_horizon(
+        self, temp_home
+    ):
+        """The release had no condition on the RECOVERY axis at all.
+
+        Its only release was `left >= active x HORIZON_HEADROOM_RATIO`, a pure
+        headroom test — while `_recovery_is_useful` deliberately ranks by RESET
+        when a candidate returns inside the horizon, and this module's own
+        docstring names that case as the one the horizon exists to preserve:
+        a weekly-bound active days out against a peer back in minutes.
+
+        A barred peer in exactly that state was refused, because 4 points
+        against an active on 3 misses `4 >= 3 x 2`. Measured on the predicate
+        form: barred peer back in 1h, active 200h out — 10 ticks all BLOCKED.
+
+        Asking the ranking covers it without a third predicate: barring the
+        only account the reset axis would pick empties the list, so the retry
+        opens. That is the point of not predicting — the release now follows
+        every axis the ranking has, including ones added later.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(92, self._days_out(h, 500)),
+            "2": _usage(10, self._days_out(h, 400)),
+        }) is TickOutcome.SWITCHED
+        h.clock.advance(301.0)
+
+        outcomes = []
+        for _ in range(10):
+            outcomes.append(h.tick_with_usage({
+                "1": _usage(96, self._at(h, 3600)),      # barred, back in 1h
+                "2": _usage(97, self._days_out(h, 200)),  # active, 200h out
+            }))
+            h.clock.advance(1801.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"{[o.name for o in outcomes]} — the bar refused the only peer "
+            "returning inside the horizon, so the engine holds an account 200h "
+            "out while a peer is back in one"
+        )
+
+    def test_the_same_fleet_moves_with_the_bar_cleared(self, temp_home):
+        """The control for the test above: identical state, no bar.
+
+        Without this, a stall could be the fleet's own numbers rather than the
+        bar, and the assertion above would be measuring nothing. Same seeds,
+        same usage, same clock — only `lastSwitchFrom` is popped.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(92, self._days_out(h, 500)),
+            "2": _usage(10, self._days_out(h, 400)),
+            "3": _usage(99, self._days_out(h, 300)),
+        }) is TickOutcome.SWITCHED
+        h.clock.advance(301.0)
+        h.engine._mutate_state(lambda st: st.pop("lastSwitchFrom", None))
+
+        assert h.tick_with_usage({
+            "1": _usage(96.5, self._days_out(h, 10)),
+            "2": _usage(98, self._days_out(h, 500)),
+            "3": _usage(99, self._days_out(h, 300)),
+        }) is TickOutcome.SWITCHED, (
+            "the control blocked too — the stall above is the fleet's numbers, "
+            "not the bar, and that assertion is measuring nothing"
+        )
+
+    def test_the_bar_reaches_the_ranking_through_tick(self, temp_home):
+        """The bar's production WIRING, which nothing pinned.
+
+        `_no_return_account` is computed in `_tick_inner` and threaded into
+        both `_rank_candidates` calls. Measured: replacing that computation
+        with `no_return = None` — the whole feature off in production — left
+        the FULL suite at 1732 passed. The only test of the bar's effect drives
+        `_rank_candidates` directly and passes `no_return` by hand, so the unit
+        was pinned and the integration was not: any refactor that drops the
+        kwarg reverts the anti-flap bound silently.
+
+        Asserts a DIFFERENT DESTINATION, not a block: the leaves-nothing
+        release is now answered by the ranking itself, so a bar that empties
+        the list re-ranks unbarred and the engine moves anyway. A fleet where
+        the bar blocks therefore proves nothing about the wiring — the only
+        observable left is the engine landing somewhere else.
+
+        ON THE RECOVERY AXIS, which is the only axis where the bar can change
+        an answer at all. Past the horizon the release (`left >= active x
+        RATIO` -> not barred) and the ranking gate (`h >= active x RATIO` ->
+        qualifies) are the SAME inequality, so anything the bar could remove
+        the loop had already dropped: swept 18 headroom combinations, every one
+        `unbarred == barred`. Inside the horizon the ranking sorts by reset
+        time instead, the two stop agreeing, and the bar bites — 162 of the
+        swept combinations differ. Both peers are back within the hour here,
+        which is what puts the tick on that axis.
+
+        ONE fleet, ticked twice: `temp_home` is a single home and a second
+        `EngineHarness` over it inherits the first run's roster, so the control
+        comes from popping `lastSwitchFrom`, not from a fresh box.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        assert h.tick_with_usage({
+            "1": _usage(92, self._days_out(h, 500)),
+            "2": _usage(10, self._days_out(h, 400)),
+            "3": _usage(50, self._days_out(h, 300)),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(301.0)
+        assert h.engine._read_state().get("lastSwitchFrom") is not None, (
+            "premise: the move recorded what it left"
+        )
+
+        second = {
+            "1": _usage(99, self._at(h, 1800)),      # left; back in 30 min
+            "2": _usage(99, self._at(h, 7200)),      # active, spent, back in 2h
+            "3": _usage(99, self._at(h, 3600)),      # back in 1h
+        }
+        assert h.tick_with_usage(second) is TickOutcome.SWITCHED
+        assert h.active_number() == 3, (
+            "the bar never reached the ranking through tick() — the engine "
+            "went back to the account it had just left, which returns sooner "
+            "than the peer it should have taken"
+        )
+
+        # Control: same numbers, the bar removed — the soonest return wins.
+        # The clock advances past the post-switch cooldown, and `second`'s
+        # resets are relative to the ORIGINAL now, so both peers are still
+        # ahead of the active by the same margins.
+        h.make_live("b@example.com", 2)
+        h.clock.advance(301.0)
+        h.engine._mutate_state(lambda st: st.pop("lastSwitchFrom", None))
+        assert h.tick_with_usage(second) is TickOutcome.SWITCHED
+        assert h.active_number() == 1, (
+            "premise: unbarred, the account we left returns soonest and IS the "
+            "pick — without this the assertion above would pass on a fleet "
+            "where 3 wins for its own reasons"
         )
 
     def test_the_fallback_never_outranks_a_real_qualifier(self, harness):

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -15,6 +15,7 @@ from claude_swap import oauth, poll_policy
 from claude_swap.autoswitch import (
     IDLE_HOLD_MAX_S,
     NO_RESET_FALLBACK_S,
+    RECOVERY_HORIZON_S,
     AllExhaustedEvent,
     AutoSwitchEngine,
     ConfigWarningEvent,
@@ -25,6 +26,7 @@ from claude_swap.autoswitch import (
     SwitchEvent,
     TickOutcome,
     UnquarantineEvent,
+    _recovery_is_useful,
     pct_label,
 )
 from claude_swap.json_output import USAGE_FOREIGN_CREDENTIAL, USAGE_TOKEN_EXPIRED
@@ -3331,6 +3333,50 @@ class TestEveryAccountAboveThreshold:
         assert sw.trigger == "at-limit"
 
 
+class TestRecoveryIsUsefulEitherClause:
+    """I1: the `or active_recovery_ts` leg of `_recovery_is_useful` had no
+    killer in the full suite, even through `tick()`.
+
+    `test_a_pair_straddling_the_horizon_does_not_ping_pong` (the branch's own
+    headline test for this clause) is masked by the no-return bar: 5 of its 6
+    ticks are BLOCKED by the bar before `_recovery_is_useful` is ever asked,
+    so removing `either` and leaving `cand-only` does not change that test's
+    outcome. `either` differs from `cand-only` in exactly one of the four
+    (candidate inside/outside horizon) x (active inside/outside horizon)
+    combinations: `cand-outside / act-inside`. This drives that quadrant
+    directly, at the unit level, bypassing the bar entirely.
+    """
+
+    def test_the_active_alone_being_inside_the_horizon_is_enough(self):
+        """cand-outside / act-inside: `either` says True, `cand-only` says
+        False. Past `SPENT_HEADROOM_PCT` on both sides, so the all-spent
+        escape hatch at the top of the function does not pre-empt this."""
+        now = 1_000_000.0
+        cand_recovery_ts = now + RECOVERY_HORIZON_S + 3600.0   # OUTSIDE
+        active_recovery_ts = now + 1800.0                       # INSIDE
+        assert _recovery_is_useful(
+            cand_recovery_ts, active_recovery_ts,
+            active_headroom=50.0, best_candidate_headroom=50.0, now=now,
+        ) is True, (
+            "the active's own reset is inside the horizon, which must rank "
+            "by recovery even though the candidate's reset is not — this is "
+            "the `either` clause, and `cand-only` would answer False here"
+        )
+
+    def test_the_control_neither_inside_falls_back_to_headroom(self):
+        """Control: both outside the horizon -> ranks by headroom (False)."""
+        now = 1_000_000.0
+        cand_recovery_ts = now + RECOVERY_HORIZON_S + 3600.0
+        active_recovery_ts = now + RECOVERY_HORIZON_S + 7200.0
+        assert _recovery_is_useful(
+            cand_recovery_ts, active_recovery_ts,
+            active_headroom=50.0, best_candidate_headroom=50.0, now=now,
+        ) is False, (
+            "premise: with neither reset inside the horizon, the function "
+            "must fall back to headroom — control for the test above"
+        )
+
+
 class TestRecoveryHorizon:
     """The recovery escape must not spend real headroom on a distant reset.
 
@@ -3402,6 +3448,51 @@ class TestRecoveryHorizon:
             "an unreadable peer vetoed the spent check and parked the engine "
             "on the account resetting last"
         )
+
+    def test_an_unreadable_peer_does_not_forge_headroom_for_the_spent_check(
+        self, temp_home
+    ):
+        """I2: counting an unreadable candidate's headroom as 100.0 instead
+        of excluding it turns the all-spent gate off for the whole fleet.
+
+        `best_candidate_headroom` filters `None` (unreadable) rows out of the
+        max — the sibling test above proves exclusion doesn't VETO the check.
+        This proves the other failure mode: if an unreadable row were instead
+        counted as a maximal 100.0, `best_candidate_headroom` would read 100
+        even though every REAL candidate is spent, so the all-spent branch
+        of `_recovery_is_useful` goes false and the far-out-reset fallback
+        below it (which requires the candidate to be no worse than the
+        active) excludes a candidate that is legitimately better on the
+        recovery axis alone.
+
+        Active and the one real candidate are both spent (<= SPENT_HEADROOM_
+        PCT), the candidate resets meaningfully sooner than the active but
+        both resets are far past RECOVERY_HORIZON_S (so the per-pair "back
+        soon" fallback in `_recovery_is_useful` cannot rescue it either), and
+        the candidate holds LESS raw headroom than the active (so the
+        separate spent-headroom fallback, which requires `h >= active_
+        headroom`, does not re-admit it). Only the all-spent branch treating
+        `best_candidate_headroom` as the real 2.0 (not a forged 100.0) lets
+        this candidate through.
+        """
+        h = EngineHarness(temp_home)
+        for n, e in ((1, "a@example.com"), (2, "b@example.com"),
+                     (3, "c@example.com")):
+            h.seed(n, e)
+        h.make_live("a@example.com", 1)
+
+        outcome = h.tick_with_usage({
+            "1": _usage(97.5, self._at(h, 500 * 3600)),  # active, 2.5 pts
+            "2": _usage(98.0, self._at(h, 490 * 3600)),  # 2.0 pts, sooner reset
+            "3": USAGE_TOKEN_EXPIRED,                     # sentinel: headroom None
+        })
+        assert outcome is TickOutcome.SWITCHED, (
+            "the real candidate is spent but resets meaningfully sooner than "
+            "the active; forging its unreadable sibling's headroom as 100.0 "
+            "turns off the all-spent recovery escape that should have picked "
+            "it"
+        )
+        assert h.active_number() == 2
 
     def test_a_weekly_bound_active_does_not_refuse_a_peer_back_in_minutes(
         self, harness
@@ -3607,7 +3698,59 @@ class TestHorizonAxisDoesNotFlap:
         )
 
     def _days_out(self, harness, hours):
-        return self._at(harness, hours * 3600)
+        """Absolute reset ANCHORED on first use, per (harness, hours).
+
+        `_at(harness, seconds)` computes `now + seconds` from the CURRENT
+        clock every call. Called again after `harness.clock.advance(...)`
+        with the same `hours`, that keeps producing "N hours from NOW",
+        which never approaches -- a real `resets_at` is a fixed epoch, and
+        the remaining time to it shrinks as the clock advances. Memoizing
+        the first computed timestamp per (harness, hours) makes repeated
+        calls in a multi-tick loop return the SAME absolute instant, so it
+        genuinely draws nearer as the test's clock advances.
+        """
+        cache = self.__dict__.setdefault("_days_out_cache", {})
+        key = (id(harness), hours)
+        if key not in cache:
+            cache[key] = self._at(harness, hours * 3600)
+        return cache[key]
+
+    def test_a_fixed_reset_crosses_into_the_horizon_as_the_clock_advances(
+        self, harness
+    ):
+        """I4: `_days_out` must return a FIXED absolute instant, not
+        "N hours from whenever this is called."
+
+        Both accounts start above the threshold (`all_above`), the peer's
+        reset fixed 5h out — outside `RECOVERY_HORIZON_S` (4h) — so the
+        first tick ranks by headroom, where the peer's one extra point does
+        not clear `HORIZON_HEADROOM_RATIO` and the tick holds. Advancing the
+        clock 90 minutes brings that SAME fixed reset to 3.5h away — inside
+        the horizon — so the second tick must rank by recovery instead and
+        switch. A `_days_out` that recomputes "N hours from now" on every
+        call would keep reporting the peer's reset as exactly 5h out
+        forever, and the horizon would never be crossed.
+        """
+        outcome1 = harness.tick_with_usage({
+            "1": _usage(95, self._days_out(harness, 400)),   # active, far reset
+            "2": _usage(94, self._days_out(harness, 5)),     # peer, 5h out
+        })
+        assert outcome1 is not TickOutcome.SWITCHED, (
+            "premise: 5h is outside RECOVERY_HORIZON_S and one point of "
+            "headroom is not enough to qualify on its own"
+        )
+        harness.clock.advance(90 * 60.0)
+
+        outcome2 = harness.tick_with_usage({
+            "1": _usage(95, self._days_out(harness, 400)),
+            "2": _usage(94, self._days_out(harness, 5)),     # SAME fixed reset
+        })
+        assert outcome2 is TickOutcome.SWITCHED, (
+            "the peer's fixed reset is now 3.5h away, inside the horizon — "
+            "a `_days_out` that recomputes from `now` every call would still "
+            "report 5h out and never cross it"
+        )
+        assert harness.active_number() == 2
 
     def test_one_point_of_headroom_does_not_move(self, harness):
         """The measured flap: 95% active against a 94% peer, both days out."""

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -4679,6 +4679,44 @@ class TestHorizonAxisDoesNotFlap:
             "which is the persisted lockout, not anti-flap"
         )
 
+    def test_absence_of_a_snapshot_releases_even_a_poor_or_unreadable_peer(
+        self, harness
+    ):
+        """The pre-upgrade absence guard must fire before the null check.
+
+        The sibling test above only drives absence with a peer at FULL quota
+        — `(headroom.get(barred) or 0.0) >= 100.0 - SPENT_HEADROOM_PCT` also
+        happens to return `True` for that shape, so a suite with only that
+        case cannot tell "the absence guard ran" from "the near-full floor
+        happened to agree with it". Genuinely absent keys carry NO evidence
+        either way (`_perform` never ran to record any), which is a different
+        state from a failover's `(None, None)` — real evidence the departure
+        was unmeasurable — and the two must not collapse onto the same
+        answer merely because they share a code path once the leading `if
+        "leftHeadroom" not in state: return True` guard is gone.
+
+        Drives the two shapes that DO tell them apart: the barred account
+        POOR (well under the near-full floor) and UNREADABLE (`headroom` is
+        `None`, which the null-check branch maps to `0.0` via `or 0.0` and
+        so also fails the floor). Absence must still release both.
+        """
+        state = {"lastSwitchFrom": "2"}  # pre-upgrade: keys genuinely absent
+
+        assert harness.engine._left_account_recovered(
+            state, {"2": _usage(96)}, {"2": 4.0}, harness.clock()
+        ) is True, (
+            "a pre-upgrade record (no snapshot) must release even when the "
+            "barred account is currently poor (4 pts) — absence of evidence "
+            "is not the same state as a measured-unmeasurable failover"
+        )
+        assert harness.engine._left_account_recovered(
+            state, {"2": None}, {"2": None}, harness.clock()
+        ) is True, (
+            "a pre-upgrade record (no snapshot) must release even when the "
+            "barred account is currently unreadable — absence of evidence "
+            "releases regardless of what can be measured right now"
+        )
+
     def test_a_failover_departure_does_not_disarm_the_bar(self, temp_home):
         """`(None, None)` from a failover must not read the same as `absent`.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3664,6 +3664,53 @@ class TestHorizonAxisDoesNotFlap:
         )
         assert outcome is not TickOutcome.SWITCHED
 
+    def test_a_burn_walk_settles_instead_of_oscillating(self, harness):
+        """A-B-A under burn is the fleet changing regime, not a gate leaking.
+
+        The reviewed concern was that the outbound gate is RELATIVE
+        (`h >= active x HORIZON_HEADROOM_RATIO`) while the fallback's is
+        ABSOLUTE (`active <= SPENT_HEADROOM_PCT`), so a pair could take one
+        gate out and the other back. Measured at the moment of each move,
+        only the active burning, both resets past the horizon:
+
+            out    active 2.0 / peer 4.0   headroom axis, 4.0 >= 2.0x2
+            back   active 3.0 / peer 2.0   recovery  axis, 10h vs 80h
+
+        Both legs are legitimate on the axis their own state selects: at the
+        first the fleet still held real headroom, by the second every account
+        is spent, which is the regime the reset axis exists for. 21 of 576
+        burn walks make that transition; base makes 0 because it refuses the
+        outbound leg too.
+
+        Two candidate constraints were measured and BOTH changed the count by
+        zero — requiring the fallback's candidate to be spent, and taking
+        `max`/`min` over the pair in `_recovery_is_useful`. The transition is
+        in the data, not in the gates, so neither is shipped.
+
+        What must hold is that a walk SETTLES. This one does: two moves in 24
+        ticks, then stationary.
+        """
+        seen = []
+        pct = {"1": 96.0, "2": 92.0}          # 4.0 and 8.0 points
+        for _ in range(24):
+            harness.tick_with_usage({
+                "1": _usage(pct["1"], self._days_out(harness, 20)),
+                "2": _usage(pct["2"], self._days_out(harness, 80)),
+            })
+            active = harness.active_number()
+            seen.append(active)
+            pct[str(active)] = min(99.95, pct[str(active)] + 0.25)   # burn
+            harness.clock.advance(301.0)
+
+        moves = [n for i, n in enumerate(seen) if i == 0 or n != seen[i - 1]]
+        assert len(moves) <= 3, (
+            f"move sequence {moves} — a burn walk that keeps moving is a flap, "
+            "whatever axis each leg took"
+        )
+        assert seen[-4:] == [seen[-1]] * 4, (
+            f"active trace {seen} — the walk never settled"
+        )
+
     def test_the_fallback_never_outranks_a_real_qualifier(self, harness):
         """It runs only when nothing else qualifies, and the key is why.
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3961,6 +3961,160 @@ class TestHorizonAxisDoesNotFlap:
             "disproves it"
         )
 
+    def test_the_bar_does_not_hide_the_account_from_the_census(
+        self, temp_home
+    ):
+        """Barring a candidate must not make it cease to EXIST.
+
+        Removing it from `oauth_candidates` fed eight consumers a list with a
+        healthy account missing. `truly_exhausted` is the loudest: measured,
+        peer 1 holding 15 points while the engine emitted AllExhaustedEvent —
+        a macOS notification and a critical TUI row — because `all()` over the
+        shortened list was vacuously true.
+
+        DRIVES THE BARRED BRANCH, which is the part the previous tests missed.
+        Peer 15 pts against active 10 pts does NOT satisfy `left >= active x
+        2`, so the release does not fire and the bar is genuinely in effect.
+        Both earlier tests used a 0% peer against a 97% active, where the
+        release always fired — measured, disabling the filter outright left
+        the whole suite green.
+        """
+        h = EngineHarness(temp_home)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage(92, self._days_out(h, 500)),
+            "2": _usage(10, self._days_out(h, 400)),
+            "3": _usage(100, self._days_out(h, 300)),
+        }) is TickOutcome.SWITCHED
+        h.clock.advance(301.0)
+
+        h.events.clear()
+        h.tick_with_usage({
+            "1": _usage(85, self._days_out(h, 400)),   # left; 15 pts, BARRED
+            "2": _usage(90, self._days_out(h, 500)),   # active; 10 pts
+            "3": _usage(100, self._days_out(h, 300)),  # genuinely spent
+        })
+        assert not any(isinstance(e, AllExhaustedEvent) for e in h.events), (
+            f"events {[type(e).__name__ for e in h.events]} — account 1 holds "
+            "15 points; barring it from the CHOICE must not erase it from the "
+            "fleet"
+        )
+
+    def test_the_bar_lifts_when_it_would_leave_nothing(self, temp_home):
+        """Identity has no release of its own, and the ratio cannot cover it.
+
+        `lastSwitchFrom` is rewritten only by a successful switch — the one
+        the bar prevents — so on two accounts it was permanent. The ratio
+        release does not reach it either: `left >= active x 2` is unsatisfiable
+        for any active headroom above 50, and consume-first fires exactly
+        there. Measured before this: active 70 pts against a peer at 100 pts,
+        20 ticks answering below-threshold, still locked after seven days.
+
+        A bar that leaves the engine nothing to choose is a stall, not
+        anti-flap.
+        """
+        h = EngineHarness(temp_home, strategy="consume-first")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        assert h.tick_with_usage({
+            "1": _usage7(95, 95, self._days_out(h, 500)),
+            "2": _usage7(5, 5, self._days_out(h, 400)),
+        }) is TickOutcome.SWITCHED
+        h.clock.advance(301.0)
+
+        outcomes = []
+        for _ in range(20):
+            outcomes.append(h.tick_with_usage({
+                # left; weekly window resets SOONEST, which is what
+                # consume-first ranks on
+                "1": _usage7(0, 0, self._days_out(h, 10)),
+                "2": _usage7(30, 30, self._days_out(h, 500)),   # active, 70 pts
+            }))
+            h.clock.advance(1801.0)
+
+        assert TickOutcome.SWITCHED in outcomes, (
+            f"20 ticks of {[o.name for o in outcomes]} — the only peer was "
+            "barred with no way to lift it, so consume-first is off for good"
+        )
+
+    def test_the_bar_never_applies_to_an_escape(self, harness):
+        """`at-limit` and `failover` skip every anti-flap gate by design.
+
+        There we are escaping a dead or unreadable active, not optimising a
+        return time — and the account we left may be the only place to go.
+        Measured: dropping the trigger check left the full suite green, so
+        nothing pinned it. The at-limit half is defended for the wrong reason
+        (at-limit implies `active_headroom <= 0`, so the ratio release fires
+        anyway); failover has no such accident, because an unreadable active
+        gives `active_headroom is None` and the release cannot fire.
+
+        Asserts on the BAR, not on a tick outcome: the ratio release makes the
+        at-limit case pass either way, which is what hid this.
+        """
+        state = {"lastSwitchFrom": 1}
+        # 15 pts against an active on 10: does NOT clear `left >= active x 2`,
+        # so the ratio release cannot fire and only the trigger check can
+        # answer. A peer far ahead would pass for the wrong reason.
+        headroom = {"1": 15.0, "2": 10.0, "3": 1.0}
+        for trigger in ("at-limit", "failover"):
+            for active in (10.0, None):
+                assert harness.engine._no_return_account(
+                    trigger, state, headroom, active, ["1", "3"]
+                ) is None, (
+                    f"trigger={trigger} active_headroom={active} barred the "
+                    "account we left; an escape must reach every candidate"
+                )
+        # The control: the SAME state bars on a proactive tick.
+        assert harness.engine._no_return_account(
+            "proactive", state, headroom, 10.0, ["1", "3"]
+        ) == "1", "premise: these inputs are barred when the trigger allows it"
+
+    def test_the_bar_actually_removes_the_account_from_the_ranking(
+        self, harness
+    ):
+        """The bar has to BAR something, and nothing pinned that.
+
+        Measured: disabling it outright — `if num == no_return` -> `if False`
+        — left the whole suite green, this class included. Both sibling tests
+        assert what happens when the bar is LIFTED (the census stays intact,
+        the lockout ends), so neither notices when it never engages.
+
+        Drives `_rank_candidates` directly. Through `tick()` the cooldown and
+        the hysteresis gates decide these inputs first, so the same pair moves
+        identically with the bar on and off — measured across 12 peer/active
+        combinations, every one identical. The ranking is the only place the
+        bar's effect is observable in isolation.
+        """
+        from claude_swap.settings import AutoSwitchSettings
+
+        args = dict(
+            trigger="proactive",
+            consume_first=False,
+            oauth_candidates=["1", "3"],
+            usage={"1": _usage(40), "2": _usage(96), "3": _usage(99)},
+            headroom={"1": 60.0, "2": 4.0, "3": 1.0},
+            current="2",
+            active_headroom=4.0,
+            settings=AutoSwitchSettings(),
+            now=harness.clock.now,
+        )
+        unbarred, _, _ = harness.engine._rank_candidates(no_return=None, **args)
+        barred, _, _ = harness.engine._rank_candidates(no_return="1", **args)
+
+        assert list(unbarred) == ["1"], (
+            f"premise: account 1 holds 60 points against an active on 4 and "
+            f"is the pick when nothing bars it — got {list(unbarred)}"
+        )
+        assert list(barred) == [], (
+            f"the bar did not remove account 1 from the ranking: {list(barred)}"
+        )
+
     def test_the_fallback_never_outranks_a_real_qualifier(self, harness):
         """It runs only when nothing else qualifies, and the key is why.
 


### PR DESCRIPTION
Follow-up to #202, from running it on a live 3-account setup.

## What #202 got right, and where it has no bound

#202 added: when *every* account is above the threshold, rank by which one's binding window resets soonest. The evidence was minutes-scale — the measured case had a peer whose 5-hour window reset in **8 minutes**, and trading 9 points of headroom for an 8-minute wait is plainly right.

The rule shipped with no upper bound on that wait, so it applies identically when every reset is days out.

## Measured

Live, three accounts, threshold 90, `strategy: best`:

```
 1 (active)  7d 91%   resets in 109h   <- 9 points of headroom
 2           7d 94%   resets in  80h
 3           7d 98%   resets in  50h   <- 2 points, but "soonest"
```

The engine ranked by recovery and moved to account 3 — from 9 points of headroom to 2. Nothing returns within the session either way, so those 9 points were the only resource that could still do work. The user switched back to account 1 by hand; the engine moved them off again on the next tick.

| | headroom | recovery |
|---|---|---|
| acct 1 | **9%** — most | 109h — worst |
| acct 3 | 2% — least | **50h** — best |

## The change

Past `RECOVERY_HORIZON_S` (4h — one whole 5-hour cycle, so same-day resets keep the recovery ranking), rank by headroom instead.

The escape itself stays. Dropping out of `all_above` entirely would re-arm the landing-health gate, which has no answer when everything is above the line, and park the engine rather than fix it — so only the ranking axis changes.

## The anti-flap bar

Ranking by a *reset* rather than by headroom needs a matching no-return rule, because burn changes headroom continuously while a reset does not: without one the engine returns to the account it just left as soon as the active burns past it. `_left_account_recovered` holds the departed account barred until it genuinely recovers.

A failover departure records `(leftHeadroom, leftRecoveryAt) = (None, None)` — a real departure whose severity was unmeasured — so its release cannot use headroom at all and falls to two legs: the landing floor, and "the peer's binding reset is meaningfully sooner than the active's".

That second leg is where the analysis matters, because **`_binding_recovery_ts` returns `inf` for five distinct states**:

```
A  finite reset, far out      D  unreadable (None)
B  no resets_at               E  no windows ({})
C  reset in the past
```

One predicate over five states is wrong in both directions, and both readings ship a real defect. Reading every `inf` as "never" releases onto a peer arbitrarily far out on no evidence. Reading every `inf` as "unknown" and holding pins the engine on a near-spent active for up to a full window while the peer is back in minutes.

The release condition is therefore `math.isfinite(active_recovery_ts) or peer_recovery_ts - now <= RECOVERY_HORIZON_S`: a known-finite active decides on the comparison, and an unknown active still yields to a peer that is provably close. Measured, with both controls invariant and only the damage rows moving:

```
POS  active 400h / peer 50min   SWITCHED
NEG  peer only 60s sooner       BLOCKED
DMG-a active NO resets_at       SWITCHED
DMG-b active reset in PAST      SWITCHED
DMG-long 40 ticks               switched=1
```

This releases on all five `inf` states when the peer is inside the horizon, not only the two the motivation names. Whether that violates F6 (an unreadable active must not flip a verdict) was **adjudicated as unreachable**: `trigger` is derived from `active_headroom`, so an unreadable active always classifies as `failover`, which `_no_return_account` scopes out of the bar entirely. The one route that survives classification is closed by exact complementarity — with `active_headroom=None`, `_every_account_above_threshold` returns `False` unconditionally, making the landing gate and the failover landing leg exact complements. Swept every headroom in [0,100] at 0.01 across five thresholds: **0 values where the horizon term could decide**, and 0 over 1920 random ticks.

## A `consume-first` departure could write the failover snapshot shape

`_left_account_recovered` inferred the trigger from `(None, None)`. But a consume-first phase-2 refetch writes that same shape whenever the refetched active row has a `pct` but is otherwise unmeasurable in the same tick its weekly reset is known — `account_headroom` needs a numeric `pct`, `_seven_day_reset_ts` needs only `resets_at`, and one row can satisfy one and not the other. The reader then ran the more permissive failover legs on an ordinary departure. Reproduced end-to-end; reclassification differs on ~31% of swept fleets, both directions. `_perform` now records `state["leftTrigger"]` directly; records written before the field existed keep the old two-null inference.

## Verification

- Suite 1793 passed, 3 skipped; 7.1s.
- 21 mutants in place with controls (`POS-rename` killed 140, `NOOP` survived, `SYNTAX` errored). Every horizon and `leftTrigger` mutant killed except one float-boundary equivalent (needs a peer at exactly 14400.000000s).
- `leftTrigger` blast radius: sole reader/writer is `autoswitch.py`; a downgrade ignores the key.
- Real account store unchanged across every run.

## Base

Rebased onto the current `main` (`3d9f596`). The xdist parallelisation, the
real-Keychain serialisation hook and the `uv sync --locked` CI gate this branch
used to carry landed upstream via #209, so those commits dropped out of the
range — `pyproject.toml`, `tests/conftest.py`, `.github/workflows/ci.yml` and
`uv.lock` are byte-identical to `main` here, and the diff is only
`autoswitch.py` and its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
