### PR TITLE
feat(auth): show credential capabilities per account

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ cswap switch 2 --json
   "schemaVersion": 1,
   "activeAccountNumber": 2,
   "accounts": [
-    { "number": 2, "email": "you@example.com", "active": true, "usageStatus": "ok",
+    { "number": 2, "email": "you@example.com", "active": true,
+      "authMethod": "setup_token", "usageStatus": "ok",
       "usage": { "fiveHour": { "pct": 25.0, "resetsAt": "2026-06-22T23:29:59Z" },
                  "sevenDay": { "pct": 16.0, "resetsAt": "2026-06-26T17:59:59Z" } } }
   ]
@@ -344,7 +345,11 @@ Every payload carries a `schemaVersion` (currently `1`); on a handled error stdo
 
 Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
 
-An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
+Each account row carries an additive `authMethod`: `browser_oauth`,
+`setup_token`, `api_key`, or `unknown`. The human list and TUI use the same
+classification and show it separately from the account's usage. An account row
+also carries an additive `alias` field once one is set with `cswap alias` (e.g.
+`"alias": "dev"`); accounts without one simply omit the key.
 
 Weekly windows (`sevenDay` and per-model `scoped` entries — never `fiveHour`) additively carry pace fields once the week is ~a day old: `expectedPct` (where usage would sit if spread evenly across the week) and `aheadOfPace` (`true` when meaningfully above that — the same signal the human views show as an `(ahead)`/`(ahead of pace)` marker). `projectedExhaustionAt`/`willLastToReset` extrapolate the current rate into an ETA to 100% and a yes/no "will it last to the reset"; they stay `--json`-only since a linear projection is too rough to present as fact in the UI.
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,40 @@ Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP ser
 
 </details>
 
+### Switch Claude Desktop accounts (macOS)
+
+Switch the account used by Claude Desktop while keeping every resumable local
+Claude Code session visible in the Desktop sidebar:
+
+```bash
+cswap desktop 2
+cswap desktop user@example.com
+cswap desktop 2 --dry-run
+```
+
+Claude Desktop's web login is separate from Claude Code credentials. The command
+therefore keeps one isolated Desktop profile per account and shares only the
+local Claude Code session index between them. The first switch to an account
+opens Claude's normal login flow once. Later switches reuse that authenticated
+profile. After visually verifying the email on that first login, record it once:
+
+```bash
+cswap desktop 2 --confirm-login
+```
+
+The command closes Claude Desktop, switches credentials through the normal
+cswap path, copies only missing resumable index entries, and launches the target
+profile. Existing entries and transcripts under `~/.claude/projects/` are never
+changed. It refuses to close Desktop while a local task is active. The explicit
+first-login confirmation avoids depending on Claude's private login-storage
+format, which changes between Desktop releases.
+The Mac must be unlocked before a relaunch so encrypted login storage remains
+available. Claude Chat and remote Cowork history remain account-specific.
+
+Run the command outside any manually selected Claude profile;
+`CLAUDE_CONFIG_DIR`, `CLAUDE_SECURESTORAGE_CONFIG_DIR`, and
+`CLAUDE_USER_DATA_DIR` are rejected because cswap owns profile selection.
+
 <details>
 <summary>Map accounts to directories — auto-pick per repo</summary>
 
@@ -175,6 +209,7 @@ This will update the stored credentials without creating a duplicate.
 
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
+cswap desktop 2                 # Switch Claude Desktop accounts (macOS)
 cswap auto                      # Auto-switch when nearing rate limits (see above)
 cswap config                    # Show or edit settings (see Configuration below)
 cswap list                      # Show all accounts with 5h/7d usage and reset times

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -217,6 +217,87 @@ Examples:
         sys.exit(130)
 
 
+def _desktop_command(argv: list[str]) -> None:
+    """Handle ``cswap desktop NUM|EMAIL [options]``."""
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} desktop",
+        description=(
+            "Switch Claude Desktop to a stored account while keeping resumable "
+            "local Code sessions visible. macOS only."
+        ),
+    )
+    parser.add_argument("account", metavar="NUM|EMAIL")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the local sessions that would be added; change nothing",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    parser.add_argument(
+        "--confirm-login",
+        action="store_true",
+        help="Record a visually verified one-time Desktop login",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    try:
+        profile_overrides = (
+            "CLAUDE_CONFIG_DIR",
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+            "CLAUDE_USER_DATA_DIR",
+        )
+        if any(os.environ.get(name) for name in profile_overrides):
+            raise ClaudeSwitchError(
+                "Desktop switching must run from the default Claude profile. "
+                f"Unset {', '.join(profile_overrides)} first."
+            )
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+        from claude_swap.desktop import DesktopManager
+
+        payload = DesktopManager(switcher).run(
+            args.account,
+            dry_run=args.dry_run,
+            json_output=args.json,
+            confirm_login=args.confirm_login,
+        )
+        if args.json:
+            print(json.dumps(payload, indent=2))
+            return
+        sessions = payload["sessions"]
+        verb = "Would add" if args.dry_run else "Added"
+        print(
+            f"{accent(verb)} {sessions['copied']} local session(s); "
+            f"{sessions['existing']} already visible; "
+            f"{sessions['unavailable']} unavailable."
+        )
+        if payload["loginRequired"] and not args.dry_run:
+            print(
+                "Sign in once in the opened Claude window, verify the account "
+                "email, then rerun with --confirm-login."
+            )
+        elif not args.dry_run:
+            state = "already active" if payload["alreadyActive"] else "switched"
+            print(f"Claude Desktop {state} to {payload['account']['email']}.")
+    except ClaudeSwitchError as e:
+        if args.json:
+            print(json.dumps(error_envelope(e), indent=2))
+        else:
+            error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(
+            f"\n{dimmed('Operation cancelled')}",
+            file=sys.stderr if args.json else sys.stdout,
+        )
+        sys.exit(130)
+
+
 def _guard_root(switcher: ClaudeAccountSwitcher) -> None:
     """Refuse to run as root outside a container (shared by run/map/unmap)."""
     if sys.platform != "win32":
@@ -865,10 +946,13 @@ def main() -> None:
     except Exception:
         pass  # theme is cosmetic; never block the CLI on it
 
-    # `run` and `auto` keep their dedicated pre-dispatch parsers.
+    # `run`, `desktop`, and `auto` keep their dedicated pre-dispatch parsers.
     if argv and argv[0] == "run":
         _run_command(argv[1:])
         return  # only reachable in tests where exec/exit is mocked
+    if argv and argv[0] == "desktop":
+        _desktop_command(argv[1:])
+        return
     if argv and argv[0] == "auto":
         _auto_command(argv[1:])
         return  # only reachable in tests where sys.exit is mocked
@@ -920,6 +1004,7 @@ Commands:
   %(prog)s enable <num|email>         return a disabled account to rotation
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s run                        run the current dir's mapped account
+  %(prog)s desktop <num|email>        switch Claude Desktop and share local sessions
   %(prog)s map <num|email> [path]     map a directory to an account
   %(prog)s map                        list directory mappings
   %(prog)s unmap [path]               remove a directory mapping
@@ -949,6 +1034,7 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s add --slot 3                      # add to a specific slot
   %(prog)s add-token sk-ant-oat01-... --email me@example.com
   %(prog)s run 2 -- --resume                 # forward args after '--' to claude
+  %(prog)s desktop 2 --dry-run                # preview Desktop session reconciliation
   %(prog)s auto --once                       # single auto-switch tick (cron-friendly)
   %(prog)s config set autoswitch.threshold 80
 

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -113,6 +113,48 @@ def _credential_object(credentials: str | None) -> dict | None:
     return data if isinstance(data, dict) else None
 
 
+AUTH_BROWSER_OAUTH = "browser_oauth"
+AUTH_SETUP_TOKEN = "setup_token"
+AUTH_API_KEY = "api_key"
+AUTH_UNKNOWN = "unknown"
+
+AUTH_METHOD_LABELS = {
+    AUTH_BROWSER_OAUTH: "browser OAuth",
+    AUTH_SETUP_TOKEN: "one-year setup token",
+    AUTH_API_KEY: "API key",
+    AUTH_UNKNOWN: "unknown login",
+}
+
+
+def classify_auth_method(credentials: str | None) -> str:
+    """Classify one stored Claude Code credential without exposing its value.
+
+    Browser OAuth carries a refresh token. A setup token is a standalone
+    ``sk-ant-oat`` access token with no refresh token. Managed API keys use the
+    raw ``sk-ant-api`` form. Anything else stays explicitly unknown rather than
+    being guessed from account metadata.
+    """
+    if looks_like_api_key(credentials):
+        return AUTH_API_KEY
+    data = _credential_object(credentials)
+    if data is None:
+        return AUTH_UNKNOWN
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return AUTH_UNKNOWN
+    if oauth.get("refreshToken"):
+        return AUTH_BROWSER_OAUTH
+    access_token = oauth.get("accessToken")
+    if isinstance(access_token, str) and access_token.startswith("sk-ant-oat"):
+        return AUTH_SETUP_TOKEN
+    return AUTH_UNKNOWN
+
+
+def auth_method_label(method: str) -> str:
+    """Return the human label for a classified authentication method."""
+    return AUTH_METHOD_LABELS.get(method, AUTH_METHOD_LABELS[AUTH_UNKNOWN])
+
+
 # The credential object's siblings of claudeAiOauth are not uniformly owned:
 # these keys hold machine-shared OAuth integrations that rotate independently
 # of any account slot, so on activation the live copy is authoritative.

--- a/src/claude_swap/desktop.py
+++ b/src/claude_swap/desktop.py
@@ -1,0 +1,824 @@
+"""macOS Claude Desktop account switching with shared local session history.
+
+Claude Code transcripts live under ``~/.claude/projects`` and are independent
+of the logged-in account. Claude Desktop keeps a separate session index under
+``~/Library/Application Support/Claude/claude-code-sessions/<account-uuid>/``
+and filters the sidebar by the active account. This module copies only missing,
+resumable local-session index entries into the target account's index. Source
+metadata and transcripts are never changed.
+
+Claude Desktop's web login is stored in Electron's user-data directory. It is
+independent from Claude Code's credential store, so changing only the global
+Claude Code login does not switch the Desktop account. Each account therefore
+gets one persistent Desktop profile. Managed profiles symlink only their
+``claude-code-sessions`` directory to the default profile, keeping web auth
+isolated while sharing the local-session index.
+
+The Desktop app must be closed while the index is reconciled because it caches
+the index in memory. ``DesktopManager`` refuses to close an app with a non-idle
+local task, switches through the existing ``ClaudeAccountSwitcher`` authority,
+then launches the target account's authenticated Desktop profile.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from claude_swap.exceptions import DesktopError
+from claude_swap.json_output import SCHEMA_VERSION
+from claude_swap.paths import (
+    get_default_claude_config_home,
+    get_default_global_config_path,
+)
+from claude_swap.process_detection import list_sessions
+from claude_swap.settings import atomic_write_json
+
+if TYPE_CHECKING:
+    from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+CLAUDE_DESKTOP_BUNDLE_ID = "com.anthropic.claudefordesktop"
+CLAUDE_DESKTOP_EXECUTABLE = Path(
+    "/Applications/Claude.app/Contents/MacOS/Claude"
+)
+DESKTOP_PROFILES_SCHEMA_VERSION = 1
+_LOCAL_SESSION_RE = re.compile(r"^local_[A-Za-z0-9_-]+\.json$")
+_STALE_ACCOUNT_FIELDS = ("bridgeSessionIds", "error", "errorAt")
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        return str(uuid.UUID(value)) == value.lower()
+    except (ValueError, AttributeError):
+        return False
+
+
+def default_user_data_dir() -> Path:
+    """Return the Claude Desktop profile selected for this invocation."""
+    override = os.environ.get("CLAUDE_USER_DATA_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / "Library" / "Application Support" / "Claude"
+
+
+@dataclass(frozen=True)
+class DesktopSyncResult:
+    copied: int = 0
+    existing: int = 0
+    unavailable: int = 0
+    invalid: int = 0
+
+    def to_json(self) -> dict:
+        return {
+            "copied": self.copied,
+            "existing": self.existing,
+            "unavailable": self.unavailable,
+            "invalid": self.invalid,
+        }
+
+
+@dataclass(frozen=True)
+class DesktopProfile:
+    account_uuid: str
+    email: str
+    path: Path
+    is_default: bool
+    initialized: bool
+
+    def to_json(self) -> dict:
+        return {
+            "initialized": self.initialized,
+            "isDefault": self.is_default,
+        }
+
+
+class DesktopProfileStore:
+    """Own the account-to-Electron-profile mapping and shared-session link."""
+
+    def __init__(
+        self,
+        backup_dir: Path,
+        *,
+        default_profile_dir: Path | None = None,
+    ) -> None:
+        self.root = backup_dir / "desktop"
+        self.registry_path = self.root / "profiles.json"
+        self.default_profile_dir = default_profile_dir or default_user_data_dir()
+        self.shared_sessions = self.default_profile_dir / "claude-code-sessions"
+
+    def _load(self) -> dict:
+        if not self.registry_path.exists():
+            return {
+                "schemaVersion": DESKTOP_PROFILES_SCHEMA_VERSION,
+                "profiles": {},
+            }
+        try:
+            data = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise DesktopError(
+                f"Could not read Desktop profile registry: {exc}"
+            ) from exc
+        if (
+            not isinstance(data, dict)
+            or data.get("schemaVersion") != DESKTOP_PROFILES_SCHEMA_VERSION
+            or not isinstance(data.get("profiles"), dict)
+        ):
+            raise DesktopError("Desktop profile registry has an unsupported format.")
+        return data
+
+    def _save(self, data: dict) -> None:
+        atomic_write_json(self.registry_path, data)
+
+    def _managed_profile_path(self, account_uuid: str) -> Path:
+        return self.root / account_uuid
+
+    def _profile_from_record(self, account_uuid: str, record: dict) -> DesktopProfile:
+        path_value = record.get("path")
+        email = record.get("email")
+        if not isinstance(path_value, str) or not isinstance(email, str):
+            raise DesktopError("Desktop profile registry contains an invalid record.")
+        return DesktopProfile(
+            account_uuid=account_uuid,
+            email=email,
+            path=Path(path_value),
+            is_default=bool(record.get("isDefault")),
+            initialized=bool(record.get("initialized")),
+        )
+
+    def _record(self, profile: DesktopProfile) -> dict:
+        return {
+            "email": profile.email,
+            "path": str(profile.path),
+            "isDefault": profile.is_default,
+            "initialized": profile.initialized,
+        }
+
+    def _ensure_managed_profile(self, profile: DesktopProfile) -> None:
+        profile.path.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(profile.path, 0o700)
+        if not self.shared_sessions.is_dir():
+            raise DesktopError(
+                f"Shared Claude Desktop session index not found at "
+                f"{self.shared_sessions}"
+            )
+        link = profile.path / "claude-code-sessions"
+        if link.is_symlink():
+            if link.resolve() != self.shared_sessions.resolve():
+                raise DesktopError(
+                    f"Desktop profile has an unexpected session link at {link}"
+                )
+            return
+        if link.exists():
+            raise DesktopError(
+                f"Desktop profile already has private session data at {link}; "
+                "refusing to replace it."
+            )
+        link.symlink_to(self.shared_sessions, target_is_directory=True)
+
+    def resolve(
+        self,
+        account_uuid: str,
+        email: str,
+        *,
+        current_account_uuid: str | None,
+        current_email: str,
+        current_profile_dir: Path,
+        dry_run: bool = False,
+    ) -> DesktopProfile:
+        """Resolve a profile, adopting the current profile and creating targets."""
+        data = self._load()
+        profiles = data["profiles"]
+        changed = False
+
+        if current_account_uuid and current_account_uuid not in profiles:
+            current = DesktopProfile(
+                account_uuid=current_account_uuid,
+                email=current_email,
+                path=current_profile_dir,
+                is_default=current_profile_dir == self.default_profile_dir,
+                initialized=True,
+            )
+            profiles[current_account_uuid] = self._record(current)
+            changed = True
+
+        record = profiles.get(account_uuid)
+        if record is not None:
+            profile = self._profile_from_record(account_uuid, record)
+            if profile.email != email:
+                profile = DesktopProfile(
+                    account_uuid=profile.account_uuid,
+                    email=email,
+                    path=profile.path,
+                    is_default=profile.is_default,
+                    initialized=profile.initialized,
+                )
+                profiles[account_uuid] = self._record(profile)
+                changed = True
+        elif current_account_uuid == account_uuid:
+            profile = DesktopProfile(
+                account_uuid=account_uuid,
+                email=email,
+                path=current_profile_dir,
+                is_default=current_profile_dir == self.default_profile_dir,
+                initialized=True,
+            )
+            profiles[account_uuid] = self._record(profile)
+            changed = True
+        else:
+            profile = DesktopProfile(
+                account_uuid=account_uuid,
+                email=email,
+                path=self._managed_profile_path(account_uuid),
+                is_default=False,
+                initialized=False,
+            )
+            profiles[account_uuid] = self._record(profile)
+            changed = True
+
+        if not dry_run:
+            if not profile.is_default:
+                self._ensure_managed_profile(profile)
+            if changed:
+                self._save(data)
+        return profile
+
+    def mark_initialized(self, profile: DesktopProfile) -> DesktopProfile:
+        return self._set_initialized(profile, True)
+
+    def mark_uninitialized(self, profile: DesktopProfile) -> DesktopProfile:
+        return self._set_initialized(profile, False)
+
+    def _set_initialized(
+        self, profile: DesktopProfile, initialized: bool
+    ) -> DesktopProfile:
+        data = self._load()
+        updated = DesktopProfile(
+            account_uuid=profile.account_uuid,
+            email=profile.email,
+            path=profile.path,
+            is_default=profile.is_default,
+            initialized=initialized,
+        )
+        data["profiles"][profile.account_uuid] = self._record(updated)
+        self._save(data)
+        return updated
+
+
+class DesktopSessionSync:
+    """Reconcile resumable Desktop index entries into one account root."""
+
+    def __init__(
+        self,
+        user_data_dir: Path | None = None,
+        claude_config_dir: Path | None = None,
+    ) -> None:
+        self.user_data_dir = user_data_dir or default_user_data_dir()
+        self.sessions_root = self.user_data_dir / "claude-code-sessions"
+        self.claude_config_dir = claude_config_dir or get_default_claude_config_home()
+
+    def _transcript_ids(self) -> set[str]:
+        projects = self.claude_config_dir / "projects"
+        if not projects.is_dir():
+            return set()
+        return {path.stem for path in projects.rglob("*.jsonl") if path.is_file()}
+
+    @staticmethod
+    def _read_entry(path: Path) -> dict | None:
+        if not _LOCAL_SESSION_RE.fullmatch(path.name):
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict) or data.get("sessionId") != path.stem:
+            return None
+        return data
+
+    @staticmethod
+    def _write_new_entry(path: Path, data: dict) -> bool:
+        """Atomically create ``path`` without replacing an existing entry."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(path.parent, 0o700)
+        fd, temp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(temp_name, path)
+            except FileExistsError:
+                return False
+            if sys.platform != "win32":
+                os.chmod(path, 0o600)
+            return True
+        finally:
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+
+    def sync(
+        self,
+        target_account_uuid: str,
+        target_organization_uuid: str,
+        *,
+        dry_run: bool = False,
+    ) -> DesktopSyncResult:
+        """Copy missing resumable entries into the active account and org.
+
+        A session is resumable only when its metadata has a ``cliSessionId``
+        and the matching transcript exists under ``projects/``. Existing entries
+        in the active target org win by session ID.
+        """
+        if not _is_uuid(target_account_uuid):
+            raise DesktopError(
+                "The target account has no valid account UUID; re-add it with "
+                "`cswap add --slot N` before using Desktop switching."
+            )
+        if not _is_uuid(target_organization_uuid):
+            raise DesktopError(
+                "The target account has no valid organization UUID; re-add it "
+                "with `cswap add --slot N` before using Desktop switching."
+            )
+        if not self.sessions_root.is_dir():
+            raise DesktopError(
+                f"Claude Desktop session index not found at {self.sessions_root}"
+            )
+
+        transcript_ids = self._transcript_ids()
+        target_root = self.sessions_root / target_account_uuid
+        target_org_root = target_root / target_organization_uuid
+        existing_ids: set[str] = set()
+        if target_org_root.is_dir():
+            for path in target_org_root.glob("*.json"):
+                entry = self._read_entry(path)
+                if entry is not None:
+                    existing_ids.add(entry["sessionId"])
+
+        candidates: dict[str, dict] = {}
+        unavailable = 0
+        invalid = 0
+        for account_root in sorted(self.sessions_root.iterdir()):
+            if not account_root.is_dir() or not _is_uuid(account_root.name):
+                continue
+            for org_root in sorted(account_root.iterdir()):
+                if not org_root.is_dir() or not _is_uuid(org_root.name):
+                    continue
+                if (
+                    account_root.name == target_account_uuid
+                    and org_root.name == target_organization_uuid
+                ):
+                    continue
+                for path in sorted(org_root.glob("local_*.json")):
+                    entry = self._read_entry(path)
+                    if entry is None:
+                        invalid += 1
+                        continue
+                    cli_session_id = entry.get("cliSessionId")
+                    if (
+                        entry.get("transcriptUnavailable") is True
+                        or not isinstance(cli_session_id, str)
+                        or cli_session_id not in transcript_ids
+                    ):
+                        unavailable += 1
+                        continue
+                    candidates.setdefault(entry["sessionId"], entry)
+
+        copied = 0
+        existing = 0
+        for session_id, entry in sorted(candidates.items()):
+            if session_id in existing_ids:
+                existing += 1
+                continue
+            cleaned = dict(entry)
+            for field in _STALE_ACCOUNT_FIELDS:
+                cleaned.pop(field, None)
+            destination = target_org_root / f"{session_id}.json"
+            if not dry_run and not self._write_new_entry(destination, cleaned):
+                existing += 1
+                existing_ids.add(session_id)
+                continue
+            copied += 1
+            existing_ids.add(session_id)
+
+        return DesktopSyncResult(
+            copied=copied,
+            existing=existing,
+            unavailable=unavailable,
+            invalid=invalid,
+        )
+
+
+class DesktopManager:
+    """Switch auth, reconcile history, and launch the account's web profile."""
+
+    def __init__(
+        self,
+        switcher: "ClaudeAccountSwitcher",
+        *,
+        syncer: DesktopSessionSync | None = None,
+        profile_store: DesktopProfileStore | None = None,
+        quit_timeout: float = 10.0,
+        launch_timeout: float = 15.0,
+        identity_timeout: float = 15.0,
+    ) -> None:
+        self.switcher = switcher
+        self.syncer = syncer or DesktopSessionSync()
+        self.profile_store = profile_store or DesktopProfileStore(
+            switcher.backup_dir
+        )
+        self.quit_timeout = quit_timeout
+        self.launch_timeout = launch_timeout
+        self.identity_timeout = identity_timeout
+
+    @staticmethod
+    def _desktop_pids() -> list[int]:
+        result = subprocess.run(
+            ["pgrep", "-x", "Claude"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        return [int(pid) for pid in result.stdout.split() if pid.isdigit()]
+
+    @classmethod
+    def _desktop_is_running(cls) -> bool:
+        return bool(cls._desktop_pids())
+
+    @staticmethod
+    def _console_is_unlocked() -> bool:
+        """Return whether the console can provide encrypted web storage."""
+        result = subprocess.run(
+            ["ioreg", "-n", "Root", "-d1", "-a"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+        try:
+            data = plistlib.loads(result.stdout)
+            root = data[0] if isinstance(data, list) and data else data
+            return (
+                isinstance(root, dict)
+                and root.get("IOConsoleLocked") is False
+            )
+        except (plistlib.InvalidFileException, TypeError):
+            return False
+
+    def _running_profile_dir(self) -> Path:
+        """Return the user-data directory selected by the running main process."""
+        for pid in reversed(self._desktop_pids()):
+            result = subprocess.run(
+                ["ps", "eww", "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            match = re.search(
+                r"(?:^|\s)CLAUDE_USER_DATA_DIR=(\S+)", result.stdout
+            )
+            if match:
+                return Path(match.group(1))
+        return self.profile_store.default_profile_dir
+
+    @staticmethod
+    def _live_identity() -> tuple[str | None, str]:
+        path = get_default_global_config_path()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return None, ""
+        account = data.get("oauthAccount")
+        if not isinstance(account, dict):
+            return None, ""
+        account_uuid = account.get("accountUuid")
+        email = account.get("emailAddress") or account.get("email") or ""
+        return (
+            account_uuid if isinstance(account_uuid, str) else None,
+            email if isinstance(email, str) else "",
+        )
+
+    def _blocking_sessions(self) -> list:
+        return [
+            session
+            for session in list_sessions(self.syncer.claude_config_dir)
+            if session.entrypoint == "claude-desktop" and session.status != "idle"
+        ]
+
+    def _quit_desktop(self) -> None:
+        result = subprocess.run(
+            [
+                "osascript",
+                "-e",
+                f'tell application id "{CLAUDE_DESKTOP_BUNDLE_ID}" to quit',
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or "AppleScript quit failed"
+            raise DesktopError(f"Could not close Claude Desktop: {detail}")
+        deadline = time.monotonic() + self.quit_timeout
+        while self._desktop_is_running():
+            if time.monotonic() >= deadline:
+                raise DesktopError(
+                    "Claude Desktop did not quit within 10 seconds; account unchanged."
+                )
+            time.sleep(0.1)
+
+    def _launch_desktop(self, profile: DesktopProfile) -> None:
+        if not CLAUDE_DESKTOP_EXECUTABLE.is_file():
+            raise DesktopError(
+                f"Claude Desktop executable not found at {CLAUDE_DESKTOP_EXECUTABLE}"
+            )
+        command = [
+            "/usr/bin/open",
+            "-n",
+            "-b",
+            CLAUDE_DESKTOP_BUNDLE_ID,
+        ]
+        if not profile.is_default:
+            command.extend(
+                ["--env", f"CLAUDE_USER_DATA_DIR={profile.path}"]
+            )
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:
+            raise DesktopError(f"Could not launch Claude Desktop: {exc}") from exc
+        if result.returncode != 0:
+            detail = result.stderr.strip() or "LaunchServices failed"
+            raise DesktopError(f"Could not launch Claude Desktop: {detail}")
+        deadline = time.monotonic() + self.launch_timeout
+        while not self._desktop_is_running():
+            if time.monotonic() >= deadline:
+                raise DesktopError("Claude Desktop did not start within 15 seconds.")
+            time.sleep(0.1)
+
+    @staticmethod
+    def _profile_matches_account(
+        profile: DesktopProfile, account_uuid: str
+    ) -> bool:
+        """Verify the account identity cached in this Electron profile."""
+        needle = account_uuid.encode("ascii")
+        indexed_db = profile.path / "IndexedDB"
+        if not indexed_db.is_dir():
+            return False
+        try:
+            files = (path for path in indexed_db.rglob("*") if path.is_file())
+            for path in files:
+                with path.open("rb") as handle:
+                    overlap = b""
+                    while chunk := handle.read(1024 * 1024):
+                        data = overlap + chunk
+                        if needle in data:
+                            return True
+                        overlap = data[-len(needle) :]
+        except OSError:
+            return False
+        return False
+
+    def _wait_for_identity(
+        self, profile: DesktopProfile, account_uuid: str
+    ) -> bool:
+        deadline = time.monotonic() + self.identity_timeout
+        matching_since: float | None = None
+        profile_matches = False
+        next_profile_check = 0.0
+        while time.monotonic() < deadline:
+            live_uuid, _ = self._live_identity()
+            now = time.monotonic()
+            if not profile_matches and now >= next_profile_check:
+                profile_matches = self._profile_matches_account(
+                    profile, account_uuid
+                )
+                next_profile_check = now + 1.0
+            if (
+                profile_matches and live_uuid == account_uuid
+            ):
+                if matching_since is None:
+                    matching_since = now
+                elif now - matching_since >= 2.0:
+                    return True
+            else:
+                matching_since = None
+            if not self._desktop_is_running():
+                return False
+            time.sleep(0.25)
+        return False
+
+    def _restore_original(
+        self,
+        original_identifier: str | None,
+        original_profile: DesktopProfile | None,
+        *,
+        was_running: bool,
+        switch_completed: bool,
+    ) -> None:
+        if self._desktop_is_running():
+            self._quit_desktop()
+        if switch_completed and original_identifier:
+            self.switcher.switch_to(original_identifier, json_output=True)
+        if was_running and original_profile:
+            self._launch_desktop(original_profile)
+
+    def run(
+        self,
+        identifier: str,
+        *,
+        dry_run: bool = False,
+        json_output: bool = False,
+        confirm_login: bool = False,
+    ) -> dict:
+        if sys.platform != "darwin":
+            raise DesktopError("Claude Desktop switching is currently macOS-only.")
+
+        account_num, email, organization_uuid = self.switcher.resolve_account(
+            identifier
+        )
+        account_uuid = self.switcher.account_identity(account_num).get("uuid", "")
+        if not _is_uuid(account_uuid):
+            raise DesktopError(
+                "The target account has no valid account UUID; re-add it with "
+                "`cswap add --slot N` before using Desktop switching."
+            )
+
+        was_running = self._desktop_is_running()
+        current_uuid, current_email = self._live_identity()
+        current_profile_dir = self._running_profile_dir()
+        running_uuid = current_uuid if was_running else None
+        original_profile = None
+        if running_uuid:
+            original_profile = self.profile_store.resolve(
+                running_uuid,
+                current_email,
+                current_account_uuid=running_uuid,
+                current_email=current_email,
+                current_profile_dir=current_profile_dir,
+                dry_run=dry_run,
+            )
+        profile = self.profile_store.resolve(
+            account_uuid,
+            email,
+            current_account_uuid=running_uuid,
+            current_email=current_email,
+            current_profile_dir=current_profile_dir,
+            dry_run=dry_run,
+        )
+
+        preview = self.syncer.sync(
+            account_uuid, organization_uuid, dry_run=True
+        )
+        already_active = (
+            was_running
+            and running_uuid == account_uuid
+            and current_profile_dir.resolve() == profile.path.resolve()
+        )
+        if dry_run:
+            if confirm_login:
+                raise DesktopError("--confirm-login cannot be used with --dry-run.")
+            return self._payload(
+                account_num,
+                email,
+                preview,
+                profile,
+                dry_run=True,
+                login_required=not profile.initialized,
+                already_active=already_active,
+            )
+
+        if already_active:
+            if confirm_login:
+                profile = self.profile_store.mark_initialized(profile)
+                identity_matches = True
+            elif profile.initialized:
+                identity_matches = True
+            else:
+                identity_matches = self._wait_for_identity(profile, account_uuid)
+                if identity_matches:
+                    profile = self.profile_store.mark_initialized(profile)
+            result = self.syncer.sync(account_uuid, organization_uuid)
+            return self._payload(
+                account_num,
+                email,
+                result,
+                profile,
+                dry_run=False,
+                login_required=not identity_matches,
+                already_active=True,
+            )
+
+        blocking = self._blocking_sessions()
+        if blocking:
+            raise DesktopError(
+                "Claude Desktop has an active local task. Let it finish or stop it "
+                "before switching accounts."
+            )
+
+        if confirm_login:
+            raise DesktopError(
+                "--confirm-login requires Claude Desktop to be open on the "
+                "selected profile."
+            )
+
+        if not self._console_is_unlocked():
+            raise DesktopError(
+                "The Mac is locked. Unlock it before switching Claude Desktop "
+                "accounts so encrypted login storage remains available."
+            )
+
+        original_identifier = None
+        if running_uuid:
+            data = self.switcher._get_sequence_data() or {}
+            for number, record in data.get("accounts", {}).items():
+                if record.get("uuid") == running_uuid:
+                    original_identifier = str(number)
+                    break
+            if original_identifier is None:
+                raise DesktopError(
+                    "The current Claude Desktop account is not stored in cswap; "
+                    "add it before switching so rollback remains possible."
+                )
+
+        if was_running:
+            self._quit_desktop()
+
+        switch_completed = False
+        try:
+            self.switcher.switch_to(identifier, json_output=json_output)
+            switch_completed = True
+            result = self.syncer.sync(account_uuid, organization_uuid)
+            self._launch_desktop(profile)
+            identity_matches = profile.initialized
+            if not identity_matches and self._profile_matches_account(
+                profile, account_uuid
+            ):
+                identity_matches = self._wait_for_identity(profile, account_uuid)
+            if identity_matches:
+                profile = self.profile_store.mark_initialized(profile)
+            return self._payload(
+                account_num,
+                email,
+                result,
+                profile,
+                dry_run=False,
+                login_required=not identity_matches,
+                already_active=False,
+            )
+        except Exception as exc:
+            try:
+                self._restore_original(
+                    original_identifier,
+                    original_profile,
+                    was_running=was_running,
+                    switch_completed=switch_completed,
+                )
+            except Exception as rollback_exc:
+                raise DesktopError(
+                    f"Desktop switch failed ({exc}); rollback also failed "
+                    f"({rollback_exc})."
+                ) from exc
+            raise
+
+    @staticmethod
+    def _payload(
+        account_num: str,
+        email: str,
+        result: DesktopSyncResult,
+        profile: DesktopProfile,
+        *,
+        dry_run: bool,
+        login_required: bool,
+        already_active: bool,
+    ) -> dict:
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "dryRun": dry_run,
+            "account": {"number": int(account_num), "email": email},
+            "profile": profile.to_json(),
+            "loginRequired": login_required,
+            "alreadyActive": already_active,
+            "sessions": result.to_json(),
+        }

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -43,6 +43,12 @@ class SessionError(ClaudeSwitchError):
     pass
 
 
+class DesktopError(ClaudeSwitchError):
+    """Error switching or reconciling Claude Desktop."""
+
+    pass
+
+
 class LockError(ClaudeSwitchError):
     """Error acquiring lock."""
 

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -219,6 +219,7 @@ def account_row(
     usage_fetched_at: float | None = None,
     usage_age_s: float | None = None,
     last_good_usage: dict | None = None,
+    auth_method: str | None = None,
     alias: str = "",
     disabled: bool = False,
 ) -> dict:
@@ -234,6 +235,8 @@ def account_row(
         "usageStatus": status,
         "usage": usage,
     }
+    if auth_method is not None:
+        row["authMethod"] = auth_method
     if alias:
         row["alias"] = alias
     # Additive field: present only when the slot is held out of rotation, so

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -138,6 +138,7 @@ class AccountSnapshot:
     kind: str  # "oauth" | "api_key"
     switchable: bool
     usage: UsageEntry
+    auth_method: str = "unknown"
     alias: str = ""
     disabled: bool = False  # held out of auto-rotation (still a valid explicit target)
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -44,6 +44,8 @@ from claude_swap.credentials import (  # noqa: F401  (constants re-exported for 
     SECURITY_SERVICE,
     ActiveCredentials,
     CredentialStore,
+    auth_method_label,
+    classify_auth_method,
     looks_like_api_key,
     merge_shared_credential_fields,
     shared_credential_fields,
@@ -1494,6 +1496,7 @@ class ClaudeAccountSwitcher:
                     kind=self._account_kind(n),
                     switchable=self._account_is_switchable(n),
                     usage=entries[n],
+                    auth_method=classify_auth_method(_creds),
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, n),
                 )
@@ -3881,7 +3884,7 @@ class ClaudeAccountSwitcher:
         active_num: int | None = None
         accounts = []
         seq_data = self._get_sequence_data() or {}
-        for num, email, org_name, org_uuid, is_active, _, alias in accounts_info:
+        for num, email, org_name, org_uuid, is_active, creds, alias in accounts_info:
             if is_active:
                 active_num = num
             entry = entries[str(num)]
@@ -3896,6 +3899,7 @@ class ClaudeAccountSwitcher:
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
                     last_good_usage=entry.last_good,
+                    auth_method=classify_auth_method(creds),
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, str(num)),
                 )
@@ -3954,7 +3958,7 @@ class ClaudeAccountSwitcher:
 
         seq_data = self._get_sequence_data() or {}
         print(bolded("Accounts:"))
-        for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
+        for i, (num, email, org_name, org_uuid, is_active, creds, alias) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
             label = f"{accent(alias)} ({email})" if alias else email
             markers = ""
@@ -3963,6 +3967,10 @@ class ClaudeAccountSwitcher:
             if self._disabled_from_data(seq_data, str(num)):
                 markers += f" {muted('(disabled)')}"
             print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
+            print(
+                f"     {dimmed('Claude Code:')} "
+                f"{muted(auth_method_label(classify_auth_method(creds)))}"
+            )
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
 

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -15,6 +15,7 @@ from rich.text import Text
 from textual.widgets import ListItem, Static
 
 from claude_swap import pace
+from claude_swap.credentials import auth_method_label
 from claude_swap.json_output import USAGE_API_KEY
 from claude_swap.models import AccountSnapshot
 from claude_swap.usage_store import STALE_OK_S
@@ -186,6 +187,10 @@ def account_card_text(
     if age:
         text.append(f"   {age}", style=palette.muted)
 
+    text.append("\n    ")
+    text.append("Claude Code  ", style=palette.muted)
+    text.append(auth_method_label(acc.auth_method), style=palette.foreground)
+
     sentinel = acc.usage.sentinel
     if sentinel is not None:
         text.append("\n    ")
@@ -255,6 +260,7 @@ def mini_account_text(
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.disabled:
         text.append("  (disabled)", style=palette.muted)
+    text.append(f"  · {auth_method_label(acc.auth_method)}", style=palette.muted)
     text.append("   ")
 
     sentinel = acc.usage.sentinel

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -16,9 +16,13 @@ import pytest
 from claude_swap import macos_keychain
 from claude_swap import session as session_mod
 from claude_swap.credentials import (
+    AUTH_API_KEY,
+    AUTH_BROWSER_OAUTH,
+    AUTH_SETUP_TOKEN,
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
     approved_form,
+    classify_auth_method,
     looks_like_api_key,
 )
 from claude_swap.exceptions import SessionError, ValidationError
@@ -62,6 +66,22 @@ def _read_global_config() -> dict:
 
 
 class TestKindDetection:
+    def test_classifies_every_supported_auth_method(self):
+        browser = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat01-browser",
+                    "refreshToken": "refresh",
+                }
+            }
+        )
+        setup = json.dumps(
+            {"claudeAiOauth": {"accessToken": "sk-ant-oat01-setup"}}
+        )
+        assert classify_auth_method(browser) == AUTH_BROWSER_OAUTH
+        assert classify_auth_method(setup) == AUTH_SETUP_TOKEN
+        assert classify_auth_method(API_KEY) == AUTH_API_KEY
+
     def test_api_key_detected(self):
         assert looks_like_api_key(API_KEY) is True
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -665,6 +665,95 @@ class TestRunCommand:
         assert "boom" in capsys.readouterr().err
 
 
+class TestDesktopCommand:
+    def test_dispatches_account_and_flags(self, capsys):
+        payload = {
+            "schemaVersion": 1,
+            "dryRun": True,
+            "account": {"number": 2, "email": "user@example.com"},
+            "sessions": {
+                "copied": 3,
+                "existing": 4,
+                "unavailable": 1,
+                "invalid": 0,
+            },
+        }
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch("claude_swap.desktop.DesktopManager") as manager_cls, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(
+                 sys, "argv", ["claude-swap", "desktop", "2", "--dry-run", "--json"]
+             ):
+            manager_cls.return_value.run.return_value = payload
+            cli.main()
+
+        manager_cls.assert_called_once_with(switcher_cls.return_value)
+        manager_cls.return_value.run.assert_called_once_with(
+            "2", dry_run=True, json_output=True, confirm_login=False
+        )
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_prompts_for_one_time_desktop_login(self, capsys):
+        payload = {
+            "schemaVersion": 1,
+            "dryRun": False,
+            "account": {"number": 2, "email": "user@example.com"},
+            "profile": {"initialized": False, "isDefault": False},
+            "loginRequired": True,
+            "alreadyActive": False,
+            "sessions": {
+                "copied": 0,
+                "existing": 1,
+                "unavailable": 0,
+                "invalid": 0,
+            },
+        }
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("claude_swap.desktop.DesktopManager") as manager_cls, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "desktop", "2"]):
+            manager_cls.return_value.run.return_value = payload
+            cli.main()
+
+        output = capsys.readouterr().out
+        assert "Sign in once" in output
+        assert "--confirm-login" in output
+
+    def test_help_mentions_desktop(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "desktop <num|email>" in result.stdout
+
+    def test_rejects_non_default_claude_profile(self, capsys):
+        with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": "/tmp/isolated"}), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "desktop", "2"]), \
+             pytest.raises(SystemExit) as excinfo:
+            cli.main()
+
+        assert excinfo.value.code == 1
+        switcher_cls.assert_not_called()
+        assert "default Claude profile" in capsys.readouterr().err
+
+    def test_error_exits_cleanly(self, capsys):
+        from claude_swap.exceptions import DesktopError
+
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("claude_swap.desktop.DesktopManager") as manager_cls, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "desktop", "2"]), \
+             pytest.raises(SystemExit) as excinfo:
+            manager_cls.return_value.run.side_effect = DesktopError("boom")
+            cli.main()
+
+        assert excinfo.value.code == 1
+        assert "boom" in capsys.readouterr().err
+
+
 class TestSubcommandAliases:
     """Memorable subcommands (`cswap switch`, `cswap list`, ...) → classic flags."""
 

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -1,0 +1,710 @@
+"""Tests for macOS Claude Desktop account switching and session sharing."""
+
+from __future__ import annotations
+
+import json
+import plistlib
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from claude_swap.desktop import (
+    DesktopManager,
+    DesktopProfile,
+    DesktopProfileStore,
+    DesktopSessionSync,
+    DesktopSyncResult,
+)
+from claude_swap.exceptions import DesktopError, SwitchError
+from claude_swap.process_detection import ClaudeSession
+
+
+ACCOUNT_A = "11111111-1111-4111-8111-111111111111"
+ACCOUNT_B = "22222222-2222-4222-8222-222222222222"
+ORG_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+ORG_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+CLI_SESSION = "33333333-3333-4333-8333-333333333333"
+LOCAL_SESSION = "local_44444444-4444-4444-8444-444444444444"
+
+
+def _write_transcript(config_dir: Path, cli_session_id: str = CLI_SESSION) -> None:
+    project = config_dir / "projects" / "project"
+    project.mkdir(parents=True, exist_ok=True)
+    (project / f"{cli_session_id}.jsonl").write_text("{}\n", encoding="utf-8")
+
+
+def _write_entry(
+    sessions_root: Path,
+    account: str,
+    org: str,
+    *,
+    session_id: str = LOCAL_SESSION,
+    cli_session_id: str | None = CLI_SESSION,
+    unavailable: bool = False,
+    **extra,
+) -> Path:
+    path = sessions_root / account / org / f"{session_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "sessionId": session_id,
+        "cliSessionId": cli_session_id,
+        "title": "Shared task",
+        **extra,
+    }
+    if unavailable:
+        data["transcriptUnavailable"] = True
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class TestDesktopSessionSync:
+    def test_copies_resumable_entry_and_removes_account_bound_fields(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        source = _write_entry(
+            sessions_root,
+            ACCOUNT_A,
+            ORG_A,
+            bridgeSessionIds=["old-server-id"],
+            error="out of usage credits",
+            errorAt="2026-01-01T00:00:00Z",
+        )
+
+        result = DesktopSessionSync(user_data, config_dir).sync(ACCOUNT_B, ORG_B)
+
+        assert result == DesktopSyncResult(copied=1)
+        destination = sessions_root / ACCOUNT_B / ORG_B / source.name
+        copied = json.loads(destination.read_text(encoding="utf-8"))
+        assert copied["sessionId"] == LOCAL_SESSION
+        assert copied["cliSessionId"] == CLI_SESSION
+        assert "bridgeSessionIds" not in copied
+        assert "error" not in copied
+        assert "errorAt" not in copied
+        assert json.loads(source.read_text(encoding="utf-8"))["bridgeSessionIds"] == [
+            "old-server-id"
+        ]
+
+    def test_skips_unavailable_and_missing_transcripts(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        _write_entry(sessions_root, ACCOUNT_A, ORG_A, unavailable=True)
+        _write_entry(
+            sessions_root,
+            ACCOUNT_A,
+            ORG_A,
+            session_id="local_missing-transcript",
+            cli_session_id="55555555-5555-4555-8555-555555555555",
+        )
+
+        result = DesktopSessionSync(user_data, config_dir).sync(ACCOUNT_B, ORG_B)
+
+        assert result == DesktopSyncResult(unavailable=2)
+        assert not (sessions_root / ACCOUNT_B).exists()
+
+    def test_existing_session_in_active_target_org_wins(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        _write_entry(sessions_root, ACCOUNT_A, ORG_A, title="source")
+        target = _write_entry(sessions_root, ACCOUNT_B, ORG_B, title="target")
+
+        result = DesktopSessionSync(user_data, config_dir).sync(ACCOUNT_B, ORG_B)
+
+        assert result == DesktopSyncResult(existing=1)
+        assert json.loads(target.read_text(encoding="utf-8"))["title"] == "target"
+        assert not (sessions_root / ACCOUNT_B / ORG_A / target.name).exists()
+
+    def test_copies_entry_from_another_org_of_same_account(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        source = _write_entry(sessions_root, ACCOUNT_B, ORG_A)
+
+        result = DesktopSessionSync(user_data, config_dir).sync(ACCOUNT_B, ORG_B)
+
+        assert result == DesktopSyncResult(copied=1)
+        destination = sessions_root / ACCOUNT_B / ORG_B / source.name
+        assert destination.is_file()
+        assert source.is_file()
+
+    def test_dry_run_reports_copy_without_writing(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        _write_entry(sessions_root, ACCOUNT_A, ORG_A)
+
+        result = DesktopSessionSync(user_data, config_dir).sync(
+            ACCOUNT_B, ORG_B, dry_run=True
+        )
+
+        assert result == DesktopSyncResult(copied=1)
+        assert not (sessions_root / ACCOUNT_B).exists()
+
+    def test_new_entry_writer_never_replaces_existing_file(self, tmp_path):
+        destination = tmp_path / "org" / f"{LOCAL_SESSION}.json"
+        destination.parent.mkdir()
+        destination.write_text('{"title": "keep"}', encoding="utf-8")
+
+        created = DesktopSessionSync._write_new_entry(
+            destination, {"title": "replace"}
+        )
+
+        assert created is False
+        assert json.loads(destination.read_text(encoding="utf-8")) == {
+            "title": "keep"
+        }
+
+    def test_rejects_invalid_account_uuid(self, tmp_path):
+        syncer = DesktopSessionSync(tmp_path / "Claude", tmp_path / ".claude")
+        with pytest.raises(DesktopError, match="valid account UUID"):
+            syncer.sync("not-a-uuid", ORG_B)
+
+    def test_rejects_invalid_organization_uuid(self, tmp_path):
+        syncer = DesktopSessionSync(tmp_path / "Claude", tmp_path / ".claude")
+        with pytest.raises(DesktopError, match="valid organization UUID"):
+            syncer.sync(ACCOUNT_B, "not-a-uuid")
+
+    def test_rejects_missing_desktop_index(self, tmp_path):
+        syncer = DesktopSessionSync(tmp_path / "Claude", tmp_path / ".claude")
+        with pytest.raises(DesktopError, match="session index not found"):
+            syncer.sync(ACCOUNT_B, ORG_B)
+
+
+class TestDesktopProfileStore:
+    def test_dry_run_predicts_profile_without_writing(self, tmp_path):
+        default = tmp_path / "Application Support" / "Claude"
+        (default / "claude-code-sessions").mkdir(parents=True)
+        backup = tmp_path / "backup"
+        store = DesktopProfileStore(backup, default_profile_dir=default)
+
+        profile = store.resolve(
+            ACCOUNT_B,
+            "user@example.com",
+            current_account_uuid=None,
+            current_email="",
+            current_profile_dir=default,
+            dry_run=True,
+        )
+
+        assert profile.path == backup / "desktop" / ACCOUNT_B
+        assert profile.initialized is False
+        assert not backup.exists()
+
+    def test_adopts_default_and_creates_shared_session_link(self, tmp_path):
+        default = tmp_path / "Application Support" / "Claude"
+        shared = default / "claude-code-sessions"
+        shared.mkdir(parents=True)
+        store = DesktopProfileStore(tmp_path / "backup", default_profile_dir=default)
+
+        profile = store.resolve(
+            ACCOUNT_B,
+            "user@example.com",
+            current_account_uuid=ACCOUNT_A,
+            current_email="old@example.com",
+            current_profile_dir=default,
+        )
+
+        link = profile.path / "claude-code-sessions"
+        assert link.is_symlink()
+        assert link.resolve() == shared.resolve()
+        registry = json.loads(store.registry_path.read_text(encoding="utf-8"))
+        assert registry["profiles"][ACCOUNT_A]["isDefault"] is True
+        assert registry["profiles"][ACCOUNT_B]["initialized"] is False
+
+    def test_refuses_to_replace_private_session_data(self, tmp_path):
+        default = tmp_path / "Claude"
+        (default / "claude-code-sessions").mkdir(parents=True)
+        backup = tmp_path / "backup"
+        private = backup / "desktop" / ACCOUNT_B / "claude-code-sessions"
+        private.mkdir(parents=True)
+        store = DesktopProfileStore(backup, default_profile_dir=default)
+
+        with pytest.raises(DesktopError, match="private session data"):
+            store.resolve(
+                ACCOUNT_B,
+                "user@example.com",
+                current_account_uuid=None,
+                current_email="",
+                current_profile_dir=default,
+            )
+
+    def test_marks_profile_initialized(self, tmp_path):
+        default = tmp_path / "Claude"
+        (default / "claude-code-sessions").mkdir(parents=True)
+        store = DesktopProfileStore(tmp_path / "backup", default_profile_dir=default)
+        profile = store.resolve(
+            ACCOUNT_B,
+            "user@example.com",
+            current_account_uuid=None,
+            current_email="",
+            current_profile_dir=default,
+        )
+
+        initialized = store.mark_initialized(profile)
+
+        assert initialized.initialized is True
+        stored = json.loads(store.registry_path.read_text(encoding="utf-8"))
+        assert stored["profiles"][ACCOUNT_B]["initialized"] is True
+
+        uninitialized = store.mark_uninitialized(initialized)
+
+        assert uninitialized.initialized is False
+        stored = json.loads(store.registry_path.read_text(encoding="utf-8"))
+        assert stored["profiles"][ACCOUNT_B]["initialized"] is False
+
+
+def _authenticated_profile(tmp_path: Path) -> DesktopProfile:
+    profile_dir = tmp_path / "profile"
+    profile_dir.mkdir()
+    indexed = profile_dir / "IndexedDB" / "https_claude.ai_0.indexeddb.leveldb"
+    indexed.mkdir(parents=True)
+    (indexed / "000003.log").write_bytes(b"prefix" + ACCOUNT_B.encode() + b"suffix")
+    return DesktopProfile(
+        account_uuid=ACCOUNT_B,
+        email="user@example.com",
+        path=profile_dir,
+        is_default=False,
+        initialized=False,
+    )
+
+
+class TestDesktopProfileIdentity:
+    def test_profile_storage_contains_account(self, tmp_path):
+        profile = _authenticated_profile(tmp_path)
+
+        assert DesktopManager._profile_matches_account(profile, ACCOUNT_B) is True
+        assert DesktopManager._profile_matches_account(profile, ACCOUNT_A) is False
+
+    def test_missing_account_identity_is_not_authenticated(self, tmp_path):
+        profile = DesktopProfile(
+            ACCOUNT_B,
+            "user@example.com",
+            tmp_path,
+            False,
+            False,
+        )
+        indexed = tmp_path / "IndexedDB"
+        indexed.mkdir()
+        (indexed / "data").write_text("no account here", encoding="ascii")
+
+        assert DesktopManager._profile_matches_account(profile, ACCOUNT_B) is False
+
+
+def _switcher() -> MagicMock:
+    switcher = MagicMock()
+    switcher.resolve_account.return_value = ("2", "user@example.com", ORG_B)
+    switcher.account_identity.return_value = {
+        "email": "user@example.com",
+        "organizationUuid": ORG_B,
+        "uuid": ACCOUNT_B,
+    }
+    return switcher
+
+
+class TestDesktopManager:
+    def test_launches_managed_profile_through_gui_session(self, tmp_path):
+        switcher = _switcher()
+        store = MagicMock()
+        store.default_profile_dir = tmp_path / "default"
+        manager = DesktopManager(
+            switcher, syncer=MagicMock(), profile_store=store
+        )
+        profile = DesktopProfile(
+            ACCOUNT_B, "user@example.com", tmp_path / "profile", False, True
+        )
+        completed = MagicMock(returncode=0, stderr="")
+
+        with patch.object(Path, "is_file", return_value=True), \
+             patch("claude_swap.desktop.subprocess.run", return_value=completed) as run, \
+             patch.object(manager, "_desktop_is_running", return_value=True):
+            manager._launch_desktop(profile)
+
+        run.assert_called_once_with(
+            [
+                "/usr/bin/open",
+                "-n",
+                "-b",
+                "com.anthropic.claudefordesktop",
+                "--env",
+                f"CLAUDE_USER_DATA_DIR={profile.path}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_running_profile_path_drops_ps_trailing_newline(self):
+        switcher = _switcher()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        manager = DesktopManager(
+            switcher, syncer=MagicMock(), profile_store=store
+        )
+        ps_result = MagicMock(
+            returncode=0,
+            stdout=(
+                "/Applications/Claude.app/Contents/MacOS/Claude "
+                "CLAUDE_USER_DATA_DIR=/profiles/b\n"
+            ),
+        )
+
+        with patch.object(manager, "_desktop_pids", return_value=[42]), \
+             patch("claude_swap.desktop.subprocess.run", return_value=ps_result):
+            profile = manager._running_profile_dir()
+
+        assert profile == Path("/profiles/b")
+
+    def test_dry_run_never_switches_or_touches_app(self):
+        switcher = _switcher()
+        syncer = MagicMock()
+        syncer.sync.return_value = DesktopSyncResult(copied=3, existing=2)
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        store.resolve.return_value = target
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_desktop_is_running", return_value=False), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             patch.object(manager, "_launch_desktop") as launch:
+            payload = manager.run("2", dry_run=True)
+
+        syncer.sync.assert_called_once_with(ACCOUNT_B, ORG_B, dry_run=True)
+        switcher.switch_to.assert_not_called()
+        quit_desktop.assert_not_called()
+        launch.assert_not_called()
+        assert payload["dryRun"] is True
+        assert payload["loginRequired"] is True
+        assert payload["sessions"]["copied"] == 3
+
+    def test_switches_syncs_and_relaunches(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult(copied=2)
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        store.mark_initialized.return_value = target
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             patch.object(manager, "_launch_desktop") as launch, \
+             patch.object(manager, "_wait_for_identity", return_value=True):
+            payload = manager.run("2", json_output=True)
+
+        quit_desktop.assert_called_once_with()
+        switcher.switch_to.assert_called_once_with("2", json_output=True)
+        assert syncer.sync.call_args_list == [
+            call(ACCOUNT_B, ORG_B, dry_run=True),
+            call(ACCOUNT_B, ORG_B),
+        ]
+        launch.assert_called_once_with(target)
+        store.mark_initialized.assert_called_once_with(target)
+        assert payload["loginRequired"] is False
+        assert payload["sessions"]["copied"] == 2
+
+    def test_new_profile_opens_for_one_time_login(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop"), \
+             patch.object(manager, "_launch_desktop") as launch, \
+             patch.object(manager, "_profile_matches_account", return_value=False), \
+             patch.object(manager, "_wait_for_identity") as wait:
+            payload = manager.run("2")
+
+        launch.assert_called_once_with(target)
+        wait.assert_not_called()
+        store.mark_initialized.assert_not_called()
+        assert payload["loginRequired"] is True
+
+    def test_already_active_profile_is_verified_without_switching(self):
+        switcher = _switcher()
+        syncer = MagicMock()
+        syncer.sync.return_value = DesktopSyncResult(existing=2)
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        initialized = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [target, target]
+        store.mark_initialized.return_value = initialized
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_B, "user@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/profiles/b")), \
+             patch.object(manager, "_wait_for_identity", return_value=True), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             patch.object(manager, "_launch_desktop") as launch:
+            payload = manager.run("2")
+
+        switcher.switch_to.assert_not_called()
+        quit_desktop.assert_not_called()
+        launch.assert_not_called()
+        assert payload["alreadyActive"] is True
+        assert payload["loginRequired"] is False
+
+    def test_confirms_visually_verified_active_profile(self):
+        switcher = _switcher()
+        syncer = MagicMock()
+        syncer.sync.return_value = DesktopSyncResult(existing=2)
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        initialized = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [target, target]
+        store.mark_initialized.return_value = initialized
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_B, "user@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/profiles/b")), \
+             patch.object(manager, "_wait_for_identity") as wait:
+            payload = manager.run("2", confirm_login=True)
+
+        store.mark_initialized.assert_called_once_with(target)
+        wait.assert_not_called()
+        assert payload["loginRequired"] is False
+
+    def test_refuses_non_idle_desktop_task(self):
+        switcher = _switcher()
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+        busy = ClaudeSession(
+            pid=42,
+            session_id="s",
+            cwd="/tmp/project",
+            started_at=0,
+            kind="interactive",
+            entrypoint="claude-desktop",
+            status="busy",
+        )
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[busy]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             patch.object(manager, "_launch_desktop") as launch, \
+             pytest.raises(DesktopError, match="active local task"):
+            manager.run("2")
+
+        switcher.switch_to.assert_not_called()
+        quit_desktop.assert_not_called()
+        launch.assert_not_called()
+
+    def test_refuses_locked_console_before_closing(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_console_is_unlocked", return_value=False), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             pytest.raises(DesktopError, match="Mac is locked"):
+            manager.run("2")
+
+        quit_desktop.assert_not_called()
+        switcher.switch_to.assert_not_called()
+
+    def test_console_lock_probe_reads_ioreg_plist(self):
+        unlocked = plistlib.dumps({"IOConsoleLocked": False})
+        locked = plistlib.dumps({"IOConsoleLocked": True})
+
+        with patch("claude_swap.desktop.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout=unlocked)
+            assert DesktopManager._console_is_unlocked() is True
+            run.return_value = MagicMock(returncode=0, stdout=locked)
+            assert DesktopManager._console_is_unlocked() is False
+
+    def test_relaunches_original_app_when_switch_fails(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        switcher.switch_to.side_effect = SwitchError("boom")
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop"), \
+             patch.object(manager, "_restore_original") as restore, \
+             pytest.raises(SwitchError, match="boom"):
+            manager.run("2")
+
+        restore.assert_called_once_with(
+            "1", original, was_running=True, switch_completed=False
+        )
+        syncer.sync.assert_called_once_with(ACCOUNT_B, ORG_B, dry_run=True)
+
+    def test_confirmed_profile_reuses_isolated_login_without_private_storage_probe(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop"), \
+             patch.object(manager, "_launch_desktop"), \
+             patch.object(manager, "_wait_for_identity") as wait, \
+             patch.object(manager, "_restore_original") as restore:
+            payload = manager.run("2")
+
+        wait.assert_not_called()
+        restore.assert_not_called()
+        assert payload["loginRequired"] is False
+
+    def test_refuses_untracked_current_account_before_closing(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {"accounts": {}}
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             pytest.raises(DesktopError, match="not stored in cswap"):
+            manager.run("2")
+
+        quit_desktop.assert_not_called()
+        switcher.switch_to.assert_not_called()
+
+    def test_rejects_non_macos(self):
+        manager = DesktopManager(
+            _switcher(), syncer=MagicMock(), profile_store=MagicMock()
+        )
+        with patch("claude_swap.desktop.sys.platform", "linux"), \
+             pytest.raises(DesktopError, match="macOS-only"):
+            manager.run("2")

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -197,7 +197,9 @@ class TestListJson:
         sample_sequence_data: dict, capsys,
     ):
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
-        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        active_creds = json.dumps(
+            {"claudeAiOauth": {"accessToken": "sk-ant-oat01-active"}}
+        )
         backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
         usage = {
             "five_hour": {"pct": 10.0, "resets_at": "2026-01-01T00:00:00Z",
@@ -221,6 +223,7 @@ class TestListJson:
         acct1 = next(a for a in payload["accounts"] if a["number"] == 1)
         assert acct1["active"] is True
         assert acct1["usageStatus"] == "ok"
+        assert acct1["authMethod"] == "setup_token"
         assert acct1["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
 
     def test_list_payload_includes_alias(

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -77,6 +77,7 @@ def make_account(
     active: bool = False,
     switchable: bool = True,
     kind: str = "oauth",
+    auth_method: str = "browser_oauth",
     entry: UsageEntry | None = None,
     email: str | None = None,
     alias: str = "",
@@ -91,6 +92,7 @@ def make_account(
         kind=kind,
         switchable=switchable,
         usage=entry if entry is not None else make_entry(),
+        auth_method=auth_method,
         alias=alias,
         disabled=disabled,
     )
@@ -626,6 +628,16 @@ class TestUsageRows:
 
 
 class TestMiniAccountText:
+    def test_auth_method_is_visible_without_repeating_usage(self):
+        from claude_swap.tui.widgets import account_card_text, mini_account_text
+
+        active = make_account(1, active=True, auth_method="setup_token")
+        inactive = make_account(2, auth_method="api_key")
+        assert "Claude Code  one-year setup token" in account_card_text(
+            active, 100
+        ).plain
+        assert "API key" in mini_account_text(inactive, time.time()).plain
+
     def test_seven_day_ahead_of_pace_marker(self):
         from claude_swap.tui.widgets import mini_account_text
 
@@ -1709,4 +1721,3 @@ class TestThemeWiring:
             await menu_select(pilot, "theme:light")
             assert app._theme_name == "light"
             assert app.theme == "cswap-light"
-


### PR DESCRIPTION
## Summary

- Classify each saved CLI credential as browser OAuth, setup token, or API key.
- Show its scope, Remote Control support, and setup-token expiry in the CLI list, TUI, and JSON output.
- Keep usage at the account level.

## Why

Remote Control requires full-scope browser OAuth. Setup tokens and API keys are inference-only, so the credential method alone does not tell users whether a saved login can run the requested workflow.

## Stack

This builds on #230. It remains closed until that foundational PR lands.

## Validation

- 1,854 tests passed and 3 skipped, excluding five macOS locked-console cases and one pre-existing filesystem permission case.
- Focused auth, JSON, and TUI suite: 151 passed.
- P0 autoreview: clean.