### PR TITLE
Make cswap list a clearer quota dashboard by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Not sure which one? `cswap list` is the dashboard — every account's 5-hour and
 cswap list
 ```
 
+![Quota table with anonymized example accounts](assets/quota-table.svg)
+
 Or let claude-swap auto-pick by remaining quota — `cswap switch --strategy best` (most quota left) or `--strategy next-available` (skip rate-limited accounts).
 
 **Note:** You usually don't need to restart — on Linux/Windows the new account is picked up automatically, and on macOS after the Keychain cache expires. To apply it instantly, restart Claude Code or reopen the VS Code extension tab. See [Tips](#tips) for the per-platform details.

--- a/assets/quota-table.svg
+++ b/assets/quota-table.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="580" viewBox="0 0 1440 580">
+  <rect width="1440" height="580" rx="18" fill="#1e1e1e"/>
+  <rect x="1" y="1" width="1438" height="578" rx="17" fill="none" stroke="#454545"/>
+  <circle cx="35" cy="32" r="10" fill="#ff5f57"/><circle cx="65" cy="32" r="10" fill="#febc2e"/><circle cx="95" cy="32" r="10" fill="#28c840"/>
+  <text x="720" y="39" text-anchor="middle" fill="#b9b9b9" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="18">cswap list</text>
+  <text x="720" y="94" text-anchor="middle" fill="#f2f2f2" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="21" font-weight="600">Claude Code quota</text>
+  <g fill="#d7d7d7" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="18">
+    <path d="M35 118h1370M35 163h1370M35 244h1370M35 325h1370M35 406h1370M35 487h1370" stroke="#5a5a5a" fill="none"/>
+    <path d="M35 118v369M86 118v369M455 118v369M654 118v369M781 118v369M980 118v369M1118 118v369M1330 118v369M1405 118v369" stroke="#5a5a5a" fill="none"/>
+    <text x="61" y="147" text-anchor="middle" font-weight="600">#</text>
+    <text x="106" y="147" font-weight="600">Account</text>
+    <text x="475" y="147" font-weight="600">5h limit</text>
+    <text x="674" y="147" font-weight="600">5h reset</text>
+    <text x="801" y="147" font-weight="600">Weekly limit</text>
+    <text x="1000" y="147" font-weight="600">Weekly reset</text>
+    <text x="1138" y="147" font-weight="600">Status</text>
+    <text x="61" y="205" text-anchor="middle">1</text><text x="106" y="205">personal@example.com</text>
+    <text x="475" y="205" fill="#f14c4c" font-weight="600">100% █████████</text><text x="674" y="205" fill="#a9a9a9">45m</text>
+    <text x="801" y="205" fill="#72c472">22% ██░░░░░░░</text><text x="1000" y="205" fill="#a9a9a9">6d 2h</text><text x="1138" y="205">ready</text>
+    <text x="61" y="286" text-anchor="middle">2</text><text x="106" y="286" font-weight="600">work@example.com</text>
+    <text x="475" y="286" fill="#e89c3c">72% ██████░░░</text><text x="674" y="286" fill="#a9a9a9">2h 34m</text>
+    <text x="801" y="286" fill="#e56262">94% ████████░</text><text x="1000" y="286" fill="#a9a9a9">3d 19h</text><text x="1138" y="286" fill="#72c472" font-weight="600">active</text>
+    <text x="61" y="367" text-anchor="middle">3</text><text x="106" y="367">client@example.com</text>
+    <text x="475" y="367" fill="#e7d36d">48% ████░░░░░</text><text x="674" y="367" fill="#a9a9a9">4h 8m</text>
+    <text x="801" y="367" fill="#72c472">11% █░░░░░░░░</text><text x="1000" y="367" fill="#a9a9a9">6d 5h</text><text x="1138" y="367">ready</text>
+    <text x="61" y="448" text-anchor="middle">4</text><text x="106" y="448">backup@example.com</text>
+    <text x="475" y="448" fill="#72c472"> 7% █░░░░░░░░</text><text x="674" y="448" fill="#a9a9a9">4h 41m</text>
+    <text x="801" y="448" fill="#e7d36d">58% █████░░░░</text><text x="1000" y="448" fill="#a9a9a9">5d 11h</text><text x="1138" y="448">ready</text>
+  </g>
+</svg>

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -973,6 +973,16 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         help="Show source-labelled OAuth token diagnostics (use with 'list')",
     )
     parser.add_argument(
+        "--table",
+        action="store_true",
+        help="Render 'list' as a colourized quota table (the default)",
+    )
+    parser.add_argument(
+        "--plain",
+        action="store_true",
+        help="Use the legacy plain-text rendering for 'list'",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help=(
@@ -1160,6 +1170,15 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.token_status and not args.list:
         parser.error("--token-status can only be used with 'list'")
 
+    if args.table and not args.list:
+        parser.error("--table can only be used with 'list'")
+
+    if args.plain and not args.list:
+        parser.error("--plain can only be used with 'list'")
+
+    if args.table and args.plain:
+        parser.error("--table and --plain cannot be combined")
+
     if args.json and not (args.list or args.status or args.switch or args.switch_to):
         parser.error("--json can only be used with 'list', 'status', or 'switch'")
 
@@ -1167,6 +1186,9 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         # Token status is not part of the JSON v1 schema; reject rather than
         # silently ignore it (a future additive field can add it).
         parser.error("--token-status cannot be combined with --json")
+
+    if args.json and args.table:
+        parser.error("--table cannot be combined with --json")
 
     if args.strategy is not None and not args.switch:
         parser.error("--strategy can only be used with bare 'switch'")
@@ -1239,10 +1261,12 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         elif args.enable_account is not None:
             switcher.set_account_disabled(args.enable_account, False)
         elif args.list:
-            payload = switcher.list_accounts(
+            list_kwargs = dict(
                 show_token_status=args.token_status,
                 json_output=args.json,
+                table_output=not (args.plain or args.json),
             )
+            payload = switcher.list_accounts(**list_kwargs)
         elif args.switch:
             from claude_swap.settings import load_settings, parse_model_names
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -12,6 +12,11 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+from rich import box
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
 from claude_swap import macos_keychain
 
 from claude_swap.exceptions import (
@@ -218,6 +223,101 @@ def _usage_entry_lines(entry: UsageEntry) -> list[str]:
     if entry.last_error:
         detail += f" ({entry.last_error})"
     return [dimmed(detail)]
+
+
+def _quota_style(pct: float) -> str:
+    """Return the urgency colour for a used-quota percentage."""
+    if pct >= 100:
+        return "bold red"
+    if pct >= 90:
+        return "bright_red"
+    if pct >= 70:
+        return "dark_orange"
+    if pct >= 40:
+        return "yellow"
+    return "green"
+
+
+def _usage_table_cell(entry: UsageEntry, key: str, bar_width: int) -> Text:
+    """Return a fixed-width percentage and mini progress bar for a quota window."""
+    if entry.last_good is None or (window := entry.last_good.get(key)) is None:
+        if entry.sentinel is not None:
+            return Text(SENTINEL_NOTES.get(entry.sentinel, entry.sentinel), style="dim")
+        return Text("unavailable", style="dim")
+
+    pct = window["pct"]
+    style = _quota_style(pct)
+    filled = min(bar_width, max(0, round(pct * bar_width / 100)))
+    cell = Text(f"{pct:>3.0f}% ", style=style)
+    cell.append("█" * filled, style=style)
+    cell.append("░" * (bar_width - filled), style="dim")
+    return cell
+
+
+def _reset_table_cell(entry: UsageEntry, key: str) -> Text:
+    """Return one quota window's reset countdown for the adjacent reset column."""
+    if entry.last_good is None or (window := entry.last_good.get(key)) is None:
+        return Text("—", style="dim")
+    reset = oauth.fresh_reset_strings(window)
+    return Text(reset[0].replace(" ", "") if reset else "—", style="dim")
+
+
+def _compact_reset_table_cell(entry: UsageEntry) -> Text:
+    """Return the 5h/weekly reset pair for the narrow table layout."""
+    five_hour = _reset_table_cell(entry, "five_hour").plain
+    seven_day = _reset_table_cell(entry, "seven_day").plain
+    return Text(f"{five_hour}/{seven_day}", style="dim")
+
+
+def _accounts_table(
+    accounts_info: list[tuple], entries: dict[str, UsageEntry], seq_data: dict, wide: bool = True
+) -> Table:
+    """Build the human-facing account and quota overview used by ``list --table``."""
+    cached_quota = any(entry.sentinel is not None for entry in entries.values())
+    table = Table(
+        title="Claude Code quota · cached values" if cached_quota else "Claude Code quota",
+        box=box.ROUNDED,
+        header_style="bold",
+        pad_edge=False,
+        show_lines=False,
+    )
+    table.add_column("#", justify="right", style="bold", no_wrap=True, min_width=2)
+    table.add_column("Account", no_wrap=True, max_width=26 if wide else 18)
+    table.add_column("5h limit", justify="right", no_wrap=True, min_width=14 if wide else 10)
+    if wide:
+        table.add_column("5h reset", justify="right", no_wrap=True, min_width=8)
+    table.add_column("Weekly limit", justify="right", no_wrap=True, min_width=14 if wide else 12)
+    table.add_column("Weekly reset" if wide else "Reset", justify="right", no_wrap=True, min_width=10 if wide else 11)
+    table.add_column("Status", no_wrap=True, min_width=7)
+
+    for num, email, org_name, org_uuid, is_active, _, alias in accounts_info:
+        account = Text()
+        if alias:
+            account.append(alias, style="bold bright_cyan")
+            account.append(f" ({email})", style="dim")
+        else:
+            account.append(email)
+        if is_active:
+            account.stylize("bold")
+        status = Text("active", style="bold green") if is_active else Text("ready", style="dim")
+        if ClaudeAccountSwitcher._disabled_from_data(seq_data, str(num)):
+            status = Text("disabled", style="yellow")
+        row = [
+            str(num),
+            account,
+            _usage_table_cell(entries[str(num)], "five_hour", bar_width=9 if wide else 5),
+        ]
+        if wide:
+            row.append(_reset_table_cell(entries[str(num)], "five_hour"))
+        row.append(_usage_table_cell(entries[str(num)], "seven_day", bar_width=9 if wide else 5))
+        row.append(
+            _reset_table_cell(entries[str(num)], "seven_day")
+            if wide
+            else _compact_reset_table_cell(entries[str(num)])
+        )
+        row.append(status)
+        table.add_row(*row)
+    return table
 
 
 def _label_token_status(source: str, credentials: str) -> str | None:
@@ -3922,6 +4022,7 @@ class ClaudeAccountSwitcher:
         self,
         show_token_status: bool = False,
         json_output: bool = False,
+        table_output: bool = False,
         fetch: set[str] | None = None,
     ) -> dict | None:
         """List all managed accounts.
@@ -3953,24 +4054,32 @@ class ClaudeAccountSwitcher:
             return self._build_list_payload(accounts_info, entries)
 
         seq_data = self._get_sequence_data() or {}
-        print(bolded("Accounts:"))
-        for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
-            tag = self._get_display_tag(email, org_name, org_uuid)
-            label = f"{accent(alias)} ({email})" if alias else email
-            markers = ""
-            if is_active:
-                markers += f" {bold_accent('(active)')}"
-            if self._disabled_from_data(seq_data, str(num)):
-                markers += f" {muted('(disabled)')}"
-            print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
-            for line in _usage_entry_lines(entries[str(num)]):
-                print(f"     {line}")
-
+        if table_output:
+            console = Console()
+            console.print(_accounts_table(accounts_info, entries, seq_data, wide=console.width >= 100))
             if show_token_status:
-                for line in self._token_status_lines(accounts_info[i]):
-                    print(f"     {dimmed('•')} {muted(line)}")
-            if i < len(accounts_info) - 1:
-                print()
+                for account in accounts_info:
+                    for line in self._token_status_lines(account):
+                        print(f"  {dimmed('•')} {muted(line)}")
+        else:
+            print(bolded("Accounts:"))
+            for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
+                tag = self._get_display_tag(email, org_name, org_uuid)
+                label = f"{accent(alias)} ({email})" if alias else email
+                markers = ""
+                if is_active:
+                    markers += f" {bold_accent('(active)')}"
+                if self._disabled_from_data(seq_data, str(num)):
+                    markers += f" {muted('(disabled)')}"
+                print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
+                for line in _usage_entry_lines(entries[str(num)]):
+                    print(f"     {line}")
+
+                if show_token_status:
+                    for line in self._token_status_lines(accounts_info[i]):
+                        print(f"     {dimmed('•')} {muted(line)}")
+                if i < len(accounts_info) - 1:
+                    print()
 
         # Safety copies (unclaimed credentials) are deliberately NOT surfaced
         # here: users can't act on them (recovery is always /login + cswap

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,41 @@ class TestCLI:
         switcher_cls.return_value.list_accounts.assert_called_once_with(
             show_token_status=True,
             json_output=False,
+            table_output=True,
+        )
+
+    def test_table_flag_requires_list(self, capsys):
+        with patch.object(sys, "argv", ["claude-swap", "--table", "--status"]):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 2
+        assert "--table can only be used with 'list'" in capsys.readouterr().err
+
+    def test_table_flag_is_forwarded_to_list(self):
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "--list", "--table"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.list_accounts.assert_called_once_with(
+            show_token_status=False,
+            json_output=False,
+            table_output=True,
+        )
+
+    def test_plain_flag_uses_legacy_list_rendering(self):
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "--list", "--plain"]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.list_accounts.assert_called_once_with(
+            show_token_status=False,
+            json_output=False,
+            table_output=False,
         )
 
     def test_strategy_best_requires_switch(self, capsys):
@@ -740,7 +775,7 @@ class TestSubcommandAliases:
             switcher_cls.return_value.list_accounts.return_value = payload
             cli.main()
         switcher_cls.return_value.list_accounts.assert_called_once_with(
-            show_token_status=False, json_output=True,
+            show_token_status=False, json_output=True, table_output=False,
         )
 
     def test_run_subcommand_still_dispatches(self):
@@ -803,7 +838,7 @@ class TestJsonOutputCli:
             cli.main()
 
         switcher_cls.return_value.list_accounts.assert_called_once_with(
-            show_token_status=False, json_output=True,
+            show_token_status=False, json_output=True, table_output=False,
         )
         out = capsys.readouterr().out
         assert json.loads(out) == payload  # exactly one JSON object, no extra text


### PR DESCRIPTION
I use `claude-swap` with several Claude Code accounts, and I found the existing `cswap list` output a little difficult to scan quickly when deciding which account to use
  next.

  This changes the default list view to a compact quota table:

  - 5-hour and weekly limits are visually separated
  - Colored progress bars make accounts near their limit stand out immediately
  - Reset times sit next to the corresponding limit
  - The active account is emphasized
  - The layout adapts for narrower terminals
  - `cswap list --plain` keeps the previous text-based output available

  I also added an anonymized screenshot to the README so the output is easier to understand before installing.

  The JSON output is unchanged. I ran the focused CLI and switcher tests (`482 passed`).

Example:
<img width="725" height="107" alt="SCR-20260805-ovjl" src="https://github.com/user-attachments/assets/70e6cafa-a808-4a72-a9dc-d35516481ea4" />
