### PR TITLE
fix(add): resolve the capture profile through CLAUDE_SECURESTORAGE_CONFIG_DIR the way claude 2.1.220 does

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -228,7 +228,12 @@ _STRICT_KEYCHAIN_ATTEMPTS = 2
 _STRICT_KEYCHAIN_RETRY_DELAY = 0.3  # seconds between attempts
 
 
-def read_config_dir_credentials(config_dir: str, *, strict_keychain: bool = False) -> str | None:
+def read_config_dir_credentials(
+    config_dir: str,
+    *,
+    strict_keychain: bool = False,
+    keychain_service: str | None = None,
+) -> str | None:
     """Same read for an arbitrary ``CLAUDE_CONFIG_DIR`` value.
 
     Takes the raw string rather than a ``Path``: claude derives the keychain
@@ -236,6 +241,10 @@ def read_config_dir_credentials(config_dir: str, *, strict_keychain: bool = Fals
     which drops a trailing slash or a leading ``./`` — would look up a service
     name claude never wrote and fall back to the (possibly stale) plaintext
     seed instead.
+
+    ``keychain_service`` overrides the derived hashed name for the one profile
+    whose item is *unsuffixed*: the default profile, which claude selects with
+    ``CLAUDE_SECURESTORAGE_CONFIG_DIR`` defined-but-empty.
 
     ``strict_keychain`` is for capture (``add``): an *unreadable* keychain —
     locked, denied, timed out — retries once and then raises
@@ -253,7 +262,8 @@ def read_config_dir_credentials(config_dir: str, *, strict_keychain: bool = Fals
         for attempt in range(attempts):
             try:
                 creds = macos_keychain.get_password(
-                    keychain_service_name(config_dir), _keychain_account_name()
+                    keychain_service or keychain_service_name(config_dir),
+                    _keychain_account_name(),
                 )
             except macos_keychain.KEYCHAIN_ERRORS as e:
                 if attempt + 1 < attempts:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -477,7 +477,7 @@ class ClaudeAccountSwitcher:
         return self._store._read_active_credentials()
 
     def _read_capture_credentials(self) -> str | None:
-        """Read the credential of the profile ``CLAUDE_CONFIG_DIR`` points at.
+        """Read the credential of the profile the environment points at.
 
         ``add_account`` fills one slot from two reads: the identity out of
         ``.claude.json`` and the credential out of the active store. The active
@@ -489,6 +489,14 @@ class ClaudeAccountSwitcher:
 
         Read the OAuth credential the way claude resolves it for the same
         environment, so the slot's email and token come from one profile.
+        Claude (2.1.220 ``getMacOsKeychainStorageServiceName``/storage-path
+        resolution) sources secure storage from ``CLAUDE_SECURESTORAGE_CONFIG_DIR``
+        when that is *defined*, else ``CLAUDE_CONFIG_DIR`` — with defined-but-empty
+        meaning the *default secure store* (unsuffixed Keychain item,
+        ``~/.claude/.credentials.json``). Not the active store: its file backend
+        follows ``CLAUDE_CONFIG_DIR``, which may point elsewhere. Identity stays
+        on ``CLAUDE_CONFIG_DIR`` either way; only the credential read moves.
+
         Two fallbacks stay inside that profile. An env var naming the default
         profile means the active store, since a user exporting
         ``CLAUDE_CONFIG_DIR=~/.claude`` may only have the unsuffixed item.
@@ -503,17 +511,36 @@ class ClaudeAccountSwitcher:
         Read-only. cswap does not write claude's hashed keychain entry — see
         the ``session`` module docstring for why.
         """
-        config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
-        if not config_dir:
-            return self._read_credentials()
-
         from claude_swap.session import read_config_dir_credentials
 
-        creds = read_config_dir_credentials(config_dir, strict_keychain=True)
-        if creds:
-            return creds
-        if _same_directory(Path(config_dir), get_default_claude_config_home()):
+        secure_env = os.environ.get("CLAUDE_SECURESTORAGE_CONFIG_DIR")
+        config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+
+        if secure_env is not None:
+            # A defined override names the *only* store claude will read for
+            # this environment — defined-but-empty pins the default profile
+            # (unsuffixed keychain item, ``~/.claude/.credentials.json``). On
+            # a miss claude sees a logged-out environment, so no falling back
+            # into the active store: its file backend follows
+            # ``CLAUDE_CONFIG_DIR``, and with the two vars diverged that would
+            # capture a profile claude is not reading (cross-profile leak).
+            creds = read_config_dir_credentials(
+                secure_env or str(get_default_claude_config_home()),
+                strict_keychain=True,
+                keychain_service=CLAUDE_CODE_KEYCHAIN_SERVICE if not secure_env else None,
+            )
+            if creds:
+                return creds
+        elif not config_dir:
             return self._read_credentials()
+        else:
+            creds = read_config_dir_credentials(config_dir, strict_keychain=True)
+            if creds:
+                return creds
+            if _same_directory(Path(config_dir), get_default_claude_config_home()):
+                # Safe only on this legacy path: the active store's env-following
+                # file backend and the default profile coincide here.
+                return self._read_credentials()
         # Only this profile's own ``primaryApiKey`` — never the unsuffixed
         # "Claude Code" Keychain item, which belongs to the default profile
         # and would answer for a login that is not the one being added.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ def _isolate_real_home(request, tmp_path_factory, monkeypatch):
     exercise those vars set them explicitly, overriding this.
     """
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     if "temp_home" in request.fixturenames:
         return  # temp_home provides its own isolated home

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1905,7 +1905,7 @@ class TestCaptureCredentials:
             switcher.add_account()
 
         assert len(calls) == session_mod._STRICT_KEYCHAIN_ATTEMPTS
-        assert "1" not in switcher._get_sequence_data().get("accounts", {})
+        assert "1" not in (switcher._get_sequence_data() or {}).get("accounts", {})
 
     def test_transient_keychain_error_retries(
         self, temp_home: Path, tmp_path: Path, monkeypatch
@@ -1947,3 +1947,119 @@ class TestCaptureCredentials:
         creds = session_mod.read_session_credentials(session_dir)
 
         assert creds is not None and CONFIG_DIR_TOKEN in creds
+
+    @staticmethod
+    def _secure_dir(base: Path, token: str = "secure-store-token") -> Path:
+        """A bare secure-storage dir: credentials only, no identity — claude's
+        ``CLAUDE_SECURESTORAGE_CONFIG_DIR`` moves secure storage, not config."""
+        directory = base / "securestore"
+        directory.mkdir()
+        (directory / ".credentials.json").write_text(
+            json.dumps({"claudeAiOauth": {"accessToken": token}}), encoding="utf-8"
+        )
+        return directory
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_securestorage_dir_overrides_config_dir(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        """Claude sources secure storage from ``CLAUDE_SECURESTORAGE_CONFIG_DIR``
+        when it is defined, ``CLAUDE_CONFIG_DIR`` otherwise; identity stays on
+        ``CLAUDE_CONFIG_DIR``."""
+        switcher = self._switcher(platform, monkeypatch)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(self._config_dir(tmp_path)))
+        monkeypatch.setenv(
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR", str(self._secure_dir(tmp_path))
+        )
+
+        switcher.add_account()
+
+        assert "secure-store-token" in self._stored(switcher)
+        assert CONFIG_DIR_TOKEN not in self._stored(switcher)
+
+    def test_securestorage_hashed_keychain_entry(
+        self, temp_home: Path, tmp_path: Path, block_real_keychain, monkeypatch
+    ):
+        """The hashed keychain service name derives from the securestorage
+        value when defined, not from ``CLAUDE_CONFIG_DIR``."""
+        switcher = self._switcher(Platform.MACOS, monkeypatch)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(self._config_dir(tmp_path)))
+        secure = self._secure_dir(tmp_path)
+        block_real_keychain.set_password(
+            keychain_service_name(str(secure)),
+            session_mod._keychain_account_name(),
+            json.dumps({"claudeAiOauth": {"accessToken": "rotated"}}),
+        )
+        monkeypatch.setenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", str(secure))
+
+        switcher.add_account()
+
+        assert "rotated" in self._stored(switcher)
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_empty_securestorage_dir_forces_default_store(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        """Defined-but-empty is claude's "force the default secure store":
+        unsuffixed keychain item and ``~/.claude/.credentials.json`` — even
+        though ``CLAUDE_CONFIG_DIR`` names a profile with its own seed."""
+        switcher = self._switcher(platform, monkeypatch)
+        switcher._write_credentials(ACTIVE_CREDS)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(self._config_dir(tmp_path)))
+        monkeypatch.setenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", "")
+
+        switcher.add_account()
+
+        assert ACTIVE_TOKEN in self._stored(switcher)
+        assert CONFIG_DIR_TOKEN not in self._stored(switcher)
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_securestorage_without_config_dir(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        """Securestorage alone moves only the credential read; identity still
+        resolves through the (default) config profile."""
+        switcher = self._switcher(platform, monkeypatch)
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        get_global_config_path().write_text(CONFIG_DIR_CONFIG, encoding="utf-8")
+        monkeypatch.setenv(
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR", str(self._secure_dir(tmp_path))
+        )
+
+        switcher.add_account()
+
+        assert "secure-store-token" in self._stored(switcher)
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_empty_selected_store_does_not_leak_config_profile(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        """Defined-but-empty selects the default store; when that store is
+        credentialless, claude sees a logged-out environment — the config
+        profile's seed must not answer in its place."""
+        switcher = self._switcher(platform, monkeypatch)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(self._config_dir(tmp_path)))
+        monkeypatch.setenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", "")
+
+        with pytest.raises(CredentialReadError):
+            switcher.add_account()
+
+        assert "1" not in (switcher._get_sequence_data() or {}).get("accounts", {})
+
+    @pytest.mark.parametrize("platform", [Platform.LINUX, Platform.MACOS])
+    def test_credentialless_securestorage_default_dir_does_not_fall_back(
+        self, platform, temp_home: Path, tmp_path: Path, monkeypatch
+    ):
+        """A non-empty override naming ``~/.claude`` uses the *hashed* service
+        name (claude keys the suffix off env presence, not the path), so
+        neither the unsuffixed item nor the config profile's seed may answer."""
+        switcher = self._switcher(platform, monkeypatch)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(self._config_dir(tmp_path)))
+        monkeypatch.setenv(
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR", str(Path.home() / ".claude")
+        )
+
+        with pytest.raises(CredentialReadError):
+            switcher.add_account()
+
+        assert "1" not in (switcher._get_sequence_data() or {}).get("accounts", {})


### PR DESCRIPTION
Follow-up to #190. While verifying that fix against the current Claude Code binary (2.1.220), we found the binary has grown a second environment variable the capture path needs to honor: `CLAUDE_SECURESTORAGE_CONFIG_DIR`.

## What the binary does

Claude's secure-storage resolution (`getMacOsKeychainStorageServiceName` and the storage-path helper) sources the storage directory from `CLAUDE_SECURESTORAGE_CONFIG_DIR` when that variable is **defined**, falling back to `CLAUDE_CONFIG_DIR` otherwise:

| environment | keychain service | plaintext file |
| --- | --- | --- |
| securestorage defined, non-empty | `Claude Code-credentials-<sha256(raw NFC value)[:8]>` | `<value>/.credentials.json` |
| securestorage defined, **empty** | unsuffixed `Claude Code-credentials` | `~/.claude/.credentials.json` |
| securestorage undefined | #190 behavior (keyed off `CLAUDE_CONFIG_DIR` presence) | #190 behavior |

Two details matter. Defined-but-empty is not "unset" — it pins storage to the default profile regardless of `CLAUDE_CONFIG_DIR`. And the hash is over the raw NFC-normalized value, same as #190 established for `CLAUDE_CONFIG_DIR` (env *presence* selects the suffix, not path equality — so a non-empty override naming `~/.claude` still uses the hashed name).

Identity (`.claude.json`) stays on `CLAUDE_CONFIG_DIR`; the variable moves only secure storage. So with the two variables diverged, #190's capture read the wrong store and could again pair one profile's email with another store's token — the exact mismatch #190 fixed for the single-variable case.

## The fix

`_read_capture_credentials` resolves the secure store the same way the binary does. When the override is defined, the selected store answers **alone**: on a miss it proceeds only to the profile's own `primaryApiKey` (so the API-key guard still gets to speak) and otherwise the add fails with `CredentialReadError` — because claude in that environment sees a logged-out state, and capturing anything else would file a token claude is not using.

That "alone" is load-bearing, and review caught it: an earlier draft fell back to the active store on a miss, but the active store's file backend follows `CLAUDE_CONFIG_DIR`, so with diverged variables it silently captured the config profile's seed — a cross-profile leak reintroducing the #190 bug class. #190's own default-dir fallback was only ever safe because on that path the env-following backend and the default profile coincide; that fallback is now isolated to the `secure_env is None` path, which stays byte-for-byte the merged #190 behavior.

`read_config_dir_credentials` gains an optional `keychain_service` override for the one profile whose item is unsuffixed (the default store), and the conftest env-isolation fixture scrubs the new variable alongside `CLAUDE_CONFIG_DIR` so a developer's exported value can't change what the suite exercises.

## Tests

Eight new cases in `TestCaptureCredentials`: the override winning over `CLAUDE_CONFIG_DIR` (both platforms), hash derivation from the override value, defined-empty forcing the default store (both platforms), the override working without `CLAUDE_CONFIG_DIR`, and two adversarial regressions — a credentialless selected store with a seeded config profile, and a non-empty override naming a credentialless `~/.claude` — both of which must raise instead of capturing across profiles.

## Validation

- Capture suite: 33 passed.
- Full suite: 1689 passed, 3 skipped, plus the 6 pre-existing `test_move_accounts`/`test_swap_accounts` failures that reproduce on unmodified `main`.
- `uv run python -m compileall -q src`, `git diff --check`.
