### PR TITLE
Auto-switch: reset-aware grace window + settings.json hot-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Let claude-swap watch your usage and switch for you. When the active account's 5
 ```bash
 cswap auto                     # foreground loop, polls every 60s
 cswap auto --threshold 80      # switch earlier
+cswap auto --grace-before-reset 300   # ride an about-to-reset account to ~100%%
 cswap auto --model Fable       # also switch when the Fable weekly limit is hit
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
@@ -103,6 +104,8 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
+- **Reset grace** (`--grace-before-reset MINUTES`, or `cswap config set autoswitch.graceBeforeResetMinutes 300`): skip a *proactive* switch (over the threshold, but not yet at the hard limit) when the active account's own binding window is about to reset anyway — any headroom a switch would "save" gets wiped out by the reset regardless, so it only spends quota on an account that didn't need touching. Set it to your 5h window's length or more (e.g. `300`) to stop the fast-cycling 5h window from ever triggering an early switch, while the 7d window — which doesn't recycle for days — still switches normally, since its reset is almost never inside the grace window. Off (`0`) by default; never applies once an account is already at its hard limit, where moving is strictly an improvement.
+- A running `cswap auto` loop picks up `cswap config set` / hand edits to `settings.json` made from another terminal without needing a restart (a `settings-reloaded` event is logged when it does); any `--flag` passed at launch keeps overriding the file, same as at startup.
 
 For cron/systemd timers, `--once` reports the outcome in its exit code (`0` switched, `1` error, `2` nothing to do, `3` blocked — no viable target), and `--json` emits one JSON event per line:
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -36,7 +36,7 @@ import random
 import threading
 import time
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import ClassVar
@@ -50,7 +50,14 @@ from claude_swap.poll_policy import (
     RESET_SLACK_S,
     binding_pct,
 )
-from claude_swap.settings import AutoSwitchSettings, atomic_write_json, parse_model_names
+from claude_swap.settings import (
+    AutoSwitchSettings,
+    apply_overrides,
+    atomic_write_json,
+    load_settings,
+    parse_model_names,
+    settings_path,
+)
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.usage_store import due_candidate, plan_oversleeps_interval
 
@@ -104,9 +111,7 @@ RECOVERY_HYSTERESIS_S = 300.0
 
 def _now_iso() -> str:
     return (
-        datetime.now(timezone.utc)
-        .isoformat(timespec="seconds")
-        .replace("+00:00", "Z")
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
     )
 
 
@@ -196,9 +201,7 @@ class PollEvent(AutoSwitchEvent):
             err = self.fetch_errors.get(str(num))
             used = f"usage unknown ({err})" if err else "usage unknown"
         others = ", ".join(
-            f"#{n}: {self._describe(n)}"
-            for n in self.headroom
-            if n != str(num)
+            f"#{n}: {self._describe(n)}" for n in self.headroom if n != str(num)
         )
         tail = f" | others: {others}" if others else ""
         return (
@@ -226,9 +229,7 @@ class SwitchEvent(AutoSwitchEvent):
         }
 
     def human(self) -> str:
-        src = (
-            f"Account-{self.from_ref.get('number')}" if self.from_ref else "(none)"
-        )
+        src = f"Account-{self.from_ref.get('number')}" if self.from_ref else "(none)"
         dst = (
             f"Account-{self.to_ref.get('number')} ({self.to_ref.get('email')})"
             if self.to_ref
@@ -248,7 +249,9 @@ class NoSwitchEvent(AutoSwitchEvent):
         return {"reason": self.reason, "detail": self.detail}
 
     def human(self) -> str:
-        return f"no switch: {self.reason}" + (f" ({self.detail})" if self.detail else "")
+        return f"no switch: {self.reason}" + (
+            f" ({self.detail})" if self.detail else ""
+        )
 
 
 @dataclass(frozen=True)
@@ -339,6 +342,24 @@ class ConfigWarningEvent(AutoSwitchEvent):
         return f"warning: {self.message}"
 
 
+@dataclass(frozen=True)
+class SettingsReloadedEvent(AutoSwitchEvent):
+    """settings.json changed on disk (e.g. ``cswap config set`` from another
+    terminal) while a `cswap auto` loop was already running, and the engine
+    picked up the new values without needing a restart."""
+
+    kind: ClassVar[str] = "settings-reloaded"
+    changed: tuple[str, ...] = ()
+
+    def _fields(self) -> dict:
+        return {"changed": list(self.changed)}
+
+    def human(self) -> str:
+        if self.changed:
+            return f"settings.json reloaded ({', '.join(self.changed)})"
+        return "settings.json reloaded"
+
+
 # ---------------------------------------------------------------------------
 # Engine
 # ---------------------------------------------------------------------------
@@ -361,9 +382,7 @@ class TickOutcome(enum.Enum):
 _refresh_fingerprint = oauth.credential_fingerprint
 
 
-def _window_pcts(
-    usage: dict | None, models: tuple[str, ...] = ()
-) -> dict[str, float]:
+def _window_pcts(usage: dict | None, models: tuple[str, ...] = ()) -> dict[str, float]:
     """Ordered window label → pct: "5h", "7d", then configured scoped names.
 
     Deliberately restricted to the windows the *decision* reads (same
@@ -371,9 +390,7 @@ def _window_pcts(
     to a switch onto that account would look like a bug, when the engine
     correctly ignored it. Full per-model usage lives in ``cswap list``.
     """
-    return {
-        name: pct for name, pct, _ in oauth.relevant_windows(usage, models)
-    }
+    return {name: pct for name, pct, _ in oauth.relevant_windows(usage, models)}
 
 
 # Reset math moved to poll_policy with the cadence numbers; aliased for the
@@ -471,9 +488,7 @@ def _headroom_by_account(
 ) -> dict[str, float | None]:
     """Per-account headroom derived from decision values."""
     return {
-        num: oauth.account_headroom(
-            value if isinstance(value, dict) else None, models
-        )
+        num: oauth.account_headroom(value if isinstance(value, dict) else None, models)
         for num, value in usage.items()
     }
 
@@ -495,9 +510,26 @@ class AutoSwitchEngine:
         dry_run: bool = False,
         state_path: Path | None = None,
         clock: Callable[[], float] = time.time,
+        cli_overrides: dict | None = None,
+        watch_settings: bool = False,
     ):
         self.switcher = switcher
         self.settings = settings
+        # Overrides an owning CLI passed on the command line (e.g. `cswap
+        # auto --threshold 95`); a settings.json hot-reload re-applies these
+        # on top of the fresh file read, same precedence as at startup, so a
+        # flag never gets silently defeated by a later file edit.
+        self._cli_overrides = cli_overrides or {}
+        # `run_loop()` watches settings.json for edits made by another
+        # process (`cswap config set ...`, a hand edit) while this loop is
+        # already running, and hot-applies them — mirrors the menubar app's
+        # own mtime-gated reload. Off by default: only the plain CLI loop
+        # (`cswap auto`) needs it — the TUI and menubar already have their
+        # own live-apply paths (session slider / explicit restart) and must
+        # not have a second, uncoordinated writer of `self.settings`.
+        self._watch_settings = watch_settings
+        self._settings_path = settings_path(switcher.backup_dir)
+        self._settings_mtime = self._current_settings_mtime()
         # Model(s) whose per-model weekly limit also binds the switch decision
         # (empty = account-wide 5h/7d only). ``settings.model`` is a comma-
         # separated list ("Fable", "Opus,Sonnet", "all"); parse once here and
@@ -590,9 +622,7 @@ class AutoSwitchEngine:
         for number, entry in quarantine.items():
             email_now = self.switcher.account_email(number)
             if not email_now or email_now != entry.get("email"):
-                to_release.append(
-                    (number, entry.get("email", ""), "account-replaced")
-                )
+                to_release.append((number, entry.get("email", ""), "account-replaced"))
                 continue
             creds = self.switcher.read_account_credentials(number, email_now)
             fingerprint = _refresh_fingerprint(creds) if creds else None
@@ -654,9 +684,7 @@ class AutoSwitchEngine:
             # Persist first, unconditionally: the grant consumed a generation,
             # and not writing the successor would kill the lineage regardless
             # of whose it turns out to be.
-            self.switcher.persist_backup_credentials(
-                number, email, outcome.credentials
-            )
+            self.switcher.persist_backup_credentials(number, email, outcome.credentials)
             if self._note_token_identity(number, outcome.token_account):
                 # The slot's stored credential authenticates as a *different*
                 # account — activating it would put the user on the wrong
@@ -669,9 +697,7 @@ class AutoSwitchEngine:
             return "invalid_grant"
         return "transient"
 
-    def _note_token_identity(
-        self, number: str, token_account: dict | None
-    ) -> bool:
+    def _note_token_identity(self, number: str, token_account: dict | None) -> bool:
         """Use the token endpoint's free identity to verify/backfill a slot.
 
         The refresh grant just ran against the slot's own stored credential,
@@ -720,9 +746,7 @@ class AutoSwitchEngine:
             self._emit(ErrorEvent(message=str(e), transient=True))
             return TickOutcome.ERROR
         except Exception as e:  # pragma: no cover - safety net
-            self._emit(
-                ErrorEvent(message=f"{type(e).__name__}: {e}", transient=True)
-            )
+            self._emit(ErrorEvent(message=f"{type(e).__name__}: {e}", transient=True))
             return TickOutcome.ERROR
 
     def _tick_inner(self) -> TickOutcome:
@@ -765,10 +789,14 @@ class AutoSwitchEngine:
             return TickOutcome.NO_ACTION
 
         current_email = self.switcher.account_email(current)
-        active_ref = _ref(current, current_email) if current_email else {
-            "number": int(current),
-            "email": "",
-        }
+        active_ref = (
+            _ref(current, current_email)
+            if current_email
+            else {
+                "number": int(current),
+                "email": "",
+            }
+        )
 
         entries, usage, headroom = self._collect_scheduled_usage(
             current, quarantined, threshold=settings.threshold
@@ -786,9 +814,11 @@ class AutoSwitchEngine:
                 windows={
                     num: pcts
                     for num, value in usage.items()
-                    if (pcts := _window_pcts(
-                        value if isinstance(value, dict) else None, self._models
-                    ))
+                    if (
+                        pcts := _window_pcts(
+                            value if isinstance(value, dict) else None, self._models
+                        )
+                    )
                 },
             )
         )
@@ -881,6 +911,36 @@ class AutoSwitchEngine:
                 )
                 return TickOutcome.NO_ACTION
             trigger = "failover"
+
+        if trigger == "proactive" and settings.grace_before_reset_minutes > 0:
+            # Ride it to ~100% instead of jumping accounts: the active
+            # account is over the threshold but not yet blocked, and its own
+            # binding window (the one driving this trigger) is about to
+            # reset anyway — any headroom "saved" by switching away gets
+            # wiped out by the reset regardless, so the switch would only
+            # spend quota on an account that didn't need touching. Scoped to
+            # "proactive" only: "at-limit"/"failover" mean the account is
+            # already unusable, where moving is strictly an improvement, and
+            # "consume-first" already has its own reset-driven logic for
+            # below-threshold moves that this would fight.
+            recovery_ts = _binding_recovery_ts(
+                usage.get(current), self._models, self.clock()
+            )
+            if recovery_ts != float("inf"):
+                remaining_s = recovery_ts - self.clock()
+                grace_s = settings.grace_before_reset_minutes * 60.0
+                if 0 < remaining_s <= grace_s:
+                    self._emit(
+                        NoSwitchEvent(
+                            reason="reset-imminent",
+                            detail=(
+                                f"binding window resets in {remaining_s / 60:.0f}m "
+                                f"(<= grace {pct_label(settings.grace_before_reset_minutes)}m); "
+                                "riding it out instead of switching"
+                            ),
+                        )
+                    )
+                    return TickOutcome.NO_ACTION
 
         if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
             self._emit(NoSwitchEvent(reason="cooldown"))
@@ -1027,9 +1087,7 @@ class AutoSwitchEngine:
             # viable at any moment — and the active account can hit 100% and
             # need the at-limit escape — so those keep the normal cadence.
             candidate_headrooms = [headroom.get(n) for n in oauth_candidates]
-            truly_exhausted = all(
-                h is not None and h <= 0 for h in candidate_headrooms
-            )
+            truly_exhausted = all(h is not None and h <= 0 for h in candidate_headrooms)
             if not truly_exhausted:
                 self._emit(
                     NoSwitchEvent(
@@ -1309,23 +1367,18 @@ class AutoSwitchEngine:
             active_pre is not None
             and active_pre.age_s is not None
             and active_pre.age_s >= poll_policy.ACTIVE_MAX_INTERVAL_S
-            and (active_pre.poll_interval_s or 0.0)
-            > poll_policy.ACTIVE_MAX_INTERVAL_S
+            and (active_pre.poll_interval_s or 0.0) > poll_policy.ACTIVE_MAX_INTERVAL_S
             and (binding_pct(active_pre.last_good, self._models) or 0.0) < 100.0
         )
-        overslept_plan = (
-            active_pre is not None
-            and plan_oversleeps_interval(active_pre, now)
+        overslept_plan = active_pre is not None and plan_oversleeps_interval(
+            active_pre, now
         )
         if (
             active_pre is None
             or active_pre.age_s is None
             or stale_candidate_plan
             or overslept_plan
-            or (
-                active_pre.next_poll_at is not None
-                and now >= active_pre.next_poll_at
-            )
+            or (active_pre.next_poll_at is not None and now >= active_pre.next_poll_at)
             or (
                 active_pre.next_poll_at is None
                 and active_pre.age_s >= poll_policy.MIN_INTERVAL_S
@@ -1382,9 +1435,7 @@ class AutoSwitchEngine:
                     and planned_headroom <= 0
                 ):
                     escalation_fetch.remove(num)
-            entries = self.switcher.usage_entries_by_account(
-                fetch=escalation_fetch
-            )
+            entries = self.switcher.usage_entries_by_account(fetch=escalation_fetch)
             usage = {num: entry.decision_value() for num, entry in entries.items()}
 
         headroom = _headroom_by_account(usage, self._models)
@@ -1467,8 +1518,7 @@ class AutoSwitchEngine:
         relevant = [
             n
             for n in self.switcher.switchable_account_numbers()
-            if n not in quarantined
-            and self.switcher.account_kind_for(n) != "api_key"
+            if n not in quarantined and self.switcher.account_kind_for(n) != "api_key"
         ]
         values = [usage.get(n) for n in relevant]
         readable = [v for v in values if isinstance(v, dict)]
@@ -1548,10 +1598,61 @@ class AutoSwitchEngine:
     def apply_threshold(self, threshold: float) -> None:
         """Session override from the TUI: retarget the trigger and poll
         cadence mid-run. Threshold only — the model axes (and their derived
-        state) are fixed at construction. The frozen-settings swap is atomic
-        and each tick snapshots ``self.settings`` once, so no locking."""
-        self.settings = replace(self.settings, threshold=threshold)
-        self.switcher.set_poll_policy_inputs(threshold, self._models)
+        state) are fixed at construction."""
+        self.apply_settings(replace(self.settings, threshold=threshold))
+
+    def apply_settings(self, settings: AutoSwitchSettings) -> None:
+        """Hot-swap every policy knob except the model axis mid-run.
+
+        ``self._models`` (parsed once in ``__init__``) is never re-derived
+        here — same fixed-at-construction invariant ``apply_threshold``
+        already documented, generalized: a live settings.json edit to
+        ``autoswitch.model`` must not desync ``self._models`` from
+        ``self.settings.model`` out from under the one-shot typo guard and
+        every window filter that reads ``self._models``. Callers that build
+        ``settings`` from a fresh file read (``_maybe_reload_settings``)
+        pin ``model`` back to the current value before calling this. The
+        frozen-settings swap is atomic and each tick snapshots
+        ``self.settings`` once, so no locking.
+        """
+        self.settings = settings
+        self.switcher.set_poll_policy_inputs(settings.threshold, self._models)
+
+    def _current_settings_mtime(self) -> float | None:
+        try:
+            return self._settings_path.stat().st_mtime
+        except OSError:
+            return None
+
+    def _maybe_reload_settings(self) -> None:
+        """Pick up settings.json edits made by another process while this
+        loop is already running (``cswap config set ...``, a hand edit).
+
+        Mtime-gated so a normal tick costs one cheap ``stat()`` — same
+        technique the menubar app already uses for its own active-account
+        change detection. Only wired into ``run_loop()`` when the engine was
+        constructed with ``watch_settings=True`` (the plain CLI loop); the
+        TUI and menubar own their settings application some other way and
+        must not have two uncoordinated writers of ``self.settings``.
+        """
+        mtime = self._current_settings_mtime()
+        if mtime is None or mtime == self._settings_mtime:
+            return
+        self._settings_mtime = mtime
+        file_settings = load_settings(self.switcher.backup_dir)
+        merged = apply_overrides(file_settings, self._cli_overrides)
+        # The model axis is fixed at construction (see apply_settings) —
+        # never let a live file edit change it out from under self._models.
+        merged = replace(merged, model=self.settings.model)
+        changed = tuple(
+            f.name
+            for f in fields(merged)
+            if getattr(merged, f.name) != getattr(self.settings, f.name)
+        )
+        if not changed:
+            return
+        self.apply_settings(merged)
+        self._emit(SettingsReloadedEvent(changed=changed))
 
     def _next_delay(self, outcome: TickOutcome) -> float:
         interval = self.settings.interval_seconds
@@ -1613,6 +1714,8 @@ class AutoSwitchEngine:
             self._wake.clear()
             if self._stop.is_set():
                 return 0
+            if self._watch_settings:
+                self._maybe_reload_settings()
             try:
                 outcome = self.tick()
             except Exception as e:  # pragma: no cover - tick() already guards

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -221,7 +221,9 @@ def _guard_root(switcher: ClaudeAccountSwitcher) -> None:
     """Refuse to run as root outside a container (shared by run/map/unmap)."""
     if sys.platform != "win32":
         if os.geteuid() == 0 and not switcher._is_running_in_container():
-            error("Error: Do not run this script as root (unless running in a container)")
+            error(
+                "Error: Do not run this script as root (unless running in a container)"
+            )
             sys.exit(1)
 
 
@@ -277,7 +279,9 @@ Examples:
         account_num, email, org_uuid = switcher.resolve_account(args.account)
         target = args.path or os.getcwd()
         if not os.path.isdir(target):
-            warning(f"Warning: {target} is not an existing directory (mapping it anyway)")
+            warning(
+                f"Warning: {target} is not an existing directory (mapping it anyway)"
+            )
         previous = store.get(target)
         store.set(target, email, org_uuid)
 
@@ -468,7 +472,9 @@ Examples:
         metavar="NAME",
         help="Alias to set (letters, digits, ., -, _; not purely numeric).",
     )
-    parser.add_argument("--unset", action="store_true", help="Remove the account's alias")
+    parser.add_argument(
+        "--unset", action="store_true", help="Remove the account's alias"
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     args = parser.parse_args(argv)
 
@@ -538,6 +544,8 @@ Exit codes with --once:
 Examples:
   cswap auto                       # foreground loop, switch at 90%% used
   cswap auto --threshold 80        # switch earlier
+  cswap auto --grace-before-reset 300  # ride the active account to ~100%% instead of
+                                    #   switching away when its window resets within 5h
   cswap auto --model Fable         # also switch when the Fable weekly limit is hit
   cswap auto --json                # one JSON event per line (for scripts)
   cswap auto --once; echo $?       # single tick, outcome in exit code
@@ -576,6 +584,18 @@ Defaults live in settings.json in the backup root; flags override them.
         type=float,
         metavar="SECONDS",
         help="Minimum time between proactive switches (default 300)",
+    )
+    parser.add_argument(
+        "--grace-before-reset",
+        type=float,
+        metavar="MINUTES",
+        dest="grace_before_reset",
+        help=(
+            "Skip a proactive switch when the active account's binding "
+            "window resets within this many minutes — ride it to ~100%% "
+            "instead of jumping accounts right before a refresh "
+            "(0-1440; default 0 = off)"
+        ),
     )
     parser.add_argument(
         "--model",
@@ -620,6 +640,7 @@ Defaults live in settings.json in the backup root; flags override them.
 
     from claude_swap.autoswitch import AutoSwitchEngine, AutoSwitchEvent
     from claude_swap.printer import accent, yellowed
+    from claude_swap.settings import cli_overrides as auto_cli_overrides
     from claude_swap.settings import load_settings, merged_with_cli
 
     def jsonl_emit(event: AutoSwitchEvent) -> None:
@@ -632,7 +653,7 @@ Defaults live in settings.json in the backup root; flags override them.
             line = accent(line)
         elif event.kind in ("error", "account-quarantined"):
             line = yellowed(line)
-        elif event.kind in ("poll", "no-switch", "sleep"):
+        elif event.kind in ("poll", "no-switch", "sleep", "settings-reloaded"):
             line = dimmed(line)
         print(f"{stamp}  {line}", flush=True)
 
@@ -640,15 +661,24 @@ Defaults live in settings.json in the backup root; flags override them.
         switcher = ClaudeAccountSwitcher(debug=args.debug)
         if sys.platform != "win32":
             if os.geteuid() == 0 and not switcher._is_running_in_container():
-                error("Error: Do not run this script as root (unless running in a container)")
+                error(
+                    "Error: Do not run this script as root (unless running in a container)"
+                )
                 sys.exit(1)
 
+        overrides = auto_cli_overrides(args)
         settings = merged_with_cli(load_settings(switcher.backup_dir), args)
         engine = AutoSwitchEngine(
             switcher,
             settings,
             jsonl_emit if args.json else human_emit,
             dry_run=args.dry_run,
+            # Loop mode only: pick up `cswap config set ...` / hand edits to
+            # settings.json made in another terminal while this loop runs,
+            # instead of silently ignoring them until the process restarts.
+            # `--once` never needs it — it reloads fresh on every invocation.
+            cli_overrides=overrides,
+            watch_settings=not args.once,
         )
 
         if args.once:
@@ -657,10 +687,15 @@ Defaults live in settings.json in the backup root; flags override them.
         # Loop mode: SIGTERM (systemd stop) exits the loop cleanly.
         signal.signal(signal.SIGTERM, lambda *_: engine.stop())
         if not args.json:
+            grace_note = (
+                f", {settings.grace_before_reset_minutes:.0f}m reset grace"
+                if settings.grace_before_reset_minutes > 0
+                else ""
+            )
             print(
                 dimmed(
                     f"Auto-switch running: threshold {settings.threshold:.0f}%, "
-                    f"every {settings.interval_seconds:.0f}s"
+                    f"every {settings.interval_seconds:.0f}s{grace_note}"
                     f"{' (dry-run)' if args.dry_run else ''} — Ctrl-C to stop"
                 )
             )
@@ -705,8 +740,7 @@ def _config_command(argv: list[str]) -> None:
     parser = argparse.ArgumentParser(
         prog="cswap config",
         description=(
-            "Read and edit claude-swap settings (settings.json in the "
-            "backup root)."
+            "Read and edit claude-swap settings (settings.json in the backup root)."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=f"""
@@ -735,7 +769,9 @@ Examples:
 
     p_list = sub.add_parser("list", help="Show all effective settings (the default)")
     p_get = sub.add_parser("get", help="Print one setting's effective value")
-    p_get.add_argument("key", metavar="KEY", help="Dotted key, e.g. autoswitch.threshold")
+    p_get.add_argument(
+        "key", metavar="KEY", help="Dotted key, e.g. autoswitch.threshold"
+    )
     for p in (p_list, p_get):
         # SUPPRESS: without it the subparser's False default would clobber a
         # pre-verb `cswap config --json` in the shared namespace.
@@ -762,7 +798,9 @@ Examples:
         switcher = ClaudeAccountSwitcher(debug=args.debug)
         if sys.platform != "win32":
             if os.geteuid() == 0 and not switcher._is_running_in_container():
-                error("Error: Do not run this script as root (unless running in a container)")
+                error(
+                    "Error: Do not run this script as root (unless running in a container)"
+                )
                 sys.exit(1)
         root = switcher.backup_dir
 
@@ -856,6 +894,7 @@ def main() -> None:
     argv = sys.argv[1:]
     try:
         from claude_swap.appearance import cli_should_probe, cli_theme
+
         # `run` execs a child that takes over the terminal, and `--json`
         # must stay machine-readable — never probe (and emit the OSC query)
         # in either case.
@@ -1221,7 +1260,9 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         # Check for root (unless in container) - POSIX only
         if sys.platform != "win32":
             if os.geteuid() == 0 and not switcher._is_running_in_container():
-                error("Error: Do not run this script as root (unless running in a container)")
+                error(
+                    "Error: Do not run this script as root (unless running in a container)"
+                )
                 sys.exit(1)
 
         if args.add_account:

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -47,7 +47,9 @@ class AutoSwitchSettings:
     interval_seconds: float = 60.0
     cooldown_seconds: float = 300.0
     hysteresis_pct: float = 10.0
-    strategy: str = "best"  # "best" (most headroom) or "consume-first" (soonest weekly reset)
+    strategy: str = (
+        "best"  # "best" (most headroom) or "consume-first" (soonest weekly reset)
+    )
     include_api_key_accounts: bool = False
     unhealthy_ticks: int = 3
     # Comma-separated model display name(s) (e.g. "Fable" or "Fable,Opus"),
@@ -57,6 +59,17 @@ class AutoSwitchSettings:
     # 5h/7d windows still have headroom. None = account-wide 5h/7d only
     # (default).
     model: str | None = None
+    # 0 (default) = disabled. Otherwise: skip a *proactive* switch (active
+    # account over the threshold but not yet at its hard limit) when the
+    # account's own binding window will reset within this many minutes —
+    # ride it to ~100% instead of jumping to a fresh account that didn't
+    # need touching, since the headroom being "saved" would be wiped out by
+    # the reset anyway. Set it >= your 5h window's length (e.g. 300+) to
+    # stop the 5h window from ever triggering an early switch while still
+    # letting the 7d window (which doesn't recycle for days) switch
+    # normally. Never suppresses "at-limit"/failover — those mean the
+    # account is already unusable, so moving is strictly an improvement.
+    grace_before_reset_minutes: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -103,40 +116,90 @@ SETTING_SPECS: dict[str, SettingSpec] = {
     spec.dotted: spec
     for spec in (
         SettingSpec(
-            "autoswitch", "threshold", "threshold", "float", 50.0, 99.9,
+            "autoswitch",
+            "threshold",
+            "threshold",
+            "float",
+            50.0,
+            99.9,
             help="Switch when the binding 5h/7d window reaches this pct",
         ),
         SettingSpec(
-            "autoswitch", "intervalSeconds", "interval_seconds", "float", 15.0, 3600.0,
+            "autoswitch",
+            "intervalSeconds",
+            "interval_seconds",
+            "float",
+            15.0,
+            3600.0,
             help="Poll interval for the cswap auto loop, in seconds",
         ),
         SettingSpec(
-            "autoswitch", "cooldownSeconds", "cooldown_seconds", "float", 0.0, 86400.0,
+            "autoswitch",
+            "cooldownSeconds",
+            "cooldown_seconds",
+            "float",
+            0.0,
+            86400.0,
             help="Minimum seconds between proactive switches",
         ),
         SettingSpec(
-            "autoswitch", "hysteresisPct", "hysteresis_pct", "float", 0.0, 50.0,
+            "autoswitch",
+            "hysteresisPct",
+            "hysteresis_pct",
+            "float",
+            0.0,
+            50.0,
             help="A target must beat the active account by this many pct",
         ),
         SettingSpec(
-            "autoswitch", "strategy", "strategy", "choice",
+            "autoswitch",
+            "strategy",
+            "strategy",
+            "choice",
             choices=("best", "consume-first"),
             help="How auto-switch picks the target account",
         ),
         SettingSpec(
-            "autoswitch", "includeApiKeyAccounts", "include_api_key_accounts", "bool",
+            "autoswitch",
+            "includeApiKeyAccounts",
+            "include_api_key_accounts",
+            "bool",
             help="Allow rotating onto managed API-key accounts (bill per token)",
         ),
         SettingSpec(
-            "autoswitch", "unhealthyTicks", "unhealthy_ticks", "int", 1, 100,
+            "autoswitch",
+            "unhealthyTicks",
+            "unhealthy_ticks",
+            "int",
+            1,
+            100,
             help="Consecutive failed polls before an account is unhealthy",
         ),
         SettingSpec(
-            "autoswitch", "model", "model", "string",
+            "autoswitch",
+            "model",
+            "model",
+            "string",
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
         ),
         SettingSpec(
-            "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
+            "autoswitch",
+            "graceBeforeResetMinutes",
+            "grace_before_reset_minutes",
+            "float",
+            0.0,
+            1440.0,
+            help=(
+                "Skip a proactive switch when the active account's binding "
+                "window resets within this many minutes (0=disabled)"
+            ),
+        ),
+        SettingSpec(
+            "ui",
+            "theme",
+            "theme",
+            "choice",
+            choices=("dark", "light", "auto"),
             help="Color theme; auto follows the terminal background",
         ),
     )
@@ -188,12 +251,16 @@ def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:
         elif spec.kind == "string":
             # A non-empty string keeps as-is; anything else reverts to default
             # (None) so a null/garbage settings.json value disables the filter.
-            kwargs[spec.field] = value if isinstance(value, str) and value else spec.default
+            kwargs[spec.field] = (
+                value if isinstance(value, str) and value else spec.default
+            )
         else:  # choice
             if value not in spec.choices:
                 _logger.warning(
                     "settings.json: unsupported %s %r; using %r",
-                    spec.dotted, value, spec.default,
+                    spec.dotted,
+                    value,
+                    spec.default,
                 )
                 value = spec.default
             kwargs[spec.field] = value
@@ -242,7 +309,8 @@ def load_ui_settings(backup_root: Path) -> UiSettings:
     if theme not in SETTING_SPECS["ui.theme"].choices:
         _logger.warning(
             "settings.json: unsupported ui.theme %r; using %r",
-            theme, default.theme,
+            theme,
+            default.theme,
         )
         return default
     return UiSettings(theme=theme)
@@ -267,15 +335,18 @@ def setting_spec(dotted_key: str) -> SettingSpec:
     spec = SETTING_SPECS.get(dotted_key)
     if spec is None:
         raise ConfigError(
-            f"unknown setting '{dotted_key}'\n"
-            f"Valid keys: {', '.join(SETTING_SPECS)}"
+            f"unknown setting '{dotted_key}'\nValid keys: {', '.join(SETTING_SPECS)}"
         )
     return spec
 
 
 _BOOL_WORDS = {
-    "true": True, "1": True, "yes": True,
-    "false": False, "0": False, "no": False,
+    "true": True,
+    "1": True,
+    "yes": True,
+    "false": False,
+    "0": False,
+    "no": False,
 }
 
 
@@ -313,9 +384,7 @@ def parse_setting_value(spec: SettingSpec, raw_value: str):
         value = int(raw_value) if spec.kind == "int" else float(raw_value)
     except ValueError:
         noun = "an integer" if spec.kind == "int" else "a number"
-        raise ConfigError(
-            f"{spec.dotted} expects {noun}, got '{raw_value}'"
-        ) from None
+        raise ConfigError(f"{spec.dotted} expects {noun}, got '{raw_value}'") from None
     if not spec.lo <= value <= spec.hi:
         raise ConfigError(
             f"{spec.dotted} must be between {format_setting_value(spec.lo)} "
@@ -352,13 +421,11 @@ def _read_raw_for_write(path: Path) -> dict:
         raw = json.loads(text)
     except json.JSONDecodeError as e:
         raise ConfigError(
-            f"{path} is not valid JSON ({e}); fix or delete it before "
-            "changing settings"
+            f"{path} is not valid JSON ({e}); fix or delete it before changing settings"
         ) from e
     if not isinstance(raw, dict):
         raise ConfigError(
-            f"{path} is not a JSON object; fix or delete it before "
-            "changing settings"
+            f"{path} is not a JSON object; fix or delete it before changing settings"
         )
     return raw
 
@@ -421,8 +488,13 @@ def effective_settings(backup_root: Path) -> list[tuple[SettingSpec, object, boo
     return rows
 
 
-def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
-    """Overlay non-None CLI overrides (argparse Namespace) onto settings."""
+def cli_overrides(args) -> dict:
+    """Non-None ``cswap auto`` CLI-flag overrides, keyed by ``AutoSwitchSettings``
+    field name. Shared by ``merged_with_cli`` (startup) and the auto-loop's
+    settings.json hot-reload (``AutoSwitchEngine._maybe_reload_settings``), so a
+    flag passed at launch keeps winning over a later file edit exactly as it
+    does at startup.
+    """
     overrides = {}
     for attr, field in (
         ("threshold", "threshold"),
@@ -431,13 +503,30 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
         ("include_api_key_accounts", "include_api_key_accounts"),
         ("model", "model"),
         ("strategy", "strategy"),
+        ("grace_before_reset", "grace_before_reset_minutes"),
     ):
         value = getattr(args, attr, None)
         if value is not None:
             overrides[field] = value
+    return overrides
+
+
+def apply_overrides(
+    settings: AutoSwitchSettings, overrides: dict
+) -> AutoSwitchSettings:
+    """Replace fields in ``settings`` from ``overrides`` (field-name keyed),
+    re-clamped into range. The single place both CLI-arg merging and the
+    settings.json hot-reload path build a merged ``AutoSwitchSettings``, so
+    they can never apply overrides differently.
+    """
     if not overrides:
         return settings
     return _clamped(dataclasses.replace(settings, **overrides))
+
+
+def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
+    """Overlay non-None CLI overrides (argparse Namespace) onto settings."""
+    return apply_overrides(settings, cli_overrides(args))
 
 
 def atomic_write_json(path: Path, data: dict) -> None:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -21,6 +21,7 @@ from claude_swap.autoswitch import (
     NoSwitchEvent,
     PollEvent,
     QuarantineEvent,
+    SettingsReloadedEvent,
     SwitchEvent,
     TickOutcome,
     UnquarantineEvent,
@@ -29,7 +30,7 @@ from claude_swap.autoswitch import (
 from claude_swap.json_output import USAGE_FOREIGN_CREDENTIAL, USAGE_TOKEN_EXPIRED
 from claude_swap.usage_store import FetchRecord, UsageEntry
 from claude_swap.models import Platform
-from claude_swap.settings import AutoSwitchSettings
+from claude_swap.settings import AutoSwitchSettings, set_setting
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
@@ -49,6 +50,17 @@ def _usage(pct: float, resets_at: str | None = None) -> dict:
     if resets_at:
         window["resets_at"] = resets_at
     return {"five_hour": window, "seven_day": {"pct": 0.0}}
+
+
+def _reset_iso(now: float, seconds: float) -> str:
+    """An ISO8601 ``resets_at`` timestamp ``seconds`` after ``now``."""
+    from datetime import datetime, timezone
+
+    return (
+        datetime.fromtimestamp(now + seconds, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def _entry_for(value: dict | str | None, now: float) -> UsageEntry:
@@ -99,9 +111,14 @@ class EngineHarness:
         self.switcher._write_account_config(
             str(num),
             email,
-            json.dumps({
-                "oauthAccount": {"emailAddress": email, "accountUuid": f"uuid-{num}"},
-            }),
+            json.dumps(
+                {
+                    "oauthAccount": {
+                        "emailAddress": email,
+                        "accountUuid": f"uuid-{num}",
+                    },
+                }
+            ),
         )
         data = self.switcher._get_sequence_data()
         data["accounts"][str(num)] = {
@@ -119,12 +136,26 @@ class EngineHarness:
         self.switcher._write_json(self.switcher.sequence_file, data)
 
     def make_live(self, email: str, num: int) -> None:
-        (self.temp_home / ".claude" / ".credentials.json").write_text(json.dumps({
-            "claudeAiOauth": {"accessToken": "sk-live", "refreshToken": "rt-live"},
-        }))
-        (self.temp_home / ".claude.json").write_text(json.dumps({
-            "oauthAccount": {"emailAddress": email, "accountUuid": f"uuid-{num}"},
-        }))
+        (self.temp_home / ".claude" / ".credentials.json").write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-live",
+                        "refreshToken": "rt-live",
+                    },
+                }
+            )
+        )
+        (self.temp_home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "oauthAccount": {
+                        "emailAddress": email,
+                        "accountUuid": f"uuid-{num}",
+                    },
+                }
+            )
+        )
 
     def tick_with_usage(self, usage: dict) -> TickOutcome:
         entries = {
@@ -163,18 +194,26 @@ def harness(temp_home: Path) -> EngineHarness:
 
 class TestDecisionTable:
     def test_below_threshold_is_no_action(self, harness):
-        outcome = harness.tick_with_usage({
-            "1": _usage(50), "2": _usage(10), "3": _usage(10),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(50),
+                "2": _usage(10),
+                "3": _usage(10),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert harness.active_number() == 1
         reasons = [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)]
         assert reasons == ["below-threshold"]
 
     def test_over_threshold_switches_to_max_headroom(self, harness):
-        outcome = harness.tick_with_usage({
-            "1": _usage(95), "2": _usage(40), "3": _usage(20),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": _usage(40),
+                "3": _usage(20),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 3
         switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
@@ -195,9 +234,13 @@ class TestDecisionTable:
         # Failing the margin is NOT exhaustion: no all-exhausted event, no
         # reset-sleep — the next tick must stay at normal cadence so the
         # at-limit escape isn't missed when the active account tops out.
-        outcome = harness.tick_with_usage({
-            "1": _usage(95), "2": _usage(86), "3": _usage(88),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": _usage(86),
+                "3": _usage(88),
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         assert harness.active_number() == 1
         assert not any(isinstance(e, AllExhaustedEvent) for e in harness.events)
@@ -211,11 +254,13 @@ class TestDecisionTable:
         # Regression for #115: active bound by 5h (99%), candidate bound by
         # 7d (89%). The old absolute bar (<= 80% used) vetoed the candidate;
         # the relative gate takes it: 89 < 90 and 99 - 89 >= 10.
-        outcome = harness.tick_with_usage({
-            "1": {"five_hour": {"pct": 99.0}, "seven_day": {"pct": 24.0}},
-            "2": {"five_hour": {"pct": 3.0}, "seven_day": {"pct": 89.0}},
-            "3": {"five_hour": {"pct": 95.0}, "seven_day": {"pct": 10.0}},
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": {"five_hour": {"pct": 99.0}, "seven_day": {"pct": 24.0}},
+                "2": {"five_hour": {"pct": 3.0}, "seven_day": {"pct": 89.0}},
+                "3": {"five_hour": {"pct": 95.0}, "seven_day": {"pct": 10.0}},
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
         assert switch.trigger == "proactive"
@@ -258,11 +303,13 @@ class TestDecisionTable:
     def test_mixed_unknown_and_exhausted_is_not_all_exhausted(self, harness):
         # One candidate at its limit, the other unreadable this tick: usage
         # could recover any moment, so no long reset-sleep.
-        outcome = harness.tick_with_usage({
-            "1": _usage(95),
-            "2": _usage(100, "2026-07-03T12:00:00Z"),
-            "3": None,
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": _usage(100, "2026-07-03T12:00:00Z"),
+                "3": None,
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         assert not any(isinstance(e, AllExhaustedEvent) for e in harness.events)
         reasons = [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)]
@@ -277,14 +324,21 @@ class TestDecisionTable:
         # unknown candidate could be viable, so no long reset-sleep.
         now = harness.clock.now
         reset = "2026-07-05T12:00:00Z"
-        outcome = harness.tick_with_entries({
-            "1": UsageEntry(last_good=_usage(95), fetched_at=now, age_s=0.0),
-            "2": UsageEntry(
-                last_good=_usage(100, reset), fetched_at=now - 400, age_s=400.0,
-                consecutive_failures=1, trust_extended=True,
-            ),
-            "3": UsageEntry(last_good=_usage(10), fetched_at=now - 400, age_s=400.0),
-        })
+        outcome = harness.tick_with_entries(
+            {
+                "1": UsageEntry(last_good=_usage(95), fetched_at=now, age_s=0.0),
+                "2": UsageEntry(
+                    last_good=_usage(100, reset),
+                    fetched_at=now - 400,
+                    age_s=400.0,
+                    consecutive_failures=1,
+                    trust_extended=True,
+                ),
+                "3": UsageEntry(
+                    last_good=_usage(10), fetched_at=now - 400, age_s=400.0
+                ),
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         assert not any(isinstance(e, AllExhaustedEvent) for e in harness.events)
         reasons = [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)]
@@ -296,27 +350,34 @@ class TestDecisionTable:
         now = harness.clock.now
         reset = "2026-07-05T12:00:00Z"
         stale_exhausted = UsageEntry(
-            last_good=_usage(100, reset), fetched_at=now - 400, age_s=400.0,
-            consecutive_failures=1, trust_extended=True,
+            last_good=_usage(100, reset),
+            fetched_at=now - 400,
+            age_s=400.0,
+            consecutive_failures=1,
+            trust_extended=True,
         )
-        outcome = harness.tick_with_entries({
-            "1": UsageEntry(last_good=_usage(95), fetched_at=now, age_s=0.0),
-            "2": stale_exhausted,
-            "3": stale_exhausted,
-        })
+        outcome = harness.tick_with_entries(
+            {
+                "1": UsageEntry(last_good=_usage(95), fetched_at=now, age_s=0.0),
+                "2": stale_exhausted,
+                "3": stale_exhausted,
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
-        exhausted = next(
-            e for e in harness.events if isinstance(e, AllExhaustedEvent)
-        )
+        exhausted = next(e for e in harness.events if isinstance(e, AllExhaustedEvent))
         assert exhausted.earliest_reset_at == reset
 
     def test_cooldown_suppresses_proactive(self, harness):
         harness.engine._mutate_state(
             lambda s: s.update(lastSwitchAt=harness.clock() - 10)
         )
-        outcome = harness.tick_with_usage({
-            "1": _usage(95), "2": _usage(10), "3": _usage(10),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": _usage(10),
+                "3": _usage(10),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)] == [
             "cooldown"
@@ -326,22 +387,28 @@ class TestDecisionTable:
         harness.engine._mutate_state(
             lambda s: s.update(lastSwitchAt=harness.clock() - 10)
         )
-        outcome = harness.tick_with_usage({
-            "1": _usage(100), "2": _usage(10), "3": _usage(50),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(100),
+                "2": _usage(10),
+                "3": _usage(50),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
         assert switch.trigger == "at-limit"
         assert harness.active_number() == 2
 
     def test_cooldown_expires(self, harness):
-        harness.engine._mutate_state(
-            lambda s: s.update(lastSwitchAt=harness.clock())
-        )
+        harness.engine._mutate_state(lambda s: s.update(lastSwitchAt=harness.clock()))
         harness.clock.advance(400)  # past the 300s default cooldown
-        outcome = harness.tick_with_usage({
-            "1": _usage(95), "2": _usage(10), "3": _usage(50),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": _usage(10),
+                "3": _usage(50),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
 
     def test_unknown_active_usage_waits_then_fails_over(self, harness):
@@ -363,26 +430,38 @@ class TestDecisionTable:
         assert harness.active_number() == 1
 
     def test_all_candidates_unknown_is_no_comparison(self, harness):
-        outcome = harness.tick_with_usage({
-            "1": _usage(95), "2": None, "3": None,
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": None,
+                "3": None,
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         assert [e.reason for e in harness.events if isinstance(e, NoSwitchEvent)] == [
             "no-comparison"
         ]
 
     def test_tie_resolves_to_earliest_slot(self, harness):
-        outcome = harness.tick_with_usage({
-            "1": _usage(95), "2": _usage(30), "3": _usage(30),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": _usage(30),
+                "3": _usage(30),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 2
 
     def test_candidate_not_better_than_active_is_skipped(self, harness):
         # Active 91% used (9 headroom); candidates worse or equal → exhausted.
-        outcome = harness.tick_with_usage({
-            "1": _usage(91), "2": _usage(95), "3": _usage(99),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(91),
+                "2": _usage(95),
+                "3": _usage(99),
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         assert harness.active_number() == 1
 
@@ -390,18 +469,26 @@ class TestDecisionTable:
         # Active hard at 100%; the only room anywhere is a candidate at 85%,
         # which the proactive hysteresis bar (<=80%) would reject. At-limit is
         # an escape: any account with real headroom beats a blocked one.
-        outcome = harness.tick_with_usage({
-            "1": _usage(100), "2": _usage(85), "3": _usage(97),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(100),
+                "2": _usage(85),
+                "3": _usage(97),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
         assert switch.trigger == "at-limit"
         assert harness.active_number() == 2
 
     def test_at_limit_never_targets_another_at_limit_account(self, harness):
-        outcome = harness.tick_with_usage({
-            "1": _usage(100), "2": _usage(100), "3": _usage(100),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(100),
+                "2": _usage(100),
+                "3": _usage(100),
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         assert harness.active_number() == 1
 
@@ -431,11 +518,13 @@ class TestDecisionTable:
         assert (temp_home / ".claude" / ".credentials.json").read_text() == live_before
 
     def test_all_exhausted_carries_earliest_reset(self, harness):
-        outcome = harness.tick_with_usage({
-            "1": _usage(100, "2026-07-03T12:00:00Z"),
-            "2": _usage(100, "2026-07-03T10:30:00Z"),
-            "3": _usage(100, "2026-07-03T11:00:00Z"),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(100, "2026-07-03T12:00:00Z"),
+                "2": _usage(100, "2026-07-03T10:30:00Z"),
+                "3": _usage(100, "2026-07-03T11:00:00Z"),
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         event = next(e for e in harness.events if isinstance(e, AllExhaustedEvent))
         assert event.earliest_reset_at == "2026-07-03T10:30:00Z"
@@ -450,11 +539,13 @@ class TestDecisionTable:
             .isoformat()
             .replace("+00:00", "Z")
         )
-        outcome = harness.tick_with_usage({
-            "1": _usage(100, reset),
-            "2": _usage(100, reset),
-            "3": _usage(100, reset),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(100, reset),
+                "2": _usage(100, reset),
+                "3": _usage(100, reset),
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         event = next(e for e in harness.events if isinstance(e, AllExhaustedEvent))
         assert event.earliest_reset_at is None
@@ -513,15 +604,15 @@ class TestIdleHold:
         assert harness.engine._unhealthy_ticks == 1
         assert harness.engine._idle_hold_since is None
 
-    def test_foreign_credential_sentinel_fails_over_instead_of_holding(
-        self, harness
-    ):
+    def test_foreign_credential_sentinel_fails_over_instead_of_holding(self, harness):
         """The foreign sentinel (live credential proven to be another
         account's) must NOT idle-hold like TOKEN_EXPIRED: holding preserves
         the drift, while the failover switch stashes the foreign credential
         and restores the slot's backup — the switch IS the repair."""
         foreign = {
-            "1": USAGE_FOREIGN_CREDENTIAL, "2": _usage(10), "3": _usage(20),
+            "1": USAGE_FOREIGN_CREDENTIAL,
+            "2": _usage(10),
+            "3": _usage(20),
         }
         assert harness.tick_with_usage(foreign) is TickOutcome.NO_ACTION
         assert harness.tick_with_usage(foreign) is TickOutcome.NO_ACTION
@@ -541,9 +632,7 @@ class TestAdaptiveScheduler:
         backup probe the profile oracle before resyncing — unpatched, a real
         HTTP call. "Probe failed" (resync skipped) is inert for scheduler
         behavior."""
-        with patch(
-            "claude_swap.oauth.fetch_oauth_profile", return_value=None
-        ):
+        with patch("claude_swap.oauth.fetch_oauth_profile", return_value=None):
             yield
 
     def _harness(self, temp_home, monkeypatch, accounts=3, **settings_kwargs):
@@ -565,6 +654,7 @@ class TestAdaptiveScheduler:
                 return oauth.UsageOutcome(None, error=error)
             value = usage_by_num.get(num)
             return oauth.UsageOutcome(dict(value) if value else None)
+
         return fake
 
     def _tick(self, h, counts, usage_by_num, errors_by_num=None):
@@ -609,7 +699,8 @@ class TestAdaptiveScheduler:
         h = self._harness(temp_home, monkeypatch, unhealthy_ticks=1)
         counts: dict[str, int] = {}
         outcome = self._tick(
-            h, counts,
+            h,
+            counts,
             {"2": _usage(10), "3": _usage(50)},
             errors_by_num={"1": "timeout"},
         )
@@ -690,9 +781,7 @@ class TestAdaptiveScheduler:
         self._tick(h, counts, usage)  # urgent plan due after only 60s
         assert counts["1"] == 3
 
-    def test_stale_candidate_plan_never_gates_the_active(
-        self, temp_home, monkeypatch
-    ):
+    def test_stale_candidate_plan_never_gates_the_active(self, temp_home, monkeypatch):
         # Role change outside a cswap switch (e.g. manual login): the active
         # slot can carry a plan written while it was an idle candidate, up to
         # 600s out. The ACTIVE_MAX_INTERVAL_S age cap overrides it.
@@ -753,15 +842,11 @@ class TestAdaptiveScheduler:
         h.clock.advance(400)
         self._tick(h, counts, usage)
         assert counts["1"] == 2
-        entry = h.switcher._usage_store.entries(
-            {"1": ("a@example.com", "")}
-        )["1"]
+        entry = h.switcher._usage_store.entries({"1": ("a@example.com", "")})["1"]
         assert entry.next_poll_at is not None
         assert entry.next_poll_at < reset_ts
 
-    def test_band_jump_is_seen_at_most_one_poll_late(
-        self, temp_home, monkeypatch
-    ):
+    def test_band_jump_is_seen_at_most_one_poll_late(self, temp_home, monkeypatch):
         # Active at 40% jumps into the band between polls: the jump is picked
         # up on the next planned poll, escalates the same tick, and the
         # movement flips the active onto the urgent cadence.
@@ -836,9 +921,7 @@ class TestAdaptiveScheduler:
             self._tick(h, counts, usage)
             h.clock.advance(60)
         assert counts["2"] == 1
-        entry = h.switcher._usage_store.entries(
-            {"2": ("b@example.com", "")}
-        )["2"]
+        entry = h.switcher._usage_store.entries({"2": ("b@example.com", "")})["2"]
         assert entry.poll_interval_s == poll_policy.EXHAUSTED_INTERVAL_S
         assert entry.next_poll_at is not None
         assert entry.next_poll_at <= (
@@ -864,9 +947,7 @@ class TestAdaptiveScheduler:
         usage = {"1": _usage(50), "2": _usage(40, reset_iso)}
         counts: dict[str, int] = {}
         self._tick(h, counts, usage)
-        entry = h.switcher._usage_store.entries(
-            {"2": ("b@example.com", "")}
-        )["2"]
+        entry = h.switcher._usage_store.entries({"2": ("b@example.com", "")})["2"]
         assert entry.next_poll_at == pytest.approx(reset_ts + RESET_SLACK_S)
         # Learned cadence untouched by the clamp.
         assert entry.poll_interval_s == poll_policy.CANDIDATE_DEFAULT_INTERVAL_S
@@ -877,24 +958,24 @@ class TestAdaptiveScheduler:
         counts: dict[str, int] = {}
 
         def interval() -> float | None:
-            return h.switcher._usage_store.entries(
-                {"2": ("b@example.com", "")}
-            )["2"].poll_interval_s
+            return h.switcher._usage_store.entries({"2": ("b@example.com", "")})[
+                "2"
+            ].poll_interval_s
 
-        self._tick(h, counts, usage)          # first data point → base interval
+        self._tick(h, counts, usage)  # first data point → base interval
         assert interval() == poll_policy.CANDIDATE_DEFAULT_INTERVAL_S  # 300s
         h.clock.advance(180)
-        self._tick(h, counts, usage)          # not due yet (300s interval)
+        self._tick(h, counts, usage)  # not due yet (300s interval)
         assert counts["2"] == 1
         h.clock.advance(120)
-        self._tick(h, counts, usage)          # unmoved → backs off ×1.5
+        self._tick(h, counts, usage)  # unmoved → backs off ×1.5
         assert counts["2"] == 2
         assert interval() == 450.0
         h.clock.advance(450)
-        usage["2"] = _usage(20)               # moved 10 pts on another machine
+        usage["2"] = _usage(20)  # moved 10 pts on another machine
         self._tick(h, counts, usage)
         assert counts["2"] == 3
-        assert interval() == 225.0            # halved: polled closer while moving
+        assert interval() == 225.0  # halved: polled closer while moving
 
     def test_idle_hold_skips_candidate_polling(self, temp_home, monkeypatch):
         h = self._harness(temp_home, monkeypatch)
@@ -903,12 +984,17 @@ class TestAdaptiveScheduler:
         # (network down), the row enters a failure backoff and subsequent
         # ticks surface the expired sentinel statically → idle-hold, with no
         # candidate slot spent.
-        (h.temp_home / ".claude" / ".credentials.json").write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "sk-live", "refreshToken": "rt-live",
-                "expiresAt": 1000,
-            },
-        }))
+        (h.temp_home / ".claude" / ".credentials.json").write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-live",
+                        "refreshToken": "rt-live",
+                        "expiresAt": 1000,
+                    },
+                }
+            )
+        )
         # The slot backup must be expired too — a non-expired backup would be
         # restored without any POST (no failure, no backoff, no hold).
         h.seed(1, "a@example.com", expires_at=1000)
@@ -932,9 +1018,7 @@ class TestAdaptiveScheduler:
     def test_poll_event_carries_fetch_errors(self, temp_home, monkeypatch):
         h = self._harness(temp_home, monkeypatch, accounts=2, unhealthy_ticks=3)
         counts: dict[str, int] = {}
-        self._tick(
-            h, counts, {"2": _usage(10)}, errors_by_num={"1": "http-429"}
-        )
+        self._tick(h, counts, {"2": _usage(10)}, errors_by_num={"1": "http-429"})
         poll = next(e for e in h.events if isinstance(e, PollEvent))
         assert poll.fetch_errors.get("1") == "http-429"
         assert "http-429" in poll.human()
@@ -964,12 +1048,17 @@ class TestAdaptiveScheduler:
 
         h = self._harness(temp_home, monkeypatch)
         # Active token locally expired while an owner is present.
-        (h.temp_home / ".claude" / ".credentials.json").write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "sk-live", "refreshToken": "rt-live",
-                "expiresAt": 1000,
-            },
-        }))
+        (h.temp_home / ".claude" / ".credentials.json").write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-live",
+                        "refreshToken": "rt-live",
+                        "expiresAt": 1000,
+                    },
+                }
+            )
+        )
         # Active row sits in a long failure backoff → the fetch path (and its
         # own expired short-circuit) is unreachable this tick.
         h.switcher._usage_store.record(
@@ -1034,9 +1123,9 @@ class TestAdaptiveScheduler:
             "2": _usage7(10, 10, _R_LATER),
             "3": _usage7(10, 10, _R_LATEST),
         }
-        self._tick(h, counts, view_a)          # t0: fetches 1, 2
+        self._tick(h, counts, view_a)  # t0: fetches 1, 2
         h.clock.advance(60)
-        self._tick(h, counts, view_a)          # t60: fetches 3
+        self._tick(h, counts, view_a)  # t60: fetches 3
         assert counts == {"1": 1, "2": 1, "3": 1}
         # #2 enters a Retry-After backoff; its stored entry ages past the
         # serve TTL (180s) while staying inside decision trust (300s).
@@ -1044,7 +1133,7 @@ class TestAdaptiveScheduler:
             {"2": FetchRecord(error="http-429", retry_after_s=600.0)},
             {"2": ("b@example.com", "")},
         )
-        h.clock.advance(181)                   # t241
+        h.clock.advance(181)  # t241
         h.events.clear()
         # The active refetch now reports the LATEST reset, so stored #2
         # (age 241: decision-trusted, no longer fresh) is the provisional
@@ -1094,9 +1183,13 @@ class TestApiKeyAccounts:
         h.make_live("a@example.com", 1)
         self._mark_api_key(h, 2)
         # A qualifying OAuth candidate wins over the API key...
-        outcome = h.tick_with_usage({
-            "1": _usage(95), "2": "api key", "3": _usage(10),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": "api key",
+                "3": _usage(10),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 3
 
@@ -1107,9 +1200,13 @@ class TestApiKeyAccounts:
         h.seed(3, "c@example.com")
         h.make_live("a@example.com", 1)
         self._mark_api_key(h, 2)
-        outcome = h.tick_with_usage({
-            "1": _usage(100), "2": "api key", "3": _usage(100),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage(100),
+                "2": "api key",
+                "3": _usage(100),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
 
@@ -1133,13 +1230,15 @@ class TestFreshening:
         h.seed(2, "b@example.com", expires_at=int(h.clock() * 1000) + 60_000)
         h.make_live("a@example.com", 1)
 
-        rotated = json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "sk-2-new",
-                "refreshToken": "rt-2-new",
-                "expiresAt": int(h.clock() * 1000) + 3_600_000,
+        rotated = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-2-new",
+                    "refreshToken": "rt-2-new",
+                    "expiresAt": int(h.clock() * 1000) + 3_600_000,
+                }
             }
-        })
+        )
         live_creds_path = temp_home / ".claude" / ".credentials.json"
         live_before = live_creds_path.read_text()
         with patch(
@@ -1178,9 +1277,13 @@ class TestFreshening:
             "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
             return_value=oauth.RefreshOutcome(None, "invalid_grant"),
         ):
-            outcome = h.tick_with_usage({
-                "1": _usage(95), "2": _usage(10), "3": _usage(20),
-            })
+            outcome = h.tick_with_usage(
+                {
+                    "1": _usage(95),
+                    "2": _usage(10),
+                    "3": _usage(20),
+                }
+            )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 3  # next candidate after 2 was quarantined
         q = next(e for e in h.events if isinstance(e, QuarantineEvent))
@@ -1209,11 +1312,12 @@ class TestFreshening:
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com", expires_at=int(h.clock() * 1000) + 3_600_000)
         h.make_live("a@example.com", 1)
-        with patch.object(
-            h.switcher, "live_session_pids_for", return_value=[4242]
-        ), patch(
-            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials"
-        ) as mock_refresh:
+        with (
+            patch.object(h.switcher, "live_session_pids_for", return_value=[4242]),
+            patch(
+                "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials"
+            ) as mock_refresh,
+        ):
             outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
         assert outcome is TickOutcome.BLOCKED
         mock_refresh.assert_not_called()
@@ -1224,11 +1328,12 @@ class TestFreshening:
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com", expires_at=1)  # long expired
         h.make_live("a@example.com", 1)
-        with patch.object(
-            h.switcher, "live_session_pids_for", return_value=[4242]
-        ), patch(
-            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials"
-        ) as mock_refresh:
+        with (
+            patch.object(h.switcher, "live_session_pids_for", return_value=[4242]),
+            patch(
+                "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials"
+            ) as mock_refresh,
+        ):
             outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
         assert outcome is TickOutcome.BLOCKED
         mock_refresh.assert_not_called()
@@ -1260,14 +1365,20 @@ class TestQuarantineLifecycle:
         harness.switcher._write_account_credentials(
             "2",
             "b@example.com",
-            json.dumps({
-                "claudeAiOauth": {"accessToken": "sk-2b", "refreshToken": "rt-2b"},
-            }),
+            json.dumps(
+                {
+                    "claudeAiOauth": {"accessToken": "sk-2b", "refreshToken": "rt-2b"},
+                }
+            ),
         )
         harness.events.clear()
-        outcome = harness.tick_with_usage({
-            "1": _usage(95), "2": _usage(0), "3": _usage(50),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95),
+                "2": _usage(0),
+                "3": _usage(50),
+            }
+        )
         assert any(isinstance(e, UnquarantineEvent) for e in harness.events)
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 2
@@ -1278,8 +1389,14 @@ class TestQuarantineLifecycle:
         # RMW under the state lock must preserve its quarantine entry.
         harness.engine._mutate_state(
             lambda s: s.setdefault("quarantine", {}).update(
-                {"3": {"email": "c@example.com", "reason": "invalid_grant",
-                       "at": "x", "refreshTokenFingerprint": None}}
+                {
+                    "3": {
+                        "email": "c@example.com",
+                        "reason": "invalid_grant",
+                        "at": "x",
+                        "refreshTokenFingerprint": None,
+                    }
+                }
             )
         )
         harness.engine._mutate_state(lambda s: s.update(lastSwitchAt=123.0))
@@ -1324,7 +1441,9 @@ class TestDryRunAndNoOp:
 
         assert outcome is TickOutcome.SWITCHED  # reported the would-switch
         mock_refresh.assert_not_called()
-        assert h.switcher.read_account_credentials("2", "b@example.com") == backup_before
+        assert (
+            h.switcher.read_account_credentials("2", "b@example.com") == backup_before
+        )
         assert h.state() == {}  # no quarantine, no lastSwitchAt
 
     def test_dry_run_does_not_release_quarantines(self, temp_home):
@@ -1335,7 +1454,8 @@ class TestDryRunAndNoOp:
         h.engine._quarantine("2", "b@example.com", "invalid_grant")
         # Replace the credential — a real tick would lift the quarantine.
         h.switcher._write_account_credentials(
-            "2", "b@example.com",
+            "2",
+            "b@example.com",
             json.dumps({"claudeAiOauth": {"accessToken": "n", "refreshToken": "n"}}),
         )
         h.events.clear()
@@ -1355,9 +1475,13 @@ class TestDryRunAndNoOp:
             "switch_to",
             return_value={"switched": False, "reason": "already-active"},
         ):
-            outcome = harness.tick_with_usage({
-                "1": _usage(95), "2": _usage(10), "3": _usage(50),
-            })
+            outcome = harness.tick_with_usage(
+                {
+                    "1": _usage(95),
+                    "2": _usage(10),
+                    "3": _usage(50),
+                }
+            )
         assert outcome is TickOutcome.NO_ACTION
         assert "lastSwitchAt" not in harness.state()
 
@@ -1419,7 +1543,9 @@ class TestEventsShape:
         poll = next(e for e in modeled.events if isinstance(e, PollEvent))
         assert "#2: 5h 3% · 7d 89% · Fable 21%" in poll.human()
         assert poll.to_json()["windowsPct"]["2"] == {
-            "5h": 3.0, "7d": 89.0, "Fable": 21.0,
+            "5h": 3.0,
+            "7d": 89.0,
+            "Fable": 21.0,
         }
 
 
@@ -1433,8 +1559,10 @@ class TestRunLoop:
                 harness.engine.stop()
             return TickOutcome.NO_ACTION
 
-        with patch.object(harness.engine, "tick", side_effect=fake_tick), \
-             patch.object(harness.engine._wake, "wait", return_value=None):
+        with (
+            patch.object(harness.engine, "tick", side_effect=fake_tick),
+            patch.object(harness.engine._wake, "wait", return_value=None),
+        ):
             assert harness.engine.run_loop() == 0
         assert len(ticks) == 2
 
@@ -1448,9 +1576,10 @@ class TestRunLoop:
             harness.engine.stop()
             return TickOutcome.NO_ACTION
 
-        with patch.object(
-            harness.engine, "_tick_inner", side_effect=raising_inner
-        ), patch.object(harness.engine._wake, "wait", return_value=None):
+        with (
+            patch.object(harness.engine, "_tick_inner", side_effect=raising_inner),
+            patch.object(harness.engine._wake, "wait", return_value=None),
+        ):
             harness.engine.run_loop()
         assert len(calls) == 2
         assert any(isinstance(e, ErrorEvent) for e in harness.events)
@@ -1534,9 +1663,7 @@ class TestLoopObeysThePollPlan:
 
         def patched(fetch=frozenset(), **kw):
             entries = dict(real(fetch=fetch, **kw))
-            entries[num] = replace(
-                entries[num], next_poll_at=harness.clock() + due_in
-            )
+            entries[num] = replace(entries[num], next_poll_at=harness.clock() + due_in)
             return entries
 
         harness.engine.switcher.usage_entries_by_account = patched
@@ -1588,9 +1715,13 @@ class TestSessionThreshold:
         assert harness.switcher._poll_inputs_override == (72.0, ())
         # And the very next tick decides with it: 80% ≥ 72 switches, where
         # the constructed 90 would not have.
-        outcome = harness.tick_with_usage({
-            "1": _usage(80), "2": _usage(10), "3": _usage(10),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(80),
+                "2": _usage(10),
+                "3": _usage(10),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
 
     def test_clear_poll_policy_inputs_unpins(self, harness):
@@ -1616,6 +1747,170 @@ class TestSessionThreshold:
         assert {"1", "2", "3"} in self._collect_fetch_sets(harness, 90.0)
         # ...but not of 99.9 → baseline fetching only.
         assert {"1", "2", "3"} not in self._collect_fetch_sets(harness, 99.9)
+
+
+class TestResetGrace:
+    """grace_before_reset_minutes: ride an about-to-reset account to ~100%
+    instead of proactively switching away from it."""
+
+    def test_disabled_by_default_switches_normally(self, harness):
+        # grace_before_reset_minutes defaults to 0 — an imminent reset must
+        # not change baseline behavior at all.
+        reset = _reset_iso(harness.clock.now, 120.0)  # 2 minutes away
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(95, reset),
+                "2": _usage(10),
+                "3": _usage(10),
+            }
+        )
+        assert outcome is TickOutcome.SWITCHED
+        assert harness.active_number() != 1
+
+    def test_suppresses_proactive_switch_when_reset_imminent(self, temp_home):
+        h = EngineHarness(temp_home, grace_before_reset_minutes=10.0)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        reset = _reset_iso(h.clock.now, 300.0)  # 5 minutes — inside the 10m grace
+        outcome = h.tick_with_usage({"1": _usage(95, reset), "2": _usage(10)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["reset-imminent"]
+
+    def test_does_not_suppress_when_reset_beyond_grace(self, temp_home):
+        h = EngineHarness(temp_home, grace_before_reset_minutes=5.0)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        reset = _reset_iso(h.clock.now, 1200.0)  # 20 minutes — beyond the 5m grace
+        outcome = h.tick_with_usage({"1": _usage(95, reset), "2": _usage(10)})
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_never_suppresses_at_limit(self, temp_home):
+        # Already at the hard cap: moving is strictly an improvement, grace
+        # only ever applies to the proactive (not-yet-blocked) trigger.
+        h = EngineHarness(temp_home, grace_before_reset_minutes=1440.0)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        reset = _reset_iso(h.clock.now, 60.0)
+        outcome = h.tick_with_usage({"1": _usage(100, reset), "2": _usage(10)})
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_unknown_reset_does_not_suppress(self, temp_home):
+        # No resets_at on the binding window — the moment can't be proven
+        # imminent, so grace must not block a switch that would otherwise fire.
+        h = EngineHarness(temp_home, grace_before_reset_minutes=1440.0)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        outcome = h.tick_with_usage({"1": _usage(95), "2": _usage(10)})
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_high_grace_lets_the_weekly_window_still_switch(self, temp_home):
+        # A grace long enough to cover the whole 5h window (e.g. 360m) must
+        # not blind the engine to a 7d window resetting days away — grace
+        # only suppresses when the reset genuinely falls inside the window.
+        h = EngineHarness(temp_home, grace_before_reset_minutes=360.0)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        far_reset = _reset_iso(h.clock.now, 3 * 24 * 3600.0)  # 3 days away
+        outcome = h.tick_with_usage(
+            {
+                "1": {
+                    "five_hour": {"pct": 0.0},
+                    "seven_day": {"pct": 95.0, "resets_at": far_reset},
+                },
+                "2": _usage(10),
+            }
+        )
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+
+class TestSettingsHotReload:
+    """_maybe_reload_settings(): a running `cswap auto` loop picking up
+    settings.json edits made by another process without restarting."""
+
+    def test_reloads_changed_value_and_emits_event(self, harness):
+        assert harness.engine.settings.threshold == 90.0
+        set_setting(harness.switcher.backup_dir, "autoswitch.threshold", "77")
+        harness.engine._maybe_reload_settings()
+        assert harness.engine.settings.threshold == 77.0
+        events = [e for e in harness.events if isinstance(e, SettingsReloadedEvent)]
+        assert len(events) == 1
+        assert "threshold" in events[0].changed
+
+    def test_noop_when_file_unchanged(self, harness):
+        # No settings.json write at all: mtime stays None -> None, never
+        # "changed", so this must not spin up a reload every tick.
+        settings_before = harness.engine.settings
+        harness.engine._maybe_reload_settings()
+        assert harness.engine.settings is settings_before
+        assert not any(isinstance(e, SettingsReloadedEvent) for e in harness.events)
+
+    def test_cli_override_wins_over_file_value_on_reload(self, harness):
+        engine = harness._make_engine(cli_overrides={"threshold": 95.0})
+        set_setting(harness.switcher.backup_dir, "autoswitch.threshold", "50")
+        set_setting(harness.switcher.backup_dir, "autoswitch.cooldownSeconds", "10")
+        engine._maybe_reload_settings()
+        # The CLI flag keeps winning over the file, exactly as at startup...
+        assert engine.settings.threshold == 95.0
+        # ...but a field with no CLI override still picks up the file edit.
+        assert engine.settings.cooldown_seconds == 10.0
+
+    def test_model_axis_pinned_across_reload(self, harness):
+        assert harness.engine._models == ()
+        set_setting(harness.switcher.backup_dir, "autoswitch.model", "Fable")
+        harness.engine._maybe_reload_settings()
+        # A live file edit to the model axis must never desync self._models
+        # from self.settings.model — it stays fixed at construction.
+        assert harness.engine.settings.model is None
+        assert harness.engine._models == ()
+
+    def test_apply_settings_updates_poll_policy_pin(self, harness):
+        new_settings = replace(harness.engine.settings, threshold=65.0)
+        harness.engine.apply_settings(new_settings)
+        assert harness.engine.settings.threshold == 65.0
+        assert harness.switcher._poll_inputs_override == (65.0, ())
+
+    def test_run_loop_reloads_only_when_watching(self, harness):
+        set_setting(harness.switcher.backup_dir, "autoswitch.threshold", "77")
+        harness.engine._watch_settings = True
+
+        def fake_tick():
+            # By the time tick() runs, the reload (which happens earlier in
+            # the loop body) must already have landed.
+            harness.engine.stop()
+            return TickOutcome.NO_ACTION
+
+        with (
+            patch.object(harness.engine, "tick", side_effect=fake_tick),
+            patch.object(harness.engine._wake, "wait", return_value=None),
+        ):
+            harness.engine.run_loop()
+        assert harness.engine.settings.threshold == 77.0
+
+    def test_run_loop_does_not_reload_when_not_watching(self, harness):
+        set_setting(harness.switcher.backup_dir, "autoswitch.threshold", "77")
+        harness.engine._watch_settings = False
+
+        def fake_tick():
+            harness.engine.stop()
+            return TickOutcome.NO_ACTION
+
+        with (
+            patch.object(harness.engine, "tick", side_effect=fake_tick),
+            patch.object(harness.engine._wake, "wait", return_value=None),
+        ):
+            harness.engine.run_loop()
+        assert harness.engine.settings.threshold == 90.0
 
 
 class TestPctLabel:
@@ -1649,14 +1944,10 @@ class TestPctLabel:
         h.seed(2, "b@example.com")
         h.make_live("a@example.com", 1)
         h.tick_with_usage({"1": _usage(50), "2": _usage(10)})
-        details = [
-            e.detail for e in h.events if isinstance(e, NoSwitchEvent)
-        ]
+        details = [e.detail for e in h.events if isinstance(e, NoSwitchEvent)]
         assert details == ["50% < 99.9%"]
 
-    def test_below_threshold_detail_never_shows_impossible_comparison(
-        self, temp_home
-    ):
+    def test_below_threshold_detail_never_shows_impossible_comparison(self, temp_home):
         # utilization 99.85 with threshold 99.9: .0f on the left side used
         # to render the logically impossible "100% < 99.9%".
         h = EngineHarness(temp_home, threshold=99.9)
@@ -1664,9 +1955,7 @@ class TestPctLabel:
         h.seed(2, "b@example.com")
         h.make_live("a@example.com", 1)
         h.tick_with_usage({"1": _usage(99.85), "2": _usage(10)})
-        details = [
-            e.detail for e in h.events if isinstance(e, NoSwitchEvent)
-        ]
+        details = [e.detail for e in h.events if isinstance(e, NoSwitchEvent)]
         assert details == ["99.85% < 99.9%"]
 
 
@@ -1681,21 +1970,37 @@ class TestTokenIdentity:
         harness.switcher._write_json(harness.switcher.sequence_file, data)
         # Slot 2 near expiry → freshen path runs.
         harness.switcher._write_account_credentials(
-            "2", "b@example.com",
-            json.dumps({"claudeAiOauth": {
-                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
-            }}),
+            "2",
+            "b@example.com",
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-2",
+                        "refreshToken": "rt-2",
+                        "expiresAt": 0,
+                    }
+                }
+            ),
         )
-        fresh = json.dumps({"claudeAiOauth": {
-            "accessToken": "sk-2f", "refreshToken": "rt-2f",
-            "expiresAt": 99_999_999_999_000,
-        }})
+        fresh = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-2f",
+                    "refreshToken": "rt-2f",
+                    "expiresAt": 99_999_999_999_000,
+                }
+            }
+        )
         with patch(
             "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
             return_value=oauth.RefreshOutcome(
-                fresh, None,
-                {"uuid": "uuid-2-real", "email": "b@example.com",
-                 "organizationUuid": ""},
+                fresh,
+                None,
+                {
+                    "uuid": "uuid-2-real",
+                    "email": "b@example.com",
+                    "organizationUuid": "",
+                },
             ),
         ):
             status = harness.engine._freshen_target("2", "b@example.com")
@@ -1709,51 +2014,81 @@ class TestTokenIdentity:
         a viable target — but the rotated generation is still persisted (the
         grant consumed its predecessor)."""
         harness.switcher._write_account_credentials(
-            "2", "b@example.com",
-            json.dumps({"claudeAiOauth": {
-                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
-            }}),
+            "2",
+            "b@example.com",
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-2",
+                        "refreshToken": "rt-2",
+                        "expiresAt": 0,
+                    }
+                }
+            ),
         )
-        fresh = json.dumps({"claudeAiOauth": {
-            "accessToken": "sk-2f", "refreshToken": "rt-2f",
-            "expiresAt": 99_999_999_999_000,
-        }})
+        fresh = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-2f",
+                    "refreshToken": "rt-2f",
+                    "expiresAt": 99_999_999_999_000,
+                }
+            }
+        )
         with patch(
             "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
             return_value=oauth.RefreshOutcome(
-                fresh, None,
-                {"uuid": "uuid-somebody-else", "email": "z@example.com",
-                 "organizationUuid": ""},
+                fresh,
+                None,
+                {
+                    "uuid": "uuid-somebody-else",
+                    "email": "z@example.com",
+                    "organizationUuid": "",
+                },
             ),
         ):
             status = harness.engine._freshen_target("2", "b@example.com")
         assert status == "identity-conflict"
         # The consumed generation's successor was persisted regardless.
-        assert harness.switcher.read_account_credentials(
-            "2", "b@example.com"
-        ) == fresh
+        assert harness.switcher.read_account_credentials("2", "b@example.com") == fresh
 
     def test_identity_conflict_quarantines_instead_of_activating(self, harness):
         """Tick path: the conflicted slot is quarantined (wrong-account switch
         prevented); rotation falls through to the next candidate."""
         harness.switcher._write_account_credentials(
-            "2", "b@example.com",
-            json.dumps({"claudeAiOauth": {
-                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
-            }}),
+            "2",
+            "b@example.com",
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-2",
+                        "refreshToken": "rt-2",
+                        "expiresAt": 0,
+                    }
+                }
+            ),
         )
-        fresh = json.dumps({"claudeAiOauth": {
-            "accessToken": "sk-2f", "refreshToken": "rt-2f",
-            "expiresAt": 99_999_999_999_000,
-        }})
+        fresh = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-2f",
+                    "refreshToken": "rt-2f",
+                    "expiresAt": 99_999_999_999_000,
+                }
+            }
+        )
 
         def refresh(creds):
             data = json.loads(creds)["claudeAiOauth"]
             if data["refreshToken"] == "rt-2":
                 return oauth.RefreshOutcome(
-                    fresh, None,
-                    {"uuid": "uuid-somebody-else", "email": "z@example.com",
-                     "organizationUuid": ""},
+                    fresh,
+                    None,
+                    {
+                        "uuid": "uuid-somebody-else",
+                        "email": "z@example.com",
+                        "organizationUuid": "",
+                    },
                 )
             return oauth.RefreshOutcome(creds, None)
 
@@ -1761,9 +2096,13 @@ class TestTokenIdentity:
             "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
             side_effect=refresh,
         ):
-            outcome = harness.tick_with_usage({
-                "1": _usage(95), "2": _usage(10), "3": _usage(80),
-            })
+            outcome = harness.tick_with_usage(
+                {
+                    "1": _usage(95),
+                    "2": _usage(10),
+                    "3": _usage(80),
+                }
+            )
         # Account 2 had the most headroom but is conflicted → quarantined,
         # and the switch landed elsewhere.
         assert "account-quarantined" in harness.kinds()
@@ -1777,22 +2116,35 @@ class TestTokenIdentity:
         a dead slot is quarantined outright; safety copies are forensic
         material, and recovery is the documented /login + cswap add."""
         harness.switcher._store._write_unclaimed_credential(
-            json.dumps({"claudeAiOauth": {
-                "accessToken": "sk-2-successor",
-                "refreshToken": "rt-2-successor",
-                "expiresAt": 99_999_999_999_000,
-            }}),
-            {"resolvedIdentity": {
-                "uuid": "uuid-2", "email": "b@example.com",
-                "organizationUuid": "",
-            }},
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-2-successor",
+                        "refreshToken": "rt-2-successor",
+                        "expiresAt": 99_999_999_999_000,
+                    }
+                }
+            ),
+            {
+                "resolvedIdentity": {
+                    "uuid": "uuid-2",
+                    "email": "b@example.com",
+                    "organizationUuid": "",
+                }
+            },
         )
         harness.switcher._write_account_credentials(
-            "2", "b@example.com",
-            json.dumps({"claudeAiOauth": {
-                "accessToken": "sk-2-dead", "refreshToken": "rt-2-dead",
-                "expiresAt": 0,
-            }}),
+            "2",
+            "b@example.com",
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-2-dead",
+                        "refreshToken": "rt-2-dead",
+                        "expiresAt": 0,
+                    }
+                }
+            ),
         )
 
         def refresh(creds):
@@ -1805,9 +2157,13 @@ class TestTokenIdentity:
             "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
             side_effect=refresh,
         ):
-            outcome = harness.tick_with_usage({
-                "1": _usage(95), "2": _usage(10), "3": _usage(80),
-            })
+            outcome = harness.tick_with_usage(
+                {
+                    "1": _usage(95),
+                    "2": _usage(10),
+                    "3": _usage(80),
+                }
+            )
         q = harness.state().get("quarantine", {})
         assert q.get("2", {}).get("reason") == "invalid_grant"
         # The safety copy was not consumed, and the switch landed elsewhere.
@@ -1823,21 +2179,37 @@ class TestTokenIdentity:
         data["accounts"]["2"]["organizationUuid"] = "org-2"
         harness.switcher._write_json(harness.switcher.sequence_file, data)
         harness.switcher._write_account_credentials(
-            "2", "b@example.com",
-            json.dumps({"claudeAiOauth": {
-                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
-            }}),
+            "2",
+            "b@example.com",
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-2",
+                        "refreshToken": "rt-2",
+                        "expiresAt": 0,
+                    }
+                }
+            ),
         )
-        fresh = json.dumps({"claudeAiOauth": {
-            "accessToken": "sk-2f", "refreshToken": "rt-2f",
-            "expiresAt": 99_999_999_999_000,
-        }})
+        fresh = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-2f",
+                    "refreshToken": "rt-2f",
+                    "expiresAt": 99_999_999_999_000,
+                }
+            }
+        )
         with patch(
             "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
             return_value=oauth.RefreshOutcome(
-                fresh, None,
-                {"uuid": "uuid-2", "email": "b@example.com",
-                 "organizationUuid": "org-other"},
+                fresh,
+                None,
+                {
+                    "uuid": "uuid-2",
+                    "email": "b@example.com",
+                    "organizationUuid": "org-other",
+                },
             ),
         ):
             status = harness.engine._freshen_target("2", "b@example.com")
@@ -1849,29 +2221,42 @@ class TestTokenIdentity:
         and a crash here would skip the persist bookkeeping and error the
         tick."""
         harness.switcher._write_account_credentials(
-            "2", "b@example.com",
-            json.dumps({"claudeAiOauth": {
-                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
-            }}),
+            "2",
+            "b@example.com",
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-2",
+                        "refreshToken": "rt-2",
+                        "expiresAt": 0,
+                    }
+                }
+            ),
         )
-        fresh = json.dumps({"claudeAiOauth": {
-            "accessToken": "sk-2f", "refreshToken": "rt-2f",
-            "expiresAt": 99_999_999_999_000,
-        }})
+        fresh = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-2f",
+                    "refreshToken": "rt-2f",
+                    "expiresAt": 99_999_999_999_000,
+                }
+            }
+        )
         with patch(
             "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
             return_value=oauth.RefreshOutcome(
-                fresh, None, {"uuid": 12345, "email": ["weird"]},
+                fresh,
+                None,
+                {"uuid": 12345, "email": ["weird"]},
             ),
         ):
             status = harness.engine._freshen_target("2", "b@example.com")
         assert status == "ok"
-        assert harness.switcher.read_account_credentials(
-            "2", "b@example.com"
-        ) == fresh
+        assert harness.switcher.read_account_credentials("2", "b@example.com") == fresh
 
     def test_blank_uuid_slot_with_org_conflict_quarantines_not_backfills(
-        self, harness,
+        self,
+        harness,
     ):
         """Org conflict must be checked before the blank-uuid backfill: a
         wrong-org credential is evidence the slot holds the wrong account,
@@ -1884,21 +2269,37 @@ class TestTokenIdentity:
         data["accounts"]["2"]["organizationUuid"] = "org-A"
         harness.switcher._write_json(harness.switcher.sequence_file, data)
         harness.switcher._write_account_credentials(
-            "2", "b@example.com",
-            json.dumps({"claudeAiOauth": {
-                "accessToken": "sk-2", "refreshToken": "rt-2", "expiresAt": 0,
-            }}),
+            "2",
+            "b@example.com",
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-2",
+                        "refreshToken": "rt-2",
+                        "expiresAt": 0,
+                    }
+                }
+            ),
         )
-        fresh = json.dumps({"claudeAiOauth": {
-            "accessToken": "sk-2f", "refreshToken": "rt-2f",
-            "expiresAt": 99_999_999_999_000,
-        }})
+        fresh = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-2f",
+                    "refreshToken": "rt-2f",
+                    "expiresAt": 99_999_999_999_000,
+                }
+            }
+        )
         with patch(
             "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
             return_value=oauth.RefreshOutcome(
-                fresh, None,
-                {"uuid": "uuid-real", "email": "z@example.com",
-                 "organizationUuid": "org-B"},
+                fresh,
+                None,
+                {
+                    "uuid": "uuid-real",
+                    "email": "z@example.com",
+                    "organizationUuid": "org-B",
+                },
             ),
         ):
             status = harness.engine._freshen_target("2", "b@example.com")
@@ -1906,9 +2307,7 @@ class TestTokenIdentity:
         # The foreign uuid was NOT backfilled onto the slot.
         assert harness.switcher._get_sequence_data()["accounts"]["2"]["uuid"] == ""
         # The successor generation was still persisted (grant consumed it).
-        assert harness.switcher.read_account_credentials(
-            "2", "b@example.com"
-        ) == fresh
+        assert harness.switcher.read_account_credentials("2", "b@example.com") == fresh
 
 
 def _model_usage(five_h: float, fable: float) -> dict:
@@ -1934,11 +2333,13 @@ class TestModelAwareSwitch:
     def test_model_maxed_switches_despite_session_headroom(self, temp_home):
         # Active #1: 5h only 5% used, but Fable is maxed → must leave.
         h = self._seed(temp_home, model="Fable")
-        outcome = h.tick_with_usage({
-            "1": _model_usage(5, 100),
-            "2": _model_usage(5, 30),
-            "3": _model_usage(5, 60),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _model_usage(5, 100),
+                "2": _model_usage(5, 30),
+                "3": _model_usage(5, 60),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2  # most Fable headroom
         switch = next(e for e in h.events if isinstance(e, SwitchEvent))
@@ -1947,11 +2348,13 @@ class TestModelAwareSwitch:
     def test_without_model_setting_the_same_usage_holds(self, temp_home):
         # Default engine ignores scoped windows → #1 reads 5% used, no switch.
         h = self._seed(temp_home)
-        outcome = h.tick_with_usage({
-            "1": _model_usage(5, 100),
-            "2": _model_usage(5, 30),
-            "3": _model_usage(5, 60),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _model_usage(5, 100),
+                "2": _model_usage(5, 30),
+                "3": _model_usage(5, 60),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
@@ -1960,11 +2363,13 @@ class TestModelAwareSwitch:
     def test_model_headroom_still_gated_by_session_window(self, temp_home):
         # Fable has room on every account, but #1's 5h is maxed → still leaves.
         h = self._seed(temp_home, model="Fable")
-        outcome = h.tick_with_usage({
-            "1": _model_usage(100, 40),
-            "2": _model_usage(10, 40),
-            "3": _model_usage(20, 40),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _model_usage(100, 40),
+                "2": _model_usage(10, 40),
+                "3": _model_usage(20, 40),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2  # lowest binding (max of 5h, Fable)
 
@@ -1983,11 +2388,13 @@ class TestModelAwareSwitch:
                 ],
             }
 
-        outcome = h.tick_with_usage({
-            "1": usage(5, 20, 100),   # Opus maxed
-            "2": usage(5, 20, 30),    # most headroom
-            "3": usage(5, 20, 70),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": usage(5, 20, 100),  # Opus maxed
+                "2": usage(5, 20, 30),  # most headroom
+                "3": usage(5, 20, 70),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
 
@@ -1995,14 +2402,25 @@ class TestModelAwareSwitch:
         # "all" needs no names: each account's own scoped windows bind,
         # whatever they're called.
         h = self._seed(temp_home, model="all")
-        outcome = h.tick_with_usage({
-            "1": {"five_hour": {"pct": 5.0}, "seven_day": {"pct": 0.0},
-                  "scoped": [{"name": "Sonnet", "pct": 100.0}]},
-            "2": {"five_hour": {"pct": 5.0}, "seven_day": {"pct": 0.0},
-                  "scoped": [{"name": "Sonnet", "pct": 20.0}]},
-            "3": {"five_hour": {"pct": 5.0}, "seven_day": {"pct": 0.0},
-                  "scoped": [{"name": "Opus", "pct": 60.0}]},
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": {
+                    "five_hour": {"pct": 5.0},
+                    "seven_day": {"pct": 0.0},
+                    "scoped": [{"name": "Sonnet", "pct": 100.0}],
+                },
+                "2": {
+                    "five_hour": {"pct": 5.0},
+                    "seven_day": {"pct": 0.0},
+                    "scoped": [{"name": "Sonnet", "pct": 20.0}],
+                },
+                "3": {
+                    "five_hour": {"pct": 5.0},
+                    "seven_day": {"pct": 0.0},
+                    "scoped": [{"name": "Opus", "pct": 60.0}],
+                },
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
 
@@ -2013,20 +2431,22 @@ class TestModelAwareSwitch:
         # earliest-of-any-window scan (12:00) would have jumped early for.
         h = self._seed(temp_home, model="Fable")
         fable_reset = "2026-07-05T15:00:00Z"
-        outcome = h.tick_with_usage({
-            "1": _model_usage(95, 10),
-            "2": {
-                "five_hour": {"pct": 100.0, "resets_at": "2026-07-05T12:00:00Z"},
-                "seven_day": {"pct": 0.0},
-                "scoped": [
-                    {"name": "Fable", "pct": 100.0, "resets_at": fable_reset},
-                ],
-            },
-            "3": {
-                "five_hour": {"pct": 100.0, "resets_at": "2026-07-05T20:00:00Z"},
-                "seven_day": {"pct": 0.0},
-            },
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _model_usage(95, 10),
+                "2": {
+                    "five_hour": {"pct": 100.0, "resets_at": "2026-07-05T12:00:00Z"},
+                    "seven_day": {"pct": 0.0},
+                    "scoped": [
+                        {"name": "Fable", "pct": 100.0, "resets_at": fable_reset},
+                    ],
+                },
+                "3": {
+                    "five_hour": {"pct": 100.0, "resets_at": "2026-07-05T20:00:00Z"},
+                    "seven_day": {"pct": 0.0},
+                },
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         exhausted = next(e for e in h.events if isinstance(e, AllExhaustedEvent))
         assert exhausted.earliest_reset_at == fable_reset
@@ -2037,18 +2457,20 @@ class TestModelAwareSwitch:
         # checks for hours, so the wake time must be unprovable (bounded
         # blocked-cadence fallback instead of a reset sleep).
         h = self._seed(temp_home, model="Fable")
-        outcome = h.tick_with_usage({
-            "1": _model_usage(95, 10),
-            "2": {
-                "five_hour": {"pct": 0.0},
-                "seven_day": {"pct": 0.0},
-                "scoped": [{"name": "Fable", "pct": 100.0}],  # no resets_at
-            },
-            "3": {
-                "five_hour": {"pct": 100.0, "resets_at": "2026-07-05T20:00:00Z"},
-                "seven_day": {"pct": 0.0},
-            },
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _model_usage(95, 10),
+                "2": {
+                    "five_hour": {"pct": 0.0},
+                    "seven_day": {"pct": 0.0},
+                    "scoped": [{"name": "Fable", "pct": 100.0}],  # no resets_at
+                },
+                "3": {
+                    "five_hour": {"pct": 100.0, "resets_at": "2026-07-05T20:00:00Z"},
+                    "seven_day": {"pct": 0.0},
+                },
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         exhausted = next(e for e in h.events if isinstance(e, AllExhaustedEvent))
         assert exhausted.earliest_reset_at is None
@@ -2065,9 +2487,13 @@ class TestModelAwareSwitch:
             "seven_day": {"pct": 0.0},
             "scoped": [{"name": "Fable", "pct": 100.0, "resets_at": fable_reset}],
         }
-        outcome = h.tick_with_usage({
-            "1": _model_usage(95, 10), "2": blocked, "3": blocked,
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _model_usage(95, 10),
+                "2": blocked,
+                "3": blocked,
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         exhausted = next(e for e in h.events if isinstance(e, AllExhaustedEvent))
         assert exhausted.earliest_reset_at == fable_reset
@@ -2109,25 +2535,33 @@ class TestModelAwareSwitch:
 
     def test_no_false_warning_while_an_account_is_unreadable(self, temp_home):
         h = self._seed(temp_home, model="Fabel")
-        h.tick_with_usage({
-            "1": _model_usage(5, 10), "2": _model_usage(5, 10), "3": None,
-        })
+        h.tick_with_usage(
+            {
+                "1": _model_usage(5, 10),
+                "2": _model_usage(5, 10),
+                "3": None,
+            }
+        )
         assert not any(isinstance(e, ConfigWarningEvent) for e in h.events)
         # Once every account reports, the check completes and warns.
-        h.tick_with_usage({
-            "1": _model_usage(5, 10),
-            "2": _model_usage(5, 10),
-            "3": _model_usage(5, 10),
-        })
+        h.tick_with_usage(
+            {
+                "1": _model_usage(5, 10),
+                "2": _model_usage(5, 10),
+                "3": _model_usage(5, 10),
+            }
+        )
         assert any(isinstance(e, ConfigWarningEvent) for e in h.events)
 
     def test_matching_name_never_warns(self, temp_home):
         h = self._seed(temp_home, model="Fable")
-        h.tick_with_usage({
-            "1": _model_usage(5, 10),
-            "2": _model_usage(5, 10),
-            "3": _model_usage(5, 10),
-        })
+        h.tick_with_usage(
+            {
+                "1": _model_usage(5, 10),
+                "2": _model_usage(5, 10),
+                "3": _model_usage(5, 10),
+            }
+        )
         assert not any(isinstance(e, ConfigWarningEvent) for e in h.events)
 
 
@@ -2161,11 +2595,13 @@ class TestConsumeFirstStrategy:
 
     def test_below_threshold_switches_to_soonest_weekly_reset(self, temp_home):
         h = self._harness(temp_home)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_LATER),    # active resets later
-            "2": _usage7(10, 10, _R_SOON),     # soonest -> consume first
-            "3": _usage7(10, 10, _R_LATEST),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_LATER),  # active resets later
+                "2": _usage7(10, 10, _R_SOON),  # soonest -> consume first
+                "3": _usage7(10, 10, _R_LATEST),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
         sw = next(e for e in h.events if isinstance(e, SwitchEvent))
@@ -2174,11 +2610,13 @@ class TestConsumeFirstStrategy:
 
     def test_stays_when_active_already_resets_soonest(self, temp_home):
         h = self._harness(temp_home)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_SOON),     # active is soonest -> stay
-            "2": _usage7(10, 10, _R_LATER),
-            "3": _usage7(10, 10, _R_LATEST),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_SOON),  # active is soonest -> stay
+                "2": _usage7(10, 10, _R_LATER),
+                "3": _usage7(10, 10, _R_LATEST),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
@@ -2188,32 +2626,40 @@ class TestConsumeFirstStrategy:
         h = self._harness(temp_home)
         # Active over threshold -> must move. #2 has LESS headroom but resets
         # sooner; #3 has more headroom but resets latest. consume-first -> #2.
-        outcome = h.tick_with_usage({
-            "1": _usage7(95, 20, _R_LATER),
-            "2": _usage7(50, 40, _R_SOON),
-            "3": _usage7(10, 10, _R_LATEST),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(95, 20, _R_LATER),
+                "2": _usage7(50, 40, _R_SOON),
+                "3": _usage7(10, 10, _R_LATEST),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
 
     def test_respects_cooldown(self, temp_home):
         h = self._harness(temp_home)  # default cooldown 300s
-        h.tick_with_usage({
-            "1": _usage7(20, 20, _R_LATER),
-            "2": _usage7(10, 10, _R_SOON),
-            "3": _usage7(10, 10, _R_LATEST),
-        })
+        h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_LATER),
+                "2": _usage7(10, 10, _R_SOON),
+                "3": _usage7(10, 10, _R_LATEST),
+            }
+        )
         assert h.active_number() == 2  # switched to soonest
         h.events.clear()
         # Now a sooner account (#3) appears, but we're within cooldown.
-        outcome = h.tick_with_usage({
-            "2": _usage7(20, 20, _R_LATER),
-            "1": _usage7(10, 10, _R_LATEST),
-            "3": _usage7(10, 10, _R_SOON),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "2": _usage7(20, 20, _R_LATER),
+                "1": _usage7(10, 10, _R_LATEST),
+                "3": _usage7(10, 10, _R_SOON),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 2
-        assert "cooldown" in [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert "cooldown" in [
+            e.reason for e in h.events if isinstance(e, NoSwitchEvent)
+        ]
 
     def test_locked_recheck_stops_concurrent_engine(self, temp_home):
         """The under-lock cooldown recheck in _perform must cover consume-first.
@@ -2228,11 +2674,13 @@ class TestConsumeFirstStrategy:
         h = self._harness(temp_home)  # default cooldown 300s
         loser = h._make_engine()
         # Winner: 1 -> 2 (soonest reset), records lastSwitchAt.
-        h.tick_with_usage({
-            "1": _usage7(20, 20, _R_LATER),
-            "2": _usage7(10, 10, _R_SOON),
-            "3": _usage7(10, 10, _R_LATEST),
-        })
+        h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_LATER),
+                "2": _usage7(10, 10, _R_SOON),
+                "3": _usage7(10, 10, _R_LATEST),
+            }
+        )
         assert h.active_number() == 2
         h.events.clear()
         # Loser's first (pre-lock) state read predates the winner's write; its
@@ -2260,18 +2708,22 @@ class TestConsumeFirstStrategy:
                 outcome = loser.tick()
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 2  # no double-switch
-        assert "cooldown" in [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert "cooldown" in [
+            e.reason for e in h.events if isinstance(e, NoSwitchEvent)
+        ]
 
     def test_reset_unknown_when_active_reset_missing(self, temp_home):
         # Active has no seven_day.resets_at: the strictly-sooner filter skips
         # every candidate, so the strategy is inert — say so, instead of the
         # false "already consuming soonest".
         h = self._harness(temp_home)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20),              # no reset timestamp
-            "2": _usage7(10, 10, _R_SOON),
-            "3": _usage7(10, 10, _R_LATEST),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20),  # no reset timestamp
+                "2": _usage7(10, 10, _R_SOON),
+                "3": _usage7(10, 10, _R_LATEST),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
@@ -2281,11 +2733,13 @@ class TestConsumeFirstStrategy:
         # Every candidate unreadable this tick is a BLOCKED no-comparison for
         # any strategy — consume-first must not relabel it as a healthy hold.
         h = self._harness(temp_home)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_LATER),
-            "2": None,
-            "3": None,
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_LATER),
+                "2": None,
+                "3": None,
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
         assert reasons == ["no-comparison"]
@@ -2295,11 +2749,13 @@ class TestConsumeFirstStrategy:
         # staying put is right, but the detail must not claim the active
         # account resets first.
         h = self._harness(temp_home)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_LATER),
-            "2": _usage7(100, 100, _R_SOON),
-            "3": _usage7(100, 100, _R_LATEST),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_LATER),
+                "2": _usage7(100, 100, _R_SOON),
+                "3": _usage7(100, 100, _R_LATEST),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         holds = [e for e in h.events if isinstance(e, NoSwitchEvent)]
@@ -2333,10 +2789,12 @@ class TestConsumeFirstStrategy:
         data = h.switcher._get_sequence_data()
         data["accounts"]["2"]["kind"] = "api_key"
         h.switcher._write_json(h.switcher.sequence_file, data)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_SOON),
-            "2": "api key",
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_SOON),
+                "2": "api key",
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
@@ -2346,11 +2804,13 @@ class TestConsumeFirstStrategy:
         h = self._harness(temp_home)
         # #2 resets soonest but is itself at its limit (no headroom) -> ignored;
         # #3 resets later but has room and is sooner than active -> switch there.
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_LATEST),   # active resets latest
-            "2": _usage7(100, 100, _R_SOON),   # soonest but exhausted
-            "3": _usage7(10, 10, _R_LATER),    # sooner than active, has room
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_LATEST),  # active resets latest
+                "2": _usage7(100, 100, _R_SOON),  # soonest but exhausted
+                "3": _usage7(10, 10, _R_LATER),  # sooner than active, has room
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 3
 
@@ -2361,10 +2821,12 @@ class TestConsumeFirstStrategy:
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
         h.make_live("a@example.com", 1)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_LATER),
-            "2": _usage7(10, 10, _R_SOON),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_LATER),
+                "2": _usage7(10, 10, _R_SOON),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
@@ -2376,11 +2838,13 @@ class TestConsumeFirstStrategy:
         # weekly window just rolled over — the LEAST perishable quota. It
         # must rank as unknown, never as "soonest".
         h = self._harness(temp_home)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_LATER),
-            "2": _usage7(10, 10, _R_PAST),     # inverted pick pre-fix
-            "3": _usage7(10, 10, _R_SOON),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_LATER),
+                "2": _usage7(10, 10, _R_PAST),  # inverted pick pre-fix
+                "3": _usage7(10, 10, _R_SOON),
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 3
         sw = next(e for e in h.events if isinstance(e, SwitchEvent))
@@ -2390,11 +2854,13 @@ class TestConsumeFirstStrategy:
         # The active account's own reset can be stale too: past == unknown,
         # which lands on the existing reset-unknown hold.
         h = self._harness(temp_home)
-        outcome = h.tick_with_usage({
-            "1": _usage7(20, 20, _R_PAST),
-            "2": _usage7(10, 10, _R_SOON),
-            "3": _usage7(10, 10, _R_LATER),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(20, 20, _R_PAST),
+                "2": _usage7(10, 10, _R_SOON),
+                "3": _usage7(10, 10, _R_LATER),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
@@ -2418,14 +2884,9 @@ class TestConsumeFirstStrategy:
             requested = set(fetch or ())
             fetch_sets.append(requested)
             view = fresh if requested == {"1", "2", "3"} else stored
-            return {
-                num: _entry_for(value, h.clock.now)
-                for num, value in view.items()
-            }
+            return {num: _entry_for(value, h.clock.now) for num, value in view.items()}
 
-        with patch.object(
-            h.switcher, "usage_entries_by_account", side_effect=collect
-        ):
+        with patch.object(h.switcher, "usage_entries_by_account", side_effect=collect):
             outcome = h.engine.tick()
         return outcome, fetch_sets
 
@@ -2440,7 +2901,7 @@ class TestConsumeFirstStrategy:
         }
         fresh = {
             "1": _usage7(20, 20, _R_LATER),
-            "2": _usage7(100, 100, _R_SOON),   # burned out since the snapshot
+            "2": _usage7(100, 100, _R_SOON),  # burned out since the snapshot
             "3": _usage7(10, 10, _R_LATEST),
         }
         outcome, fetch_sets = self._two_phase_tick(h, stored, fresh)
@@ -2476,8 +2937,8 @@ class TestConsumeFirstStrategy:
         }
         fresh = {
             "1": _usage7(20, 20, _R_LATEST),
-            "2": _usage7(10, 10, _R_LATER),    # still sooner than active
-            "3": _usage7(10, 10, _R_SOON),     # but #3 is now soonest
+            "2": _usage7(10, 10, _R_LATER),  # still sooner than active
+            "3": _usage7(10, 10, _R_SOON),  # but #3 is now soonest
         }
         outcome, _ = self._two_phase_tick(h, stored, fresh)
         assert outcome is TickOutcome.SWITCHED
@@ -2497,8 +2958,8 @@ class TestConsumeFirstStrategy:
             "3": _usage7(10, 10, _R_LATEST),
         }
         fresh = {
-            "1": _usage7(100, 20, _R_LATER),   # crossed while the snapshot aged
-            "2": _usage7(10, 10, _R_LATEST),   # no longer strictly sooner
+            "1": _usage7(100, 20, _R_LATER),  # crossed while the snapshot aged
+            "2": _usage7(10, 10, _R_LATEST),  # no longer strictly sooner
             "3": _usage7(10, 10, _R_LATEST),
         }
         outcome, fetch_sets = self._two_phase_tick(h, stored, fresh)
@@ -2545,11 +3006,13 @@ class TestEveryAccountAboveThreshold:
     def test_moves_to_the_soonest_recovering_account(self, harness):
         """The measured shape: active 99, peers 100 and 95. Account 3 is the
         only one both viable and soon, and it is where we must land."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(99, self._at(harness, 3600 * 2)),   # active, back in 2h
-            "2": _usage(100, self._at(harness, 600)),       # at limit — never a target
-            "3": _usage(95, self._at(harness, 480)),        # back in 8 minutes
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(99, self._at(harness, 3600 * 2)),  # active, back in 2h
+                "2": _usage(100, self._at(harness, 600)),  # at limit — never a target
+                "3": _usage(95, self._at(harness, 480)),  # back in 8 minutes
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 3
 
@@ -2557,51 +3020,65 @@ class TestEveryAccountAboveThreshold:
         """Ranking flips in this state: the usual "most headroom" pick is the
         wrong one when every account is nearly spent — what matters is which
         one can work again first."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(99, self._at(harness, 3600)),
-            "2": _usage(91, self._at(harness, 3600 * 3)),  # most headroom, latest back
-            "3": _usage(97, self._at(harness, 300)),       # least headroom, soonest back
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(99, self._at(harness, 3600)),
+                "2": _usage(
+                    91, self._at(harness, 3600 * 3)
+                ),  # most headroom, latest back
+                "3": _usage(97, self._at(harness, 300)),  # least headroom, soonest back
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 3
 
     def test_a_single_healthy_peer_still_wins_normally(self, harness):
         """The escape must not fire while an ordinary target exists."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(99, self._at(harness, 3600)),
-            "2": _usage(95, self._at(harness, 60)),   # soonest, but still spent
-            "3": _usage(20, self._at(harness, 3600 * 5)),  # healthy
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(99, self._at(harness, 3600)),
+                "2": _usage(95, self._at(harness, 60)),  # soonest, but still spent
+                "3": _usage(20, self._at(harness, 3600 * 5)),  # healthy
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 3
 
     def test_below_threshold_is_untouched(self, harness):
         """Nothing about the ordinary below-threshold path changes."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(50), "2": _usage(10), "3": _usage(10),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(50),
+                "2": _usage(10),
+                "3": _usage(10),
+            }
+        )
         assert outcome is TickOutcome.NO_ACTION
         assert harness.active_number() == 1
 
     def test_all_at_limit_still_reports_exhausted(self, harness):
         """h <= 0 is still never a target: with everything truly maxed there
         is nowhere to go and the exhausted path must still own that case."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(100, self._at(harness, 600)),
-            "2": _usage(100, self._at(harness, 300)),
-            "3": _usage(100, self._at(harness, 900)),
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(100, self._at(harness, 600)),
+                "2": _usage(100, self._at(harness, 300)),
+                "3": _usage(100, self._at(harness, 900)),
+            }
+        )
         assert outcome is TickOutcome.BLOCKED
         assert harness.active_number() == 1
 
     def test_unknown_reset_sorts_last_not_first(self, harness):
         """A candidate whose reset nobody knows must not masquerade as
         'back immediately' and beat a measured, genuinely imminent one."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(99, self._at(harness, 3600)),
-            "2": _usage(95),                          # no resets_at at all
-            "3": _usage(97, self._at(harness, 600)),  # known, soon
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(99, self._at(harness, 3600)),
+                "2": _usage(95),  # no resets_at at all
+                "3": _usage(97, self._at(harness, 600)),  # known, soon
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 3
 
@@ -2611,19 +3088,25 @@ class TestEveryAccountAboveThreshold:
         over at nearly the same time must not trade places forever."""
         a = self._at(harness, 600)
         b = self._at(harness, 660)  # 60s apart — inside RECOVERY_HYSTERESIS_S
-        first = harness.tick_with_usage({
-            "1": _usage(99, a), "2": _usage(98, b), "3": _usage(100, a),
-        })
+        first = harness.tick_with_usage(
+            {
+                "1": _usage(99, a),
+                "2": _usage(98, b),
+                "3": _usage(100, a),
+            }
+        )
         assert first is TickOutcome.BLOCKED, "60s sooner is not worth a switch"
         assert harness.active_number() == 1
 
     def test_a_meaningfully_sooner_account_still_wins(self, harness):
         """The margin must not be so wide it swallows the real case."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(99, self._at(harness, 3600)),
-            "2": _usage(98, self._at(harness, 600)),  # an hour sooner
-            "3": _usage(100, self._at(harness, 60)),  # at limit — not a target
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(99, self._at(harness, 3600)),
+                "2": _usage(98, self._at(harness, 600)),  # an hour sooner
+                "3": _usage(100, self._at(harness, 60)),  # at limit — not a target
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 2
 
@@ -2637,13 +3120,19 @@ class TestEveryAccountAboveThreshold:
         then trade places forever.
         """
         h = EngineHarness(temp_home, strategy="consume-first")
-        h.seed(1, "a@example.com"); h.seed(2, "b@example.com")
-        h.seed(3, "c@example.com"); h.make_live("a@example.com", 1)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
         a = self._at(h, 600)
         b = self._at(h, 660)  # 60s apart — inside RECOVERY_HYSTERESIS_S
-        outcome = h.tick_with_usage({
-            "1": _usage(99, a), "2": _usage(98, b), "3": _usage(100, a),
-        })
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage(99, a),
+                "2": _usage(98, b),
+                "3": _usage(100, a),
+            }
+        )
         assert outcome is TickOutcome.BLOCKED, (
             "consume-first skipped the recovery hysteresis"
         )
@@ -2653,11 +3142,13 @@ class TestEveryAccountAboveThreshold:
         """at-limit and failover skip the whole proactive block. The escape
         must not have made the active account's 100% case *narrower* — an
         account with real headroom still wins there regardless of resets."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(100, self._at(harness, 60)),   # active, at limit
-            "2": _usage(30, self._at(harness, 86400)),  # healthy but far reset
-            "3": _usage(95, self._at(harness, 120)),    # soon but spent
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(100, self._at(harness, 60)),  # active, at limit
+                "2": _usage(30, self._at(harness, 86400)),  # healthy but far reset
+                "3": _usage(95, self._at(harness, 120)),  # soon but spent
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 2, (
             "at-limit must still take the account with real headroom"
@@ -2722,11 +3213,13 @@ class TestReviewFindings202:
         test missed it because its healthy candidate made all_above False —
         this one keeps every account above the line, which is the combination
         that reaches the key."""
-        outcome = harness.tick_with_usage({
-            "1": _usage(100, self._at(harness, 60)),    # active, at its limit
-            "2": _usage(91, self._at(harness, 86400)),  # most headroom, far reset
-            "3": _usage(97, self._at(harness, 120)),    # soonest back, less room
-        })
+        outcome = harness.tick_with_usage(
+            {
+                "1": _usage(100, self._at(harness, 60)),  # active, at its limit
+                "2": _usage(91, self._at(harness, 86400)),  # most headroom, far reset
+                "3": _usage(97, self._at(harness, 120)),  # soonest back, less room
+            }
+        )
         assert outcome is TickOutcome.SWITCHED
         assert harness.active_number() == 2, (
             "at-limit must take the most headroom, not the soonest recovery"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,10 +139,12 @@ class TestCLI:
 
     def test_token_status_flag_is_forwarded_to_list(self):
         """--list --token-status should call list_accounts(show_token_status=True)."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--list", "--token-status"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "--list", "--token-status"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
 
         switcher_cls.return_value.list_accounts.assert_called_once_with(
@@ -157,20 +159,28 @@ class TestCLI:
                 cli.main()
 
         assert excinfo.value.code == 2
-        assert "--strategy can only be used with bare 'switch'" in capsys.readouterr().err
+        assert (
+            "--strategy can only be used with bare 'switch'" in capsys.readouterr().err
+        )
 
     def test_strategy_next_available_requires_switch(self, capsys):
         """--strategy next-available should only be accepted alongside --switch."""
-        with patch.object(sys, "argv", ["claude-swap", "--strategy", "next-available", "--list"]):
+        with patch.object(
+            sys, "argv", ["claude-swap", "--strategy", "next-available", "--list"]
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
 
         assert excinfo.value.code == 2
-        assert "--strategy can only be used with bare 'switch'" in capsys.readouterr().err
+        assert (
+            "--strategy can only be used with bare 'switch'" in capsys.readouterr().err
+        )
 
     def test_strategy_rejects_unknown_value(self, capsys):
         """argparse rejects strategies outside the known choices."""
-        with patch.object(sys, "argv", ["claude-swap", "--switch", "--strategy", "bogus"]):
+        with patch.object(
+            sys, "argv", ["claude-swap", "--switch", "--strategy", "bogus"]
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
 
@@ -180,12 +190,17 @@ class TestCLI:
         """--switch --strategy best forwards the strategy to switch()."""
         from claude_swap.settings import AutoSwitchSettings
 
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--switch", "--strategy", "best"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.settings.load_settings",
-                   return_value=AutoSwitchSettings()), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(
+                sys, "argv", ["claude-swap", "--switch", "--strategy", "best"]
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch(
+                "claude_swap.settings.load_settings", return_value=AutoSwitchSettings()
+            ),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
 
         switcher_cls.return_value.switch.assert_called_once_with(
@@ -197,37 +212,59 @@ class TestCLI:
         strategy — reported as coming from the setting, not the CLI."""
         from claude_swap.settings import AutoSwitchSettings
 
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--switch", "--strategy", "best"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.settings.load_settings",
-                   return_value=AutoSwitchSettings(model="Fable")), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(
+                sys, "argv", ["claude-swap", "--switch", "--strategy", "best"]
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch(
+                "claude_swap.settings.load_settings",
+                return_value=AutoSwitchSettings(model="Fable"),
+            ),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
 
         switcher_cls.return_value.switch.assert_called_once_with(
-            strategy="best", json_output=False,
-            models=("Fable",), model_source="autoswitch.model",
+            strategy="best",
+            json_output=False,
+            models=("Fable",),
+            model_source="autoswitch.model",
         )
 
     def test_switch_model_flag_overrides_setting(self):
         """--model beats autoswitch.model, is deduped, and reports 'cli'."""
         from claude_swap.settings import AutoSwitchSettings
 
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", [
-                 "claude-swap", "--switch", "--strategy", "next-available",
-                 "--model", "Opus, opus,Fable",
-             ]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.settings.load_settings",
-                   return_value=AutoSwitchSettings(model="Sonnet")), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "claude-swap",
+                    "--switch",
+                    "--strategy",
+                    "next-available",
+                    "--model",
+                    "Opus, opus,Fable",
+                ],
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch(
+                "claude_swap.settings.load_settings",
+                return_value=AutoSwitchSettings(model="Sonnet"),
+            ),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
 
         switcher_cls.return_value.switch.assert_called_once_with(
-            strategy="next-available", json_output=False,
-            models=("Opus", "Fable"), model_source="cli",
+            strategy="next-available",
+            json_output=False,
+            models=("Opus", "Fable"),
+            model_source="cli",
         )
 
     def test_switch_model_without_strategy_is_rejected(self, capsys):
@@ -240,10 +277,12 @@ class TestCLI:
 
     def test_plain_switch_passes_no_strategy(self):
         """Bare --switch forwards strategy=None."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--switch"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "--switch"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
 
         switcher_cls.return_value.switch.assert_called_once_with(
@@ -257,7 +296,10 @@ class TestCLI:
                 cli.main()
 
         assert excinfo.value.code == 2
-        assert "--slot can only be used with 'add' or 'add-token'" in capsys.readouterr().err
+        assert (
+            "--slot can only be used with 'add' or 'add-token'"
+            in capsys.readouterr().err
+        )
 
     def test_slot_flag_in_help(self):
         """--slot should appear in help output."""
@@ -271,9 +313,7 @@ class TestCLI:
 
     def test_account_flag_requires_export(self, capsys):
         """--account should only be accepted alongside --export."""
-        with patch.object(
-            sys, "argv", ["claude-swap", "--list", "--account", "1"]
-        ):
+        with patch.object(sys, "argv", ["claude-swap", "--list", "--account", "1"]):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
         assert excinfo.value.code == 2
@@ -292,10 +332,12 @@ class TestCLI:
 
     def test_switch_to_force_forwarded(self):
         """--switch-to 2 --force forwards force=True to switch_to()."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--switch-to", "2", "--force"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "--switch-to", "2", "--force"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
 
         switcher_cls.return_value.switch_to.assert_called_once_with(
@@ -304,10 +346,12 @@ class TestCLI:
 
     def test_switch_to_without_force_forwards_false(self):
         """Plain --switch-to forwards force=False."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--switch-to", "2"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "--switch-to", "2"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
 
         switcher_cls.return_value.switch_to.assert_called_once_with(
@@ -346,13 +390,15 @@ class TestCLI:
 
     def test_export_dispatch_calls_transfer(self):
         """--export dispatches into transfer.export_accounts."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch("claude_swap.transfer.export_accounts") as export_fn, \
-             patch.object(
-                 sys, "argv", ["claude-swap", "--export", "/tmp/x", "--account", "2"]
-             ), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch("claude_swap.transfer.export_accounts") as export_fn,
+            patch.object(
+                sys, "argv", ["claude-swap", "--export", "/tmp/x", "--account", "2"]
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
         export_fn.assert_called_once_with(
             switcher_cls.return_value, "/tmp/x", account="2", full=False
@@ -368,13 +414,13 @@ class TestCLI:
 
     def test_full_flag_dispatches_with_full_true(self):
         """--export --full should pass full=True into export_accounts."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch("claude_swap.transfer.export_accounts") as export_fn, \
-             patch.object(
-                 sys, "argv", ["claude-swap", "--export", "/tmp/x", "--full"]
-             ), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch("claude_swap.transfer.export_accounts") as export_fn,
+            patch.object(sys, "argv", ["claude-swap", "--export", "/tmp/x", "--full"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
         export_fn.assert_called_once_with(
             switcher_cls.return_value, "/tmp/x", account=None, full=True
@@ -382,13 +428,13 @@ class TestCLI:
 
     def test_import_dispatch_calls_transfer(self):
         """--import dispatches into transfer.import_accounts."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch("claude_swap.transfer.import_accounts") as import_fn, \
-             patch.object(
-                 sys, "argv", ["claude-swap", "--import", "/tmp/x", "--force"]
-             ), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch("claude_swap.transfer.import_accounts") as import_fn,
+            patch.object(sys, "argv", ["claude-swap", "--import", "/tmp/x", "--force"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
         import_fn.assert_called_once_with(
             switcher_cls.return_value, "/tmp/x", force=True
@@ -406,11 +452,13 @@ class TestCLI:
 
     def test_upgrade_dispatches_without_constructing_switcher(self):
         """--upgrade should call run_self_upgrade and skip switcher init."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch(
-                 "claude_swap.update_check.run_self_upgrade", return_value=0
-             ) as upgrade_fn, \
-             patch.object(sys, "argv", ["claude-swap", "--upgrade"]):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch(
+                "claude_swap.update_check.run_self_upgrade", return_value=0
+            ) as upgrade_fn,
+            patch.object(sys, "argv", ["claude-swap", "--upgrade"]),
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
 
@@ -424,6 +472,7 @@ class TestCLI:
         class _FakeSwitcher:
             def __init__(self, *a, **k):
                 pass
+
             def _is_running_in_container(self):
                 return False
 
@@ -450,6 +499,7 @@ class TestCLI:
         class _FakeSwitcher:
             def __init__(self, *a, **k):
                 pass
+
             def _is_running_in_container(self):
                 return False
 
@@ -494,15 +544,20 @@ class TestCLICommands:
         )
         assert "No accounts" in result.stdout or "managed" in result.stdout.lower()
 
-    def test_add_token_without_email_dispatches_with_none(self, temp_home: Path, capsys):
+    def test_add_token_without_email_dispatches_with_none(
+        self, temp_home: Path, capsys
+    ):
         """--add-token without --email should dispatch with email=None (defaulted by switcher)."""
         from claude_swap.switcher import ClaudeAccountSwitcher
 
-        with patch.object(
-            sys, "argv", ["claude-swap", "--add-token", "sk-ant-oat01-abc"],
-        ), patch.object(
-            ClaudeAccountSwitcher, "add_account_from_token"
-        ) as mock_add:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["claude-swap", "--add-token", "sk-ant-oat01-abc"],
+            ),
+            patch.object(ClaudeAccountSwitcher, "add_account_from_token") as mock_add,
+        ):
             cli.main()
 
         mock_add.assert_called_once_with(
@@ -521,12 +576,14 @@ class TestCLICommands:
         """--add-token with --email should call add_account_from_token."""
         from claude_swap.switcher import ClaudeAccountSwitcher
 
-        with patch.object(
-            sys, "argv",
-            ["claude-swap", "--add-token", "mytoken", "--email", "u@example.com"],
-        ), patch.object(
-            ClaudeAccountSwitcher, "add_account_from_token"
-        ) as mock_add:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["claude-swap", "--add-token", "mytoken", "--email", "u@example.com"],
+            ),
+            patch.object(ClaudeAccountSwitcher, "add_account_from_token") as mock_add,
+        ):
             cli.main()
 
         mock_add.assert_called_once_with(
@@ -537,17 +594,25 @@ class TestCLICommands:
         """--add-token --slot should forward slot to add_account_from_token."""
         from claude_swap.switcher import ClaudeAccountSwitcher
 
-        with patch.object(
-            sys, "argv",
-            ["claude-swap", "--add-token", "tok", "--email", "u@example.com", "--slot", "3"],
-        ), patch.object(
-            ClaudeAccountSwitcher, "add_account_from_token"
-        ) as mock_add:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "claude-swap",
+                    "--add-token",
+                    "tok",
+                    "--email",
+                    "u@example.com",
+                    "--slot",
+                    "3",
+                ],
+            ),
+            patch.object(ClaudeAccountSwitcher, "add_account_from_token") as mock_add,
+        ):
             cli.main()
 
-        mock_add.assert_called_once_with(
-            token="tok", email="u@example.com", slot=3
-        )
+        mock_add.assert_called_once_with(token="tok", email="u@example.com", slot=3)
 
     def test_add_token_in_help(self):
         """The add-token subcommand and the still-visible --email modifier appear."""
@@ -575,10 +640,12 @@ class TestRunCommand:
             def run(self, identifier, claude_args, share=True, share_history=False):
                 calls.append(("run", identifier, claude_args, share, share_history))
 
-        with patch("claude_swap.session.SessionManager", FakeSessionManager), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher"), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", *argv]):
+        with (
+            patch("claude_swap.session.SessionManager", FakeSessionManager),
+            patch("claude_swap.cli.ClaudeAccountSwitcher"),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", *argv]),
+        ):
             cli.main()
         return calls
 
@@ -654,10 +721,12 @@ class TestRunCommand:
 
                 raise SessionError("boom")
 
-        with patch("claude_swap.session.SessionManager", FailingSessionManager), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher"), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run", "2"]):
+        with (
+            patch("claude_swap.session.SessionManager", FailingSessionManager),
+            patch("claude_swap.cli.ClaudeAccountSwitcher"),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run", "2"]),
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
 
@@ -671,19 +740,26 @@ class TestSubcommandAliases:
     def test_translate_is_noop_for_flags(self):
         """argv that already uses --flags is passed through untouched."""
         assert cli._translate_subcommand(["--list"]) == ["--list"]
-        assert cli._translate_subcommand(["--switch", "--json"]) == ["--switch", "--json"]
+        assert cli._translate_subcommand(["--switch", "--json"]) == [
+            "--switch",
+            "--json",
+        ]
         assert cli._translate_subcommand([]) == []
 
     def test_translate_bare_switch_rotates(self):
         assert cli._translate_subcommand(["switch"]) == ["--switch"]
         assert cli._translate_subcommand(["switch", "--strategy", "best"]) == [
-            "--switch", "--strategy", "best",
+            "--switch",
+            "--strategy",
+            "best",
         ]
 
     def test_translate_switch_with_target(self):
         assert cli._translate_subcommand(["switch", "2"]) == ["--switch-to", "2"]
         assert cli._translate_subcommand(["switch", "u@x.com", "--json"]) == [
-            "--switch-to", "u@x.com", "--json",
+            "--switch-to",
+            "u@x.com",
+            "--json",
         ]
 
     def test_translate_simple_verbs_and_aliases(self):
@@ -698,10 +774,15 @@ class TestSubcommandAliases:
 
     def test_translate_value_verbs_pass_through_extra_flags(self):
         assert cli._translate_subcommand(["export", "b.cswap", "--full"]) == [
-            "--export", "b.cswap", "--full",
+            "--export",
+            "b.cswap",
+            "--full",
         ]
         assert cli._translate_subcommand(["add-token", "sk-tok", "--slot", "3"]) == [
-            "--add-token", "sk-tok", "--slot", "3",
+            "--add-token",
+            "sk-tok",
+            "--slot",
+            "3",
         ]
 
     def test_translate_unknown_verb_unchanged(self):
@@ -710,10 +791,12 @@ class TestSubcommandAliases:
 
     def test_switch_subcommand_dispatches_switch_to(self):
         """`cswap switch 2` reaches switch_to("2")."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "switch", "2"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "switch", "2"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
         switcher_cls.return_value.switch_to.assert_called_once_with(
             "2", json_output=False, force=False
@@ -721,10 +804,12 @@ class TestSubcommandAliases:
 
     def test_bare_switch_subcommand_dispatches_switch(self):
         """`cswap switch` reaches switch() (rotate)."""
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "switch"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "switch"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
         switcher_cls.return_value.switch.assert_called_once_with(
             strategy=None, json_output=False, models=(), model_source=None
@@ -733,14 +818,17 @@ class TestSubcommandAliases:
     def test_list_subcommand_with_json(self):
         """`cswap list --json` reaches list_accounts(json_output=True)."""
         payload = {"schemaVersion": 1, "accounts": []}
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "list", "--json"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "list", "--json"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             switcher_cls.return_value.list_accounts.return_value = payload
             cli.main()
         switcher_cls.return_value.list_accounts.assert_called_once_with(
-            show_token_status=False, json_output=True,
+            show_token_status=False,
+            json_output=True,
         )
 
     def test_run_subcommand_still_dispatches(self):
@@ -754,10 +842,12 @@ class TestSubcommandAliases:
             def run(self, identifier, claude_args, share=True, share_history=False):
                 calls.append((identifier, claude_args, share))
 
-        with patch("claude_swap.session.SessionManager", FakeSessionManager), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher"), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run", "2"]):
+        with (
+            patch("claude_swap.session.SessionManager", FakeSessionManager),
+            patch("claude_swap.cli.ClaudeAccountSwitcher"),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run", "2"]),
+        ):
             cli.main()
         assert calls == [("2", [], True)]
 
@@ -787,38 +877,50 @@ class TestJsonOutputCli:
         assert "--json can only be used with" in capsys.readouterr().err
 
     def test_token_status_with_json_rejected(self, capsys):
-        with patch.object(sys, "argv", ["claude-swap", "--list", "--token-status", "--json"]):
+        with patch.object(
+            sys, "argv", ["claude-swap", "--list", "--token-status", "--json"]
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
         assert excinfo.value.code == 2
-        assert "--token-status cannot be combined with --json" in capsys.readouterr().err
+        assert (
+            "--token-status cannot be combined with --json" in capsys.readouterr().err
+        )
 
     def test_list_json_serialized_to_stdout(self, capsys):
         payload = {"schemaVersion": 1, "activeAccountNumber": None, "accounts": []}
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--list", "--json"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "--list", "--json"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             switcher_cls.return_value.list_accounts.return_value = payload
             cli.main()
 
         switcher_cls.return_value.list_accounts.assert_called_once_with(
-            show_token_status=False, json_output=True,
+            show_token_status=False,
+            json_output=True,
         )
         out = capsys.readouterr().out
         assert json.loads(out) == payload  # exactly one JSON object, no extra text
 
     def test_switch_json_forwarded_and_serialized(self, capsys):
         payload = {"schemaVersion": 1, "switched": True}
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--switch", "--json"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "--switch", "--json"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             switcher_cls.return_value.switch.return_value = payload
             cli.main()
 
         switcher_cls.return_value.switch.assert_called_once_with(
-            strategy=None, json_output=True, models=(), model_source=None,
+            strategy=None,
+            json_output=True,
+            models=(),
+            model_source=None,
         )
         assert json.loads(capsys.readouterr().out) == payload
 
@@ -826,13 +928,24 @@ class TestJsonOutputCli:
         """Additive models/modelSource fields make a model-steered pick
         auditable from scripts too."""
         payload = {"schemaVersion": 1, "switched": True}
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", [
-                 "claude-swap", "--switch", "--strategy", "best",
-                 "--model", "Fable", "--json",
-             ]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "claude-swap",
+                    "--switch",
+                    "--strategy",
+                    "best",
+                    "--model",
+                    "Fable",
+                    "--json",
+                ],
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             switcher_cls.return_value.switch.return_value = payload
             cli.main()
 
@@ -844,10 +957,12 @@ class TestJsonOutputCli:
     def test_error_envelope_on_stdout_with_exit_1(self, capsys):
         from claude_swap.exceptions import ConfigError
 
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", "--status", "--json"]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", "--status", "--json"]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             switcher_cls.return_value.status.side_effect = ConfigError("nope")
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
@@ -866,12 +981,24 @@ class TestAutoCommand:
         instances: list = []
         tick_outcome = None  # set per test (TickOutcome)
 
-        def __init__(self, switcher, settings, on_event, *, dry_run=False,
-                     state_path=None, clock=None):
+        def __init__(
+            self,
+            switcher,
+            settings,
+            on_event,
+            *,
+            dry_run=False,
+            state_path=None,
+            clock=None,
+            cli_overrides=None,
+            watch_settings=False,
+        ):
             self.switcher = switcher
             self.settings = settings
             self.on_event = on_event
             self.dry_run = dry_run
+            self.cli_overrides = cli_overrides
+            self.watch_settings = watch_settings
             type(self).instances.append(self)
 
         def tick(self):
@@ -891,9 +1018,11 @@ class TestAutoCommand:
         self.FakeEngine.tick_outcome = None
 
     def _run(self, argv: list[str], temp_home):
-        with patch("claude_swap.autoswitch.AutoSwitchEngine", self.FakeEngine), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "auto", *argv]):
+        with (
+            patch("claude_swap.autoswitch.AutoSwitchEngine", self.FakeEngine),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "auto", *argv]),
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
         return excinfo.value.code
@@ -925,13 +1054,17 @@ class TestAutoCommand:
 
         backup = get_backup_root()
         backup.mkdir(parents=True, exist_ok=True)
-        (backup / "settings.json").write_text(json.dumps({
-            "schemaVersion": 1,
-            "autoswitch": {"threshold": 80.0, "cooldownSeconds": 42.0},
-        }))
+        (backup / "settings.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "autoswitch": {"threshold": 80.0, "cooldownSeconds": 42.0},
+                }
+            )
+        )
         self._run(["--once", "--threshold", "60"], temp_home)
         engine = self.FakeEngine.instances[-1]
-        assert engine.settings.threshold == 60.0     # CLI wins
+        assert engine.settings.threshold == 60.0  # CLI wins
         assert engine.settings.cooldown_seconds == 42.0  # settings.json kept
 
     def test_dry_run_forwarded(self, temp_home):
@@ -947,9 +1080,11 @@ class TestAutoCommand:
                 self.on_event(NoSwitchEvent(reason="cooldown"))
                 return TickOutcome.NO_ACTION
 
-        with patch("claude_swap.autoswitch.AutoSwitchEngine", EmittingEngine), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "auto", "--once", "--json"]):
+        with (
+            patch("claude_swap.autoswitch.AutoSwitchEngine", EmittingEngine),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "auto", "--once", "--json"]),
+        ):
             with pytest.raises(SystemExit):
                 cli.main()
         lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
@@ -986,9 +1121,12 @@ class TestAutoCommand:
     def test_switcher_error_exits_1(self, temp_home, capsys):
         from claude_swap.exceptions import ConfigError
 
-        with patch("claude_swap.cli.ClaudeAccountSwitcher",
-                   side_effect=ConfigError("nope")), \
-             patch.object(sys, "argv", ["claude-swap", "auto", "--once"]):
+        with (
+            patch(
+                "claude_swap.cli.ClaudeAccountSwitcher", side_effect=ConfigError("nope")
+            ),
+            patch.object(sys, "argv", ["claude-swap", "auto", "--once"]),
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
         assert excinfo.value.code == 1
@@ -1017,6 +1155,7 @@ class TestMapCommand:
 
     def test_map_account_to_path(self, temp_home, capsys):
         from claude_swap.mappings import MappingStore
+
         self._seeded_switcher_env(temp_home)
         target = temp_home / "proj"
         target.mkdir()
@@ -1032,6 +1171,7 @@ class TestMapCommand:
 
     def test_map_nonexistent_path_warns_but_maps(self, temp_home, capsys):
         from claude_swap.mappings import MappingStore
+
         self._seeded_switcher_env(temp_home)
         target = temp_home / "not-created-yet"
 
@@ -1043,6 +1183,7 @@ class TestMapCommand:
 
     def test_map_by_email_defaults_to_cwd(self, temp_home, monkeypatch, capsys):
         from claude_swap.mappings import MappingStore
+
         self._seeded_switcher_env(temp_home)
         cwd = temp_home / "here"
         cwd.mkdir()
@@ -1070,6 +1211,7 @@ class TestMapCommand:
 
     def test_map_list_shows_entries(self, temp_home, capsys):
         from claude_swap.mappings import MappingStore
+
         switcher = self._seeded_switcher_env(temp_home)
         target = temp_home / "proj"
         target.mkdir()
@@ -1085,6 +1227,7 @@ class TestMapCommand:
 
     def test_map_list_flags_removed_account(self, temp_home, capsys):
         from claude_swap.mappings import MappingStore
+
         switcher = self._seeded_switcher_env(temp_home)
         target = temp_home / "proj"
         target.mkdir()
@@ -1098,6 +1241,7 @@ class TestMapCommand:
 
     def test_unmap_removes(self, temp_home, capsys):
         from claude_swap.mappings import MappingStore
+
         switcher = self._seeded_switcher_env(temp_home)
         target = temp_home / "proj"
         target.mkdir()
@@ -1120,22 +1264,30 @@ class TestMapCommand:
 
     def test_map_dispatched_from_main(self, temp_home):
         """`cswap map` routes through main() to _map_command."""
-        with patch("claude_swap.cli._map_command") as map_fn, \
-             patch.object(sys, "argv", ["claude-swap", "map", "2", "/tmp/x"]):
+        with (
+            patch("claude_swap.cli._map_command") as map_fn,
+            patch.object(sys, "argv", ["claude-swap", "map", "2", "/tmp/x"]),
+        ):
             cli.main()
         map_fn.assert_called_once_with(["2", "/tmp/x"])
 
     def test_unmap_dispatched_from_main(self, temp_home):
-        with patch("claude_swap.cli._unmap_command") as unmap_fn, \
-             patch.object(sys, "argv", ["claude-swap", "unmap", "/tmp/x"]):
+        with (
+            patch("claude_swap.cli._unmap_command") as unmap_fn,
+            patch.object(sys, "argv", ["claude-swap", "unmap", "/tmp/x"]),
+        ):
             cli.main()
         unmap_fn.assert_called_once_with(["/tmp/x"])
 
     @pytest.mark.skipif(sys.platform == "win32", reason="root guard is POSIX-only")
     def test_unmap_refuses_root(self, temp_home, capsys):
         self._seeded_switcher_env(temp_home)
-        with patch("os.geteuid", return_value=0, create=True), \
-             patch.object(ClaudeAccountSwitcher, "_is_running_in_container", return_value=False):
+        with (
+            patch("os.geteuid", return_value=0, create=True),
+            patch.object(
+                ClaudeAccountSwitcher, "_is_running_in_container", return_value=False
+            ),
+        ):
             with pytest.raises(SystemExit) as exc:
                 cli._unmap_command([str(temp_home)])
         assert exc.value.code == 1
@@ -1144,8 +1296,12 @@ class TestMapCommand:
     @pytest.mark.skipif(sys.platform == "win32", reason="root guard is POSIX-only")
     def test_map_refuses_root(self, temp_home, capsys):
         self._seeded_switcher_env(temp_home)
-        with patch("os.geteuid", return_value=0, create=True), \
-             patch.object(ClaudeAccountSwitcher, "_is_running_in_container", return_value=False):
+        with (
+            patch("os.geteuid", return_value=0, create=True),
+            patch.object(
+                ClaudeAccountSwitcher, "_is_running_in_container", return_value=False
+            ),
+        ):
             with pytest.raises(SystemExit) as exc:
                 cli._map_command(["2", str(temp_home)])
         assert exc.value.code == 1
@@ -1247,16 +1403,22 @@ class TestAliasCommand:
         assert exc.value.code == 1
 
     def test_dispatched_from_main(self, temp_home):
-        with patch("claude_swap.cli._alias_command") as alias_fn, \
-             patch.object(sys, "argv", ["claude-swap", "alias", "2", "dev"]):
+        with (
+            patch("claude_swap.cli._alias_command") as alias_fn,
+            patch.object(sys, "argv", ["claude-swap", "alias", "2", "dev"]),
+        ):
             cli.main()
         alias_fn.assert_called_once_with(["2", "dev"])
 
     @pytest.mark.skipif(sys.platform == "win32", reason="root guard is POSIX-only")
     def test_alias_refuses_root(self, temp_home, capsys):
         self._seeded_switcher_env(temp_home)
-        with patch("os.geteuid", return_value=0, create=True), \
-             patch.object(ClaudeAccountSwitcher, "_is_running_in_container", return_value=False):
+        with (
+            patch("os.geteuid", return_value=0, create=True),
+            patch.object(
+                ClaudeAccountSwitcher, "_is_running_in_container", return_value=False
+            ),
+        ):
             with pytest.raises(SystemExit) as exc:
                 cli._alias_command(["2", "dev"])
         assert exc.value.code == 1
@@ -1264,18 +1426,24 @@ class TestAliasCommand:
 
     def test_add_with_alias_flag(self, temp_home, mock_claude_config, capsys):
         fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
-        with patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(ClaudeAccountSwitcher, "_read_credentials", return_value=fake_creds), \
-             patch.object(ClaudeAccountSwitcher, "_write_account_credentials"), \
-             patch.object(sys, "argv", ["claude-swap", "add", "--alias", "dev"]):
+        with (
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(
+                ClaudeAccountSwitcher, "_read_credentials", return_value=fake_creds
+            ),
+            patch.object(ClaudeAccountSwitcher, "_write_account_credentials"),
+            patch.object(sys, "argv", ["claude-swap", "add", "--alias", "dev"]),
+        ):
             cli.main()
 
         data = ClaudeAccountSwitcher()._get_sequence_data()
         assert data["accounts"]["1"]["alias"] == "dev"
 
     def test_alias_flag_without_add_errors(self, temp_home, capsys):
-        with patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "list", "--alias", "dev"]):
+        with (
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "list", "--alias", "dev"]),
+        ):
             with pytest.raises(SystemExit) as exc:
                 cli.main()
         assert exc.value.code == 2
@@ -1304,8 +1472,8 @@ class TestRunAutoResolve:
         sw._get_sequence_data_migrated.return_value = seq
         # Use the real resolvers, not MagicMock auto-attrs.
         sw._find_account_slot = ClaudeAccountSwitcher._find_account_slot
-        sw.slot_for_directory = (
-            lambda d: ClaudeAccountSwitcher.slot_for_directory(sw, d)
+        sw.slot_for_directory = lambda d: ClaudeAccountSwitcher.slot_for_directory(
+            sw, d
         )
         return sw
 
@@ -1329,11 +1497,15 @@ class TestRunAutoResolve:
         }
         calls = []
         monkeypatch.chdir(repo)
-        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher",
-                   return_value=self._fake_switcher(backup, seq)), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run"]):
+        with (
+            patch("claude_swap.session.SessionManager", self._fake_manager(calls)),
+            patch(
+                "claude_swap.cli.ClaudeAccountSwitcher",
+                return_value=self._fake_switcher(backup, seq),
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run"]),
+        ):
             cli.main()
         assert ("run", "2", [], True, False) in calls
 
@@ -1347,17 +1519,26 @@ class TestRunAutoResolve:
         backup.mkdir()
         MappingStore(backup).set(repo, "work@co.com", "")
         seq = {
-            "accounts": {"2": {"email": "work@co.com", "organizationUuid": "",
-                                "organizationName": ""}},
+            "accounts": {
+                "2": {
+                    "email": "work@co.com",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                }
+            },
             "sequence": [2],
         }
         calls = []
         monkeypatch.chdir(sub)
-        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher",
-                   return_value=self._fake_switcher(backup, seq)), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run"]):
+        with (
+            patch("claude_swap.session.SessionManager", self._fake_manager(calls)),
+            patch(
+                "claude_swap.cli.ClaudeAccountSwitcher",
+                return_value=self._fake_switcher(backup, seq),
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run"]),
+        ):
             cli.main()
         assert ("run", "2", [], True, False) in calls
 
@@ -1368,16 +1549,24 @@ class TestRunAutoResolve:
         scratch.mkdir()
         calls = []
         monkeypatch.chdir(scratch)
-        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher",
-                   return_value=self._fake_switcher(backup, {"accounts": {}, "sequence": []})), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run"]):
+        with (
+            patch("claude_swap.session.SessionManager", self._fake_manager(calls)),
+            patch(
+                "claude_swap.cli.ClaudeAccountSwitcher",
+                return_value=self._fake_switcher(
+                    backup, {"accounts": {}, "sequence": []}
+                ),
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run"]),
+        ):
             cli.main()
         assert ("exec_default", []) in calls
         assert "No account mapped" in capsys.readouterr().out
 
-    def test_removed_account_falls_back_with_warning(self, tmp_path, monkeypatch, capsys):
+    def test_removed_account_falls_back_with_warning(
+        self, tmp_path, monkeypatch, capsys
+    ):
         from claude_swap.mappings import MappingStore
 
         repo = tmp_path / "repo"
@@ -1387,11 +1576,17 @@ class TestRunAutoResolve:
         MappingStore(backup).set(repo, "ghost@co.com", "")
         calls = []
         monkeypatch.chdir(repo)
-        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher",
-                   return_value=self._fake_switcher(backup, {"accounts": {}, "sequence": []})), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run"]):
+        with (
+            patch("claude_swap.session.SessionManager", self._fake_manager(calls)),
+            patch(
+                "claude_swap.cli.ClaudeAccountSwitcher",
+                return_value=self._fake_switcher(
+                    backup, {"accounts": {}, "sequence": []}
+                ),
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run"]),
+        ):
             cli.main()
         assert ("exec_default", []) in calls
         assert "no longer exists" in capsys.readouterr().out
@@ -1402,11 +1597,17 @@ class TestRunAutoResolve:
         backup.mkdir()
         calls = []
         monkeypatch.chdir(tmp_path)
-        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher",
-                   return_value=self._fake_switcher(backup, {"accounts": {}, "sequence": []})), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run", "3"]):
+        with (
+            patch("claude_swap.session.SessionManager", self._fake_manager(calls)),
+            patch(
+                "claude_swap.cli.ClaudeAccountSwitcher",
+                return_value=self._fake_switcher(
+                    backup, {"accounts": {}, "sequence": []}
+                ),
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run", "3"]),
+        ):
             cli.main()
         assert ("run", "3", [], True, False) in calls
 
@@ -1419,17 +1620,26 @@ class TestRunAutoResolve:
         backup.mkdir()
         MappingStore(backup).set(repo, "work@co.com", "")
         seq = {
-            "accounts": {"2": {"email": "work@co.com", "organizationUuid": "",
-                                "organizationName": ""}},
+            "accounts": {
+                "2": {
+                    "email": "work@co.com",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                }
+            },
             "sequence": [2],
         }
         calls = []
         monkeypatch.chdir(repo)
-        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher",
-                   return_value=self._fake_switcher(backup, seq)), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run", "--", "--resume"]):
+        with (
+            patch("claude_swap.session.SessionManager", self._fake_manager(calls)),
+            patch(
+                "claude_swap.cli.ClaudeAccountSwitcher",
+                return_value=self._fake_switcher(backup, seq),
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run", "--", "--resume"]),
+        ):
             cli.main()
         assert ("run", "2", ["--resume"], True, False) in calls
 
@@ -1443,17 +1653,26 @@ class TestRunAutoResolve:
         backup.mkdir()
         MappingStore(backup).set(repo, "work@co.com", "")
         seq = {
-            "accounts": {"2": {"email": "work@co.com", "organizationUuid": "",
-                                "organizationName": ""}},
+            "accounts": {
+                "2": {
+                    "email": "work@co.com",
+                    "organizationUuid": "",
+                    "organizationName": "",
+                }
+            },
             "sequence": [2],
         }
         calls = []
         monkeypatch.chdir(repo)
-        with patch("claude_swap.session.SessionManager", self._fake_manager(calls)), \
-             patch("claude_swap.cli.ClaudeAccountSwitcher",
-                   return_value=self._fake_switcher(backup, seq)), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "run", "--share-history"]):
+        with (
+            patch("claude_swap.session.SessionManager", self._fake_manager(calls)),
+            patch(
+                "claude_swap.cli.ClaudeAccountSwitcher",
+                return_value=self._fake_switcher(backup, seq),
+            ),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "run", "--share-history"]),
+        ):
             cli.main()
         assert ("run", "2", [], True, True) in calls
 
@@ -1463,10 +1682,12 @@ class TestDisableEnableDispatch:
     --enable-account flags) forward to switcher.set_account_disabled."""
 
     def _run(self, argv):
-        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
-             patch.object(sys, "argv", ["claude-swap", *argv]), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch("claude_swap.update_check.check_for_update", return_value=None):
+        with (
+            patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls,
+            patch.object(sys, "argv", ["claude-swap", *argv]),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch("claude_swap.update_check.check_for_update", return_value=None),
+        ):
             cli.main()
         return switcher_cls.return_value
 

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -18,8 +18,10 @@ def _run(argv: list[str], capsys) -> tuple[int, str, str]:
     Success returns normally from main() (no sys.exit), errors raise
     SystemExit — normalize both to an exit code.
     """
-    with patch("os.geteuid", return_value=1000, create=True), \
-         patch.object(sys, "argv", ["claude-swap", "config", *argv]):
+    with (
+        patch("os.geteuid", return_value=1000, create=True),
+        patch.object(sys, "argv", ["claude-swap", "config", *argv]),
+    ):
         code = 0
         try:
             cli.main()
@@ -48,27 +50,24 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "autoswitch.graceBeforeResetMinutes",
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
         code, out, _ = _run([], capsys)
         assert code == 0
-        cooldown_line = next(
-            ln for ln in out.splitlines() if "cooldownSeconds" in ln
-        )
+        cooldown_line = next(ln for ln in out.splitlines() if "cooldownSeconds" in ln)
         assert "600" in cooldown_line
         assert "(default)" not in cooldown_line
 
     def test_set_equal_to_default_still_counts_as_set(self, temp_home, capsys):
         _run(["set", "autoswitch.threshold", "90"], capsys)
         _, out, _ = _run([], capsys)
-        threshold_line = next(
-            ln for ln in out.splitlines() if "threshold" in ln
-        )
+        threshold_line = next(ln for ln in out.splitlines() if "threshold" in ln)
         assert "(default)" not in threshold_line
 
     def test_json_list(self, temp_home, capsys):
@@ -78,7 +77,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False
@@ -102,9 +101,7 @@ class TestConfigSetGet:
         assert raw["autoswitch"]["threshold"] == 80.0
 
     def test_set_bool_words(self, temp_home, capsys):
-        code, out, _ = _run(
-            ["set", "autoswitch.includeApiKeyAccounts", "no"], capsys
-        )
+        code, out, _ = _run(["set", "autoswitch.includeApiKeyAccounts", "no"], capsys)
         assert code == 0
         assert "= false" in out
         raw = json.loads(_settings_file(capsys).read_text())
@@ -113,11 +110,15 @@ class TestConfigSetGet:
     def test_set_preserves_unknown_keys(self, temp_home, capsys):
         path = _settings_file(capsys)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({
-            "schemaVersion": 1,
-            "futureSection": {"x": 1},
-            "autoswitch": {"threshold": 80, "futureKnob": True},
-        }))
+        path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "futureSection": {"x": 1},
+                    "autoswitch": {"threshold": 80, "futureKnob": True},
+                }
+            )
+        )
         code, _, _ = _run(["set", "autoswitch.threshold", "70"], capsys)
         assert code == 0
         raw = json.loads(path.read_text())
@@ -203,9 +204,7 @@ class TestConfigValidation:
         assert code == 2
 
     def test_json_with_set_rejected(self, temp_home, capsys):
-        code, _, _ = _run(
-            ["--json", "set", "autoswitch.threshold", "80"], capsys
-        )
+        code, _, _ = _run(["--json", "set", "autoswitch.threshold", "80"], capsys)
         assert code == 2
 
 
@@ -253,8 +252,18 @@ class TestConfigMisc:
         captured = {}
 
         class FakeEngine:
-            def __init__(self, switcher, settings, on_event, *, dry_run=False,
-                         state_path=None, clock=None):
+            def __init__(
+                self,
+                switcher,
+                settings,
+                on_event,
+                *,
+                dry_run=False,
+                state_path=None,
+                clock=None,
+                cli_overrides=None,
+                watch_settings=False,
+            ):
                 captured["settings"] = settings
 
             def tick(self):
@@ -262,9 +271,11 @@ class TestConfigMisc:
 
                 return TickOutcome.NO_ACTION
 
-        with patch("claude_swap.autoswitch.AutoSwitchEngine", FakeEngine), \
-             patch("os.geteuid", return_value=1000, create=True), \
-             patch.object(sys, "argv", ["claude-swap", "auto", "--once"]):
+        with (
+            patch("claude_swap.autoswitch.AutoSwitchEngine", FakeEngine),
+            patch("os.geteuid", return_value=1000, create=True),
+            patch.object(sys, "argv", ["claude-swap", "auto", "--once"]),
+        ):
             with pytest.raises(SystemExit):
                 cli.main()
         assert captured["settings"].threshold == 77.0


### PR DESCRIPTION
## Motivation

`cswap auto`'s switch decision is currently pure `utilization >= threshold`, with no awareness of how soon the active account's own binding window resets. That produces a needless switch in a common case:

- Threshold: 90% (default)
- Active account: 91% used, its 5h window resets in ~5 hours
- A second account sits below the threshold

Today this immediately proactively switches to the second account — even though the active account's own window is going to fully refresh regardless of whether it's used further in the meantime. The switch doesn't preserve anything (the "saved" headroom is wiped out by the reset anyway); it just starts spending quota on an account that didn't need touching.

This is most visible right at threshold-crossing with a fast-cycling 5h window, but the same shape applies any time a window's reset is close relative to how much runway is left.

## Change 1: `autoswitch.graceBeforeResetMinutes` / `--grace-before-reset`

New setting (0–1440 minutes, default `0` = off, same validation/clamping pattern as the other `autoswitch.*` keys):

```bash
cswap auto --grace-before-reset 300
# or
cswap config set autoswitch.graceBeforeResetMinutes 300
```

When set, a **proactive** switch (active account over the threshold but not yet at its hard limit) is skipped if the account's own *binding* window (the one actually driving the trigger — reused via the existing `_binding_recovery_ts` helper, same one the all-accounts-exhausted escape already uses) will reset within the grace window. The engine rides the account to ~100% instead of switching away.

Deliberately scoped:
- Only applies to the `"proactive"` trigger. `"at-limit"`/`"failover"` are left untouched — those mean the account is already unusable, so switching is a strict improvement, not a tradeoff.
- `"consume-first"` strategy is untouched too — it already has its own reset-driven logic for below-threshold moves that this would otherwise fight.
- A grace long enough to cover the whole 5h window (e.g. `300`+) effectively stops that fast-cycling window from ever triggering an early switch, while a multi-day 7d window reset is essentially never inside a reasonable grace value, so it still switches normally when *that's* what's binding.
- An unknown/missing `resets_at` never suppresses a switch — can't prove "imminent" without it.

## Change 2: `settings.json` hot-reload for the CLI loop

Separately: a plain `cswap auto` foreground/background loop currently loads `settings.json` once at process start (`merged_with_cli(load_settings(...), args)`) and then loops forever on that frozen value. `AutoSwitchEngine.apply_threshold()` exists to hot-apply a new threshold, but it's only ever wired up from the TUI's session slider and the menubar app's explicit engine restart — the plain CLI loop never called it. So `cswap config set autoswitch.threshold 95` from another terminal while `cswap auto` is already running is silently ignored until the process is killed and restarted.

Fix:
- `merged_with_cli` is refactored into two reusable pieces — `cli_overrides(args)` (extract the override dict) and `apply_overrides(settings, overrides)` (apply + clamp) — so the reload path can share the exact same override-application logic as startup.
- `AutoSwitchEngine` gains `apply_settings()` (generalizes `apply_threshold()` to every knob except the model axis, which stays fixed at construction — same invariant `apply_threshold()` already documented) and `cli_overrides`/`watch_settings` constructor params.
- The CLI loop (`_auto_command`, loop mode only — `--once` already reloads fresh every invocation) now passes `watch_settings=True`; `run_loop()` mtime-checks `settings.json` each iteration (same technique the menubar app already uses for its own active-account-change detection) and hot-applies changes via `apply_settings()`, preserving CLI-flag precedence over the file and emitting a new `settings-reloaded` event so it's visible in the log.
- TUI and menubar are untouched — they already have their own live-apply paths and shouldn't get a second, uncoordinated writer of `engine.settings`.

## Testing

- 13 new tests: `TestResetGrace` (6 — default-off, suppression, beyond-grace, never-at-limit, unknown-reset, 5h-vs-7d-window interaction) and `TestSettingsHotReload` (7 — reload + event, no-op when unchanged, CLI-override precedence, model-axis pinning, `apply_settings`, and the loop's `watch_settings` on/off wiring) in `tests/test_autoswitch.py`.
- Existing `test_config_cli.py` list/JSON tests updated for the new 10th setting key.
- Full suite: 1702 passed, 3 skipped, 6 pre-existing failures unrelated to this change (verified against a clean `git stash` baseline — `test_move_accounts.py`/`test_swap_accounts.py` rollback tests, untouched by this diff).
- README's "Automatic switching" section updated with both behaviors.

Happy to adjust naming/scope/defaults if you'd rather see this shaped differently — opening this as a concrete starting point rather than a final API.