### PR TITLE
fix(session): stop --share-history from losing transcripts on collisions and races

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -484,6 +484,62 @@ def _mkdir_private(path: Path) -> None:
         directory.mkdir(mode=0o700, exist_ok=True)
 
 
+def _last_timestamp(path: Path) -> str | None:
+    """Last ISO-8601 ``timestamp`` in a JSONL transcript, scanning backwards.
+
+    Claude closes nearly every transcript with untimestamped state lines
+    (``last-prompt``, ``mode``, ``ai-title``, ``file-history-snapshot``), so
+    reading only the final line finds a timestamp in about 1% of real files.
+    Scanning back finds one within a line or two. Values are ISO-8601 Zulu
+    with milliseconds, so lexical comparison is chronological.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for line in reversed(text.splitlines()):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(entry, dict):
+            stamp = entry.get("timestamp")
+            if isinstance(stamp, str) and stamp:
+                return stamp
+    return None
+
+
+def _line_count(path: Path) -> int:
+    """Lines in a file; 0 when it cannot be read (so it never wins a tiebreak)."""
+    try:
+        with path.open("rb") as handle:
+            return sum(1 for _ in handle)
+    except OSError:
+        return 0
+
+
+def _profile_copy_wins(target: Path, candidate: Path) -> bool:
+    """Whether the profile's ``candidate`` should replace the shared ``target``.
+
+    A same-named pair is *not* the same session: a transcript that straddled
+    an un-share event exists in both trees under one UUID with different
+    content. Order, applied in full so the outcome is deterministic: later
+    last-timestamp, then having a timestamp at all, then more lines, then the
+    incumbent. The loser is quarantined either way, never dropped.
+    """
+    target_stamp = _last_timestamp(target)
+    candidate_stamp = _last_timestamp(candidate)
+    if target_stamp != candidate_stamp:
+        if target_stamp is None:
+            return True
+        if candidate_stamp is None:
+            return False
+        return candidate_stamp > target_stamp
+    return _line_count(candidate) > _line_count(target)
+
+
 def _probe_env(session_dir: Path) -> dict[str, str]:
     """Env for the auth-status probe: session config dir, auth overrides dropped."""
     env = {k: v for k, v in os.environ.items() if k not in AUTH_OVERRIDE_ENV_VARS}

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -1458,7 +1458,12 @@ class SessionManager:
         ``history.jsonl`` merges by appending lines not already present.
         ``dest`` is removed once empty; any failure raises OSError and leaves
         remaining files in place for the next try. Returns
-        ``(moved, quarantined, run_dir)``.
+        ``(moved, quarantined, run_dir)``: ``moved`` counts files relocated
+        into ``src`` — a plain (non-colliding) move, or the winning half of a
+        collision; ``quarantined`` counts losers parked instead of dropped. A
+        collision where the profile copy wins increments *both* for the one
+        file pair (the winner is moved, the incumbent is quarantined), so
+        callers must not sum the two counters as "files handled".
         """
         run_dir: Path | None = None
         moved = 0

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -1487,10 +1487,61 @@ class SessionManager:
         return True
 
     def _report_deferral(self, session_dir: Path, dest: Path) -> None:
-        print(
-            dimmed(
-                f"Not sharing {dest.name} yet: another session is "
-                "using this profile — retrying on the next launch."
+        """Explain a skipped migration loudly enough to be noticed.
+
+        The old one-line dimmed print was scrolled away by Claude's startup
+        banner and never logged, so a profile could sit unshared for days
+        with the flag passed on every launch and no visible signal.
+        """
+        blockers, _ = scan_live_sessions(session_dir)
+        account = session_dir.name
+        slot = account.split("-")[0]
+        warning(f"share-history: {account} keeps its own {dest.name} for now.")
+        if blockers:
+            for live in blockers:
+                started = datetime.fromtimestamp(
+                    live.started_at / 1000, tz=timezone.utc
+                ).astimezone()
+                print(
+                    dimmed(
+                        f"   pid {live.pid}  {live.cwd}  "
+                        f"(since {started:%Y-%m-%d %H:%M})"
+                    )
+                )
+            print(
+                dimmed(
+                    "   Sessions started here will not appear in "
+                    "`claude --resume` under other accounts."
+                )
+            )
+            print(
+                dimmed(
+                    f"   Close them, then relaunch:  cswap run {slot} --share-history"
+                )
+            )
+        else:
+            # No live session in *this* profile — the migration lock is held
+            # by a peer cswap process instead (e.g. a concurrent launch
+            # already merging this same profile's history). Nothing to
+            # close; the only useful action is to retry once it is done.
+            print(
+                dimmed(
+                    "   Another process is migrating this profile's "
+                    "history right now."
+                )
+            )
+            print(
+                dimmed(
+                    f"   Once it finishes, relaunch:  cswap run {slot} --share-history"
+                )
+            )
+        self._logger.warning(
+            f"History migration deferred for {account}: "
+            f"{len(blockers)} live session(s)"
+            + (
+                ": " + ", ".join(f"pid {b.pid} ({b.cwd})" for b in blockers)
+                if blockers
+                else " (migration lock held by a peer process)"
             )
         )
 

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -1399,7 +1399,20 @@ class SessionManager:
             # The pre-check above is a cheap early out; the authoritative one
             # runs under the lock, so a launch that starts in between cannot
             # have its transcripts moved mid-write.
-            with FileLock(self.switcher.lock_file, timeout=_MIGRATION_LOCK_TIMEOUT):
+            #
+            # A per-profile lock, not switcher.lock_file: the risk being
+            # serialized here is two concurrent migrations of the *same*
+            # profile racing target.exists() against shutil.move. A
+            # per-profile lock covers exactly that, is finer-grained than the
+            # global lock (an unrelated account's migration is never
+            # blocked), and cannot deadlock against setup_session's bootstrap
+            # lock (which is still held across this call on some paths)
+            # because it is a different file. The bootstrap lock protects
+            # credential and profile setup — a different concern from moving
+            # transcripts.
+            with FileLock(
+                session_dir / ".migration.lock", timeout=_MIGRATION_LOCK_TIMEOUT
+            ):
                 if not profile_is_quiescent(session_dir):
                     self._report_deferral(session_dir, dest)
                     return False

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -54,9 +54,11 @@ from claude_swap.claude_locks import proper_lockfile
 from claude_swap.exceptions import (
     ClaudeCodeLockTimeout,
     CredentialReadError,
+    LockError,
     SessionError,
 )
 from claude_swap.fsutil import replace_with_retry
+from claude_swap.macos_keychain import KeychainError
 from claude_swap.locking import FileLock
 from claude_swap.models import Platform
 from claude_swap.paths import get_default_global_config_path
@@ -116,6 +118,11 @@ MCP_MIRROR_MARKER = ".cswap-mcp-mirror-v1"
 # One-time migration stash: session-local MCP definitions displaced by the
 # first mirror land here (write-once) instead of vanishing.
 MCP_DISPLACED_STASH = ".cswap-mcp-displaced.json"
+
+# Per-profile lock serializing concurrent history migrations of the same
+# profile. Permanent once created (like the markers above), so it is a named
+# constant rather than an inline literal — a later rename would orphan it.
+MIGRATION_LOCK = ".cswap-migration.lock"
 
 
 def stale_marker_for(session_dir: Path) -> Path:
@@ -1087,6 +1094,10 @@ class SessionManager:
         """
         if not session_dir.is_dir():
             return
+        # Reset per call: _prepare_history_share accumulates into this as it
+        # runs (once per HISTORY_ITEMS entry), so a launch with nothing to
+        # migrate must not report counts left over from a previous one.
+        self._last_merge_counts = (0, 0, None)
         self._sync_mcp_servers(session_dir, share)
         # History links are POSIX-only (run() rejects the flag on Windows;
         # this also drops any links left by a POSIX→Windows profile move).
@@ -1410,27 +1421,48 @@ class SessionManager:
             # because it is a different file. The bootstrap lock protects
             # credential and profile setup — a different concern from moving
             # transcripts.
-            with FileLock(
-                session_dir / ".migration.lock", timeout=_MIGRATION_LOCK_TIMEOUT
-            ):
-                if not profile_is_quiescent(session_dir):
-                    self._report_deferral(session_dir, dest)
-                    return False
-                try:
-                    self._last_merge_counts = self._merge_history_into_source(
-                        src, dest
-                    )
-                except OSError as e:
-                    self._logger.warning(
-                        f"Could not merge {dest.name} into {src}: {e}"
-                    )
-                    print(
-                        dimmed(
-                            f"Not sharing {dest.name}: merging the profile's "
-                            "existing history failed (see log)."
+            try:
+                with FileLock(
+                    session_dir / MIGRATION_LOCK, timeout=_MIGRATION_LOCK_TIMEOUT
+                ):
+                    if not profile_is_quiescent(session_dir):
+                        self._report_deferral(session_dir, dest)
+                        return False
+                    try:
+                        moved, quarantined, run_dir = (
+                            self._merge_history_into_source(src, dest)
                         )
+                    except OSError as e:
+                        self._logger.warning(
+                            f"Could not merge {dest.name} into {src}: {e}"
+                        )
+                        print(
+                            dimmed(
+                                f"Not sharing {dest.name}: merging the profile's "
+                                "existing history failed (see log)."
+                            )
+                        )
+                        return False
+                    # HISTORY_ITEMS holds two entries (projects, history.jsonl),
+                    # so this runs up to twice per launch — accumulate rather
+                    # than overwrite, and keep the first quarantine dir a run
+                    # produces (the file-merge branch never quarantines, so at
+                    # most one of the two calls sets it).
+                    prev_moved, prev_quarantined, prev_run_dir = (
+                        self._last_merge_counts
                     )
-                    return False
+                    self._last_merge_counts = (
+                        prev_moved + moved,
+                        prev_quarantined + quarantined,
+                        prev_run_dir if prev_run_dir is not None else run_dir,
+                    )
+            except LockError:
+                # A peer is migrating this same profile right now — the
+                # timeout means "still busy", not "broken", so this degrades
+                # exactly like every other deferral instead of aborting the
+                # launch.
+                self._report_deferral(session_dir, dest)
+                return False
             print(
                 dimmed(
                     f"Merged the profile's existing {dest.name} into "

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -45,6 +45,7 @@ import sys
 import tempfile
 import time
 import unicodedata
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
@@ -92,6 +93,11 @@ HISTORY_ITEMS = (
 # Records which entries in a session profile cswap created (so --no-share and
 # re-syncs only ever remove cswap-managed links/copies, never user data).
 SHARE_MANIFEST = ".cswap-shared.json"
+
+# Where a losing copy of a same-named transcript is parked. Never a delete:
+# a UUID collision after an un-share means two different halves of one
+# session, not a duplicate.
+QUARANTINE_DIRNAME = "history-conflicts"
 
 # Deferred-invalidation marker: backup credentials changed while a session was
 # live (we never pull credentials out from under a running claude), so the
@@ -1424,16 +1430,48 @@ class SessionManager:
                 return False
         return True
 
-    @staticmethod
-    def _merge_history_into_source(src: Path, dest: Path) -> None:
+    def _quarantine(self, path: Path, rel: Path, run_dir: Path) -> Path:
+        """Move a losing copy under ``run_dir``, never over an existing file."""
+        dest = run_dir / rel
+        _mkdir_private(dest.parent)
+        if dest.exists():
+            counter = 2
+            while True:
+                candidate = dest.parent / f"{dest.stem}.{counter}{dest.suffix}"
+                if not candidate.exists():
+                    dest = candidate
+                    break
+                counter += 1
+        shutil.move(str(path), str(dest))
+        self._logger.info(f"Quarantined colliding history file to {dest}")
+        return dest
+
+    def _merge_history_into_source(
+        self, src: Path, dest: Path
+    ) -> tuple[int, int, Path | None]:
         """Move the profile's own history at ``dest`` into ``src``.
 
-        Directories merge file-by-file (transcript filenames are UUIDs, so
-        collisions mean identical sessions — first writer wins and the
-        duplicate is dropped). ``history.jsonl`` merges by appending lines
-        not already present. ``dest`` is removed once empty; any failure
-        raises OSError and leaves remaining files in place for the next try.
+        Directories merge file-by-file. A name collision does *not* mean the
+        same session: a transcript that straddled an un-share event exists in
+        both trees under one UUID with different content, so the loser is
+        quarantined rather than dropped (see ``_profile_copy_wins``).
+        ``history.jsonl`` merges by appending lines not already present.
+        ``dest`` is removed once empty; any failure raises OSError and leaves
+        remaining files in place for the next try. Returns
+        ``(moved, quarantined, run_dir)``.
         """
+        run_dir: Path | None = None
+        moved = 0
+        quarantined = 0
+
+        def quarantine_root() -> Path:
+            nonlocal run_dir
+            if run_dir is None:
+                stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+                run_dir = self.switcher.backup_dir / QUARANTINE_DIRNAME / stamp
+                _mkdir_private(run_dir)
+            return run_dir
+
         if dest.is_dir():
             _mkdir_private(src)
             for path in sorted(dest.rglob("*"), reverse=True):
@@ -1443,10 +1481,21 @@ class SessionManager:
                     path.rmdir()  # children already moved (reverse walk)
                     continue
                 if target.exists():
-                    path.unlink()
+                    if _profile_copy_wins(target, path):
+                        # Park the incumbent first: a crash between the two
+                        # leaves the shared path empty, and the next run moves
+                        # the profile copy in cleanly.
+                        self._quarantine(target, rel, quarantine_root())
+                        _mkdir_private(target.parent)
+                        shutil.move(str(path), str(target))
+                        moved += 1
+                    else:
+                        self._quarantine(path, rel, quarantine_root())
+                    quarantined += 1
                     continue
                 _mkdir_private(target.parent)
                 shutil.move(str(path), str(target))
+                moved += 1
             dest.rmdir()
         else:
             existing: set[str] = set()
@@ -1464,6 +1513,7 @@ class SessionManager:
                 with src.open("a", encoding="utf-8") as f:
                     f.write("\n".join(lines) + "\n")
             dest.unlink()
+        return moved, quarantined, run_dir
 
     @staticmethod
     def _read_manifest(manifest_path: Path) -> list[str]:

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -1400,6 +1400,7 @@ class SessionManager:
         even when the manifest claims the entry is managed: a stale manifest
         (lock-free launches race) must never let the generic loop delete it.
         """
+        merged = False
         if dest.exists() and not dest.is_symlink():
             # Real per-account history accumulated before the flag existed.
             # Merging moves files out from under any claude still running in
@@ -1428,34 +1429,47 @@ class SessionManager:
                     if not profile_is_quiescent(session_dir):
                         self._report_deferral(session_dir, dest)
                         return False
-                    try:
-                        moved, quarantined, run_dir = (
-                            self._merge_history_into_source(src, dest)
-                        )
-                    except OSError as e:
-                        self._logger.warning(
-                            f"Could not merge {dest.name} into {src}: {e}"
-                        )
-                        print(
-                            dimmed(
-                                f"Not sharing {dest.name}: merging the profile's "
-                                "existing history failed (see log)."
+                    # Re-check the precondition too, not just liveness: it was
+                    # evaluated before the wait, and the peer we queued behind
+                    # may have migrated this very item. Merging a dest it
+                    # removed raises FileNotFoundError and reports a peer's
+                    # success as our failure; merging one it replaced with a
+                    # symlink is worse, since dest.is_dir() follows the link
+                    # and the walk would quarantine every shared transcript
+                    # against itself. Either way there is nothing left to
+                    # merge, and the generic loop can link as normal.
+                    if dest.exists() and not dest.is_symlink():
+                        try:
+                            moved, quarantined, run_dir = (
+                                self._merge_history_into_source(src, dest)
                             )
+                        except OSError as e:
+                            self._logger.warning(
+                                f"Could not merge {dest.name} into {src}: {e}"
+                            )
+                            print(
+                                dimmed(
+                                    f"Not sharing {dest.name}: merging the "
+                                    "profile's existing history failed "
+                                    "(see log)."
+                                )
+                            )
+                            return False
+                        # HISTORY_ITEMS holds two entries (projects,
+                        # history.jsonl), so this runs up to twice per launch —
+                        # accumulate rather than overwrite, and keep the first
+                        # quarantine dir a run produces (the file-merge branch
+                        # never quarantines, so at most one of the two calls
+                        # sets it).
+                        prev_moved, prev_quarantined, prev_run_dir = (
+                            self._last_merge_counts
                         )
-                        return False
-                    # HISTORY_ITEMS holds two entries (projects, history.jsonl),
-                    # so this runs up to twice per launch — accumulate rather
-                    # than overwrite, and keep the first quarantine dir a run
-                    # produces (the file-merge branch never quarantines, so at
-                    # most one of the two calls sets it).
-                    prev_moved, prev_quarantined, prev_run_dir = (
-                        self._last_merge_counts
-                    )
-                    self._last_merge_counts = (
-                        prev_moved + moved,
-                        prev_quarantined + quarantined,
-                        prev_run_dir if prev_run_dir is not None else run_dir,
-                    )
+                        self._last_merge_counts = (
+                            prev_moved + moved,
+                            prev_quarantined + quarantined,
+                            prev_run_dir if prev_run_dir is not None else run_dir,
+                        )
+                        merged = True
             except LockError:
                 # A peer is migrating this same profile right now — the
                 # timeout means "still busy", not "broken", so this degrades
@@ -1463,12 +1477,13 @@ class SessionManager:
                 # launch.
                 self._report_deferral(session_dir, dest)
                 return False
-            print(
-                dimmed(
-                    f"Merged the profile's existing {dest.name} into "
-                    f"{src} — conversation history is now shared."
+            if merged:
+                print(
+                    dimmed(
+                        f"Merged the profile's existing {dest.name} into "
+                        f"{src} — conversation history is now shared."
+                    )
                 )
-            )
         if not src.exists():
             # Fresh ~/.claude (or first run): seed an empty share target so
             # the generic loop below has something to link.

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -211,6 +211,10 @@ _AUTH_STATUS_TIMEOUT = 10.0
 # default 10s acquire used by the switch paths.
 _BOOTSTRAP_LOCK_TIMEOUT = 30.0
 
+# Migration moves every transcript in a profile, so it waits longer than the
+# bootstrap for a peer to finish rather than bailing and leaving a half state.
+_MIGRATION_LOCK_TIMEOUT = 30.0
+
 
 def slugify_email(email: str) -> str:
     """Filesystem-safe slug for an email address.
@@ -560,6 +564,9 @@ class SessionManager:
         self.switcher = switcher
         self.sessions_dir = switcher.backup_dir / "sessions"
         self._logger = switcher._logger
+        # Filled by the most recent merge so the launch can report counts
+        # without re-deriving them from the filesystem.
+        self._last_merge_counts: tuple[int, int, Path | None] = (0, 0, None)
 
     # -- launch ----------------------------------------------------------
 
@@ -1387,26 +1394,30 @@ class SessionManager:
             # Merging moves files out from under any claude still running in
             # this profile, so only migrate when the profile is quiescent.
             if not profile_is_quiescent(session_dir):
-                print(
-                    dimmed(
-                        f"Not sharing {dest.name} yet: another session is "
-                        "using this profile — retrying on the next launch."
-                    )
-                )
+                self._report_deferral(session_dir, dest)
                 return False
-            try:
-                self._merge_history_into_source(src, dest)
-            except OSError as e:
-                self._logger.warning(
-                    f"Could not merge {dest.name} into {src}: {e}"
-                )
-                print(
-                    dimmed(
-                        f"Not sharing {dest.name}: merging the profile's "
-                        "existing history failed (see log)."
+            # The pre-check above is a cheap early out; the authoritative one
+            # runs under the lock, so a launch that starts in between cannot
+            # have its transcripts moved mid-write.
+            with FileLock(self.switcher.lock_file, timeout=_MIGRATION_LOCK_TIMEOUT):
+                if not profile_is_quiescent(session_dir):
+                    self._report_deferral(session_dir, dest)
+                    return False
+                try:
+                    self._last_merge_counts = self._merge_history_into_source(
+                        src, dest
                     )
-                )
-                return False
+                except OSError as e:
+                    self._logger.warning(
+                        f"Could not merge {dest.name} into {src}: {e}"
+                    )
+                    print(
+                        dimmed(
+                            f"Not sharing {dest.name}: merging the profile's "
+                            "existing history failed (see log)."
+                        )
+                    )
+                    return False
             print(
                 dimmed(
                     f"Merged the profile's existing {dest.name} into "
@@ -1429,6 +1440,14 @@ class SessionManager:
                 self._logger.warning(f"Could not create {src}: {e}")
                 return False
         return True
+
+    def _report_deferral(self, session_dir: Path, dest: Path) -> None:
+        print(
+            dimmed(
+                f"Not sharing {dest.name} yet: another session is "
+                "using this profile — retrying on the next launch."
+            )
+        )
 
     def _quarantine(self, path: Path, rel: Path, run_dir: Path) -> Path:
         """Move a losing copy under ``run_dir``, never over an existing file."""

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -1494,9 +1494,15 @@ class SessionManager:
             )
         )
 
-    def _quarantine(self, path: Path, rel: Path, run_dir: Path) -> Path:
-        """Move a losing copy under ``run_dir``, never over an existing file."""
-        dest = run_dir / rel
+    def _quarantine(self, path: Path, rel: Path, run_dir: Path, side: str) -> Path:
+        """Move a losing copy under ``run_dir``, never over an existing file.
+
+        ``side`` is which tree the loser came from — ``"shared"`` or ``"profile"`` —
+        because both sides otherwise land at the same relative path and the operator
+        reconciling two disjoint halves of one session would have no way to tell which
+        half is which.
+        """
+        dest = run_dir / side / rel
         _mkdir_private(dest.parent)
         if dest.exists():
             counter = 2
@@ -1554,12 +1560,12 @@ class SessionManager:
                         # Park the incumbent first: a crash between the two
                         # leaves the shared path empty, and the next run moves
                         # the profile copy in cleanly.
-                        self._quarantine(target, rel, quarantine_root())
+                        self._quarantine(target, rel, quarantine_root(), "shared")
                         _mkdir_private(target.parent)
                         shutil.move(str(path), str(target))
                         moved += 1
                     else:
-                        self._quarantine(path, rel, quarantine_root())
+                        self._quarantine(path, rel, quarantine_root(), "profile")
                     quarantined += 1
                     continue
                 _mkdir_private(target.parent)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -6872,6 +6872,23 @@ class ClaudeAccountSwitcher:
         else:
             print(dimmed("New account is active on your next message — no restart needed."))
 
+    def _quarantined_history_files(self) -> int:
+        """How many collided transcripts are parked under the backup dir.
+
+        Only counted for purge's confirm prompt, so a full walk is fine: the
+        tree holds one file per collision a migration hit, not a profile's
+        worth of transcripts.
+        """
+        from claude_swap.session import QUARANTINE_DIRNAME
+
+        root = self.backup_dir / QUARANTINE_DIRNAME
+        if not root.is_dir():
+            return 0
+        try:
+            return sum(1 for p in root.rglob("*") if p.is_file())
+        except OSError:
+            return 0
+
     def purge(self) -> None:
         """Remove all traces of claude-swap from the system.
 
@@ -6936,6 +6953,32 @@ class ClaudeAccountSwitcher:
             print("  - All stored account credential files")
         if session_dirs:
             print("  - All session profiles and their Keychain entries")
+        # The quarantine tree sits inside the backup dir, so rmtree below takes
+        # it with everything else. Every file in it is the losing half of a
+        # transcript collision that history migration deliberately refused to
+        # delete — nothing anywhere else holds a copy, so this bullet gets its
+        # own count and its own warning colour.
+        from claude_swap.session import QUARANTINE_DIRNAME
+
+        quarantined = self._quarantined_history_files()
+        if quarantined:
+            warning(
+                f"  - {quarantined} quarantined conversation transcript(s) in "
+                f"{self.backup_dir / QUARANTINE_DIRNAME}"
+            )
+            print(
+                dimmed(
+                    "    These are the ONLY remaining copy of the losing half "
+                    "of each collided"
+                )
+            )
+            print(
+                dimmed(
+                    "    session — history migration parked them here rather "
+                    "than deleting them."
+                )
+            )
+            print(dimmed("    Copy them somewhere else first if you want them."))
         print()
         print(dimmed("Note: This does NOT affect your current Claude Code login."))
         print()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2025,6 +2025,77 @@ class TestShareHistoryPosix:
         assert (proj / "bbb.jsonl").exists()
         assert not (session_dir / "projects").is_symlink()
 
+    def _lock_that_lets_a_peer_finish_first(self, monkeypatch, on_acquire):
+        """Stand in for the migration lock a peer is already holding.
+
+        The precondition that decided to merge (``dest.exists() and not
+        dest.is_symlink()``) is evaluated *before* the wait, so whatever the
+        peer did while we queued has to be re-checked once we hold the lock.
+        """
+
+        class PeerFinishedFirst:
+            def __init__(self, path, timeout=None):
+                pass
+
+            def __enter__(self):
+                on_acquire()
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        monkeypatch.setattr(session_mod, "FileLock", PeerFinishedFirst)
+
+    def test_peer_removed_dest_while_we_waited_on_the_lock(
+        self, history_setup, monkeypatch
+    ):
+        """The peer migrated and removed the profile's copy. Merging a dest
+        that is no longer there raises FileNotFoundError and reports "merging
+        failed" for what was in fact a successful migration."""
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "bbb.jsonl").write_text("profile-b\n")
+        self._lock_that_lets_a_peer_finish_first(
+            monkeypatch,
+            lambda: session_mod.shutil.rmtree(session_dir / "projects"),
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert (session_dir / "projects").is_symlink()
+        assert (
+            source / "projects" / "-home-user-app" / "aaa.jsonl"
+        ).read_text() == "main-a\n"
+
+    def test_peer_linked_dest_while_we_waited_on_the_lock(
+        self, history_setup, monkeypatch
+    ):
+        """The peer got all the way to the symlink. dest.is_dir() follows it,
+        so the merge would walk ~/.claude/projects against itself: every
+        shared transcript collides with itself, gets quarantined, and the
+        shared directory is emptied out underneath the link."""
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "bbb.jsonl").write_text("profile-b\n")
+
+        def peer_migrated_and_linked():
+            session_mod.shutil.rmtree(session_dir / "projects")
+            (session_dir / "projects").symlink_to(source / "projects")
+
+        self._lock_that_lets_a_peer_finish_first(
+            monkeypatch, peer_migrated_and_linked
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert not (mgr.switcher.backup_dir / "history-conflicts").exists()
+        assert (
+            source / "projects" / "-home-user-app" / "aaa.jsonl"
+        ).read_text() == "main-a\n"
+        assert (session_dir / "projects").readlink() == source / "projects"
+
     def test_toggle_off_removes_links_keeps_data(self, history_setup):
         source, session_dir, mgr = history_setup
         mgr._sync_sharing(session_dir, share=True, share_history=True)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1943,6 +1943,89 @@ class TestShareHistoryPosix:
         # Real history is user data even when the manifest claims it.
         assert (proj / "bbb.jsonl").read_text() == "profile-b\n"
 
+    def test_collision_keeps_newer_profile_copy_and_quarantines_target(
+        self, history_setup
+    ):
+        source, session_dir, mgr = history_setup
+        shared = source / "projects" / "-home-user-app" / "aaa.jsonl"
+        shared.write_text('{"timestamp": "2026-07-21T20:00:00.000Z"}\n')
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-23T20:00:00.000Z"}\n'
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert "2026-07-23" in shared.read_text()
+        quarantined = list(
+            (mgr.switcher.backup_dir / "history-conflicts").rglob("aaa.jsonl")
+        )
+        assert len(quarantined) == 1
+        assert "2026-07-21" in quarantined[0].read_text()
+
+    def test_collision_keeps_newer_target_and_quarantines_profile_copy(
+        self, history_setup
+    ):
+        source, session_dir, mgr = history_setup
+        shared = source / "projects" / "-home-user-app" / "aaa.jsonl"
+        shared.write_text('{"timestamp": "2026-07-23T20:00:00.000Z"}\n')
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-21T20:00:00.000Z"}\n'
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert "2026-07-23" in shared.read_text()
+        quarantined = list(
+            (mgr.switcher.backup_dir / "history-conflicts").rglob("aaa.jsonl")
+        )
+        assert len(quarantined) == 1
+        assert "2026-07-21" in quarantined[0].read_text()
+
+    def test_quarantine_never_overwrites_an_earlier_quarantine(
+        self, history_setup, tmp_path
+    ):
+        # Two runs inside one timestamp granule land in the same run dir, so
+        # the uniquify path is exercised directly rather than through a merge.
+        source, session_dir, mgr = history_setup
+        run_dir = mgr.switcher.backup_dir / "history-conflicts" / "same-granule"
+        run_dir.mkdir(parents=True)
+        rel = Path("-home-user-app") / "aaa.jsonl"
+
+        first = tmp_path / "first.jsonl"
+        first.write_text("first-loser\n")
+        second = tmp_path / "second.jsonl"
+        second.write_text("second-loser\n")
+
+        landed_first = mgr._quarantine(first, rel, run_dir)
+        landed_second = mgr._quarantine(second, rel, run_dir)
+
+        assert landed_first != landed_second
+        assert landed_first.read_text() == "first-loser\n"
+        assert landed_second.read_text() == "second-loser\n"
+
+    def test_no_transcript_is_ever_deleted(self, history_setup):
+        source, session_dir, mgr = history_setup
+        shared = source / "projects" / "-home-user-app" / "aaa.jsonl"
+        shared.write_text('{"timestamp": "2026-07-23T20:00:00.000Z"}\n')
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-21T20:00:00.000Z"}\n'
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        bodies = {
+            p.read_text()
+            for p in mgr.switcher.backup_dir.rglob("aaa.jsonl")
+        } | {shared.read_text()}
+        assert any("2026-07-21" in b for b in bodies)
+        assert any("2026-07-23" in b for b in bodies)
+
 
 class TestShareHistoryWindows:
     def test_sync_never_links_history_in_copy_mode(self, history_setup):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -23,6 +23,7 @@ from claude_swap.exceptions import (
     SessionError,
     ValidationError,
 )
+from claude_swap.locking import FileLock
 from claude_swap.models import Platform
 from claude_swap.paths import get_global_config_path
 from claude_swap.session import (
@@ -1888,6 +1889,34 @@ class TestShareHistoryPosix:
         assert calls["n"] >= 2, "liveness must be re-checked under the lock"
         assert (proj / "bbb.jsonl").exists(), "migration must not have run"
         assert not (session_dir / "projects").is_symlink()
+
+    def test_migration_does_not_deadlock_against_the_bootstrap_lock(
+        self, history_setup, monkeypatch
+    ):
+        """setup_session calls _sync_sharing while still holding
+        switcher.lock_file (its re-validate-under-lock and post-bootstrap
+        paths). Migration must not try to re-acquire that same lock: flock
+        is per-fd, not per-process, so a second open of the same lock file
+        from inside this same process would self-block rather than proceed,
+        timing out into an error instead of migrating.
+        """
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "bbb.jsonl").write_text("profile-b\n")
+
+        # Fail fast instead of hanging the suite if the regression reappears.
+        monkeypatch.setattr(session_mod, "_MIGRATION_LOCK_TIMEOUT", 0.2)
+
+        # Simulate the bootstrap lock already being held around this call,
+        # exactly as setup_session holds it across its _sync_sharing calls.
+        with FileLock(mgr.switcher.lock_file):
+            mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        merged = source / "projects" / "-home-user-app"
+        assert merged.joinpath("aaa.jsonl").read_text() == "main-a\n"
+        assert merged.joinpath("bbb.jsonl").read_text() == "profile-b\n"
+        assert (session_dir / "projects").readlink() == source / "projects"
 
     def test_toggle_off_removes_links_keeps_data(self, history_setup):
         source, session_dir, mgr = history_setup

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2740,3 +2740,63 @@ class TestAConsumedGrantIsNotSpentOnAProfileThatWonBootstrap:
         assert "the successor is stashed" not in msg, (
             "promised a stash that never happened"
         )
+
+
+
+class TestSurvivorSelection:
+    """Which of two same-named transcripts wins a merge collision."""
+
+    def _write(self, path: Path, lines: list[str]) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("".join(f"{line}\n" for line in lines))
+        return path
+
+    def test_last_timestamp_scans_past_untimestamped_trailer(self, tmp_path):
+        # ~99% of real transcripts end on an untimestamped state line.
+        f = self._write(tmp_path / "a.jsonl", [
+            '{"type": "user", "timestamp": "2026-07-22T01:33:08.788Z"}',
+            '{"type": "last-prompt", "prompt": "hi"}',
+        ])
+        assert session_mod._last_timestamp(f) == "2026-07-22T01:33:08.788Z"
+
+    def test_last_timestamp_none_when_absent(self, tmp_path):
+        f = self._write(tmp_path / "a.jsonl", ['{"type": "last-prompt"}'])
+        assert session_mod._last_timestamp(f) is None
+
+    def test_last_timestamp_skips_unparseable_lines(self, tmp_path):
+        f = self._write(tmp_path / "a.jsonl", [
+            '{"timestamp": "2026-07-01T00:00:00.000Z"}',
+            "not json at all",
+        ])
+        assert session_mod._last_timestamp(f) == "2026-07-01T00:00:00.000Z"
+
+    def test_later_timestamp_wins(self, tmp_path):
+        target = self._write(tmp_path / "t.jsonl", [
+            '{"timestamp": "2026-07-21T20:39:55.399Z"}'] * 5)
+        cand = self._write(tmp_path / "c.jsonl", [
+            '{"timestamp": "2026-07-23T18:03:53.827Z"}'])
+        # Shorter but newer still wins: a compacted continuation must not lose.
+        assert session_mod._profile_copy_wins(target, cand) is True
+
+    def test_earlier_timestamp_loses(self, tmp_path):
+        target = self._write(tmp_path / "t.jsonl", [
+            '{"timestamp": "2026-07-23T18:03:53.827Z"}'])
+        cand = self._write(tmp_path / "c.jsonl", [
+            '{"timestamp": "2026-07-21T20:39:55.399Z"}'] * 99)
+        assert session_mod._profile_copy_wins(target, cand) is False
+
+    def test_untimestamped_loses_to_timestamped(self, tmp_path):
+        target = self._write(tmp_path / "t.jsonl", [
+            '{"timestamp": "2026-07-01T00:00:00.000Z"}'])
+        cand = self._write(tmp_path / "c.jsonl", ['{"type": "mode"}'] * 50)
+        assert session_mod._profile_copy_wins(target, cand) is False
+
+    def test_neither_timestamped_falls_back_to_line_count(self, tmp_path):
+        target = self._write(tmp_path / "t.jsonl", ["# a"])
+        cand = self._write(tmp_path / "c.jsonl", ["# a", "# b"])
+        assert session_mod._profile_copy_wins(target, cand) is True
+
+    def test_exact_tie_keeps_the_target(self, tmp_path):
+        target = self._write(tmp_path / "t.jsonl", ['{"timestamp": "2026-07-01T00:00:00.000Z"}'])
+        cand = self._write(tmp_path / "c.jsonl", ['{"timestamp": "2026-07-01T00:00:00.000Z"}'])
+        assert session_mod._profile_copy_wins(target, cand) is False

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1867,6 +1867,28 @@ class TestShareHistoryPosix:
         manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
         assert "projects" not in manifest["items"]
 
+    def test_migration_rechecks_liveness_under_the_lock(
+        self, history_setup, monkeypatch
+    ):
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "bbb.jsonl").write_text("profile-b\n")
+
+        calls = {"n": 0}
+
+        def fake_scan(path):
+            # Quiescent on the pre-lock check, busy once the lock is held.
+            calls["n"] += 1
+            return ([], 0) if calls["n"] == 1 else (["a-session"], 0)
+
+        monkeypatch.setattr(session_mod, "scan_live_sessions", fake_scan)
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        assert calls["n"] >= 2, "liveness must be re-checked under the lock"
+        assert (proj / "bbb.jsonl").exists(), "migration must not have run"
+        assert not (session_dir / "projects").is_symlink()
+
     def test_toggle_off_removes_links_keeps_data(self, history_setup):
         source, session_dir, mgr = history_setup
         mgr._sync_sharing(session_dir, share=True, share_history=True)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1918,6 +1918,60 @@ class TestShareHistoryPosix:
         assert merged.joinpath("bbb.jsonl").read_text() == "profile-b\n"
         assert (session_dir / "projects").readlink() == source / "projects"
 
+    def test_last_merge_counts_accumulate_across_history_items(self, history_setup):
+        """_prepare_history_share runs once per HISTORY_ITEMS entry (projects,
+        then history.jsonl), each merge assigning into the same field. A
+        profile with real history in both must not have the projects/ counts
+        (and its quarantine dir) clobbered by the history.jsonl merge that
+        runs right after — the file-merge branch never quarantines and always
+        reports (0, 0, None), so an overwrite would silently lose both.
+        """
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        # A genuine collision in projects/: profile copy is newer, so it
+        # wins — moved in, incumbent quarantined (moved=1, quarantined=1).
+        (source / "projects" / "-home-user-app" / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-21T20:00:00.000Z"}\n'
+        )
+        (proj / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-23T20:00:00.000Z"}\n'
+        )
+        # Real profile-side history.jsonl too, merged by the separate
+        # (0, 0, None)-always file-merge branch, right after projects/.
+        (session_dir / "history.jsonl").write_text('{"p": "profile"}\n')
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        moved, quarantined, run_dir = mgr._last_merge_counts
+        assert (moved, quarantined) == (1, 1)
+        assert run_dir is not None, "the quarantine directory must not be lost"
+
+    def test_migration_lock_timeout_degrades_instead_of_raising(
+        self, history_setup, monkeypatch
+    ):
+        """A LockError from the per-profile migration lock must degrade like
+        every other failure in this function (dimmed message, return False)
+        rather than escape and abort the launch — a lock timeout means a
+        peer is still working on this profile, which is expected, not broken.
+        """
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "bbb.jsonl").write_text("profile-b\n")
+
+        # Fail fast instead of waiting out the real 30s timeout.
+        monkeypatch.setattr(session_mod, "_MIGRATION_LOCK_TIMEOUT", 0.2)
+
+        # Hold the per-profile migration lock open, simulating a peer already
+        # migrating this same profile.
+        with FileLock(session_dir / session_mod.MIGRATION_LOCK):
+            mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        # Degraded, not raised: no migration happened, nothing linked.
+        assert (proj / "bbb.jsonl").exists()
+        assert not (session_dir / "projects").is_symlink()
+
     def test_toggle_off_removes_links_keeps_data(self, history_setup):
         source, session_dir, mgr = history_setup
         mgr._sync_sharing(session_dir, share=True, share_history=True)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import sys
 import unicodedata
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1903,6 +1904,14 @@ class TestShareHistoryPosix:
         assert "63802" in out
         assert "soribashi" in out
         assert "cswap run 2 --share-history" in out
+        # Pin the epoch-ms -> local-time conversion itself, not just the
+        # surrounding text — a timezone bug (UTC mislabeled as local) or an
+        # off-by-1000 that still lands in a plausible-looking date would slip
+        # past a loose "2026-" substring check.
+        expected_started = datetime.fromtimestamp(
+            blocker.started_at / 1000, tz=timezone.utc
+        ).astimezone()
+        assert f"{expected_started:%Y-%m-%d %H:%M}" in out
 
     def test_migration_rechecks_liveness_under_the_lock(
         self, history_setup, monkeypatch

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -26,6 +26,7 @@ from claude_swap.exceptions import (
 from claude_swap.locking import FileLock
 from claude_swap.models import Platform
 from claude_swap.paths import get_global_config_path
+from claude_swap.process_detection import ClaudeSession
 from claude_swap.session import (
     MCP_DISPLACED_STASH,
     MCP_MIRROR_MARKER,
@@ -1856,8 +1857,16 @@ class TestShareHistoryPosix:
         source, session_dir, mgr = history_setup
         (session_dir / "projects").mkdir()
         (session_dir / "projects" / "x.jsonl").write_text("live\n")
+        blocker = ClaudeSession(
+            pid=1,
+            session_id="live",
+            cwd="/tmp",
+            started_at=0,
+            kind="interactive",
+            entrypoint="cli",
+        )
         monkeypatch.setattr(
-            session_mod, "scan_live_sessions", lambda _dir: ([object()], 0)
+            session_mod, "scan_live_sessions", lambda _dir: ([blocker], 0)
         )
 
         mgr._sync_sharing(session_dir, share=True, share_history=True)
@@ -1868,6 +1877,33 @@ class TestShareHistoryPosix:
         manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
         assert "projects" not in manifest["items"]
 
+    def test_deferral_names_the_blocking_session_and_the_command(
+        self, history_setup, monkeypatch, capsys
+    ):
+        source, session_dir, mgr = history_setup
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "bbb.jsonl").write_text("profile-b\n")
+
+        blocker = ClaudeSession(
+            pid=63802,
+            session_id="abc",
+            cwd="/Users/matt/Documents/GitHub/soribashi",
+            started_at=1785041704563,
+            kind="interactive",
+            entrypoint="cli",
+        )
+        monkeypatch.setattr(
+            session_mod, "scan_live_sessions", lambda p: ([blocker], 0)
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        out = capsys.readouterr().out
+        assert "63802" in out
+        assert "soribashi" in out
+        assert "cswap run 2 --share-history" in out
+
     def test_migration_rechecks_liveness_under_the_lock(
         self, history_setup, monkeypatch
     ):
@@ -1877,11 +1913,19 @@ class TestShareHistoryPosix:
         (proj / "bbb.jsonl").write_text("profile-b\n")
 
         calls = {"n": 0}
+        blocker = ClaudeSession(
+            pid=2,
+            session_id="a-session",
+            cwd="/tmp",
+            started_at=0,
+            kind="interactive",
+            entrypoint="cli",
+        )
 
         def fake_scan(path):
             # Quiescent on the pre-lock check, busy once the lock is held.
             calls["n"] += 1
-            return ([], 0) if calls["n"] == 1 else (["a-session"], 0)
+            return ([], 0) if calls["n"] == 1 else ([blocker], 0)
 
         monkeypatch.setattr(session_mod, "scan_live_sessions", fake_scan)
         mgr._sync_sharing(session_dir, share=True, share_history=True)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2105,8 +2105,8 @@ class TestShareHistoryPosix:
         second = tmp_path / "second.jsonl"
         second.write_text("second-loser\n")
 
-        landed_first = mgr._quarantine(first, rel, run_dir)
-        landed_second = mgr._quarantine(second, rel, run_dir)
+        landed_first = mgr._quarantine(first, rel, run_dir, "profile")
+        landed_second = mgr._quarantine(second, rel, run_dir, "profile")
 
         assert landed_first != landed_second
         assert landed_first.read_text() == "first-loser\n"
@@ -2133,7 +2133,7 @@ class TestShareHistoryPosix:
         assert run_dir is not None
         assert "2026-07-23" in (src / "-home-user-app" / "aaa.jsonl").read_text()
         assert "2026-07-21" in (
-            run_dir / "-home-user-app" / "aaa.jsonl"
+            run_dir / "shared" / "-home-user-app" / "aaa.jsonl"
         ).read_text()
 
     def test_merge_return_counts_when_target_wins(self, history_setup, tmp_path):
@@ -2155,7 +2155,7 @@ class TestShareHistoryPosix:
         assert run_dir is not None
         assert "2026-07-23" in (src / "-home-user-app" / "aaa.jsonl").read_text()
         assert "2026-07-21" in (
-            run_dir / "-home-user-app" / "aaa.jsonl"
+            run_dir / "profile" / "-home-user-app" / "aaa.jsonl"
         ).read_text()
 
     def test_no_transcript_is_ever_deleted(self, history_setup):
@@ -2182,6 +2182,56 @@ class TestShareHistoryPosix:
         } | {shared.read_text()}
         assert any("2026-07-21" in b for b in bodies)
         assert any("2026-07-23" in b for b in bodies)
+
+    def test_quarantine_records_provenance_in_path_profile_wins(
+        self, history_setup
+    ):
+        source, session_dir, mgr = history_setup
+        # Profile copy is newer — it wins, shared copy is quarantined.
+        shared = source / "projects" / "-home-user-app" / "aaa.jsonl"
+        shared.write_text('{"timestamp": "2026-07-21T20:00:00.000Z"}\n')
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-23T20:00:00.000Z"}\n'
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        # The shared-side loser should be under .../shared/, not .../profile/.
+        quarantined = list(
+            (mgr.switcher.backup_dir / "history-conflicts").rglob("aaa.jsonl")
+        )
+        assert len(quarantined) == 1
+        quarantine_path = quarantined[0]
+        assert "/shared/" in str(quarantine_path)
+        assert "/profile/" not in str(quarantine_path)
+        assert "2026-07-21" in quarantine_path.read_text()
+
+    def test_quarantine_records_provenance_in_path_target_wins(
+        self, history_setup
+    ):
+        source, session_dir, mgr = history_setup
+        # Target (shared) copy is newer — it wins, profile copy is quarantined.
+        shared = source / "projects" / "-home-user-app" / "aaa.jsonl"
+        shared.write_text('{"timestamp": "2026-07-23T20:00:00.000Z"}\n')
+        proj = session_dir / "projects" / "-home-user-app"
+        proj.mkdir(parents=True)
+        (proj / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-21T20:00:00.000Z"}\n'
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_history=True)
+
+        # The profile-side loser should be under .../profile/, not .../shared/.
+        quarantined = list(
+            (mgr.switcher.backup_dir / "history-conflicts").rglob("aaa.jsonl")
+        )
+        assert len(quarantined) == 1
+        quarantine_path = quarantined[0]
+        assert "/profile/" in str(quarantine_path)
+        assert "/shared/" not in str(quarantine_path)
+        assert "2026-07-21" in quarantine_path.read_text()
 
 
 class TestShareHistoryWindows:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2007,6 +2007,52 @@ class TestShareHistoryPosix:
         assert landed_first.read_text() == "first-loser\n"
         assert landed_second.read_text() == "second-loser\n"
 
+    def test_merge_return_counts_when_profile_copy_wins(
+        self, history_setup, tmp_path
+    ):
+        _, _, mgr = history_setup
+        src = tmp_path / "shared" / "projects"
+        dest = tmp_path / "profile" / "projects"
+        (src / "-home-user-app").mkdir(parents=True)
+        (dest / "-home-user-app").mkdir(parents=True)
+        (src / "-home-user-app" / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-21T20:00:00.000Z"}\n'
+        )
+        (dest / "-home-user-app" / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-23T20:00:00.000Z"}\n'
+        )
+
+        moved, quarantined, run_dir = mgr._merge_history_into_source(src, dest)
+
+        assert (moved, quarantined) == (1, 1)
+        assert run_dir is not None
+        assert "2026-07-23" in (src / "-home-user-app" / "aaa.jsonl").read_text()
+        assert "2026-07-21" in (
+            run_dir / "-home-user-app" / "aaa.jsonl"
+        ).read_text()
+
+    def test_merge_return_counts_when_target_wins(self, history_setup, tmp_path):
+        _, _, mgr = history_setup
+        src = tmp_path / "shared" / "projects"
+        dest = tmp_path / "profile" / "projects"
+        (src / "-home-user-app").mkdir(parents=True)
+        (dest / "-home-user-app").mkdir(parents=True)
+        (src / "-home-user-app" / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-23T20:00:00.000Z"}\n'
+        )
+        (dest / "-home-user-app" / "aaa.jsonl").write_text(
+            '{"timestamp": "2026-07-21T20:00:00.000Z"}\n'
+        )
+
+        moved, quarantined, run_dir = mgr._merge_history_into_source(src, dest)
+
+        assert (moved, quarantined) == (0, 1)
+        assert run_dir is not None
+        assert "2026-07-23" in (src / "-home-user-app" / "aaa.jsonl").read_text()
+        assert "2026-07-21" in (
+            run_dir / "-home-user-app" / "aaa.jsonl"
+        ).read_text()
+
     def test_no_transcript_is_ever_deleted(self, history_setup):
         source, session_dir, mgr = history_setup
         shared = source / "projects" / "-home-user-app" / "aaa.jsonl"
@@ -2019,9 +2065,15 @@ class TestShareHistoryPosix:
 
         mgr._sync_sharing(session_dir, share=True, share_history=True)
 
+        # The merge must actually have happened (not silently skipped): the
+        # profile's projects/ is a symlink into the shared tree, so its own
+        # copy of aaa.jsonl no longer exists to double-count as "kept".
+        assert (session_dir / "projects").is_symlink()
         bodies = {
             p.read_text()
-            for p in mgr.switcher.backup_dir.rglob("aaa.jsonl")
+            for p in (mgr.switcher.backup_dir / "history-conflicts").rglob(
+                "aaa.jsonl"
+            )
         } | {shared.read_text()}
         assert any("2026-07-21" in b for b in bodies)
         assert any("2026-07-23" in b for b in bodies)

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -4752,6 +4752,72 @@ class TestPurgeLegacyCleanup:
         assert "Legacy backup directory" not in out
 
 
+class TestPurgeQuarantineWarning:
+    """``purge`` removes the whole backup directory, and the history-migration
+    quarantine tree lives inside it.
+
+    Those files are the losing half of a collided transcript -- the only copy
+    left of it anywhere, since the merge that produced them deliberately
+    refuses to delete. The confirm prompt lists credentials and profiles and
+    reassures the user that their Claude Code login is safe; it must not stay
+    silent about the one thing purge destroys that nothing can recreate.
+    """
+
+    def _quarantine(self, switcher: ClaudeAccountSwitcher, count: int) -> Path:
+        run_dir = (
+            switcher.backup_dir / "history-conflicts" / "2026-07-27T12-00-00"
+        )
+        losers = run_dir / "profile" / "-home-user-app"
+        losers.mkdir(parents=True)
+        for i in range(count):
+            (losers / f"{i}.jsonl").write_text("the other half\n")
+        return run_dir
+
+    def test_prompt_names_the_quarantined_transcripts(
+        self, temp_home: Path, capsys
+    ):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        run_dir = self._quarantine(switcher, 3)
+
+        with patch("builtins.input", return_value="n"):
+            switcher.purge()
+
+        out = capsys.readouterr().out
+        assert "history-conflicts" in out
+        assert "3" in out
+        assert "only" in out.lower()  # "the only remaining copy"
+        assert run_dir.exists()  # declined, so nothing was removed
+
+    def test_prompt_omits_the_bullet_when_the_tree_is_empty(
+        self, temp_home: Path, capsys
+    ):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        # A migration that ran without collisions leaves the dir behind with
+        # nothing in it -- no warning to give.
+        (switcher.backup_dir / "history-conflicts" / "2026-07-27T12-00-00").mkdir(
+            parents=True
+        )
+
+        with patch("builtins.input", return_value="n"):
+            switcher.purge()
+
+        assert "history-conflicts" not in capsys.readouterr().out
+
+    def test_purge_still_removes_the_quarantine_tree(self, temp_home: Path):
+        """The warning is the fix, not a behavior change: purge is the user's
+        "remove everything" hammer and still removes everything."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        run_dir = self._quarantine(switcher, 1)
+
+        with patch("builtins.input", return_value="y"):
+            switcher.purge()
+
+        assert not run_dir.exists()
+
+
 class TestAddAccountFromToken:
     """Tests for add_account_from_token (--add-token flow)."""
 


### PR DESCRIPTION
`--share-history` (#80) merges a profile's accumulated history into `~/.claude` before linking. i've been running it daily across three accounts and hit a few ways that merge can lose transcripts... this fixes the destructive ones. first of a small series splitting up history-sharing work i've been carrying on a fork.

- Picks the collision survivor by last message timestamp: a same-UUID transcript on both sides is two generations of one continued session, not a duplicate, so always dropping the profile's copy could discard the newer one (`session.py`)
- Quarantines the losing copy under `history-conflicts/` with its source tree recorded, instead of deleting it
- Serializes migration under a per-profile lock, and re-checks liveness and dest under the lock rather than before it (two concurrent launches could otherwise walk `~/.claude/projects` against itself and quarantine every shared transcript)
- Stops a `LockError` from aborting the launch, and one profile's merge counts from leaking into the next profile's report
- Reports a deferred migration (live sessions holding the profile) with the blocking pid and a retry hint
- Warns before `--purge` that quarantined transcripts go with it (`switcher.py`)

verification: full suite green locally on macOS (1849 passed; the one failure, `test_move_strict_clear_fails_closed_on_unreadable_dir`, pre-exists on main). the lock races are pinned by tests that let a simulated peer finish first while we wait on the lock.
