### PR TITLE
fix(session): treat auth-status probe timeout as indeterminate, not invalid

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -654,7 +654,13 @@ class SessionManager:
                 text=True,
                 timeout=_AUTH_STATUS_TIMEOUT,
             )
-        except (OSError, subprocess.TimeoutExpired):
+        except subprocess.TimeoutExpired:
+            # A timeout is the machine under load, not a bad profile: this
+            # check is best-effort (see docstring), and setup_session
+            # escalates a False all the way to deleting the profile. Real
+            # invalidity still fails on first use.
+            return True
+        except OSError:
             return False
         if result.returncode != 0:
             return False

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -544,6 +544,30 @@ class TestIsSessionValid:
             tmp_path / "missing", ACCOUNT_EMAIL, ORG_UUID
         )
 
+    def test_probe_timeout_leans_valid(self, manager, tmp_path, monkeypatch):
+        """A probe timeout is a busy machine, not a bad login.
+
+        setup_session escalates a False from here all the way to
+        _cleanup_failed_session deleting the profile, so an indeterminate
+        probe must not report invalid (#224).
+        """
+        tmp_path.mkdir(exist_ok=True)
+
+        def raise_timeout(*a, **k):
+            raise session_mod.subprocess.TimeoutExpired(cmd="claude", timeout=10)
+
+        monkeypatch.setattr(session_mod.subprocess, "run", raise_timeout)
+        assert manager._is_session_valid(tmp_path, ACCOUNT_EMAIL, ORG_UUID)
+
+    def test_probe_oserror_stays_invalid(self, manager, tmp_path, monkeypatch):
+        tmp_path.mkdir(exist_ok=True)
+
+        def raise_oserror(*a, **k):
+            raise OSError("spawn failed")
+
+        monkeypatch.setattr(session_mod.subprocess, "run", raise_oserror)
+        assert not manager._is_session_valid(tmp_path, ACCOUNT_EMAIL, ORG_UUID)
+
     def test_invokes_pathext_resolved_launcher(
         self, manager, tmp_path, monkeypatch, valid_payload
     ):


### PR DESCRIPTION
Fixes #224.

## What

`_is_session_valid` collapsed `subprocess.TimeoutExpired` into "not logged in". `claude` is a Node CLI with a nontrivial cold start, so on a loaded machine the 10s probe times out, and `setup_session` escalates a False from there all the way to `_cleanup_failed_session` deleting the profile — with an error telling the user to re-add an account whose login was never bad. Details and repro in #224.

## Change

Split the except clause: `TimeoutExpired` now leans valid (the check is best-effort by design — a revoked but unexpired token already passes and fails on first real use), `OSError` still fails closed. Two tests pin the distinction.

## Testing

- `tests/test_session.py`: 155 passed (includes the two new tests).
- Full suite: 1824+ passed; the only persistent failure (`test_move_strict_clear_fails_closed_on_unreadable_dir`) fails identically on unmodified `main` in my environment, so it's unrelated.
- Running this change as a local patch against v0.24.1 in the environment that surfaced the bug (orchestrator spawning many concurrent `cswap run` turns): the bursts of spurious "failed validation" errors stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RFFYYRMjVjvHhDLrVrde4