### PR TITLE
fix(session): prevent bootstrap credential churn

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -45,6 +45,7 @@ import sys
 import tempfile
 import time
 import unicodedata
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
@@ -58,7 +59,6 @@ from claude_swap.exceptions import (
 from claude_swap.fsutil import replace_with_retry
 from claude_swap.locking import FileLock
 from claude_swap.models import Platform
-from claude_swap.oauth import refresh_oauth_credentials
 from claude_swap.paths import get_default_global_config_path
 from claude_swap.printer import accent, dimmed, muted, warning
 from claude_swap.process_detection import ClaudeSession, list_sessions
@@ -141,6 +141,12 @@ _AUTH_STATUS_TIMEOUT = 10.0
 # timeout) plus auth-status probes, so it needs more headroom than the
 # default 10s acquire used by the switch paths.
 _BOOTSTRAP_LOCK_TIMEOUT = 30.0
+
+
+class _SessionValidation(Enum):
+    VALID = "valid"
+    INVALID = "invalid"
+    INDETERMINATE = "indeterminate"
 
 
 def slugify_email(email: str) -> str:
@@ -503,6 +509,16 @@ class SessionManager:
         self._ensure_not_api_key(account_num, email)
         session_dir = session_dir_for(self.switcher.backup_dir, account_num, email)
 
+        # A running Claude process owns this profile's credential lineage.
+        # Never probe-and-rebuild underneath it: even an explicit local
+        # "logged out" result may be a transient Keychain read, while deleting
+        # the profile entry is guaranteed to disrupt every process sharing it.
+        if live_sessions_for(session_dir):
+            if session_identity_drifted(session_dir, email, org_uuid):
+                raise self._validation_error(account_num, email)
+            self._sync_sharing(session_dir, share, share_history)
+            return session_dir, account_num, email
+
         # Deferred invalidation: backup credentials changed while this profile
         # was live, so its credentials are presumed stale even if they still
         # pass the local reuse check. Honored only when no session is live —
@@ -512,36 +528,65 @@ class SessionManager:
             session_dir
         )
 
-        # Cheap reuse check without the lock: most launches hit this.
-        if not stale and self._is_session_valid(session_dir, email, org_uuid):
+        # Cheap reuse check without the lock: most launches hit this. Probe
+        # failures and unknown schemas are advisory, not permission to destroy
+        # a profile that Claude may still be able to use.
+        validation = self._session_validation(session_dir, email, org_uuid)
+        if not stale and validation is not _SessionValidation.INVALID:
             self._sync_sharing(session_dir, share, share_history)
             return session_dir, account_num, email
 
         with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
-            # Re-evaluate the marker under the lock, then re-check validity:
-            # another `cswap run` may have bootstrapped while we waited.
-            if (session_dir / STALE_MARKER).exists() and not live_sessions_for(
-                session_dir
-            ):
-                self.switcher._invalidate_session_credentials(account_num, email)
-                (session_dir / STALE_MARKER).unlink(missing_ok=True)
-            if self._is_session_valid(session_dir, email, org_uuid):
+            # Another `cswap run` may have launched while we waited. A live
+            # profile wins over every local validation result and stale marker;
+            # the marker remains for the first launch after all owners exit.
+            if live_sessions_for(session_dir):
+                if session_identity_drifted(session_dir, email, org_uuid):
+                    raise self._validation_error(account_num, email)
                 self._sync_sharing(session_dir, share, share_history)
                 return session_dir, account_num, email
 
+            stale = (session_dir / STALE_MARKER).exists()
+            validation = self._session_validation(session_dir, email, org_uuid)
+            if not stale and validation is not _SessionValidation.INVALID:
+                self._sync_sharing(session_dir, share, share_history)
+                return session_dir, account_num, email
+
+            # An existing profile is only reseeded after a credential-writing
+            # operation explicitly marks it stale. A confirmed logout or wrong
+            # identity without that marker is surfaced to the caller and left
+            # byte-for-byte intact, preventing a retry loop from repeatedly
+            # deleting Keychain state.
+            if not stale and session_dir.is_dir():
+                raise self._validation_error(account_num, email)
+
+            if stale:
+                self.switcher._invalidate_session_credentials(account_num, email)
+
             self._bootstrap(session_dir, account_num, email, org_uuid)
+            (session_dir / STALE_MARKER).unlink(missing_ok=True)
             self._sync_sharing(session_dir, share, share_history)
 
-            if not self._is_session_valid(session_dir, email, org_uuid):
-                self._cleanup_failed_session(session_dir)
-                raise SessionError(
-                    f"Session profile for Account-{account_num} ({email}) failed "
-                    f"validation. Log in with that account and re-add it: "
-                    f"cswap --add-account --slot {account_num}"
-                )
+            # A clear logged-out / wrong-account result is still an error, but
+            # never cleanup: the profile may hold the only current generation.
+            # An unreadable command or future schema is allowed through so
+            # Claude itself remains the authority on whether it can run.
+            if (
+                self._session_validation(session_dir, email, org_uuid)
+                is _SessionValidation.INVALID
+            ):
+                raise self._validation_error(account_num, email)
         # Lock released here, before any exec.
 
         return session_dir, account_num, email
+
+    @staticmethod
+    def _validation_error(account_num: str, email: str) -> SessionError:
+        return SessionError(
+            f"Session profile for Account-{account_num} ({email}) failed "
+            f"validation. Log in with that account and re-add it: "
+            f"cswap --add-account --slot {account_num}"
+        )
 
     def _bootstrap(
         self, session_dir: Path, account_num: str, email: str, org_uuid: str
@@ -557,23 +602,6 @@ class SessionManager:
                 f"Account-{account_num} has no stored credentials. "
                 f"Re-add with: cswap --add-account --slot {account_num}"
             )
-
-        # One refresh so the profile starts with a fresh access token; persist
-        # a possibly-rotated refresh token back to backup so future switches
-        # and runs see the latest. Failure is non-fatal: the stored token may
-        # still be valid, and claude refreshes on its own at runtime.
-        # Setup-token accounts (--add-token) have no refresh token by design —
-        # skip silently instead of warning about a flow that can't happen.
-        if self._has_refresh_token(creds):
-            refreshed = refresh_oauth_credentials(creds)
-            if refreshed:
-                creds = refreshed
-                self.switcher.write_account_credentials(account_num, email, creds)
-            else:
-                warning(
-                    f"Could not refresh the token for Account-{account_num}; "
-                    "continuing with the stored credentials."
-                )
 
         config_text = self.switcher.read_account_config(account_num, email)
         try:
@@ -618,29 +646,20 @@ class SessionManager:
             f"Bootstrapped session profile for account {account_num} at {session_dir}"
         )
 
-    @staticmethod
-    def _has_refresh_token(creds: str) -> bool:
-        try:
-            return bool(json.loads(creds).get("claudeAiOauth", {}).get("refreshToken"))
-        except (json.JSONDecodeError, AttributeError):
-            return True  # unknown shape — let the refresh attempt decide
-
-    def _cleanup_failed_session(self, session_dir: Path) -> None:
-        # Keychain first: claude may have partially migrated the seed, and the
-        # hashed service name can't be recomputed once the dir is gone.
-        delete_macos_keychain_entry(session_dir)
-        shutil.rmtree(session_dir, ignore_errors=True)
-
     # -- validation ------------------------------------------------------
 
-    def _is_session_valid(self, session_dir: Path, email: str, org_uuid: str) -> bool:
-        """Whether claude sees the profile as logged in with the right identity.
+    def _session_validation(
+        self, session_dir: Path, email: str, org_uuid: str
+    ) -> _SessionValidation:
+        """How confidently Claude reports this profile's OAuth identity.
 
         Local check only (`claude auth status` makes no API call): a revoked
-        but unexpired token still passes and fails on first real use.
+        but unexpired token still passes and fails on first real use. Command
+        failures and unfamiliar schemas are indeterminate, never invalid: a
+        local compatibility probe must not become authority to delete tokens.
         """
         if not session_dir.is_dir():
-            return False
+            return _SessionValidation.INVALID
         # On Windows `claude` is a `.cmd` shim, and a bare "claude" passed to
         # subprocess won't resolve it (PATHEXT isn't applied) — it raises
         # FileNotFoundError, which the handler below turns into a false
@@ -655,27 +674,61 @@ class SessionManager:
                 timeout=_AUTH_STATUS_TIMEOUT,
             )
         except (OSError, subprocess.TimeoutExpired):
-            return False
+            return _SessionValidation.INDETERMINATE
         if result.returncode != 0:
-            return False
+            return _SessionValidation.INDETERMINATE
         try:
             status = json.loads(result.stdout)
-        except json.JSONDecodeError:
-            return False
-        if status.get("loggedIn") is not True:
-            return False
-        # Verified against claude 2.1.175; an env API key reports a different
-        # method, and the probe env already drops those vars anyway.
-        if status.get("authMethod") != "claude.ai":
-            return False
-        if status.get("email") != email:
-            return False
+        except (json.JSONDecodeError, TypeError):
+            return _SessionValidation.INDETERMINATE
+        if not isinstance(status, dict):
+            return _SessionValidation.INDETERMINATE
+
+        logged_in = status.get("loggedIn")
+        if logged_in is False:
+            return _SessionValidation.INVALID
+        if logged_in is not True:
+            return _SessionValidation.INDETERMINATE
+
+        # Claude <=2.1.212 reported ``claude.ai`` with email/org inline.
+        # Claude 2.1.220 reports first-party subscriptions as ``oauth_token``
+        # and omits identity. Unknown future methods are advisory rather than
+        # false negatives; known non-OAuth methods remain a genuine mismatch.
+        auth_method = status.get("authMethod")
+        if auth_method == "oauth_token":
+            provider = status.get("apiProvider")
+            if provider not in (None, "firstParty"):
+                return _SessionValidation.INDETERMINATE
+        elif auth_method == "claude.ai":
+            pass
+        elif auth_method in {"apiKey", "api_key", "none"}:
+            return _SessionValidation.INVALID
+        else:
+            return _SessionValidation.INDETERMINATE
+
+        status_email = status.get("email")
+        status_org = status.get("orgId")
+        if not status_email:
+            identity = read_session_identity(session_dir)
+            if identity is None:
+                return _SessionValidation.INDETERMINATE
+            status_email, profile_org = identity
+            status_org = status_org or profile_org
+
+        if status_email != email:
+            return _SessionValidation.INVALID
         # Lenient org check: only when both sides have a value, so schema
         # drift degrades to email-only validation instead of false negatives.
-        status_org = status.get("orgId")
         if status_org and org_uuid and status_org != org_uuid:
-            return False
-        return True
+            return _SessionValidation.INVALID
+        return _SessionValidation.VALID
+
+    def _is_session_valid(self, session_dir: Path, email: str, org_uuid: str) -> bool:
+        """Compatibility wrapper for callers that only need a strict bool."""
+        return (
+            self._session_validation(session_dir, email, org_uuid)
+            is _SessionValidation.VALID
+        )
 
     # -- sharing ---------------------------------------------------------
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 import shutil
@@ -65,7 +64,6 @@ from claude_swap.printer import (
     bolded,
     dimmed,
     entrypoint_label,
-    error,
     format_age,
     ide_short_name,
     muted,
@@ -1804,21 +1802,22 @@ class ClaudeAccountSwitcher:
             )
 
     def _invalidate_session_credentials(self, account_num: str, email: str) -> None:
-        """Drop a session profile's credential material, keeping its history.
+        """Mark a session profile for a deliberate credential reseed.
 
         The next `cswap run` fails the reuse check and re-bootstraps from
         backup; the bootstrap merges .claude.json, so the profile's own
-        projects/history survive. Used when backup credentials change under
-        an existing profile (e.g. --import --force).
+        projects/history survive. The marker is the authorization for
+        setup_session to mutate an existing profile; without it, a failed or
+        changed local auth probe is never allowed to delete profile state.
         """
-        from claude_swap.session import STALE_MARKER, delete_macos_keychain_entry
+        from claude_swap.session import delete_macos_keychain_entry, mark_session_stale
 
         session_dir = self._session_dir(account_num, email)
         if not session_dir.exists():
             return
         delete_macos_keychain_entry(session_dir)
         (session_dir / ".credentials.json").unlink(missing_ok=True)
-        (session_dir / STALE_MARKER).unlink(missing_ok=True)
+        mark_session_stale(session_dir)
         self._logger.info(
             f"Invalidated session credentials for account {account_num}"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,8 @@ import pytest
 
 from claude_swap import __version__
 from claude_swap import cli
+from claude_swap.models import Platform
+from claude_swap.session import session_dir_for
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 # src layout: ensure subprocess can find claude_swap
@@ -47,7 +49,11 @@ def _subprocess_env(**extra: str) -> dict[str, str]:
     # developer with either exported would otherwise point the spawned CLI back
     # at real config/backup paths (and on macOS, the real Keychain). Drop them
     # unless a caller set them deliberately.
-    for var in ("CLAUDE_CONFIG_DIR", "XDG_DATA_HOME"):
+    for var in (
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+        "XDG_DATA_HOME",
+    ):
         if var not in extra:
             env.pop(var, None)
     return env
@@ -663,6 +669,111 @@ class TestRunCommand:
 
         assert excinfo.value.code == 1
         assert "boom" in capsys.readouterr().err
+
+    def test_e2e_claude_220_run_keeps_backup_generation(
+        self, temp_home, tmp_path, monkeypatch
+    ):
+        """Two real CLI launches must seed once and consume no refresh grant."""
+        monkeypatch.setattr(
+            Platform, "detect", classmethod(lambda cls: Platform.LINUX)
+        )
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+
+        email = "account2@example.com"
+        org_uuid = "org-2"
+        credentials = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "stored-access",
+                    "refreshToken": "stored-refresh",
+                    "expiresAt": 1,
+                }
+            }
+        )
+        config = json.dumps(
+            {
+                "oauthAccount": {
+                    "emailAddress": email,
+                    "accountUuid": "uuid-2",
+                    "organizationUuid": org_uuid,
+                }
+            }
+        )
+        switcher._write_json(
+            switcher.sequence_file,
+            {
+                "activeAccountNumber": 1,
+                "lastUpdated": "2026-08-03T00:00:00Z",
+                "sequence": [2],
+                "accounts": {
+                    "2": {
+                        "email": email,
+                        "uuid": "uuid-2",
+                        "organizationUuid": org_uuid,
+                        "organizationName": "Org Two",
+                    }
+                },
+            },
+        )
+        switcher._write_account_credentials("2", email, credentials)
+        switcher._write_account_config("2", email, config)
+        backup_before = switcher._backup_enc_path("2", email).read_bytes()
+
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        launch_log = tmp_path / "launch.log"
+        fake_claude = fake_bin / "claude"
+        fake_claude.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = auth ] && [ "$2" = status ]; then\n'
+            "  printf '%s\\n' "
+            "'{\"loggedIn\":true,\"authMethod\":\"oauth_token\",'"
+            "'\"apiProvider\":\"firstParty\"}'\n"
+            "  exit 0\n"
+            "fi\n"
+            'printf \'%s|%s\\n\' "$CLAUDE_CONFIG_DIR" "$*" '
+            '>> "$CSWAP_E2E_LOG"\n'
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        fake_claude.chmod(0o755)
+
+        wrapper = tmp_path / "cswap_e2e.py"
+        wrapper.write_text(
+            "from claude_swap.models import Platform\n"
+            "Platform.detect = classmethod(lambda cls: Platform.LINUX)\n"
+            "from claude_swap.cli import main\n"
+            "main()\n",
+            encoding="utf-8",
+        )
+        env = _subprocess_env(
+            HOME=str(temp_home),
+            PATH=str(fake_bin) + os.pathsep + os.environ.get("PATH", ""),
+            CSWAP_E2E_LOG=str(launch_log),
+        )
+        command = [
+            sys.executable,
+            str(wrapper),
+            "run",
+            "2",
+            "--no-share",
+            "--",
+            "--model",
+            "test-model",
+        ]
+
+        for _ in range(2):
+            result = subprocess.run(command, capture_output=True, text=True, env=env)
+            assert result.returncode == 0, result.stderr
+
+        session_dir = session_dir_for(switcher.backup_dir, "2", email)
+        assert switcher._backup_enc_path("2", email).read_bytes() == backup_before
+        assert switcher.read_account_credentials("2", email) == credentials
+        assert (session_dir / ".credentials.json").read_text() == credentials
+        launches = launch_log.read_text().splitlines()
+        assert len(launches) == 2
+        assert all(str(session_dir) in line for line in launches)
 
 
 class TestSubcommandAliases:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -723,21 +723,39 @@ class TestRunCommand:
         fake_bin = tmp_path / "bin"
         fake_bin.mkdir()
         launch_log = tmp_path / "launch.log"
-        fake_claude = fake_bin / "claude"
-        fake_claude.write_text(
-            "#!/bin/sh\n"
-            'if [ "$1" = auth ] && [ "$2" = status ]; then\n'
-            "  printf '%s\\n' "
-            "'{\"loggedIn\":true,\"authMethod\":\"oauth_token\",'"
-            "'\"apiProvider\":\"firstParty\"}'\n"
-            "  exit 0\n"
-            "fi\n"
-            'printf \'%s|%s\\n\' "$CLAUDE_CONFIG_DIR" "$*" '
-            '>> "$CSWAP_E2E_LOG"\n'
-            "exit 0\n",
+        fake_program = fake_bin / "fake_claude.py"
+        fake_program.write_text(
+            "import json\n"
+            "import os\n"
+            "from pathlib import Path\n"
+            "import sys\n"
+            "if sys.argv[1:3] == ['auth', 'status']:\n"
+            "    print(json.dumps({\n"
+            "        'loggedIn': True,\n"
+            "        'authMethod': 'oauth_token',\n"
+            "        'apiProvider': 'firstParty',\n"
+            "    }))\n"
+            "    raise SystemExit(0)\n"
+            "with Path(os.environ['CSWAP_E2E_LOG']).open('a') as handle:\n"
+            "    handle.write(\n"
+            "        os.environ.get('CLAUDE_CONFIG_DIR', '')\n"
+            "        + '|' + ' '.join(sys.argv[1:]) + '\\n'\n"
+            "    )\n",
             encoding="utf-8",
         )
-        fake_claude.chmod(0o755)
+        if sys.platform == "win32":
+            fake_claude = fake_bin / "claude.cmd"
+            fake_claude.write_text(
+                f'@"{sys.executable}" "{fake_program}" %*\r\n', encoding="utf-8"
+            )
+        else:
+            fake_claude = fake_bin / "claude"
+            fake_claude.write_text(
+                f'#!{sys.executable}\nexec(compile(open({str(fake_program)!r}).read(), '
+                f'{str(fake_program)!r}, "exec"))\n',
+                encoding="utf-8",
+            )
+            fake_claude.chmod(0o755)
 
         wrapper = tmp_path / "cswap_e2e.py"
         wrapper.write_text(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import subprocess
 import sys
 import unicodedata
 from pathlib import Path
@@ -151,6 +152,28 @@ def auth_status_tracks_seed(monkeypatch):
 
 
 @pytest.fixture
+def auth_status_220_tracks_seed(monkeypatch):
+    """Claude 2.1.220's first-party subscription auth-status schema."""
+    probe_envs: list[dict] = []
+
+    def fake_run(cmd, env=None, **kwargs):
+        probe_envs.append(env)
+        config_dir = Path(env["CLAUDE_CONFIG_DIR"])
+        if (config_dir / ".credentials.json").exists():
+            payload = {
+                "loggedIn": True,
+                "authMethod": "oauth_token",
+                "apiProvider": "firstParty",
+            }
+        else:
+            payload = {"loggedIn": False, "authMethod": "none"}
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(session_mod.subprocess, "run", fake_run)
+    return probe_envs
+
+
+@pytest.fixture
 def refresh_rotates(monkeypatch):
     calls: list[str] = []
 
@@ -158,7 +181,9 @@ def refresh_rotates(monkeypatch):
         calls.append(creds)
         return ROTATED_CREDS
 
-    monkeypatch.setattr(session_mod, "refresh_oauth_credentials", fake_refresh)
+    monkeypatch.setattr(
+        session_mod, "refresh_oauth_credentials", fake_refresh, raising=False
+    )
     return calls
 
 
@@ -312,6 +337,178 @@ class TestResolveAccount:
 
 
 class TestBootstrap:
+    @staticmethod
+    def _seed_existing_profile(manager: SessionManager) -> Path:
+        session_dir = session_dir_for(
+            manager.switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        (session_dir / ".credentials.json").write_text(CREDS)
+        (session_dir / ".claude.json").write_text(CONFIG)
+        return session_dir
+
+    def test_bootstrap_never_refreshes_backup_credentials(
+        self,
+        manager,
+        seeded_switcher,
+        auth_status_tracks_seed,
+        monkeypatch,
+    ):
+        calls: list[str] = []
+        monkeypatch.setattr(
+            session_mod,
+            "refresh_oauth_credentials",
+            lambda creds: calls.append(creds) or ROTATED_CREDS,
+            raising=False,
+        )
+
+        session_dir, _, _ = manager.setup_session("2", share=False)
+
+        assert calls == []
+        assert (session_dir / ".credentials.json").read_text() == CREDS
+        assert (
+            seeded_switcher.read_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
+            == CREDS
+        )
+
+    def test_claude_220_status_bootstraps_without_churn(
+        self,
+        manager,
+        seeded_switcher,
+        auth_status_220_tracks_seed,
+        monkeypatch,
+    ):
+        calls: list[str] = []
+        monkeypatch.setattr(
+            session_mod,
+            "refresh_oauth_credentials",
+            lambda creds: calls.append(creds) or ROTATED_CREDS,
+            raising=False,
+        )
+
+        session_dir, _, _ = manager.setup_session("2", share=False)
+        manager.setup_session("2", share=False)
+
+        assert calls == []
+        assert session_dir.is_dir()
+        assert (session_dir / ".credentials.json").read_text() == CREDS
+        assert (
+            seeded_switcher.read_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
+            == CREDS
+        )
+
+    @pytest.mark.parametrize("probe_result", ["nonzero", "malformed", "timeout"])
+    def test_ambiguous_probe_reuses_existing_profile_without_mutation(
+        self, manager, monkeypatch, probe_result
+    ):
+        session_dir = self._seed_existing_profile(manager)
+        before = {
+            path.name: path.read_bytes()
+            for path in session_dir.iterdir()
+            if path.is_file()
+        }
+        bootstraps: list[Path] = []
+        monkeypatch.setattr(
+            manager,
+            "_bootstrap",
+            lambda target, *args: bootstraps.append(target),
+        )
+
+        def ambiguous(*args, **kwargs):
+            if probe_result == "timeout":
+                raise subprocess.TimeoutExpired(args[0], 10)
+            if probe_result == "malformed":
+                return SimpleNamespace(returncode=0, stdout="not-json", stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="changed CLI")
+
+        monkeypatch.setattr(session_mod.subprocess, "run", ambiguous)
+
+        got, _, _ = manager.setup_session("2", share=False)
+
+        assert got == session_dir
+        assert bootstraps == []
+        assert {
+            path.name: path.read_bytes()
+            for path in session_dir.iterdir()
+            if path.is_file()
+        } == before
+
+    def test_live_profile_is_never_rebuilt_when_probe_reports_logged_out(
+        self, manager, monkeypatch
+    ):
+        session_dir = self._seed_existing_profile(manager)
+        make_live(session_dir)
+        bootstraps: list[Path] = []
+        monkeypatch.setattr(
+            manager,
+            "_bootstrap",
+            lambda target, *args: bootstraps.append(target),
+        )
+        monkeypatch.setattr(
+            session_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"loggedIn": False, "authMethod": "none"}),
+                stderr="",
+            ),
+        )
+
+        got, _, _ = manager.setup_session("2", share=False)
+
+        assert got == session_dir
+        assert bootstraps == []
+        assert (session_dir / ".credentials.json").read_text() == CREDS
+
+    def test_confirmed_invalid_existing_profile_is_preserved(
+        self, manager, monkeypatch
+    ):
+        session_dir = self._seed_existing_profile(manager)
+        bootstraps: list[Path] = []
+        monkeypatch.setattr(
+            manager,
+            "_bootstrap",
+            lambda target, *args: bootstraps.append(target),
+        )
+        monkeypatch.setattr(
+            session_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"loggedIn": False, "authMethod": "none"}),
+                stderr="",
+            ),
+        )
+
+        with pytest.raises(SessionError, match="failed\\s+validation"):
+            manager.setup_session("2", share=False)
+
+        assert bootstraps == []
+        assert session_dir.is_dir()
+        assert (session_dir / ".credentials.json").read_text() == CREDS
+
+    def test_indeterminate_post_bootstrap_probe_keeps_seeded_profile(
+        self, manager, monkeypatch
+    ):
+        monkeypatch.setattr(
+            session_mod,
+            "refresh_oauth_credentials",
+            lambda creds: pytest.fail("bootstrap must not refresh OAuth"),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            session_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=1, stdout="", stderr="unknown auth command"
+            ),
+        )
+
+        session_dir, _, _ = manager.setup_session("2", share=False)
+
+        assert session_dir.is_dir()
+        assert (session_dir / ".credentials.json").read_text() == CREDS
+
     def test_happy_path(
         self, manager, seeded_switcher, auth_status_tracks_seed, refresh_rotates
     ):
@@ -319,17 +516,18 @@ class TestBootstrap:
 
         assert (num, email) == (ACCOUNT_NUM, ACCOUNT_EMAIL)
         creds_path = session_dir / ".credentials.json"
-        assert creds_path.read_text() == ROTATED_CREDS
+        assert creds_path.read_text() == CREDS
 
         config = json.loads((session_dir / ".claude.json").read_text())
         assert config["oauthAccount"]["emailAddress"] == ACCOUNT_EMAIL
         assert config["hasCompletedOnboarding"] is True
         assert config["theme"] == "light"  # carried over from backup config
 
-        # Rotated refresh token persisted back to backup storage.
+        # Bootstrap is a copy only: Claude owns all refreshes after seeding.
+        assert refresh_rotates == []
         assert (
             seeded_switcher.read_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
-            == ROTATED_CREDS
+            == CREDS
         )
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions")
@@ -352,13 +550,20 @@ class TestBootstrap:
         assert len(refresh_rotates) == refresh_calls_after_bootstrap  # no new refresh
         assert (session_dir / ".credentials.json").read_text() == first_creds
 
-    def test_refresh_failure_uses_stored_creds(
+    def test_bootstrap_ignores_refresh_helpers(
         self, manager, auth_status_tracks_seed, monkeypatch, capsys
     ):
-        monkeypatch.setattr(session_mod, "refresh_oauth_credentials", lambda c: None)
+        calls: list[str] = []
+        monkeypatch.setattr(
+            session_mod,
+            "refresh_oauth_credentials",
+            lambda c: calls.append(c) or None,
+            raising=False,
+        )
         session_dir, _, _ = manager.setup_session("2", share=False)
         assert (session_dir / ".credentials.json").read_text() == CREDS
-        assert "Could not refresh" in capsys.readouterr().out
+        assert calls == []
+        assert "Could not refresh" not in capsys.readouterr().out
 
     def test_setup_token_account_skips_refresh_silently(
         self, manager, seeded_switcher, auth_status_tracks_seed, monkeypatch, capsys
@@ -373,6 +578,7 @@ class TestBootstrap:
             session_mod,
             "refresh_oauth_credentials",
             lambda c: refresh_calls.append(c) or None,
+            raising=False,
         )
 
         session_dir, _, _ = manager.setup_session("2", share=False)
@@ -397,7 +603,7 @@ class TestBootstrap:
         with pytest.raises(SessionError, match="no stored config backup"):
             manager.setup_session("2", share=False)
 
-    def test_validation_failure_cleans_up(
+    def test_validation_failure_preserves_seeded_profile(
         self, manager, seeded_switcher, monkeypatch, refresh_rotates, block_real_keychain
     ):
         # Auth status never reports logged in → post-bootstrap validation fails.
@@ -420,7 +626,8 @@ class TestBootstrap:
         with pytest.raises(SessionError, match="failed\\s+validation"):
             manager.setup_session("2", share=False)
 
-        assert not session_dir.exists()
+        assert session_dir.is_dir()
+        assert (session_dir / ".credentials.json").read_text() == CREDS
         assert block_real_keychain.get_password(service, account) is None
 
     def test_stale_keychain_entry_deleted_before_seed(
@@ -455,8 +662,8 @@ class TestBootstrap:
 
         manager.setup_session("2", share=False)
 
-        # Re-bootstrapped: fresh (refreshed) creds, marker cleared.
-        assert (session_dir / ".credentials.json").read_text() == ROTATED_CREDS
+        # Re-bootstrapped from the explicitly updated backup, marker cleared.
+        assert (session_dir / ".credentials.json").read_text() == CREDS
         assert not (session_dir / session_mod.STALE_MARKER).exists()
 
     def test_stale_marker_preserved_while_session_still_live(
@@ -482,7 +689,7 @@ class TestBootstrap:
         config = json.loads((session_dir / ".claude.json").read_text())
         config["projects"] = {"/some/project": {"history": ["x"]}}
         (session_dir / ".claude.json").write_text(json.dumps(config))
-        (session_dir / ".credentials.json").unlink()
+        seeded_switcher._invalidate_session_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
 
         manager.setup_session("2", share=False)
 
@@ -1344,6 +1551,7 @@ class TestGuards:
         assert not (session_dir / ".credentials.json").exists()
         assert (session_dir / ".claude.json").exists()  # history preserved
         assert block_real_keychain.get_password(service, account) is None
+        assert (session_dir / session_mod.STALE_MARKER).exists()
 
     def test_backup_credential_write_leaves_live_profile_alone_but_marks_stale(
         self, seeded_switcher
@@ -1404,6 +1612,7 @@ class TestGuards:
         assert not (session_dir / ".credentials.json").exists()
         assert (session_dir / ".claude.json").exists()
         assert block_real_keychain.get_password(service, account) is None
+        assert (session_dir / session_mod.STALE_MARKER).exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Claude Code 2.1.220 changed subscription auth status from `authMethod: claude.ai` with inline identity fields to `authMethod: oauth_token`, `apiProvider: firstParty`, with identity omitted.

Session bootstrap treated every unknown command result or schema as a confirmed invalid profile. Each retry could then delete the profile Keychain item, proactively refresh the backup refresh token, seed the new generation, fail the same validation again, and delete the profile. A minute-cadence launcher can consume many one-time refresh-token generations and eventually turn healthy accounts into `invalid_grant` failures.

## Fix

- Remove proactive OAuth refresh from session bootstrap. Bootstrap copies the stored credential once; Claude Code is the only refresher of the profile token family.
- Make session validation tri-state: valid, invalid, or indeterminate.
- Accept Claude 2.1.220 first-party `oauth_token` status and recover identity from the profile config when the CLI omits it.
- Treat command failures, timeouts, malformed JSON, and unknown future schemas as non-destructive indeterminate results.
- Never rebuild a profile while any Claude process is live against it.
- Require the existing stale marker before reseeding an existing non-live profile; a validation probe alone cannot authorize deletion.
- Preserve explicit logged-out, API-key, wrong-email, and wrong-organization detection without deleting the profile after failure.

This is intentionally narrower than #196: session startup consumes no refresh grant at all instead of routing bootstrap through a broader consume gate.

## Validation

- `tests/test_session.py` plus a real subprocess `cswap run` test: 162 passed.
- Black-box test runs the CLI twice against a fake Claude 2.1.220 executable and asserts the backup generation is byte-identical.
- Live macOS check against an already-running profile: backup and session fingerprints were identical before and after `cswap run 5 -- --version`.
- No credential contents are logged or asserted outside synthetic fixtures.