### PR TITLE
fix(auth): keep session profiles authoritative across credential generations

### DIFF
--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -108,8 +108,10 @@ def try_refresh_oauth_credentials(
     try:
         data = json.loads(credentials)
     except json.JSONDecodeError:
-        return RefreshOutcome(None, "no_refresh_token")
-    oauth = data.get("claudeAiOauth") if isinstance(data, dict) else None
+        return RefreshOutcome(None, "transient")
+    if not isinstance(data, dict):
+        return RefreshOutcome(None, "transient")
+    oauth = data.get("claudeAiOauth")
     if not isinstance(oauth, dict) or not oauth.get("refreshToken"):
         return RefreshOutcome(None, "no_refresh_token")
 
@@ -151,10 +153,15 @@ def try_refresh_oauth_credentials(
         # an explicit marker in the body. Anything ambiguous stays transient —
         # a misclassified transient costs one retry, a misclassified permanent
         # would wrongly quarantine a live token.
-        if e.code in (400, 401, 403) and (
-            "invalid_grant" in body or "invalid_client" in body
-        ):
-            return RefreshOutcome(None, "invalid_grant")
+        if e.code in (400, 401, 403):
+            try:
+                error = json.loads(body).get("error")
+            except (ValueError, AttributeError):
+                error = None
+            if error == "invalid_grant":
+                return RefreshOutcome(None, "invalid_grant")
+            if error == "invalid_client":
+                return RefreshOutcome(None, "invalid_client")
         return RefreshOutcome(None, "transient")
     except Exception as e:
         _logger.debug("OAuth refresh failed: %r", e)
@@ -541,6 +548,7 @@ class UsageOutcome:
     usage: dict | None
     error: str | None = None
     retry_after_s: float | None = None
+    struck_fp: str | None = None
 
 
 def fetch_usage(access_token: str) -> dict | None:
@@ -589,7 +597,11 @@ def try_fetch_usage_for_account(
             # Don't hit the usage endpoint with a token we know is expired
             # (that just adds a 401/429 to a lost cause): report the permanent
             # failure distinctly so the store can quarantine the account.
-            return UsageOutcome(None, error="invalid_grant")
+            return UsageOutcome(
+                None,
+                error="invalid_grant",
+                struck_fp=credential_fingerprint(working_credentials),
+            )
         # A transient refresh failure falls through to try the (expired) token;
         # the 401 path below retries the refresh.
 
@@ -616,7 +628,13 @@ def try_fetch_usage_for_account(
         if not refresh.credentials:
             _log_usage_failure(context, e, kind)
             dead = refresh.error == "invalid_grant"
-            return UsageOutcome(None, error="invalid_grant" if dead else "refresh-failed")
+            return UsageOutcome(
+                None,
+                error="invalid_grant" if dead else "refresh-failed",
+                struck_fp=(
+                    credential_fingerprint(working_credentials) if dead else None
+                ),
+            )
 
         working_credentials = refresh.credentials
         _persist(persist_credentials, account_num, email, working_credentials)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -3441,16 +3441,13 @@ class ClaudeAccountSwitcher:
                         error=outcome.error,
                         retry_after_s=outcome.retry_after_s,
                     )
-                if has_live_session:
-                    # The live claude refreshes lazily on its next API call;
-                    # requesting now would just 401 (same rule as the owned
-                    # active account in _fetch_active_usage).
-                    return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
-                # Expired profile credential and no live session: fall through
-                # to the backup path — cswap must not rotate the profile's
-                # family, but a backup family that is still alive (e.g. the
-                # account was re-added after the profile last ran) can serve
-                # and heal via the normal refresh machinery below.
+                # The profile remains the credential authority while idle:
+                # Claude may have rotated its refresh-token family without
+                # synchronizing the stored backup. Falling back on expiry can
+                # therefore POST a consumed predecessor and falsely quarantine
+                # a healthy account as invalid_grant. Native Claude refreshes
+                # the profile lazily on its next real API call.
+                return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
 
         outcome = oauth.try_fetch_usage_for_account(
             str(num), email, creds,

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 import shutil
@@ -65,7 +64,6 @@ from claude_swap.printer import (
     bolded,
     dimmed,
     entrypoint_label,
-    error,
     format_age,
     ide_short_name,
     muted,
@@ -3129,7 +3127,10 @@ class ClaudeAccountSwitcher:
                             # "re-login needed" — a bare sentinel is a no-op
                             # to the store and would re-POST every pass.
                             return FetchRecord(
-                                error=result.error or "invalid_grant"
+                                error=result.error or "invalid_grant",
+                                struck_fp=oauth.credential_fingerprint(
+                                    refresh_input
+                                ),
                             )
                         if result.error is not None:
                             # Transient (network) failure: backoff via store.
@@ -3400,6 +3401,7 @@ class ClaudeAccountSwitcher:
                 self._write_account_credentials(acct_num, acct_email, new_creds)
 
         from claude_swap.session import (
+            STALE_MARKER,
             read_session_credentials,
             session_identity_drifted,
         )
@@ -3416,7 +3418,10 @@ class ClaudeAccountSwitcher:
         # family here would log the next `cswap run` out the same way.
         session_dir = self._session_dir(str(num), email)
         session_creds = read_session_credentials(session_dir)
-        if session_creds and session_identity_drifted(session_dir, email, org_uuid):
+        session_exists = session_dir.is_dir()
+        session_stale = (session_dir / STALE_MARKER).exists()
+        session_drifted = session_identity_drifted(session_dir, email, org_uuid)
+        if session_creds and session_drifted:
             # An in-session /login re-pointed the profile at a different
             # account; fetching with its credential would record THAT
             # account's usage under this slot's label. The profile no longer
@@ -3449,6 +3454,16 @@ class ClaudeAccountSwitcher:
                 # the profile lazily on its next real API call.
                 return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
 
+            # A non-stale session profile remains Claude Code's credential
+            # authority even after its credential was cleared or became
+            # unreadable. Falling through to the stored bootstrap copy would
+            # POST a potentially consumed predecessor and recreate the exact
+            # invalid_grant churn session mode is designed to avoid.
+            if session_exists and not session_stale and not session_drifted:
+                return FetchRecord(sentinel=USAGE_NO_CREDENTIALS)
+        elif session_exists and not session_stale and not session_drifted:
+            return FetchRecord(sentinel=USAGE_KEYCHAIN_UNAVAILABLE)
+
         outcome = oauth.try_fetch_usage_for_account(
             str(num), email, creds,
             is_active=has_live_session,
@@ -3458,7 +3473,57 @@ class ClaudeAccountSwitcher:
             usage=outcome.usage,
             error=outcome.error,
             retry_after_s=outcome.retry_after_s,
+            struck_fp=outcome.struck_fp,
         )
+
+    def _usage_credential_fingerprints(
+        self,
+        info_by_num: dict[
+            str, tuple[int, str, str, str, bool, str, str]
+        ],
+        nums: set[str],
+    ) -> tuple[dict[str, str | None], dict[str, str | None]]:
+        """Return current-authority and legacy stored fingerprints.
+
+        Session profiles are read strictly on macOS: an unavailable Keychain
+        must not fall back to an old plaintext seed and falsely look like a
+        fresh generation. Only a complete access+refresh pair can release a
+        quarantine; cleared or partial profiles keep the stored verdict.
+        """
+        from claude_swap.session import (
+            read_config_dir_credentials,
+            session_identity_drifted,
+        )
+
+        current: dict[str, str | None] = {}
+        legacy: dict[str, str | None] = {}
+        for num in nums:
+            info = info_by_num[num]
+            _, email, _, org_uuid, is_active, stored_creds, _ = info
+            stored_fp = oauth.credential_fingerprint(stored_creds)
+            legacy[num] = stored_fp
+            current_creds = stored_creds
+            if is_active:
+                if self._active_keychain_unavailable:
+                    current_creds = ""
+            else:
+                session_dir = self._session_dir(num, email)
+                if not session_identity_drifted(session_dir, email, org_uuid):
+                    try:
+                        profile_creds = read_config_dir_credentials(
+                            str(session_dir), strict_keychain=True
+                        )
+                    except CredentialReadError:
+                        profile_creds = None
+                    profile_oauth = oauth.extract_oauth_data(profile_creds or "")
+                    if (
+                        profile_oauth
+                        and profile_oauth.get("accessToken")
+                        and profile_oauth.get("refreshToken")
+                    ):
+                        current_creds = profile_creds or ""
+            current[num] = oauth.credential_fingerprint(current_creds)
+        return current, legacy
 
     def _run_usage_fetches(
         self, infos: list[tuple[int, str, str, str, bool, str, str]]
@@ -3515,6 +3580,25 @@ class ClaudeAccountSwitcher:
                 sentinels[num] = static
 
         entries = store.entries(identities, models)
+        dead_nums = {
+            num for num in info_by_num if entries[num].token_dead()
+        }
+        if dead_nums:
+            current_fps, legacy_fps = self._usage_credential_fingerprints(
+                info_by_num, dead_nums
+            )
+            cleared = store.clear_stale_dead_tokens(
+                {num: identities[num] for num in dead_nums},
+                current_fps,
+                legacy_fps,
+            )
+            if cleared:
+                self._logger.info(
+                    "Released stale auth quarantine after credential generation "
+                    "changed for account(s): %s",
+                    ", ".join(sorted(cleared, key=int)),
+                )
+                entries = store.entries(identities, models)
         # Dead refresh-token lineage: quarantine. Surfacing the sentinel here both
         # drives the "re-login needed" display and (via ``num not in sentinels``
         # below) stops the endless fetch loop that would otherwise 401/429 forever.

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -254,6 +254,7 @@ class FetchRecord:
     error: str | None = None
     retry_after_s: float | None = None
     sentinel: str | None = None
+    struck_fp: str | None = None
 
 
 @dataclass(frozen=True)
@@ -283,6 +284,9 @@ class UsageEntry:
     # Consecutive permanent-auth failures (``invalid_grant``). At or above
     # AUTH_DEAD_STRIKES the token is treated as dead: see ``token_dead``.
     auth_dead_strikes: int = 0
+    # Refresh-token lineage condemned by the permanent-auth verdict. Missing
+    # on rows written before generation binding was introduced.
+    struck_fingerprint: str | None = None
     # Staleness past STALE_OK_S is still decision-trusted when it is
     # *deliberate*: the server is refusing fresher data (failure state), or the
     # scheduler itself chose the cadence (within nextPollAt). Capped at
@@ -334,14 +338,30 @@ class UsageEntry:
         """Whether another collector's bounded fetch lease is still live."""
         return _live_claim(self.claim_until, self.last_attempt_at, now)
 
-    def token_dead(self, threshold: int = AUTH_DEAD_STRIKES) -> bool:
+    def token_dead(
+        self,
+        threshold: int = AUTH_DEAD_STRIKES,
+        stored_fp: str | None = None,
+    ) -> bool:
         """Whether the stored credential's refresh-token lineage is provably dead.
 
         True once ``invalid_grant`` has recurred ``threshold`` times without an
         intervening success. Such an account is quarantined: not fetched (see
         ``due_candidate`` and the collector) and surfaced as "re-login needed".
+
+        When a current credential fingerprint is supplied, a strike applies
+        only to the generation that produced it. A changed credential lineage
+        is eligible for a fresh test instead of inheriting the old verdict.
         """
-        return self.auth_dead_strikes >= threshold
+        if self.auth_dead_strikes < threshold:
+            return False
+        if (
+            stored_fp is not None
+            and self.struck_fingerprint is not None
+            and stored_fp != self.struck_fingerprint
+        ):
+            return False
+        return True
 
     def decision_value(self) -> dict | str | None:
         """The ``dict | sentinel | None`` value switch decisions run on.
@@ -906,6 +926,7 @@ class UsageStore:
                 poll_interval_s=_num_or_none(row.get("pollIntervalS")),
                 last_429_at=_num_or_none(row.get("last429At")),
                 auth_dead_strikes=int(row.get("authDeadStrikes") or 0),
+                struck_fingerprint=row.get("struckFingerprint"),
                 trust_extended=trust_extended,
                 claim_until=claim_until,
             )
@@ -1050,6 +1071,7 @@ class UsageStore:
                 row["lastError"] = None
                 row["backoffUntil"] = None
                 row["authDeadStrikes"] = 0  # a success proves the token is alive
+                row["struckFingerprint"] = None
             else:
                 failures = int(row.get("consecutiveFailures") or 0) + 1
                 row["consecutiveFailures"] = failures
@@ -1068,6 +1090,7 @@ class UsageStore:
                 # evidence either way and must not reset a real dead-token tally.
                 if rec.error in PERMANENT_AUTH_ERRORS:
                     row["authDeadStrikes"] = int(row.get("authDeadStrikes") or 0) + 1
+                    row["struckFingerprint"] = rec.struck_fp
 
         with self._lock():
             rows = self._read_rows()
@@ -1134,11 +1157,54 @@ class UsageStore:
             row["claimId"] = None
             row["claimUntil"] = 0.0
             row["authDeadStrikes"] = 0
+            row["struckFingerprint"] = None
             row["consecutiveFailures"] = 0
             row["lastError"] = None
             row["backoffUntil"] = None
 
         self._mutate(identities, nums, apply)
+
+    def clear_stale_dead_tokens(
+        self,
+        identities: dict[str, Identity],
+        current_fingerprints: dict[str, str | None],
+        legacy_fingerprints: dict[str, str | None] | None = None,
+    ) -> set[str]:
+        """Release quarantines that belong to an older credential generation.
+
+        ``current_fingerprints`` names the credential authority Claude Code
+        would use now. ``legacy_fingerprints`` supplies the stored credential
+        lineage for rows written before ``struckFingerprint`` existed; those
+        historical strikes came from that stored path, so it is the only safe
+        migration binding. Rows stay quarantined when either side is unknown.
+        """
+        legacy = legacy_fingerprints or {}
+        cleared: set[str] = set()
+        with self._lock():
+            rows = self._read_rows()
+            for num, identity in identities.items():
+                row = rows.get(num)
+                if not self._matches(row, identity) or not isinstance(row, dict):
+                    continue
+                if int(row.get("authDeadStrikes") or 0) < AUTH_DEAD_STRIKES:
+                    continue
+                current_fp = current_fingerprints.get(num)
+                struck_fp = row.get("struckFingerprint")
+                if not isinstance(struck_fp, str) or not struck_fp:
+                    struck_fp = legacy.get(num)
+                if not current_fp or not struck_fp or current_fp == struck_fp:
+                    continue
+                row["claimId"] = None
+                row["claimUntil"] = 0.0
+                row["authDeadStrikes"] = 0
+                row["struckFingerprint"] = None
+                row["consecutiveFailures"] = 0
+                row["lastError"] = None
+                row["backoffUntil"] = None
+                cleared.add(num)
+            if cleared:
+                self._write_rows(rows)
+        return cleared
 
 
 def _num_or_none(value: object) -> float | None:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -502,6 +502,21 @@ class TestTryRefreshOAuthCredentials:
             outcome = oauth.try_refresh_oauth_credentials(self._make_credentials())
         assert outcome.error == "transient"
 
+    def test_invalid_grant_substring_in_detail_is_transient(self):
+        err = self._http_error(
+            400,
+            b'{"error": "server_error", "detail": "mentions invalid_grant"}',
+        )
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            outcome = oauth.try_refresh_oauth_credentials(self._make_credentials())
+        assert outcome.error == "transient"
+
+    def test_invalid_client_is_systemic_not_a_dead_token(self):
+        err = self._http_error(401, b'{"error": "invalid_client"}')
+        with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
+            outcome = oauth.try_refresh_oauth_credentials(self._make_credentials())
+        assert outcome.error == "invalid_client"
+
     def test_5xx_is_transient_even_with_marker(self):
         err = self._http_error(500, b'{"error": "invalid_grant"}')
         with patch("claude_swap.oauth.urllib.request.urlopen", side_effect=err):
@@ -521,9 +536,9 @@ class TestTryRefreshOAuthCredentials:
         outcome = oauth.try_refresh_oauth_credentials(creds)
         assert outcome.error == "no_refresh_token"
 
-    def test_invalid_json_is_permanent(self):
+    def test_invalid_json_is_transient(self):
         outcome = oauth.try_refresh_oauth_credentials("not json")
-        assert outcome.error == "no_refresh_token"
+        assert outcome.error == "transient"
 
     def test_wrapper_returns_none_on_failure(self):
         err = self._http_error(400, b'{"error": "invalid_grant"}')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1362,12 +1362,15 @@ class TestGuards:
         assert (session_dir / ".credentials.json").read_text() == "live session creds"
         assert (session_dir / session_mod.STALE_MARKER).exists()
 
-    def test_list_skips_refresh_for_live_session_accounts(
+    def test_list_never_falls_back_to_backup_for_unreadable_live_profile(
         self, seeded_switcher, monkeypatch
     ):
-        """cswap --list must not proactively refresh an account that is live in
-        a session — rotating the backup copy's token could invalidate the
-        session's copy."""
+        """An unreadable live profile cannot authorize use of its backup.
+
+        The backup may be a consumed predecessor of the profile's real token
+        family. Treating it as merely ``is_active`` still sends its access
+        token and can later manufacture an invalid_grant verdict.
+        """
         session_dir = session_dir_for(
             seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
         )
@@ -1383,7 +1386,7 @@ class TestGuards:
         )
         seeded_switcher.list_accounts()
 
-        assert seen[ACCOUNT_NUM] is True  # treated like active: no refresh
+        assert ACCOUNT_NUM not in seen
         assert seen.get("1") in (None, False)  # account 1 has no live session
 
     def test_invalidate_session_credentials_keeps_history(

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -786,10 +786,15 @@ class TestFetchAccountUsageSessionProfile:
         assert record.sentinel == USAGE_TOKEN_EXPIRED
         mock_fetch.assert_not_called()
 
-    def test_expired_session_credentials_without_live_session_falls_back(
+    def test_expired_session_credentials_without_live_session_stay_authoritative(
         self, temp_home: Path
     ):
-        """No live session: the backup path (with refresh machinery) still runs."""
+        """An idle profile still owns the newest refresh-token generation.
+
+        Falling back to its stored backup would POST the consumed predecessor,
+        falsely record ``invalid_grant``, and quarantine a healthy account.
+        Native Claude refreshes the profile on its next real turn instead.
+        """
         switcher = ClaudeAccountSwitcher()
         backup = _oauth_creds("sk-backup", 7200)
         session = _oauth_creds("sk-session", -60)
@@ -797,15 +802,11 @@ class TestFetchAccountUsageSessionProfile:
         with patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch("claude_swap.session.read_session_credentials",
                    return_value=session), \
-             patch("claude_swap.oauth.try_fetch_usage_for_account",
-                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 9}})) as mock_fetch:
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
             record = switcher._fetch_account_usage(self._info(backup))
 
-        assert record.usage == {"five_hour": {"pct": 9}}
-        args, kwargs = mock_fetch.call_args
-        assert args[2] == backup
-        assert kwargs.get("is_active") is False
-        assert kwargs.get("persist_credentials") is not None
+        assert record.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_not_called()
 
     def test_no_session_profile_uses_backup_path(self, temp_home: Path):
         """Accounts without a session profile behave exactly as before."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -14,7 +14,12 @@ import pytest
 
 from claude_swap import macos_keychain
 from claude_swap import oauth
-from claude_swap.json_output import USAGE_FOREIGN_CREDENTIAL, USAGE_TOKEN_EXPIRED
+from claude_swap.json_output import (
+    USAGE_FOREIGN_CREDENTIAL,
+    USAGE_NO_CREDENTIALS,
+    USAGE_RELOGIN_REQUIRED,
+    USAGE_TOKEN_EXPIRED,
+)
 from claude_swap.exceptions import (
     AccountNotFoundError,
     ConfigError,
@@ -825,6 +830,35 @@ class TestFetchAccountUsageSessionProfile:
         assert args[2] == backup
         assert kwargs.get("is_active") is False
         assert kwargs.get("persist_credentials") is not None
+
+    def test_cleared_session_profile_never_falls_back_to_backup(
+        self, temp_home: Path
+    ):
+        """A cleared profile is authoritative; its backup may be consumed."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+        cleared = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "",
+                    "refreshToken": "",
+                    "expiresAt": 0,
+                }
+            }
+        )
+        session_dir = switcher._session_dir("2", "test@example.com")
+        session_dir.mkdir(parents=True)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=cleared), \
+             patch("claude_swap.session.session_identity_drifted",
+                   return_value=False), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.sentinel == USAGE_NO_CREDENTIALS
+        mock_fetch.assert_not_called()
 
     def _write_profile_identity(self, switcher, email: str, org_uuid) -> None:
         session_dir = switcher._session_dir("2", "test@example.com")
@@ -3960,7 +3994,91 @@ class TestDeadTokenQuarantine:
             "window has reset — it never handed its configured models to the "
             "bound"
         )
+    @pytest.mark.parametrize("legacy_row", [False, True])
+    def test_new_session_generation_releases_stale_quarantine(
+        self, temp_home, legacy_row
+    ):
+        """A healthy profile must not inherit its stored predecessor's verdict."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        backup = _oauth_creds("backup-old", -3600)
+        profile = _oauth_creds("profile-new", 7200)
+        identity = ("test@example.com", "org-uuid")
+        struck_fp = None if legacy_row else oauth.credential_fingerprint(backup)
+        switcher._usage_store.record(
+            {
+                "2": FetchRecord(
+                    error="invalid_grant", struck_fp=struck_fp
+                )
+            },
+            {"2": identity},
+        )
+        info = [(2, identity[0], "Org", identity[1], False, backup, "")]
+        usage = {"five_hour": {"pct": 12.0}}
 
+        with patch(
+            "claude_swap.session.read_config_dir_credentials",
+            return_value=profile,
+        ), patch(
+            "claude_swap.session.read_session_credentials",
+            return_value=profile,
+        ), patch(
+            "claude_swap.session.session_identity_drifted",
+            return_value=False,
+        ), patch.object(
+            switcher, "_live_session_pids", return_value=[]
+        ), patch(
+            "claude_swap.oauth.try_fetch_usage_for_account",
+            return_value=oauth.UsageOutcome(usage),
+        ) as fetch:
+            entries = switcher._collect_usage_entries(info)
+
+        fetch.assert_called_once()
+        assert entries["2"].sentinel is None
+        assert entries["2"].last_good == usage
+        assert not switcher._usage_store.entries({"2": identity})["2"].token_dead()
+
+    def test_cleared_profile_does_not_release_or_retry_dead_backup(self, temp_home):
+        """The invalid_grant wipe shape stays quarantined without another POST."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        backup = _oauth_creds("backup-dead", -3600)
+        cleared = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "",
+                    "refreshToken": "",
+                    "expiresAt": 0,
+                }
+            }
+        )
+        identity = ("test@example.com", "org-uuid")
+        switcher._usage_store.record(
+            {
+                "2": FetchRecord(
+                    error="invalid_grant",
+                    struck_fp=oauth.credential_fingerprint(backup),
+                )
+            },
+            {"2": identity},
+        )
+        info = [(2, identity[0], "Org", identity[1], False, backup, "")]
+
+        with patch(
+            "claude_swap.session.read_config_dir_credentials",
+            return_value=cleared,
+        ), patch(
+            "claude_swap.session.read_session_credentials",
+            return_value=cleared,
+        ), patch(
+            "claude_swap.session.session_identity_drifted",
+            return_value=False,
+        ), patch("claude_swap.oauth.try_fetch_usage_for_account") as fetch:
+            entries = switcher._collect_usage_entries(info)
+
+        assert entries["2"].sentinel == USAGE_RELOGIN_REQUIRED
+        assert switcher._usage_store.entries({"2": identity})["2"].token_dead()
+        fetch.assert_not_called()
     def test_readd_clears_quarantine(self, temp_home):
         # Re-adding an account (fresh credential) must lift the quarantine, so
         # the disabled fetches don't leave it stuck at "re-login needed" forever.
@@ -4669,7 +4787,7 @@ class TestAddAccountFromToken:
     def test_basic_add_stores_account(self, temp_home, capsys):
         """A valid token + email should store the account and print 'Added'."""
         switcher = self._make_switcher(temp_home)
-        with patch.object(switcher, "_write_account_credentials") as mock_creds, \
+        with patch.object(switcher, "_write_account_credentials"), \
              patch.object(switcher, "_write_account_config"):
             switcher.add_account_from_token("sk-ant-oat01-abc", "user@example.com")
 

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -1280,6 +1280,67 @@ class TestDeadTokenQuarantine:
         assert entry.last_error is None
         assert entry.backoff_until is None
 
+    def test_strike_binds_to_failed_credential_generation(self, store):
+        store.record(
+            {
+                "1": FetchRecord(
+                    error="invalid_grant", struck_fp="sha256:failed"
+                )
+            },
+            IDENT,
+        )
+        entry = store.entries(IDENT)["1"]
+        assert entry.struck_fingerprint == "sha256:failed"
+        assert entry.token_dead(stored_fp="sha256:failed")
+        assert not entry.token_dead(stored_fp="sha256:new")
+
+    def test_changed_generation_clears_bound_quarantine(self, store):
+        store.record(
+            {
+                "1": FetchRecord(
+                    error="invalid_grant", struck_fp="sha256:failed"
+                )
+            },
+            IDENT,
+        )
+        cleared = store.clear_stale_dead_tokens(
+            {"1": IDENT["1"]},
+            {"1": "sha256:new"},
+            {"1": "sha256:failed"},
+        )
+        assert cleared == {"1"}
+        entry = store.entries(IDENT)["1"]
+        assert not entry.token_dead()
+        assert entry.struck_fingerprint is None
+        assert entry.last_error is None
+
+    def test_legacy_strike_uses_stored_generation_as_migration_binding(self, store):
+        store.record({"1": FetchRecord(error="invalid_grant")}, IDENT)
+        cleared = store.clear_stale_dead_tokens(
+            {"1": IDENT["1"]},
+            {"1": "sha256:session-new"},
+            {"1": "sha256:stored-old"},
+        )
+        assert cleared == {"1"}
+        assert not store.entries(IDENT)["1"].token_dead()
+
+    def test_same_generation_keeps_quarantine(self, store):
+        store.record(
+            {
+                "1": FetchRecord(
+                    error="invalid_grant", struck_fp="sha256:failed"
+                )
+            },
+            IDENT,
+        )
+        cleared = store.clear_stale_dead_tokens(
+            {"1": IDENT["1"]},
+            {"1": "sha256:failed"},
+            {"1": "sha256:failed"},
+        )
+        assert cleared == set()
+        assert store.entries(IDENT)["1"].token_dead()
+
 
 class TestReserve:
     """Atomic fetch reservation: eligibility re-checked under the lock."""


### PR DESCRIPTION
## Problem

An inactive account with a matching `cswap run` profile can be falsely quarantined after that profile becomes idle and its access token expires.

Claude Code may have rotated the profile onto refresh-token generation B while the stored backup still contains consumed generation A. The collector currently trusts B only while a process is live; once idle, expiry falls through to the backup refresh path, POSTs A, receives `invalid_grant`, and records the healthy slot as `relogin_required`.

A later login/profile refresh can create generation C, but the usage cache stores only a generation-blind dead-token strike. That leaves C quarantined even when native Claude can authenticate successfully.

## Fix

Keep an existing matching session profile credential-authoritative whether or not a Claude process is currently alive:

- fresh profile access tokens remain usable for read-only usage fetches;
- expired profile credentials surface `token_expired`;
- cleared, partial, or unreadable profiles never fall back to a possibly consumed backup;
- native Claude refreshes the profile on its next real turn;
- each `invalid_grant` strike records the credential fingerprint that failed;
- a complete newer profile generation releases only its predecessor generation’s quarantine;
- legacy fingerprint-less rows bind to the stored generation that originally produced them;
- strict Keychain reads prevent stale plaintext fallback from falsely healing quarantine;
- RFC-style JSON classification keeps `invalid_client` systemic instead of condemning an account token.

Profiles whose identity has drifted to another account still fall back to the intended slot backup, and accounts with no session profile retain the existing backup path.

## Validation

- Rebased onto current upstream `main` on August 6, 2026.
- 715 changed-area tests pass; Ruff passes on all changed files.
- The current upstream full macOS run reaches 1,833 passed and 3 skipped. Its one existing strict-clear rollback failure is the separate credential-clear issue covered by #214, not this diff.
- The combined production deployment branch with #214 passes 1,714 tests with 3 platform-specific skips.
- Regression coverage binds quarantine to the failed fingerprint, releases it after a complete generation change, migrates legacy rows, keeps the same generation blocked, rejects cleared-profile fallback, and distinguishes exact `invalid_grant` from `invalid_client` or marker substrings.
- A controlled native Claude request succeeded through the newer profile while the old cache still reported `relogin_required`; the fixed collector then released only that stale quarantine. A genuinely cleared sibling profile remained quarantined.

Fixes #187.