### PR TITLE
feat(auth): group login methods by account

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ cswap switch 2 --json
   "schemaVersion": 1,
   "activeAccountNumber": 2,
   "accounts": [
-    { "number": 2, "email": "you@example.com", "active": true, "usageStatus": "ok",
+    { "number": 2, "email": "you@example.com", "active": true,
+      "authMethod": "setup_token", "usageStatus": "ok",
       "usage": { "fiveHour": { "pct": 25.0, "resetsAt": "2026-06-22T23:29:59Z" },
                  "sevenDay": { "pct": 16.0, "resetsAt": "2026-06-26T17:59:59Z" } } }
   ]
@@ -344,7 +345,11 @@ Every payload carries a `schemaVersion` (currently `1`); on a handled error stdo
 
 Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
 
-An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
+Each account row carries an additive `authMethod`: `browser_oauth`,
+`setup_token`, `api_key`, or `unknown`. The human list and TUI use the same
+classification and show it separately from the account's usage. An account row
+also carries an additive `alias` field once one is set with `cswap alias` (e.g.
+`"alias": "dev"`); accounts without one simply omit the key.
 
 Weekly windows (`sevenDay` and per-model `scoped` entries — never `fiveHour`) additively carry pace fields once the week is ~a day old: `expectedPct` (where usage would sit if spread evenly across the week) and `aheadOfPace` (`true` when meaningfully above that — the same signal the human views show as an `(ahead)`/`(ahead of pace)` marker). `projectedExhaustionAt`/`willLastToReset` extrapolate the current rate into an ETA to 100% and a yes/no "will it last to the reset"; they stay `--json`-only since a linear projection is too rough to present as fact in the UI.
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ cswap list --json                   # all accounts with usage/quota
 cswap status --json                 # current active account
 cswap switch --strategy best --json # switch, then report the result
 cswap switch 2 --json
+cswap switch 2 --auth-method setup-token
 ```
 
 <details>
@@ -334,7 +335,8 @@ cswap switch 2 --json
   "activeAccountNumber": 2,
   "accounts": [
     { "number": 2, "email": "you@example.com", "active": true,
-      "authMethod": "setup_token", "usageStatus": "ok",
+      "authMethod": "setup_token",
+      "authMethods": ["browser_oauth", "setup_token"], "usageStatus": "ok",
       "usage": { "fiveHour": { "pct": 25.0, "resetsAt": "2026-06-22T23:29:59Z" },
                  "sevenDay": { "pct": 16.0, "resetsAt": "2026-06-26T17:59:59Z" } } }
   ]
@@ -345,10 +347,13 @@ Every payload carries a `schemaVersion` (currently `1`); on a handled error stdo
 
 Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
 
-Each account row carries an additive `authMethod`: `browser_oauth`,
-`setup_token`, `api_key`, or `unknown`. The human list and TUI use the same
-classification and show it separately from the account's usage. An account row
-also carries an additive `alias` field once one is set with `cswap alias` (e.g.
+Each account row carries an additive `authMethod`, the preferred Claude Code
+login, plus `authMethods`, every stored login for that account. Values are
+`browser_oauth`, `setup_token`, `api_key`, or `unknown`. The human list and TUI
+group these logins under one account and show account usage once. Use
+`cswap switch N --auth-method setup-token` (or `browser-oauth` / `api-key`) to
+choose a specific login and make it preferred. An account row also carries an
+additive `alias` field once one is set with `cswap alias` (e.g.
 `"alias": "dev"`); accounts without one simply omit the key.
 
 Weekly windows (`sevenDay` and per-model `scoped` entries — never `fiveHour`) additively carry pace fields once the week is ~a day old: `expectedPct` (where usage would sit if spread evenly across the week) and `aheadOfPace` (`true` when meaningfully above that — the same signal the human views show as an `(ahead)`/`(ahead of pace)` marker). `projectedExhaustionAt`/`willLastToReset` extrapolate the current rate into an ETA to 100% and a yes/no "will it last to the reset"; they stay `--json`-only since a linear projection is too rough to present as fact in the UI.
@@ -374,12 +379,16 @@ cswap add-token --email user@example.com     # optional label override
 
 `--email` is optional; omitted values use `setup-token-{slot}@token.local`
 (or `api-key-{slot}@token.local` for API keys). No Anthropic API calls are made.
+When that email already exists, cswap adds or refreshes the login method under
+the existing account instead of creating a duplicate slot. Browser OAuth,
+setup-token, and API-key credentials can therefore coexist under one account.
+The newest method becomes preferred. Export and import carry every method.
 
 **API-key accounts.** An `sk-ant-api...` value registers a managed API-key account
 (the kind Claude Code uses after `/login` with a key) rather than an OAuth
-setup-token. It switches like any other account; since API keys have no subscription
-quota, they show no usage and the usage-aware `switch` strategies never skip them as
-rate-limited.
+setup-token. It switches like any other login. A standalone API-key account has
+no subscription quota to fetch. If the same account also has OAuth, cswap uses
+that OAuth child for the single account-level usage measurement.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,40 @@ Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP ser
 
 </details>
 
+### Switch Claude Desktop accounts (macOS)
+
+Switch the account used by Claude Desktop while keeping every resumable local
+Claude Code session visible in the Desktop sidebar:
+
+```bash
+cswap desktop 2
+cswap desktop user@example.com
+cswap desktop 2 --dry-run
+```
+
+Claude Desktop's web login is separate from Claude Code credentials. The command
+therefore keeps one isolated Desktop profile per account and shares only the
+local Claude Code session index between them. The first switch to an account
+opens Claude's normal login flow once. Later switches reuse that authenticated
+profile. After visually verifying the email on that first login, record it once:
+
+```bash
+cswap desktop 2 --confirm-login
+```
+
+The command closes Claude Desktop, switches credentials through the normal
+cswap path, copies only missing resumable index entries, and launches the target
+profile. Existing entries and transcripts under `~/.claude/projects/` are never
+changed. It refuses to close Desktop while a local task is active. The explicit
+first-login confirmation avoids depending on Claude's private login-storage
+format, which changes between Desktop releases.
+The Mac must be unlocked before a relaunch so encrypted login storage remains
+available. Claude Chat and remote Cowork history remain account-specific.
+
+Run the command outside any manually selected Claude profile;
+`CLAUDE_CONFIG_DIR`, `CLAUDE_SECURESTORAGE_CONFIG_DIR`, and
+`CLAUDE_USER_DATA_DIR` are rejected because cswap owns profile selection.
+
 <details>
 <summary>Map accounts to directories — auto-pick per repo</summary>
 
@@ -175,6 +209,7 @@ This will update the stored credentials without creating a duplicate.
 
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
+cswap desktop 2                 # Switch Claude Desktop accounts (macOS)
 cswap auto                      # Auto-switch when nearing rate limits (see above)
 cswap config                    # Show or edit settings (see Configuration below)
 cswap list                      # Show all accounts with 5h/7d usage and reset times

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -1029,6 +1029,7 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s switch --strategy best           # pick the account with most quota left
   %(prog)s switch --strategy next-available # rotate, skipping rate-limited accounts
   %(prog)s switch user@example.com
+  %(prog)s switch user@example.com --auth-method setup-token
   %(prog)s list --token-status
   %(prog)s list --json
   %(prog)s add --slot 3                      # add to a specific slot
@@ -1118,6 +1119,14 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             "Overwrite existing accounts during import; with 'switch <num|email>', "
             "activate the stored credentials without backing up the current "
             "login first"
+        ),
+    )
+    parser.add_argument(
+        "--auth-method",
+        choices=["browser-oauth", "setup-token", "api-key"],
+        help=(
+            "Claude Code login method to activate with "
+            "'switch <num|email>'; defaults to the account's preferred method"
         ),
     )
     parser.add_argument(
@@ -1280,6 +1289,9 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.force and not (args.import_ or args.switch_to):
         parser.error("--force can only be used with 'import' or 'switch <num|email>'")
 
+    if args.auth_method is not None and not args.switch_to:
+        parser.error("--auth-method can only be used with 'switch <num|email>'")
+
     if args.full and not args.export:
         parser.error("--full can only be used with 'export'")
 
@@ -1352,9 +1364,10 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
                 payload["models"] = list(models)
                 payload["modelSource"] = model_source
         elif args.switch_to:
-            payload = switcher.switch_to(
-                args.switch_to, json_output=args.json, force=args.force
-            )
+            kwargs = {"json_output": args.json, "force": args.force}
+            if args.auth_method is not None:
+                kwargs["auth_method"] = args.auth_method
+            payload = switcher.switch_to(args.switch_to, **kwargs)
         elif args.status:
             payload = switcher.status(json_output=args.json)
         elif args.purge:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -217,6 +217,87 @@ Examples:
         sys.exit(130)
 
 
+def _desktop_command(argv: list[str]) -> None:
+    """Handle ``cswap desktop NUM|EMAIL [options]``."""
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} desktop",
+        description=(
+            "Switch Claude Desktop to a stored account while keeping resumable "
+            "local Code sessions visible. macOS only."
+        ),
+    )
+    parser.add_argument("account", metavar="NUM|EMAIL")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the local sessions that would be added; change nothing",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    parser.add_argument(
+        "--confirm-login",
+        action="store_true",
+        help="Record a visually verified one-time Desktop login",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    try:
+        profile_overrides = (
+            "CLAUDE_CONFIG_DIR",
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+            "CLAUDE_USER_DATA_DIR",
+        )
+        if any(os.environ.get(name) for name in profile_overrides):
+            raise ClaudeSwitchError(
+                "Desktop switching must run from the default Claude profile. "
+                f"Unset {', '.join(profile_overrides)} first."
+            )
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+        from claude_swap.desktop import DesktopManager
+
+        payload = DesktopManager(switcher).run(
+            args.account,
+            dry_run=args.dry_run,
+            json_output=args.json,
+            confirm_login=args.confirm_login,
+        )
+        if args.json:
+            print(json.dumps(payload, indent=2))
+            return
+        sessions = payload["sessions"]
+        verb = "Would add" if args.dry_run else "Added"
+        print(
+            f"{accent(verb)} {sessions['copied']} local session(s); "
+            f"{sessions['existing']} already visible; "
+            f"{sessions['unavailable']} unavailable."
+        )
+        if payload["loginRequired"] and not args.dry_run:
+            print(
+                "Sign in once in the opened Claude window, verify the account "
+                "email, then rerun with --confirm-login."
+            )
+        elif not args.dry_run:
+            state = "already active" if payload["alreadyActive"] else "switched"
+            print(f"Claude Desktop {state} to {payload['account']['email']}.")
+    except ClaudeSwitchError as e:
+        if args.json:
+            print(json.dumps(error_envelope(e), indent=2))
+        else:
+            error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(
+            f"\n{dimmed('Operation cancelled')}",
+            file=sys.stderr if args.json else sys.stdout,
+        )
+        sys.exit(130)
+
+
 def _guard_root(switcher: ClaudeAccountSwitcher) -> None:
     """Refuse to run as root outside a container (shared by run/map/unmap)."""
     if sys.platform != "win32":
@@ -865,10 +946,13 @@ def main() -> None:
     except Exception:
         pass  # theme is cosmetic; never block the CLI on it
 
-    # `run` and `auto` keep their dedicated pre-dispatch parsers.
+    # `run`, `desktop`, and `auto` keep their dedicated pre-dispatch parsers.
     if argv and argv[0] == "run":
         _run_command(argv[1:])
         return  # only reachable in tests where exec/exit is mocked
+    if argv and argv[0] == "desktop":
+        _desktop_command(argv[1:])
+        return
     if argv and argv[0] == "auto":
         _auto_command(argv[1:])
         return  # only reachable in tests where sys.exit is mocked
@@ -920,6 +1004,7 @@ Commands:
   %(prog)s enable <num|email>         return a disabled account to rotation
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s run                        run the current dir's mapped account
+  %(prog)s desktop <num|email>        switch Claude Desktop and share local sessions
   %(prog)s map <num|email> [path]     map a directory to an account
   %(prog)s map                        list directory mappings
   %(prog)s unmap [path]               remove a directory mapping
@@ -949,6 +1034,7 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s add --slot 3                      # add to a specific slot
   %(prog)s add-token sk-ant-oat01-... --email me@example.com
   %(prog)s run 2 -- --resume                 # forward args after '--' to claude
+  %(prog)s desktop 2 --dry-run                # preview Desktop session reconciliation
   %(prog)s auto --once                       # single auto-switch tick (cron-friendly)
   %(prog)s config set autoswitch.threshold 80
 

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -113,6 +113,48 @@ def _credential_object(credentials: str | None) -> dict | None:
     return data if isinstance(data, dict) else None
 
 
+AUTH_BROWSER_OAUTH = "browser_oauth"
+AUTH_SETUP_TOKEN = "setup_token"
+AUTH_API_KEY = "api_key"
+AUTH_UNKNOWN = "unknown"
+
+AUTH_METHOD_LABELS = {
+    AUTH_BROWSER_OAUTH: "browser OAuth",
+    AUTH_SETUP_TOKEN: "one-year setup token",
+    AUTH_API_KEY: "API key",
+    AUTH_UNKNOWN: "unknown login",
+}
+
+
+def classify_auth_method(credentials: str | None) -> str:
+    """Classify one stored Claude Code credential without exposing its value.
+
+    Browser OAuth carries a refresh token. A setup token is a standalone
+    ``sk-ant-oat`` access token with no refresh token. Managed API keys use the
+    raw ``sk-ant-api`` form. Anything else stays explicitly unknown rather than
+    being guessed from account metadata.
+    """
+    if looks_like_api_key(credentials):
+        return AUTH_API_KEY
+    data = _credential_object(credentials)
+    if data is None:
+        return AUTH_UNKNOWN
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return AUTH_UNKNOWN
+    if oauth.get("refreshToken"):
+        return AUTH_BROWSER_OAUTH
+    access_token = oauth.get("accessToken")
+    if isinstance(access_token, str) and access_token.startswith("sk-ant-oat"):
+        return AUTH_SETUP_TOKEN
+    return AUTH_UNKNOWN
+
+
+def auth_method_label(method: str) -> str:
+    """Return the human label for a classified authentication method."""
+    return AUTH_METHOD_LABELS.get(method, AUTH_METHOD_LABELS[AUTH_UNKNOWN])
+
+
 # The credential object's siblings of claudeAiOauth are not uniformly owned:
 # these keys hold machine-shared OAuth integrations that rotate independently
 # of any account slot, so on activation the live copy is authoritative.

--- a/src/claude_swap/desktop.py
+++ b/src/claude_swap/desktop.py
@@ -1,0 +1,824 @@
+"""macOS Claude Desktop account switching with shared local session history.
+
+Claude Code transcripts live under ``~/.claude/projects`` and are independent
+of the logged-in account. Claude Desktop keeps a separate session index under
+``~/Library/Application Support/Claude/claude-code-sessions/<account-uuid>/``
+and filters the sidebar by the active account. This module copies only missing,
+resumable local-session index entries into the target account's index. Source
+metadata and transcripts are never changed.
+
+Claude Desktop's web login is stored in Electron's user-data directory. It is
+independent from Claude Code's credential store, so changing only the global
+Claude Code login does not switch the Desktop account. Each account therefore
+gets one persistent Desktop profile. Managed profiles symlink only their
+``claude-code-sessions`` directory to the default profile, keeping web auth
+isolated while sharing the local-session index.
+
+The Desktop app must be closed while the index is reconciled because it caches
+the index in memory. ``DesktopManager`` refuses to close an app with a non-idle
+local task, switches through the existing ``ClaudeAccountSwitcher`` authority,
+then launches the target account's authenticated Desktop profile.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from claude_swap.exceptions import DesktopError
+from claude_swap.json_output import SCHEMA_VERSION
+from claude_swap.paths import (
+    get_default_claude_config_home,
+    get_default_global_config_path,
+)
+from claude_swap.process_detection import list_sessions
+from claude_swap.settings import atomic_write_json
+
+if TYPE_CHECKING:
+    from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+CLAUDE_DESKTOP_BUNDLE_ID = "com.anthropic.claudefordesktop"
+CLAUDE_DESKTOP_EXECUTABLE = Path(
+    "/Applications/Claude.app/Contents/MacOS/Claude"
+)
+DESKTOP_PROFILES_SCHEMA_VERSION = 1
+_LOCAL_SESSION_RE = re.compile(r"^local_[A-Za-z0-9_-]+\.json$")
+_STALE_ACCOUNT_FIELDS = ("bridgeSessionIds", "error", "errorAt")
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        return str(uuid.UUID(value)) == value.lower()
+    except (ValueError, AttributeError):
+        return False
+
+
+def default_user_data_dir() -> Path:
+    """Return the Claude Desktop profile selected for this invocation."""
+    override = os.environ.get("CLAUDE_USER_DATA_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / "Library" / "Application Support" / "Claude"
+
+
+@dataclass(frozen=True)
+class DesktopSyncResult:
+    copied: int = 0
+    existing: int = 0
+    unavailable: int = 0
+    invalid: int = 0
+
+    def to_json(self) -> dict:
+        return {
+            "copied": self.copied,
+            "existing": self.existing,
+            "unavailable": self.unavailable,
+            "invalid": self.invalid,
+        }
+
+
+@dataclass(frozen=True)
+class DesktopProfile:
+    account_uuid: str
+    email: str
+    path: Path
+    is_default: bool
+    initialized: bool
+
+    def to_json(self) -> dict:
+        return {
+            "initialized": self.initialized,
+            "isDefault": self.is_default,
+        }
+
+
+class DesktopProfileStore:
+    """Own the account-to-Electron-profile mapping and shared-session link."""
+
+    def __init__(
+        self,
+        backup_dir: Path,
+        *,
+        default_profile_dir: Path | None = None,
+    ) -> None:
+        self.root = backup_dir / "desktop"
+        self.registry_path = self.root / "profiles.json"
+        self.default_profile_dir = default_profile_dir or default_user_data_dir()
+        self.shared_sessions = self.default_profile_dir / "claude-code-sessions"
+
+    def _load(self) -> dict:
+        if not self.registry_path.exists():
+            return {
+                "schemaVersion": DESKTOP_PROFILES_SCHEMA_VERSION,
+                "profiles": {},
+            }
+        try:
+            data = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise DesktopError(
+                f"Could not read Desktop profile registry: {exc}"
+            ) from exc
+        if (
+            not isinstance(data, dict)
+            or data.get("schemaVersion") != DESKTOP_PROFILES_SCHEMA_VERSION
+            or not isinstance(data.get("profiles"), dict)
+        ):
+            raise DesktopError("Desktop profile registry has an unsupported format.")
+        return data
+
+    def _save(self, data: dict) -> None:
+        atomic_write_json(self.registry_path, data)
+
+    def _managed_profile_path(self, account_uuid: str) -> Path:
+        return self.root / account_uuid
+
+    def _profile_from_record(self, account_uuid: str, record: dict) -> DesktopProfile:
+        path_value = record.get("path")
+        email = record.get("email")
+        if not isinstance(path_value, str) or not isinstance(email, str):
+            raise DesktopError("Desktop profile registry contains an invalid record.")
+        return DesktopProfile(
+            account_uuid=account_uuid,
+            email=email,
+            path=Path(path_value),
+            is_default=bool(record.get("isDefault")),
+            initialized=bool(record.get("initialized")),
+        )
+
+    def _record(self, profile: DesktopProfile) -> dict:
+        return {
+            "email": profile.email,
+            "path": str(profile.path),
+            "isDefault": profile.is_default,
+            "initialized": profile.initialized,
+        }
+
+    def _ensure_managed_profile(self, profile: DesktopProfile) -> None:
+        profile.path.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(profile.path, 0o700)
+        if not self.shared_sessions.is_dir():
+            raise DesktopError(
+                f"Shared Claude Desktop session index not found at "
+                f"{self.shared_sessions}"
+            )
+        link = profile.path / "claude-code-sessions"
+        if link.is_symlink():
+            if link.resolve() != self.shared_sessions.resolve():
+                raise DesktopError(
+                    f"Desktop profile has an unexpected session link at {link}"
+                )
+            return
+        if link.exists():
+            raise DesktopError(
+                f"Desktop profile already has private session data at {link}; "
+                "refusing to replace it."
+            )
+        link.symlink_to(self.shared_sessions, target_is_directory=True)
+
+    def resolve(
+        self,
+        account_uuid: str,
+        email: str,
+        *,
+        current_account_uuid: str | None,
+        current_email: str,
+        current_profile_dir: Path,
+        dry_run: bool = False,
+    ) -> DesktopProfile:
+        """Resolve a profile, adopting the current profile and creating targets."""
+        data = self._load()
+        profiles = data["profiles"]
+        changed = False
+
+        if current_account_uuid and current_account_uuid not in profiles:
+            current = DesktopProfile(
+                account_uuid=current_account_uuid,
+                email=current_email,
+                path=current_profile_dir,
+                is_default=current_profile_dir == self.default_profile_dir,
+                initialized=True,
+            )
+            profiles[current_account_uuid] = self._record(current)
+            changed = True
+
+        record = profiles.get(account_uuid)
+        if record is not None:
+            profile = self._profile_from_record(account_uuid, record)
+            if profile.email != email:
+                profile = DesktopProfile(
+                    account_uuid=profile.account_uuid,
+                    email=email,
+                    path=profile.path,
+                    is_default=profile.is_default,
+                    initialized=profile.initialized,
+                )
+                profiles[account_uuid] = self._record(profile)
+                changed = True
+        elif current_account_uuid == account_uuid:
+            profile = DesktopProfile(
+                account_uuid=account_uuid,
+                email=email,
+                path=current_profile_dir,
+                is_default=current_profile_dir == self.default_profile_dir,
+                initialized=True,
+            )
+            profiles[account_uuid] = self._record(profile)
+            changed = True
+        else:
+            profile = DesktopProfile(
+                account_uuid=account_uuid,
+                email=email,
+                path=self._managed_profile_path(account_uuid),
+                is_default=False,
+                initialized=False,
+            )
+            profiles[account_uuid] = self._record(profile)
+            changed = True
+
+        if not dry_run:
+            if not profile.is_default:
+                self._ensure_managed_profile(profile)
+            if changed:
+                self._save(data)
+        return profile
+
+    def mark_initialized(self, profile: DesktopProfile) -> DesktopProfile:
+        return self._set_initialized(profile, True)
+
+    def mark_uninitialized(self, profile: DesktopProfile) -> DesktopProfile:
+        return self._set_initialized(profile, False)
+
+    def _set_initialized(
+        self, profile: DesktopProfile, initialized: bool
+    ) -> DesktopProfile:
+        data = self._load()
+        updated = DesktopProfile(
+            account_uuid=profile.account_uuid,
+            email=profile.email,
+            path=profile.path,
+            is_default=profile.is_default,
+            initialized=initialized,
+        )
+        data["profiles"][profile.account_uuid] = self._record(updated)
+        self._save(data)
+        return updated
+
+
+class DesktopSessionSync:
+    """Reconcile resumable Desktop index entries into one account root."""
+
+    def __init__(
+        self,
+        user_data_dir: Path | None = None,
+        claude_config_dir: Path | None = None,
+    ) -> None:
+        self.user_data_dir = user_data_dir or default_user_data_dir()
+        self.sessions_root = self.user_data_dir / "claude-code-sessions"
+        self.claude_config_dir = claude_config_dir or get_default_claude_config_home()
+
+    def _transcript_ids(self) -> set[str]:
+        projects = self.claude_config_dir / "projects"
+        if not projects.is_dir():
+            return set()
+        return {path.stem for path in projects.rglob("*.jsonl") if path.is_file()}
+
+    @staticmethod
+    def _read_entry(path: Path) -> dict | None:
+        if not _LOCAL_SESSION_RE.fullmatch(path.name):
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict) or data.get("sessionId") != path.stem:
+            return None
+        return data
+
+    @staticmethod
+    def _write_new_entry(path: Path, data: dict) -> bool:
+        """Atomically create ``path`` without replacing an existing entry."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(path.parent, 0o700)
+        fd, temp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(temp_name, path)
+            except FileExistsError:
+                return False
+            if sys.platform != "win32":
+                os.chmod(path, 0o600)
+            return True
+        finally:
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+
+    def sync(
+        self,
+        target_account_uuid: str,
+        target_organization_uuid: str,
+        *,
+        dry_run: bool = False,
+    ) -> DesktopSyncResult:
+        """Copy missing resumable entries into the active account and org.
+
+        A session is resumable only when its metadata has a ``cliSessionId``
+        and the matching transcript exists under ``projects/``. Existing entries
+        in the active target org win by session ID.
+        """
+        if not _is_uuid(target_account_uuid):
+            raise DesktopError(
+                "The target account has no valid account UUID; re-add it with "
+                "`cswap add --slot N` before using Desktop switching."
+            )
+        if not _is_uuid(target_organization_uuid):
+            raise DesktopError(
+                "The target account has no valid organization UUID; re-add it "
+                "with `cswap add --slot N` before using Desktop switching."
+            )
+        if not self.sessions_root.is_dir():
+            raise DesktopError(
+                f"Claude Desktop session index not found at {self.sessions_root}"
+            )
+
+        transcript_ids = self._transcript_ids()
+        target_root = self.sessions_root / target_account_uuid
+        target_org_root = target_root / target_organization_uuid
+        existing_ids: set[str] = set()
+        if target_org_root.is_dir():
+            for path in target_org_root.glob("*.json"):
+                entry = self._read_entry(path)
+                if entry is not None:
+                    existing_ids.add(entry["sessionId"])
+
+        candidates: dict[str, dict] = {}
+        unavailable = 0
+        invalid = 0
+        for account_root in sorted(self.sessions_root.iterdir()):
+            if not account_root.is_dir() or not _is_uuid(account_root.name):
+                continue
+            for org_root in sorted(account_root.iterdir()):
+                if not org_root.is_dir() or not _is_uuid(org_root.name):
+                    continue
+                if (
+                    account_root.name == target_account_uuid
+                    and org_root.name == target_organization_uuid
+                ):
+                    continue
+                for path in sorted(org_root.glob("local_*.json")):
+                    entry = self._read_entry(path)
+                    if entry is None:
+                        invalid += 1
+                        continue
+                    cli_session_id = entry.get("cliSessionId")
+                    if (
+                        entry.get("transcriptUnavailable") is True
+                        or not isinstance(cli_session_id, str)
+                        or cli_session_id not in transcript_ids
+                    ):
+                        unavailable += 1
+                        continue
+                    candidates.setdefault(entry["sessionId"], entry)
+
+        copied = 0
+        existing = 0
+        for session_id, entry in sorted(candidates.items()):
+            if session_id in existing_ids:
+                existing += 1
+                continue
+            cleaned = dict(entry)
+            for field in _STALE_ACCOUNT_FIELDS:
+                cleaned.pop(field, None)
+            destination = target_org_root / f"{session_id}.json"
+            if not dry_run and not self._write_new_entry(destination, cleaned):
+                existing += 1
+                existing_ids.add(session_id)
+                continue
+            copied += 1
+            existing_ids.add(session_id)
+
+        return DesktopSyncResult(
+            copied=copied,
+            existing=existing,
+            unavailable=unavailable,
+            invalid=invalid,
+        )
+
+
+class DesktopManager:
+    """Switch auth, reconcile history, and launch the account's web profile."""
+
+    def __init__(
+        self,
+        switcher: "ClaudeAccountSwitcher",
+        *,
+        syncer: DesktopSessionSync | None = None,
+        profile_store: DesktopProfileStore | None = None,
+        quit_timeout: float = 10.0,
+        launch_timeout: float = 15.0,
+        identity_timeout: float = 15.0,
+    ) -> None:
+        self.switcher = switcher
+        self.syncer = syncer or DesktopSessionSync()
+        self.profile_store = profile_store or DesktopProfileStore(
+            switcher.backup_dir
+        )
+        self.quit_timeout = quit_timeout
+        self.launch_timeout = launch_timeout
+        self.identity_timeout = identity_timeout
+
+    @staticmethod
+    def _desktop_pids() -> list[int]:
+        result = subprocess.run(
+            ["pgrep", "-x", "Claude"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        return [int(pid) for pid in result.stdout.split() if pid.isdigit()]
+
+    @classmethod
+    def _desktop_is_running(cls) -> bool:
+        return bool(cls._desktop_pids())
+
+    @staticmethod
+    def _console_is_unlocked() -> bool:
+        """Return whether the console can provide encrypted web storage."""
+        result = subprocess.run(
+            ["ioreg", "-n", "Root", "-d1", "-a"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+        try:
+            data = plistlib.loads(result.stdout)
+            root = data[0] if isinstance(data, list) and data else data
+            return (
+                isinstance(root, dict)
+                and root.get("IOConsoleLocked") is False
+            )
+        except (plistlib.InvalidFileException, TypeError):
+            return False
+
+    def _running_profile_dir(self) -> Path:
+        """Return the user-data directory selected by the running main process."""
+        for pid in reversed(self._desktop_pids()):
+            result = subprocess.run(
+                ["ps", "eww", "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            match = re.search(
+                r"(?:^|\s)CLAUDE_USER_DATA_DIR=(\S+)", result.stdout
+            )
+            if match:
+                return Path(match.group(1))
+        return self.profile_store.default_profile_dir
+
+    @staticmethod
+    def _live_identity() -> tuple[str | None, str]:
+        path = get_default_global_config_path()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return None, ""
+        account = data.get("oauthAccount")
+        if not isinstance(account, dict):
+            return None, ""
+        account_uuid = account.get("accountUuid")
+        email = account.get("emailAddress") or account.get("email") or ""
+        return (
+            account_uuid if isinstance(account_uuid, str) else None,
+            email if isinstance(email, str) else "",
+        )
+
+    def _blocking_sessions(self) -> list:
+        return [
+            session
+            for session in list_sessions(self.syncer.claude_config_dir)
+            if session.entrypoint == "claude-desktop" and session.status != "idle"
+        ]
+
+    def _quit_desktop(self) -> None:
+        result = subprocess.run(
+            [
+                "osascript",
+                "-e",
+                f'tell application id "{CLAUDE_DESKTOP_BUNDLE_ID}" to quit',
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or "AppleScript quit failed"
+            raise DesktopError(f"Could not close Claude Desktop: {detail}")
+        deadline = time.monotonic() + self.quit_timeout
+        while self._desktop_is_running():
+            if time.monotonic() >= deadline:
+                raise DesktopError(
+                    "Claude Desktop did not quit within 10 seconds; account unchanged."
+                )
+            time.sleep(0.1)
+
+    def _launch_desktop(self, profile: DesktopProfile) -> None:
+        if not CLAUDE_DESKTOP_EXECUTABLE.is_file():
+            raise DesktopError(
+                f"Claude Desktop executable not found at {CLAUDE_DESKTOP_EXECUTABLE}"
+            )
+        command = [
+            "/usr/bin/open",
+            "-n",
+            "-b",
+            CLAUDE_DESKTOP_BUNDLE_ID,
+        ]
+        if not profile.is_default:
+            command.extend(
+                ["--env", f"CLAUDE_USER_DATA_DIR={profile.path}"]
+            )
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:
+            raise DesktopError(f"Could not launch Claude Desktop: {exc}") from exc
+        if result.returncode != 0:
+            detail = result.stderr.strip() or "LaunchServices failed"
+            raise DesktopError(f"Could not launch Claude Desktop: {detail}")
+        deadline = time.monotonic() + self.launch_timeout
+        while not self._desktop_is_running():
+            if time.monotonic() >= deadline:
+                raise DesktopError("Claude Desktop did not start within 15 seconds.")
+            time.sleep(0.1)
+
+    @staticmethod
+    def _profile_matches_account(
+        profile: DesktopProfile, account_uuid: str
+    ) -> bool:
+        """Verify the account identity cached in this Electron profile."""
+        needle = account_uuid.encode("ascii")
+        indexed_db = profile.path / "IndexedDB"
+        if not indexed_db.is_dir():
+            return False
+        try:
+            files = (path for path in indexed_db.rglob("*") if path.is_file())
+            for path in files:
+                with path.open("rb") as handle:
+                    overlap = b""
+                    while chunk := handle.read(1024 * 1024):
+                        data = overlap + chunk
+                        if needle in data:
+                            return True
+                        overlap = data[-len(needle) :]
+        except OSError:
+            return False
+        return False
+
+    def _wait_for_identity(
+        self, profile: DesktopProfile, account_uuid: str
+    ) -> bool:
+        deadline = time.monotonic() + self.identity_timeout
+        matching_since: float | None = None
+        profile_matches = False
+        next_profile_check = 0.0
+        while time.monotonic() < deadline:
+            live_uuid, _ = self._live_identity()
+            now = time.monotonic()
+            if not profile_matches and now >= next_profile_check:
+                profile_matches = self._profile_matches_account(
+                    profile, account_uuid
+                )
+                next_profile_check = now + 1.0
+            if (
+                profile_matches and live_uuid == account_uuid
+            ):
+                if matching_since is None:
+                    matching_since = now
+                elif now - matching_since >= 2.0:
+                    return True
+            else:
+                matching_since = None
+            if not self._desktop_is_running():
+                return False
+            time.sleep(0.25)
+        return False
+
+    def _restore_original(
+        self,
+        original_identifier: str | None,
+        original_profile: DesktopProfile | None,
+        *,
+        was_running: bool,
+        switch_completed: bool,
+    ) -> None:
+        if self._desktop_is_running():
+            self._quit_desktop()
+        if switch_completed and original_identifier:
+            self.switcher.switch_to(original_identifier, json_output=True)
+        if was_running and original_profile:
+            self._launch_desktop(original_profile)
+
+    def run(
+        self,
+        identifier: str,
+        *,
+        dry_run: bool = False,
+        json_output: bool = False,
+        confirm_login: bool = False,
+    ) -> dict:
+        if sys.platform != "darwin":
+            raise DesktopError("Claude Desktop switching is currently macOS-only.")
+
+        account_num, email, organization_uuid = self.switcher.resolve_account(
+            identifier
+        )
+        account_uuid = self.switcher.account_identity(account_num).get("uuid", "")
+        if not _is_uuid(account_uuid):
+            raise DesktopError(
+                "The target account has no valid account UUID; re-add it with "
+                "`cswap add --slot N` before using Desktop switching."
+            )
+
+        was_running = self._desktop_is_running()
+        current_uuid, current_email = self._live_identity()
+        current_profile_dir = self._running_profile_dir()
+        running_uuid = current_uuid if was_running else None
+        original_profile = None
+        if running_uuid:
+            original_profile = self.profile_store.resolve(
+                running_uuid,
+                current_email,
+                current_account_uuid=running_uuid,
+                current_email=current_email,
+                current_profile_dir=current_profile_dir,
+                dry_run=dry_run,
+            )
+        profile = self.profile_store.resolve(
+            account_uuid,
+            email,
+            current_account_uuid=running_uuid,
+            current_email=current_email,
+            current_profile_dir=current_profile_dir,
+            dry_run=dry_run,
+        )
+
+        preview = self.syncer.sync(
+            account_uuid, organization_uuid, dry_run=True
+        )
+        already_active = (
+            was_running
+            and running_uuid == account_uuid
+            and current_profile_dir.resolve() == profile.path.resolve()
+        )
+        if dry_run:
+            if confirm_login:
+                raise DesktopError("--confirm-login cannot be used with --dry-run.")
+            return self._payload(
+                account_num,
+                email,
+                preview,
+                profile,
+                dry_run=True,
+                login_required=not profile.initialized,
+                already_active=already_active,
+            )
+
+        if already_active:
+            if confirm_login:
+                profile = self.profile_store.mark_initialized(profile)
+                identity_matches = True
+            elif profile.initialized:
+                identity_matches = True
+            else:
+                identity_matches = self._wait_for_identity(profile, account_uuid)
+                if identity_matches:
+                    profile = self.profile_store.mark_initialized(profile)
+            result = self.syncer.sync(account_uuid, organization_uuid)
+            return self._payload(
+                account_num,
+                email,
+                result,
+                profile,
+                dry_run=False,
+                login_required=not identity_matches,
+                already_active=True,
+            )
+
+        blocking = self._blocking_sessions()
+        if blocking:
+            raise DesktopError(
+                "Claude Desktop has an active local task. Let it finish or stop it "
+                "before switching accounts."
+            )
+
+        if confirm_login:
+            raise DesktopError(
+                "--confirm-login requires Claude Desktop to be open on the "
+                "selected profile."
+            )
+
+        if not self._console_is_unlocked():
+            raise DesktopError(
+                "The Mac is locked. Unlock it before switching Claude Desktop "
+                "accounts so encrypted login storage remains available."
+            )
+
+        original_identifier = None
+        if running_uuid:
+            data = self.switcher._get_sequence_data() or {}
+            for number, record in data.get("accounts", {}).items():
+                if record.get("uuid") == running_uuid:
+                    original_identifier = str(number)
+                    break
+            if original_identifier is None:
+                raise DesktopError(
+                    "The current Claude Desktop account is not stored in cswap; "
+                    "add it before switching so rollback remains possible."
+                )
+
+        if was_running:
+            self._quit_desktop()
+
+        switch_completed = False
+        try:
+            self.switcher.switch_to(identifier, json_output=json_output)
+            switch_completed = True
+            result = self.syncer.sync(account_uuid, organization_uuid)
+            self._launch_desktop(profile)
+            identity_matches = profile.initialized
+            if not identity_matches and self._profile_matches_account(
+                profile, account_uuid
+            ):
+                identity_matches = self._wait_for_identity(profile, account_uuid)
+            if identity_matches:
+                profile = self.profile_store.mark_initialized(profile)
+            return self._payload(
+                account_num,
+                email,
+                result,
+                profile,
+                dry_run=False,
+                login_required=not identity_matches,
+                already_active=False,
+            )
+        except Exception as exc:
+            try:
+                self._restore_original(
+                    original_identifier,
+                    original_profile,
+                    was_running=was_running,
+                    switch_completed=switch_completed,
+                )
+            except Exception as rollback_exc:
+                raise DesktopError(
+                    f"Desktop switch failed ({exc}); rollback also failed "
+                    f"({rollback_exc})."
+                ) from exc
+            raise
+
+    @staticmethod
+    def _payload(
+        account_num: str,
+        email: str,
+        result: DesktopSyncResult,
+        profile: DesktopProfile,
+        *,
+        dry_run: bool,
+        login_required: bool,
+        already_active: bool,
+    ) -> dict:
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "dryRun": dry_run,
+            "account": {"number": int(account_num), "email": email},
+            "profile": profile.to_json(),
+            "loginRequired": login_required,
+            "alreadyActive": already_active,
+            "sessions": result.to_json(),
+        }

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -43,6 +43,12 @@ class SessionError(ClaudeSwitchError):
     pass
 
 
+class DesktopError(ClaudeSwitchError):
+    """Error switching or reconciling Claude Desktop."""
+
+    pass
+
+
 class LockError(ClaudeSwitchError):
     """Error acquiring lock."""
 

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -219,6 +219,7 @@ def account_row(
     usage_fetched_at: float | None = None,
     usage_age_s: float | None = None,
     last_good_usage: dict | None = None,
+    auth_method: str | None = None,
     alias: str = "",
     disabled: bool = False,
 ) -> dict:
@@ -234,6 +235,8 @@ def account_row(
         "usageStatus": status,
         "usage": usage,
     }
+    if auth_method is not None:
+        row["authMethod"] = auth_method
     if alias:
         row["alias"] = alias
     # Additive field: present only when the slot is held out of rotation, so

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -220,6 +220,7 @@ def account_row(
     usage_age_s: float | None = None,
     last_good_usage: dict | None = None,
     auth_method: str | None = None,
+    auth_methods: list[str] | None = None,
     alias: str = "",
     disabled: bool = False,
 ) -> dict:
@@ -237,6 +238,8 @@ def account_row(
     }
     if auth_method is not None:
         row["authMethod"] = auth_method
+    if auth_methods is not None:
+        row["authMethods"] = auth_methods
     if alias:
         row["alias"] = alias
     # Additive field: present only when the slot is held out of rotation, so

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -138,6 +138,7 @@ class AccountSnapshot:
     kind: str  # "oauth" | "api_key"
     switchable: bool
     usage: UsageEntry
+    auth_method: str = "unknown"
     alias: str = ""
     disabled: bool = False  # held out of auto-rotation (still a valid explicit target)
 

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -139,6 +139,7 @@ class AccountSnapshot:
     switchable: bool
     usage: UsageEntry
     auth_method: str = "unknown"
+    auth_methods: tuple[str, ...] = ()
     alias: str = ""
     disabled: bool = False  # held out of auto-rotation (still a valid explicit target)
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -44,6 +44,8 @@ from claude_swap.credentials import (  # noqa: F401  (constants re-exported for 
     SECURITY_SERVICE,
     ActiveCredentials,
     CredentialStore,
+    auth_method_label,
+    classify_auth_method,
     looks_like_api_key,
     merge_shared_credential_fields,
     shared_credential_fields,
@@ -1494,6 +1496,7 @@ class ClaudeAccountSwitcher:
                     kind=self._account_kind(n),
                     switchable=self._account_is_switchable(n),
                     usage=entries[n],
+                    auth_method=classify_auth_method(_creds),
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, n),
                 )
@@ -3881,7 +3884,7 @@ class ClaudeAccountSwitcher:
         active_num: int | None = None
         accounts = []
         seq_data = self._get_sequence_data() or {}
-        for num, email, org_name, org_uuid, is_active, _, alias in accounts_info:
+        for num, email, org_name, org_uuid, is_active, creds, alias in accounts_info:
             if is_active:
                 active_num = num
             entry = entries[str(num)]
@@ -3896,6 +3899,7 @@ class ClaudeAccountSwitcher:
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
                     last_good_usage=entry.last_good,
+                    auth_method=classify_auth_method(creds),
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, str(num)),
                 )
@@ -3954,7 +3958,7 @@ class ClaudeAccountSwitcher:
 
         seq_data = self._get_sequence_data() or {}
         print(bolded("Accounts:"))
-        for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
+        for i, (num, email, org_name, org_uuid, is_active, creds, alias) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
             label = f"{accent(alias)} ({email})" if alias else email
             markers = ""
@@ -3963,6 +3967,10 @@ class ClaudeAccountSwitcher:
             if self._disabled_from_data(seq_data, str(num)):
                 markers += f" {muted('(disabled)')}"
             print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
+            print(
+                f"     {dimmed('Claude Code:')} "
+                f"{muted(auth_method_label(classify_auth_method(creds)))}"
+            )
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -40,6 +41,11 @@ from claude_swap.json_output import (
     usage_freshness_fields,
 )
 from claude_swap.credentials import (  # noqa: F401  (constants re-exported for migrations/tests)
+    AUTH_API_KEY,
+    AUTH_BROWSER_OAUTH,
+    AUTH_METHOD_LABELS,
+    AUTH_SETUP_TOKEN,
+    AUTH_UNKNOWN,
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     SECURITY_SERVICE,
     ActiveCredentials,
@@ -335,6 +341,11 @@ class ClaudeAccountSwitcher:
         self._probe_verdicts: dict[
             tuple[str, str, str, str, str, str], bool
         ] = {}
+        # Populated by _build_accounts_info. An active account may use an API
+        # key while its account-level quota is fetched through a stored OAuth
+        # child. Those credentials must follow the inactive, backup-safe fetch
+        # path so a refresh never replaces the live API-key login.
+        self._usage_backup_slots: set[str] = set()
 
         # Run any pending one-time data migrations (e.g. relocating Windows
         # backup credentials out of Credential Manager into files). Imported
@@ -614,7 +625,215 @@ class ClaudeAccountSwitcher:
             self._invalidate_session_credentials(account_num, email)
 
     def _read_account_credentials(self, account_num: str, email: str) -> str:
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(str(account_num), {})
+        raw = record.get("authMethods")
+        preferred = record.get("preferredAuthMethod")
+        if isinstance(raw, list) and preferred in raw:
+            key = self._auth_method_storage_key(
+                email,
+                record.get("organizationUuid", "") or "",
+                preferred,
+            )
+            credentials = self._store._read_account_credentials(key, email)
+            if credentials:
+                return credentials
         return self._store._read_account_credentials(account_num, email)
+
+    @staticmethod
+    def _auth_method_storage_key(
+        email: str, organization_uuid: str, auth_method: str
+    ) -> str:
+        """Stable, non-secret backup key for one account login method.
+
+        Method backups must follow an account through slot moves and swaps, so
+        they are keyed by the account identity rather than its mutable slot.
+        The email remains part of the existing backup key for diagnostics; the
+        digest prevents organization UUIDs and separators from entering file or
+        Keychain account names.
+        """
+        identity = f"{email}\0{organization_uuid or ''}".encode("utf-8")
+        digest = hashlib.sha256(identity).hexdigest()[:20]
+        return f"auth-{digest}-{auth_method}"
+
+    def _account_auth_methods(
+        self,
+        account_num: str,
+        *,
+        credentials: str | None = None,
+        data: dict | None = None,
+    ) -> tuple[str, ...]:
+        """Return stored login methods, including legacy single-method slots."""
+        data = data if data is not None else (self._get_sequence_data() or {})
+        record = data.get("accounts", {}).get(str(account_num), {})
+        raw = record.get("authMethods")
+        if isinstance(raw, list):
+            methods = tuple(
+                method for method in AUTH_METHOD_LABELS
+                if method != AUTH_UNKNOWN and method in raw
+            )
+            if methods:
+                return methods
+        if credentials is None:
+            credentials = self._read_account_credentials(
+                str(account_num), record.get("email", "")
+            )
+        method = classify_auth_method(credentials)
+        return (method,) if method != AUTH_UNKNOWN else ()
+
+    def _preferred_auth_method(
+        self,
+        account_num: str,
+        *,
+        credentials: str | None = None,
+        data: dict | None = None,
+    ) -> str:
+        """Return the account's default Claude Code login method."""
+        data = data if data is not None else (self._get_sequence_data() or {})
+        record = data.get("accounts", {}).get(str(account_num), {})
+        methods = self._account_auth_methods(
+            account_num, credentials=credentials, data=data
+        )
+        preferred = record.get("preferredAuthMethod")
+        if preferred in methods:
+            return preferred
+        return methods[0] if methods else AUTH_UNKNOWN
+
+    def _read_auth_method_credentials(
+        self, account_num: str, email: str, organization_uuid: str, auth_method: str
+    ) -> str:
+        """Read one child login method, with legacy preferred-backup fallback."""
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(str(account_num), {})
+        raw = record.get("authMethods")
+        if not isinstance(raw, list):
+            primary = self._read_account_credentials(account_num, email)
+            if classify_auth_method(primary) in {auth_method, AUTH_UNKNOWN}:
+                return primary
+            return ""
+        primary = self._store._read_account_credentials(account_num, email)
+        methods = self._account_auth_methods(
+            account_num, credentials=primary, data=data
+        )
+        if auth_method not in methods:
+            return ""
+        key = self._auth_method_storage_key(email, organization_uuid, auth_method)
+        credentials = self._store._read_account_credentials(key, email)
+        if credentials:
+            return credentials
+        preferred = self._preferred_auth_method(
+            account_num, credentials=primary, data=data
+        )
+        if auth_method == preferred:
+            primary = self._store._read_account_credentials(account_num, email)
+            if classify_auth_method(primary) == auth_method:
+                return primary
+        return ""
+
+    def _write_auth_method_secret(
+        self, email: str, organization_uuid: str, auth_method: str, credentials: str
+    ) -> None:
+        """Write one child login secret without slot-session side effects."""
+        key = self._auth_method_storage_key(email, organization_uuid, auth_method)
+        self._store._write_account_credentials(key, email, credentials)
+
+    def _delete_auth_method_secrets(self, record: dict) -> None:
+        email = record.get("email", "")
+        org_uuid = record.get("organizationUuid", "") or ""
+        raw = record.get("authMethods")
+        if not isinstance(raw, list):
+            return
+        for method in raw:
+            if method in AUTH_METHOD_LABELS and method != AUTH_UNKNOWN:
+                key = self._auth_method_storage_key(email, org_uuid, method)
+                self._store._delete_account_credentials(key, email)
+
+    def _set_account_auth_methods(
+        self,
+        data: dict,
+        account_num: str,
+        methods: list[str],
+        preferred: str,
+    ) -> None:
+        """Persist a canonical method list and its preferred child."""
+        ordered = [
+            method for method in AUTH_METHOD_LABELS
+            if method != AUTH_UNKNOWN and method in methods
+        ]
+        if preferred not in ordered:
+            raise ValidationError(f"Unknown login method: {preferred}")
+        record = data["accounts"][str(account_num)]
+        record["authMethods"] = ordered
+        record["preferredAuthMethod"] = preferred
+        if preferred == AUTH_API_KEY:
+            record["kind"] = "api_key"
+        else:
+            record.pop("kind", None)
+
+    def _store_account_auth_method(
+        self,
+        data: dict,
+        account_num: str,
+        credentials: str,
+        *,
+        preferred: bool = True,
+        auth_method: str | None = None,
+    ) -> str:
+        """Add or refresh one child login method for an existing account.
+
+        The first time an account gains a second method, its legacy primary
+        backup is copied into child storage before the new secret is written.
+        The primary backup remains a compatibility pointer to the preferred
+        method, so existing switch, usage, session, and auto-rotation paths keep
+        one account-level credential source.
+        """
+        record = data["accounts"][str(account_num)]
+        email = record.get("email", "")
+        org_uuid = record.get("organizationUuid", "") or ""
+        primary = self._read_account_credentials(str(account_num), email)
+        methods = list(
+            self._account_auth_methods(
+                account_num, credentials=primary, data=data
+            )
+        )
+        if not isinstance(record.get("authMethods"), list):
+            old_method = classify_auth_method(primary)
+            if old_method != AUTH_UNKNOWN and primary:
+                self._write_auth_method_secret(
+                    email, org_uuid, old_method, primary
+                )
+
+        method = auth_method or classify_auth_method(credentials)
+        if method == AUTH_UNKNOWN:
+            raise ValidationError("Unsupported Claude Code login credential")
+        self._write_auth_method_secret(email, org_uuid, method, credentials)
+        if method not in methods:
+            methods.append(method)
+
+        current_preferred = self._preferred_auth_method(
+            account_num, credentials=primary, data=data
+        )
+        selected = (
+            method
+            if preferred or current_preferred == AUTH_UNKNOWN
+            else current_preferred
+        )
+        selected_credentials = (
+            credentials
+            if selected == method
+            else self._read_auth_method_credentials(
+                account_num, email, org_uuid, selected
+            )
+        )
+        if not selected_credentials:
+            raise CredentialReadError(
+                f"No stored credentials for {auth_method_label(selected)}"
+            )
+        self._write_account_credentials(
+            str(account_num), email, selected_credentials
+        )
+        self._set_account_auth_methods(data, str(account_num), methods, selected)
+        return method
 
     def _write_account_credentials(
         self, account_num: str, email: str, credentials: str
@@ -625,6 +844,18 @@ class ClaudeAccountSwitcher:
         so ``_post_backup_write`` (the session-invalidation chokepoint) runs exactly
         once and only after a successful write.
         """
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(str(account_num), {})
+        methods = record.get("authMethods")
+        if isinstance(methods, list):
+            method = classify_auth_method(credentials)
+            if method in methods:
+                self._write_auth_method_secret(
+                    email,
+                    record.get("organizationUuid", "") or "",
+                    method,
+                    credentials,
+                )
         self._store._write_account_credentials(account_num, email, credentials)
         self._post_backup_write(account_num, email)
 
@@ -1486,6 +1717,12 @@ class ClaudeAccountSwitcher:
             n = str(num)
             if is_active:
                 active_number = n
+            preferred = self._preferred_auth_method(
+                n, credentials=_creds, data=seq_data
+            )
+            methods = self._account_auth_methods(
+                n, credentials=_creds, data=seq_data
+            )
             accounts.append(
                 AccountSnapshot(
                     number=n,
@@ -1496,7 +1733,8 @@ class ClaudeAccountSwitcher:
                     kind=self._account_kind(n),
                     switchable=self._account_is_switchable(n),
                     usage=entries[n],
-                    auth_method=classify_auth_method(_creds),
+                    auth_method=preferred,
+                    auth_methods=methods or (preferred,),
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, n),
                 )
@@ -2029,34 +2267,6 @@ class ClaudeAccountSwitcher:
                 "'cswap --add-token sk-ant-api...' instead of --add-account."
             )
 
-    def _reject_cross_kind_collision(self, email: str, is_api_key: bool) -> None:
-        """Reject registering a token whose (email, personal-org) already exists as
-        the *other* kind.
-
-        Identity is matched on ``(email, organizationUuid)`` only, so two slots
-        sharing an email across kinds (one OAuth, one API key) could not be told
-        apart at switch time. Rather than thread ``kind`` through the whole identity
-        system, refuse the collision and point the user at a distinct ``--email``.
-        The default ``…@token.local`` labels never collide; this only guards a forced
-        ``--email``.
-        """
-        data = self._get_sequence_data()
-        if not data:
-            return
-        slot = self._find_account_slot(data, email, "")
-        if slot is None:
-            return
-        existing_kind = self._account_kind(slot)
-        new_kind = "api_key" if is_api_key else "oauth"
-        if existing_kind != new_kind:
-            existing_label = "API-key" if existing_kind == "api_key" else "OAuth"
-            new_label = "API-key" if is_api_key else "OAuth"
-            raise ValidationError(
-                f"'{email}' already exists as an {existing_label} account "
-                f"(slot {slot}); cannot add it as an {new_label} account. "
-                f"Pass a distinct --email."
-            )
-
     @staticmethod
     def _get_display_tag(email: str, org_name: str, org_uuid: str) -> str:
         """Return display tag for an account's org context."""
@@ -2261,7 +2471,13 @@ class ClaudeAccountSwitcher:
             except PermissionError:
                 raise ConfigError("Permission denied reading Claude config")
 
-            self._write_account_credentials(account_num, current_email, current_creds)
+            self._store_account_auth_method(
+                seq,
+                account_num,
+                current_creds,
+                preferred=True,
+                auth_method=AUTH_BROWSER_OAUTH,
+            )
             self._write_account_config(account_num, current_email, current_config)
             self._usage_store.clear_dead_token(
                 [account_num], {account_num: (current_email, current_org_uuid)}
@@ -2380,6 +2596,10 @@ class ClaudeAccountSwitcher:
         # Now safe to perform destructive cleanup (new account data is in memory)
         if displace_slot:
             d_num, d_email, d_org = displace_slot
+            displaced = (self._get_sequence_data() or {}).get("accounts", {}).get(
+                d_num, {}
+            )
+            self._delete_auth_method_secrets(displaced)
             self._delete_account_files(d_num, d_email)
             data = self._get_sequence_data()
             if int(d_num) in data["sequence"]:
@@ -2397,13 +2617,6 @@ class ClaudeAccountSwitcher:
             del data["accounts"][migrate_from]
             self._write_json(self.sequence_file, data)
 
-        # Store backups
-        self._write_account_credentials(account_num, current_email, current_creds)
-        self._write_account_config(account_num, current_email, current_config)
-        self._usage_store.clear_dead_token(
-            [account_num], {account_num: (current_email, organization_uuid)}
-        )
-
         # Update sequence.json
         data = self._get_sequence_data()
         data["accounts"][account_num] = {
@@ -2413,6 +2626,17 @@ class ClaudeAccountSwitcher:
             "organizationName": organization_name,
             "added": get_timestamp(),
         }
+        self._store_account_auth_method(
+            data,
+            account_num,
+            current_creds,
+            preferred=True,
+            auth_method=AUTH_BROWSER_OAUTH,
+        )
+        self._write_account_config(account_num, current_email, current_config)
+        self._usage_store.clear_dead_token(
+            [account_num], {account_num: (current_email, organization_uuid)}
+        )
         carried_alias = alias if alias is not None else existing_alias
         if carried_alias:
             data["accounts"][account_num]["alias"] = carried_alias
@@ -2436,7 +2660,7 @@ class ClaudeAccountSwitcher:
         slot: int | None = None,
         assume_yes: bool = False,
     ) -> None:
-        """Register a raw OAuth setup-token or managed API key as a new account.
+        """Register a raw setup-token or managed API key under an account.
 
         Useful for headless servers or when the token is received from another
         machine, without needing a prior Claude Code login on this machine. The
@@ -2450,7 +2674,8 @@ class ClaudeAccountSwitcher:
             email: Email address to associate with the account. When omitted,
                    defaults to ``setup-token-{slot}@token.local`` (or
                    ``api-key-{slot}@token.local`` for API keys) since these tokens
-                   carry no real email metadata.
+                   carry no real email metadata. An existing personal account
+                   with the same email gains or refreshes this login method.
             slot:  Slot number to use; auto-assigned when ``None``.
             assume_yes: Skip the occupied-slot overwrite prompt (callers with
                    their own confirmation UI, e.g. the TUI, confirm first).
@@ -2484,11 +2709,6 @@ class ClaudeAccountSwitcher:
             label = "api-key" if is_api_key else "setup-token"
             email = f"{label}-{slot}@token.local"
 
-        # Don't silently overwrite/convert an existing account of the other kind:
-        # identity is matched on (email, org) only, so an api-key and an OAuth
-        # account sharing an email would be indistinguishable at switch time.
-        self._reject_cross_kind_collision(email, is_api_key)
-
         # Build the credential payload by kind: a managed key is stored raw; an
         # OAuth setup-token is wrapped in Claude Code's credential JSON. The
         # synthesized config is identical for both (no real org metadata).
@@ -2518,7 +2738,13 @@ class ClaudeAccountSwitcher:
                 raise ConfigError(
                     f"Existing account metadata for {email} is inconsistent"
                 )
-            self._write_account_credentials(account_num, email, credentials)
+            method = self._store_account_auth_method(
+                seq,
+                account_num,
+                credentials,
+                preferred=True,
+                auth_method=AUTH_API_KEY if is_api_key else AUTH_SETUP_TOKEN,
+            )
             self._write_account_config(account_num, email, config)
             # A refreshed credential invalidates any dead-token quarantine on this
             # slot (mirrors ``add_account``); otherwise the stale strike row keeps
@@ -2529,7 +2755,7 @@ class ClaudeAccountSwitcher:
             )
             seq["lastUpdated"] = get_timestamp()
             self._write_json(self.sequence_file, seq)
-            kind_label = "API key" if is_api_key else "token"
+            kind_label = "API key" if method == AUTH_API_KEY else "token"
             self._logger.info(f"Updated {kind_label} for account {account_num}: {email}")
             print(
                 f"{accent(f'Updated {kind_label}')} for Account {account_num} "
@@ -2585,6 +2811,10 @@ class ClaudeAccountSwitcher:
 
         if displace_slot:
             d_num, d_email, d_org = displace_slot
+            displaced = (self._get_sequence_data() or {}).get("accounts", {}).get(
+                d_num, {}
+            )
+            self._delete_auth_method_secrets(displaced)
             self._delete_account_files(d_num, d_email)
             data = self._get_sequence_data()
             if int(d_num) in data["sequence"]:
@@ -2602,14 +2832,6 @@ class ClaudeAccountSwitcher:
             del data["accounts"][migrate_from]
             self._write_json(self.sequence_file, data)
 
-        self._write_account_credentials(account_num, email, credentials)
-        self._write_account_config(account_num, email, config)
-        # Reusing/overwriting a slot with a fresh credential lifts any dead-token
-        # quarantine carried by that slot's prior lineage (mirrors ``add_account``).
-        self._usage_store.clear_dead_token(
-            [account_num], {account_num: (email, "")}
-        )
-
         data = self._get_sequence_data()
         record = {
             "email": email,
@@ -2618,16 +2840,27 @@ class ClaudeAccountSwitcher:
             "organizationName": "",
             "added": get_timestamp(),
         }
-        if is_api_key:
-            record["kind"] = "api_key"
         data["accounts"][account_num] = record
+        method = self._store_account_auth_method(
+            data,
+            account_num,
+            credentials,
+            preferred=True,
+            auth_method=AUTH_API_KEY if is_api_key else AUTH_SETUP_TOKEN,
+        )
+        self._write_account_config(account_num, email, config)
+        # Reusing/overwriting a slot with a fresh credential lifts any dead-token
+        # quarantine carried by that slot's prior lineage (mirrors ``add_account``).
+        self._usage_store.clear_dead_token(
+            [account_num], {account_num: (email, "")}
+        )
         if int(account_num) not in data["sequence"]:
             data["sequence"].append(int(account_num))
             data["sequence"].sort()
         data["lastUpdated"] = get_timestamp()
 
         self._write_json(self.sequence_file, data)
-        source_label = "API key" if is_api_key else "token"
+        source_label = auth_method_label(method)
         self._logger.info(f"Added account {account_num} from {source_label}: {email}")
         if migrate_from:
             print(f"{dimmed(f'Moved from slot {migrate_from} → {slot}')}")
@@ -2710,6 +2943,7 @@ class ClaudeAccountSwitcher:
                 return
 
         # Remove backup files
+        self._delete_auth_method_secrets(account_info)
         self._delete_account_files(account_num, email)
 
         # Update sequence.json
@@ -2741,6 +2975,7 @@ class ClaudeAccountSwitcher:
             active_num = self._find_account_slot(data, current_email, current_org_uuid)
 
         accounts_info: list[tuple[int, str, str, str, bool, str, str]] = []
+        self._usage_backup_slots = set()
         # Reset each build; set below only when the active slot's OAuth Keychain
         # read failed with no fallback. Read by _static_usage_sentinel (main
         # thread writes it here before the fetch pool starts → no data race).
@@ -2759,6 +2994,25 @@ class ClaudeAccountSwitcher:
                 self._active_keychain_unavailable = active.keychain_unavailable
             else:
                 creds = self._read_account_credentials(str(num), email)
+
+            methods = self._account_auth_methods(
+                str(num), credentials=creds, data=data
+            )
+            live_method = classify_auth_method(creds)
+            oauth_methods = [
+                method
+                for method in (AUTH_BROWSER_OAUTH, AUTH_SETUP_TOKEN)
+                if method in methods
+            ]
+            if oauth_methods and live_method not in oauth_methods:
+                usage_method = oauth_methods[0]
+                stored_oauth = self._read_auth_method_credentials(
+                    str(num), email, org_uuid, usage_method
+                )
+                if stored_oauth:
+                    creds = stored_oauth
+                    if is_active:
+                        self._usage_backup_slots.add(str(num))
 
             accounts_info.append((num, email, org_name, org_uuid, is_active, creds, alias))
         return accounts_info
@@ -3395,7 +3649,7 @@ class ClaudeAccountSwitcher:
         # The active/default account owns the live credential — route it
         # through the locked-refresh path (refreshes an expired token under
         # Claude Code's own lock protocol, owner or not).
-        if is_active:
+        if is_active and str(num) not in self._usage_backup_slots:
             return self._fetch_active_usage(str(num), email, creds, org_uuid)
 
         def persist(acct_num: str, acct_email: str, new_creds: str) -> None:
@@ -3892,6 +4146,12 @@ class ClaudeAccountSwitcher:
             # recent enough to act on (≤ STALE_OK_S), else unavailable. Showing
             # older measurements is a human-display affordance only — scripts
             # keying on usageStatus == "ok" must not act on arbitrarily old data.
+            preferred = self._preferred_auth_method(
+                str(num), credentials=creds, data=seq_data
+            )
+            methods = self._account_auth_methods(
+                str(num), credentials=creds, data=seq_data
+            )
             accounts.append(
                 account_row(
                     num, email, org_name, org_uuid, is_active,
@@ -3899,7 +4159,8 @@ class ClaudeAccountSwitcher:
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
                     last_good_usage=entry.last_good,
-                    auth_method=classify_auth_method(creds),
+                    auth_method=preferred,
+                    auth_methods=list(methods or (preferred,)),
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, str(num)),
                 )
@@ -3967,10 +4228,18 @@ class ClaudeAccountSwitcher:
             if self._disabled_from_data(seq_data, str(num)):
                 markers += f" {muted('(disabled)')}"
             print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
-            print(
-                f"     {dimmed('Claude Code:')} "
-                f"{muted(auth_method_label(classify_auth_method(creds)))}"
+            preferred = self._preferred_auth_method(
+                str(num), credentials=creds, data=seq_data
             )
+            methods = self._account_auth_methods(
+                str(num), credentials=creds, data=seq_data
+            )
+            for method in methods or (AUTH_UNKNOWN,):
+                marker = " (preferred)" if method == preferred and len(methods) > 1 else ""
+                print(
+                    f"     {dimmed('Claude Code:')} "
+                    f"{muted(auth_method_label(method) + marker)}"
+                )
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
 
@@ -4605,7 +4874,11 @@ class ClaudeAccountSwitcher:
         )
 
     def switch_to(
-        self, identifier: str, json_output: bool = False, force: bool = False
+        self,
+        identifier: str,
+        json_output: bool = False,
+        force: bool = False,
+        auth_method: str | None = None,
     ) -> dict | None:
         """Switch to specific account.
 
@@ -4662,6 +4935,24 @@ class ClaudeAccountSwitcher:
         if target_account not in data.get("accounts", {}):
             raise AccountNotFoundError(f"Account-{target_account} does not exist")
 
+        requested_method = auth_method.replace("-", "_") if auth_method else None
+        target_email = data["accounts"][target_account].get("email", "")
+        target_primary = self._read_account_credentials(
+            target_account, target_email
+        )
+        available_methods = self._account_auth_methods(
+            target_account, credentials=target_primary, data=data
+        )
+        if requested_method is not None and requested_method not in available_methods:
+            available = ", ".join(auth_method_label(m) for m in available_methods)
+            raise ValidationError(
+                f"Account-{target_account} has no {auth_method_label(requested_method)} "
+                f"login. Available: {available or 'none'}"
+            )
+        selected_method = requested_method or self._preferred_auth_method(
+            target_account, credentials=target_primary, data=data
+        )
+
         # Short-circuit a no-op before mutating (issue #79). A self-switch
         # would first back up the live credentials into the target slot —
         # destroying a freshly imported backup with a possibly stale login —
@@ -4678,11 +4969,22 @@ class ClaudeAccountSwitcher:
             identity = self._get_current_account()
             if identity is not None:
                 cur_slot = self._find_account_slot(data, identity[0], identity[1])
-                if cur_slot == target_account:
+                current_preferred = self._preferred_auth_method(
+                    target_account, credentials=target_primary, data=data
+                )
+                method_change = (
+                    requested_method is not None
+                    and requested_method != current_preferred
+                )
+                if cur_slot == target_account and not method_change:
                     action, provenance = self._self_switch_action(
                         target_account, identity[0]
                     )
-                if cur_slot == target_account and action != "reconcile":
+                if (
+                    cur_slot == target_account
+                    and not method_change
+                    and action != "reconcile"
+                ):
                     email = (
                         data.get("accounts", {}).get(target_account, {}).get("email", "")
                     )
@@ -4705,12 +5007,14 @@ class ClaudeAccountSwitcher:
                         message=f"Already on Account-{target_account} ({email})",
                     )
 
-        op = self._perform_switch(
-            target_account,
-            emit_output=not json_output,
-            force_activate=force,
-            provenance=provenance,
-        )
+        switch_kwargs = {
+            "emit_output": not json_output,
+            "force_activate": force,
+            "provenance": provenance,
+        }
+        if selected_method != AUTH_UNKNOWN:
+            switch_kwargs["target_auth_method"] = selected_method
+        op = self._perform_switch(target_account, **switch_kwargs)
         result = self._switch_result_from_op(op, "direct") if json_output else None
         # A forced self-activation really rewrote the live credentials from the
         # stored backup — "already-active" would misdescribe that mutation.
@@ -5035,6 +5339,7 @@ class ClaudeAccountSwitcher:
         emit_output: bool = True,
         force_activate: bool = False,
         provenance: dict | None = None,
+        target_auth_method: str | None = None,
     ) -> dict:
         """Perform the actual account switch with transaction support.
 
@@ -5102,6 +5407,11 @@ class ClaudeAccountSwitcher:
             active_account = data.get("activeAccountNumber")
             current_account = str(active_account) if active_account is not None else None
             target_email = data["accounts"][target_account]["email"]
+            target_record = data["accounts"][target_account]
+            target_org_uuid = target_record.get("organizationUuid", "") or ""
+            target_method = target_auth_method or self._preferred_auth_method(
+                target_account, data=data
+            )
             to_ref = account_ref(int(target_account), target_email)
             current_identity = self._get_current_account()
             if current_identity is not None:
@@ -5130,8 +5440,11 @@ class ClaudeAccountSwitcher:
                     from_ref = account_ref(None, current_identity[0])
                 else:
                     from_ref = account_ref(int(current_account), current_identity[0])
-                target_creds = self._read_account_credentials(
-                    target_account, target_email
+                target_creds = self._read_auth_method_credentials(
+                    target_account,
+                    target_email,
+                    target_org_uuid,
+                    target_method,
                 )
                 target_config = self._read_account_config(target_account, target_email)
                 if not target_creds:
@@ -5238,6 +5551,16 @@ class ClaudeAccountSwitcher:
                         self._write_json(config_path, target_config_data)
                     config_written = True
 
+                    target_methods = self._account_auth_methods(
+                        target_account, credentials=target_creds, data=data
+                    )
+                    if target_method in target_methods:
+                        self._set_account_auth_methods(
+                            data,
+                            target_account,
+                            list(target_methods),
+                            target_method,
+                        )
                     data["activeAccountNumber"] = int(target_account)
                     data["lastUpdated"] = get_timestamp()
                     self._write_json(self.sequence_file, data)
@@ -5454,9 +5777,24 @@ class ClaudeAccountSwitcher:
                             acct["uuid"] = resolved["uuid"]
                     self._logger.info(f"Backed up account {current_account}")
 
+                outgoing_method = classify_auth_method(original_creds)
+                outgoing_methods = self._account_auth_methods(
+                    current_account, credentials=original_creds, data=data
+                )
+                if outgoing_method in outgoing_methods:
+                    self._set_account_auth_methods(
+                        data,
+                        current_account,
+                        list(outgoing_methods),
+                        outgoing_method,
+                    )
+
                 # Step 2: Retrieve target account
-                target_creds = self._read_account_credentials(
-                    target_account, target_email
+                target_creds = self._read_auth_method_credentials(
+                    target_account,
+                    target_email,
+                    target_org_uuid,
+                    target_method,
                 )
                 target_config = self._read_account_config(target_account, target_email)
 
@@ -5495,6 +5833,16 @@ class ClaudeAccountSwitcher:
                 self._logger.info("Updated config file")
 
                 # Step 5: Update sequence state
+                target_methods = self._account_auth_methods(
+                    target_account, credentials=target_creds, data=data
+                )
+                if target_method in target_methods:
+                    self._set_account_auth_methods(
+                        data,
+                        target_account,
+                        list(target_methods),
+                        target_method,
+                    )
                 data["activeAccountNumber"] = int(target_account)
                 data["lastUpdated"] = get_timestamp()
                 self._write_json(self.sequence_file, data)
@@ -5635,6 +5983,17 @@ class ClaudeAccountSwitcher:
                 nums = [account_num]
                 if str(account_num) != "None":
                     nums.append("None")
+                raw_methods = account_info.get("authMethods")
+                if isinstance(raw_methods, list):
+                    nums.extend(
+                        self._auth_method_storage_key(
+                            email,
+                            account_info.get("organizationUuid", "") or "",
+                            method,
+                        )
+                        for method in raw_methods
+                        if method in AUTH_METHOD_LABELS and method != AUTH_UNKNOWN
+                    )
                 usernames = [f"account-{num}-{email}" for num in nums]
 
                 # .enc files (Linux/WSL/Windows always; macOS fallback copies).

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -15,7 +15,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from claude_swap import __version__
-from claude_swap.credentials import looks_like_api_key
+from claude_swap.credentials import (
+    AUTH_API_KEY,
+    AUTH_BROWSER_OAUTH,
+    AUTH_SETUP_TOKEN,
+    classify_auth_method,
+    looks_like_api_key,
+)
 from claude_swap.exceptions import (
     ConfigError,
     CredentialReadError,
@@ -29,6 +35,11 @@ if TYPE_CHECKING:
 
 
 FORMAT_VERSION = 1
+_TRANSFER_AUTH_METHODS = {
+    AUTH_BROWSER_OAUTH,
+    AUTH_SETUP_TOKEN,
+    AUTH_API_KEY,
+}
 
 _PLATFORM_TAG = {
     Platform.MACOS: "macos",
@@ -160,6 +171,33 @@ def _slim_credentials(creds_obj: dict) -> dict:
     return {"claudeAiOauth": creds_obj["claudeAiOauth"]}
 
 
+def _credentials_payload(credentials: str, label: str, full: bool) -> Any:
+    """Serialize one login secret using the existing transfer representation."""
+    if looks_like_api_key(credentials):
+        return credentials.strip()
+    payload = _parse_payload(credentials, label)
+    return payload if full else _slim_credentials(payload)
+
+
+def _imported_credentials_text(value: Any, method: str, email: str) -> str:
+    """Validate and normalize one imported login method secret."""
+    if method == AUTH_API_KEY:
+        if not (isinstance(value, str) and looks_like_api_key(value)):
+            raise TransferError(
+                f"API-key credentials for {email} must be a raw sk-ant-api… string"
+            )
+        return value.strip()
+    if not isinstance(value, dict):
+        raise TransferError(f"credentials for {email} must be a JSON object")
+    text = json.dumps(value)
+    classified = classify_auth_method(text)
+    if classified != method:
+        raise TransferError(
+            f"credentials for {email} do not match auth method {method}"
+        )
+    return text
+
+
 def export_accounts(
     switcher: ClaudeAccountSwitcher,
     destination: str,
@@ -225,6 +263,19 @@ def export_accounts(
             if not config_path.exists():
                 raise ConfigError("Claude config file not found")
             config_text = config_path.read_text(encoding="utf-8")
+            if isinstance(record.get("authMethods"), list):
+                preferred = switcher._preferred_auth_method(
+                    num, data=sequence_data
+                )
+                if classify_auth_method(creds_text) != preferred:
+                    creds_text = switcher._read_auth_method_credentials(
+                        num, email, org_uuid, preferred
+                    )
+                    if not creds_text:
+                        raise CredentialReadError(
+                            f"no stored {preferred} credentials found for "
+                            f"account {num} ({email})"
+                        )
         else:
             creds_text = switcher._read_account_credentials(num, email)
             config_text = switcher._read_account_config(num, email)
@@ -248,16 +299,13 @@ def export_accounts(
         if not full:
             config_obj = _slim_config(config_obj, f"config for {email}")
 
-        # API-key accounts store the credential as a raw ``sk-ant-api…`` string,
-        # not OAuth JSON — carry it verbatim (and tag the kind) so the JSON parse
-        # below doesn't choke and import can restore it as-is.
+        # Keep the v1 preferred credential fields for older importers. Accounts
+        # with child login methods add an optional list below; usage and identity
+        # remain account-owned and are not duplicated per method.
         is_api_key = looks_like_api_key(creds_text)
-        if is_api_key:
-            creds_payload: Any = creds_text.strip()
-        else:
-            creds_payload = _parse_payload(creds_text, f"credentials for {email}")
-            if not full:
-                creds_payload = _slim_credentials(creds_payload)
+        creds_payload = _credentials_payload(
+            creds_text, f"credentials for {email}", full
+        )
         entry: dict[str, Any] = {
             "number": int(num),
             "email": email,
@@ -270,6 +318,38 @@ def export_accounts(
         }
         if is_api_key:
             entry["kind"] = "api_key"
+        stored_methods = record.get("authMethods")
+        if isinstance(stored_methods, list):
+            preferred = switcher._preferred_auth_method(
+                num, credentials=creds_text, data=sequence_data
+            )
+            method_entries: list[dict[str, Any]] = []
+            for method in switcher._account_auth_methods(
+                num, credentials=creds_text, data=sequence_data
+            ):
+                method_creds = (
+                    creds_text
+                    if method == preferred
+                    else switcher._read_auth_method_credentials(
+                        num, email, org_uuid, method
+                    )
+                )
+                if not method_creds:
+                    raise CredentialReadError(
+                        f"no stored {method} credentials found for account {num} ({email})"
+                    )
+                method_entries.append(
+                    {
+                        "method": method,
+                        "credentials": _credentials_payload(
+                            method_creds,
+                            f"{method} credentials for {email}",
+                            full,
+                        ),
+                    }
+                )
+            entry["authMethods"] = method_entries
+            entry["preferredAuthMethod"] = preferred
         if record.get("alias"):
             entry["alias"] = record["alias"]
         accounts_payload.append(entry)
@@ -383,20 +463,51 @@ def import_accounts(
         if not isinstance(config_obj, dict):
             raise TransferError(f"config for {email} must be a JSON object")
         # API-key accounts carry the credential as a raw string; OAuth accounts
-        # carry a JSON object.
+        # carry a JSON object. Optional child methods are additive to format v1.
         is_api_key = raw.get("kind") == "api_key" or isinstance(creds_obj, str)
         if is_api_key:
-            if not (isinstance(creds_obj, str) and looks_like_api_key(creds_obj)):
-                raise TransferError(
-                    f"API-key credentials for {email} must be a raw sk-ant-api… string"
-                )
-            creds_text = creds_obj.strip()
+            preferred_method = AUTH_API_KEY
+            creds_text = _imported_credentials_text(
+                creds_obj, preferred_method, email
+            )
         else:
             if not isinstance(creds_obj, dict):
                 raise TransferError(
                     f"credentials for {email} must be a JSON object"
                 )
             creds_text = json.dumps(creds_obj)
+            preferred_method = classify_auth_method(creds_text)
+            if preferred_method not in _TRANSFER_AUTH_METHODS:
+                # Legacy exports may use an old OAuth object shape that cannot
+                # be classified locally. Version 1 accepted it as OAuth.
+                preferred_method = AUTH_BROWSER_OAUTH
+
+        method_credentials: dict[str, str] = {}
+        raw_methods = raw.get("authMethods")
+        if raw_methods is not None:
+            if not isinstance(raw_methods, list) or not raw_methods:
+                raise TransferError(
+                    f"authMethods for {email} must be a non-empty list"
+                )
+            for child in raw_methods:
+                if not isinstance(child, dict):
+                    raise TransferError(f"authMethods for {email} must contain objects")
+                method = child.get("method")
+                if method not in _TRANSFER_AUTH_METHODS:
+                    raise TransferError(
+                        f"unsupported auth method for {email}: {method!r}"
+                    )
+                if method in method_credentials:
+                    raise TransferError(f"duplicate auth method for {email}: {method}")
+                method_credentials[method] = _imported_credentials_text(
+                    child.get("credentials"), method, email
+                )
+            preferred_method = raw.get("preferredAuthMethod")
+            if preferred_method not in method_credentials:
+                raise TransferError(
+                    f"preferredAuthMethod for {email} must name an imported auth method"
+                )
+            creds_text = method_credentials[preferred_method]
         key = (email, org_uuid)
         if key in seen_keys:
             raise TransferError(
@@ -428,7 +539,9 @@ def import_accounts(
                 "org_name": raw.get("organizationName", "") or "",
                 "uuid": raw.get("uuid", "") or "",
                 "added": raw.get("added") or get_timestamp(),
-                "kind": "api_key" if is_api_key else "oauth",
+                "kind": "api_key" if preferred_method == AUTH_API_KEY else "oauth",
+                "preferred_method": preferred_method,
+                "method_credentials": method_credentials,
                 "alias": alias,
                 "creds_text": creds_text,
                 "config_text": json.dumps(config_obj, indent=2),
@@ -528,6 +641,10 @@ def import_accounts(
         switcher._write_account_config(
             target_num, entry["email"], entry["config_text"]
         )
+        for method, method_creds in entry["method_credentials"].items():
+            switcher._write_auth_method_secret(
+                entry["email"], entry["org_uuid"], method, method_creds
+            )
         # Every successful import write introduces credential material whose
         # previous auth verdict is no longer authoritative, so lift any
         # dead-token quarantine on this slot (mirrors add_account / the
@@ -550,6 +667,9 @@ def import_accounts(
         }
         if entry["kind"] == "api_key":
             new_record["kind"] = "api_key"
+        if entry["method_credentials"]:
+            new_record["authMethods"] = list(entry["method_credentials"])
+            new_record["preferredAuthMethod"] = entry["preferred_method"]
         if entry.get("alias"):
             new_record["alias"] = entry["alias"]
         data["accounts"][target_num] = new_record

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -187,9 +187,13 @@ def account_card_text(
     if age:
         text.append(f"   {age}", style=palette.muted)
 
-    text.append("\n    ")
-    text.append("Claude Code  ", style=palette.muted)
-    text.append(auth_method_label(acc.auth_method), style=palette.foreground)
+    methods = acc.auth_methods or (acc.auth_method,)
+    for method in methods:
+        text.append("\n    ")
+        text.append("Claude Code  ", style=palette.muted)
+        text.append(auth_method_label(method), style=palette.foreground)
+        if len(methods) > 1 and method == acc.auth_method:
+            text.append("  preferred", style=palette.muted)
 
     sentinel = acc.usage.sentinel
     if sentinel is not None:
@@ -260,7 +264,9 @@ def mini_account_text(
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.disabled:
         text.append("  (disabled)", style=palette.muted)
-    text.append(f"  · {auth_method_label(acc.auth_method)}", style=palette.muted)
+    methods = acc.auth_methods or (acc.auth_method,)
+    labels = ", ".join(auth_method_label(method) for method in methods)
+    text.append(f"  · {labels}", style=palette.muted)
     text.append("   ")
 
     sentinel = acc.usage.sentinel

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -15,6 +15,7 @@ from rich.text import Text
 from textual.widgets import ListItem, Static
 
 from claude_swap import pace
+from claude_swap.credentials import auth_method_label
 from claude_swap.json_output import USAGE_API_KEY
 from claude_swap.models import AccountSnapshot
 from claude_swap.usage_store import STALE_OK_S
@@ -186,6 +187,10 @@ def account_card_text(
     if age:
         text.append(f"   {age}", style=palette.muted)
 
+    text.append("\n    ")
+    text.append("Claude Code  ", style=palette.muted)
+    text.append(auth_method_label(acc.auth_method), style=palette.foreground)
+
     sentinel = acc.usage.sentinel
     if sentinel is not None:
         text.append("\n    ")
@@ -255,6 +260,7 @@ def mini_account_text(
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.disabled:
         text.append("  (disabled)", style=palette.muted)
+    text.append(f"  · {auth_method_label(acc.auth_method)}", style=palette.muted)
     text.append("   ")
 
     sentinel = acc.usage.sentinel

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -16,9 +16,13 @@ import pytest
 from claude_swap import macos_keychain
 from claude_swap import session as session_mod
 from claude_swap.credentials import (
+    AUTH_API_KEY,
+    AUTH_BROWSER_OAUTH,
+    AUTH_SETUP_TOKEN,
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
     approved_form,
+    classify_auth_method,
     looks_like_api_key,
 )
 from claude_swap.exceptions import SessionError, ValidationError
@@ -62,6 +66,22 @@ def _read_global_config() -> dict:
 
 
 class TestKindDetection:
+    def test_classifies_every_supported_auth_method(self):
+        browser = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat01-browser",
+                    "refreshToken": "refresh",
+                }
+            }
+        )
+        setup = json.dumps(
+            {"claudeAiOauth": {"accessToken": "sk-ant-oat01-setup"}}
+        )
+        assert classify_auth_method(browser) == AUTH_BROWSER_OAUTH
+        assert classify_auth_method(setup) == AUTH_SETUP_TOKEN
+        assert classify_auth_method(API_KEY) == AUTH_API_KEY
+
     def test_api_key_detected(self):
         assert looks_like_api_key(API_KEY) is True
 

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -1,7 +1,7 @@
 """Tests for managed API-key (``/login`` key) account support.
 
-Covers kind detection, ``--add-token`` auto-detection, the cross-kind collision
-guard, the ``add_account`` live-key guard, kind+platform-aware active credential
+Covers kind detection, ``--add-token`` auto-detection, account-owned login methods,
+the ``add_account`` live-key guard, kind+platform-aware active credential
 read/write with OAuth↔API-key mutual exclusion, the "API key — no quota" usage
 display, the ``cswap run`` session guard, and export/import of raw keys.
 """
@@ -140,18 +140,131 @@ class TestAddTokenApiKey:
         assert s._read_account_credentials("1", "me@example.com") == OTHER_KEY
 
 
-class TestCrossKindCollision:
-    def test_api_key_rejected_when_email_is_oauth(self, temp_home: Path):
+class TestAccountAuthMethods:
+    def test_browser_oauth_joins_existing_setup_token_account(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token(
+            "sk-ant-oat01-setup", email="dup@example.com"
+        )
+        (temp_home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "oauthAccount": {
+                        "emailAddress": "dup@example.com",
+                        "accountUuid": "account-1",
+                        "organizationUuid": None,
+                        "organizationName": None,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        get_credentials_path().parent.mkdir(parents=True, exist_ok=True)
+        get_credentials_path().write_text(OAUTH_JSON, encoding="utf-8")
+
+        s.add_account()
+
+        record = s._get_sequence_data()["accounts"]["1"]
+        assert record["authMethods"] == [AUTH_BROWSER_OAUTH, AUTH_SETUP_TOKEN]
+        assert record["preferredAuthMethod"] == AUTH_BROWSER_OAUTH
+
+    def test_api_key_and_setup_token_share_one_account(self, temp_home: Path):
         s = _linux_switcher()
         s.add_account_from_token("sk-ant-oat01-abc", email="dup@example.com")
-        with pytest.raises(ValidationError, match="already exists as an OAuth account"):
-            s.add_account_from_token(API_KEY, email="dup@example.com")
+        s.add_account_from_token(API_KEY, email="dup@example.com")
 
-    def test_oauth_rejected_when_email_is_api_key(self, temp_home: Path):
+        data = s._get_sequence_data()
+        record = data["accounts"]["1"]
+        assert len(data["accounts"]) == 1
+        assert record["authMethods"] == [AUTH_SETUP_TOKEN, AUTH_API_KEY]
+        assert record["preferredAuthMethod"] == AUTH_API_KEY
+        assert s._read_auth_method_credentials(
+            "1", "dup@example.com", "", AUTH_SETUP_TOKEN
+        )
+        assert s._read_auth_method_credentials(
+            "1", "dup@example.com", "", AUTH_API_KEY
+        ) == API_KEY
+
+    def test_explicit_method_switch_updates_preference(self, temp_home: Path):
         s = _linux_switcher()
         s.add_account_from_token(API_KEY, email="dup@example.com")
-        with pytest.raises(ValidationError, match="already exists as an API-key account"):
-            s.add_account_from_token("sk-ant-oat01-abc", email="dup@example.com")
+        s.add_account_from_token("sk-ant-oat01-abc", email="dup@example.com")
+
+        s.switch_to("1", force=True, auth_method="api-key")
+        s.switch_to("1", auth_method="setup-token")
+
+        record = s._get_sequence_data()["accounts"]["1"]
+        assert record["preferredAuthMethod"] == AUTH_SETUP_TOKEN
+        assert classify_auth_method(
+            s._read_account_credentials("1", "dup@example.com")
+        ) == AUTH_SETUP_TOKEN
+
+    def test_usage_stays_account_level_when_api_key_is_preferred(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token(
+            "sk-ant-oat01-setup", email="dup@example.com"
+        )
+        s.add_account_from_token(API_KEY, email="dup@example.com")
+
+        info = s._build_accounts_info()
+        snapshot = s.accounts_snapshot(fetch=set())
+
+        assert classify_auth_method(info[0][5]) == AUTH_SETUP_TOKEN
+        assert len(snapshot.accounts) == 1
+        assert snapshot.accounts[0].auth_method == AUTH_API_KEY
+        assert snapshot.accounts[0].auth_methods == (
+            AUTH_SETUP_TOKEN,
+            AUTH_API_KEY,
+        )
+        assert snapshot.accounts[0].usage.sentinel != USAGE_API_KEY
+
+    def test_active_api_key_uses_oauth_backup_without_replacing_live_login(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token(
+            "sk-ant-oat01-setup", email="dup@example.com"
+        )
+        s.add_account_from_token(API_KEY, email="dup@example.com")
+        s.switch_to("1", force=True, auth_method="api-key")
+
+        info = s._build_accounts_info()
+
+        assert info[0][4] is True
+        assert classify_auth_method(info[0][5]) == AUTH_SETUP_TOKEN
+        assert "1" in s._usage_backup_slots
+        assert s._read_credentials() == API_KEY
+
+    def test_method_secrets_follow_slot_move_and_delete_with_account(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        email = "dup@example.com"
+        s.add_account_from_token("sk-ant-oat01-setup", email=email)
+        s.add_account_from_token(API_KEY, email=email)
+
+        s.move_account("1", "3")
+
+        assert s._read_auth_method_credentials(
+            "3", email, "", AUTH_SETUP_TOKEN
+        )
+        assert s._read_auth_method_credentials(
+            "3", email, "", AUTH_API_KEY
+        ) == API_KEY
+        keys = [
+            s._auth_method_storage_key(email, "", method)
+            for method in (AUTH_SETUP_TOKEN, AUTH_API_KEY)
+        ]
+
+        s.remove_account("3", assume_yes=True)
+
+        assert all(
+            not s._store._read_account_credentials(key, email) for key in keys
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -314,6 +314,24 @@ class TestCLI:
             "2", json_output=False, force=False
         )
 
+    def test_switch_to_forwards_auth_method(self):
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(
+                 sys,
+                 "argv",
+                 ["claude-swap", "switch", "2", "--auth-method", "setup-token"],
+             ), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.switch_to.assert_called_once_with(
+            "2",
+            json_output=False,
+            force=False,
+            auth_method="setup-token",
+        )
+
     def test_export_and_import_are_mutually_exclusive(self):
         """--export and --import cannot be combined."""
         result = subprocess.run(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -665,6 +665,95 @@ class TestRunCommand:
         assert "boom" in capsys.readouterr().err
 
 
+class TestDesktopCommand:
+    def test_dispatches_account_and_flags(self, capsys):
+        payload = {
+            "schemaVersion": 1,
+            "dryRun": True,
+            "account": {"number": 2, "email": "user@example.com"},
+            "sessions": {
+                "copied": 3,
+                "existing": 4,
+                "unavailable": 1,
+                "invalid": 0,
+            },
+        }
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch("claude_swap.desktop.DesktopManager") as manager_cls, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(
+                 sys, "argv", ["claude-swap", "desktop", "2", "--dry-run", "--json"]
+             ):
+            manager_cls.return_value.run.return_value = payload
+            cli.main()
+
+        manager_cls.assert_called_once_with(switcher_cls.return_value)
+        manager_cls.return_value.run.assert_called_once_with(
+            "2", dry_run=True, json_output=True, confirm_login=False
+        )
+        assert json.loads(capsys.readouterr().out) == payload
+
+    def test_prompts_for_one_time_desktop_login(self, capsys):
+        payload = {
+            "schemaVersion": 1,
+            "dryRun": False,
+            "account": {"number": 2, "email": "user@example.com"},
+            "profile": {"initialized": False, "isDefault": False},
+            "loginRequired": True,
+            "alreadyActive": False,
+            "sessions": {
+                "copied": 0,
+                "existing": 1,
+                "unavailable": 0,
+                "invalid": 0,
+            },
+        }
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("claude_swap.desktop.DesktopManager") as manager_cls, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "desktop", "2"]):
+            manager_cls.return_value.run.return_value = payload
+            cli.main()
+
+        output = capsys.readouterr().out
+        assert "Sign in once" in output
+        assert "--confirm-login" in output
+
+    def test_help_mentions_desktop(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_swap", "--help"],
+            capture_output=True,
+            text=True,
+            env=_subprocess_env(),
+        )
+        assert "desktop <num|email>" in result.stdout
+
+    def test_rejects_non_default_claude_profile(self, capsys):
+        with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": "/tmp/isolated"}), \
+             patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", ["claude-swap", "desktop", "2"]), \
+             pytest.raises(SystemExit) as excinfo:
+            cli.main()
+
+        assert excinfo.value.code == 1
+        switcher_cls.assert_not_called()
+        assert "default Claude profile" in capsys.readouterr().err
+
+    def test_error_exits_cleanly(self, capsys):
+        from claude_swap.exceptions import DesktopError
+
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("claude_swap.desktop.DesktopManager") as manager_cls, \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch.object(sys, "argv", ["claude-swap", "desktop", "2"]), \
+             pytest.raises(SystemExit) as excinfo:
+            manager_cls.return_value.run.side_effect = DesktopError("boom")
+            cli.main()
+
+        assert excinfo.value.code == 1
+        assert "boom" in capsys.readouterr().err
+
+
 class TestSubcommandAliases:
     """Memorable subcommands (`cswap switch`, `cswap list`, ...) → classic flags."""
 

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -1,0 +1,710 @@
+"""Tests for macOS Claude Desktop account switching and session sharing."""
+
+from __future__ import annotations
+
+import json
+import plistlib
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from claude_swap.desktop import (
+    DesktopManager,
+    DesktopProfile,
+    DesktopProfileStore,
+    DesktopSessionSync,
+    DesktopSyncResult,
+)
+from claude_swap.exceptions import DesktopError, SwitchError
+from claude_swap.process_detection import ClaudeSession
+
+
+ACCOUNT_A = "11111111-1111-4111-8111-111111111111"
+ACCOUNT_B = "22222222-2222-4222-8222-222222222222"
+ORG_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+ORG_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+CLI_SESSION = "33333333-3333-4333-8333-333333333333"
+LOCAL_SESSION = "local_44444444-4444-4444-8444-444444444444"
+
+
+def _write_transcript(config_dir: Path, cli_session_id: str = CLI_SESSION) -> None:
+    project = config_dir / "projects" / "project"
+    project.mkdir(parents=True, exist_ok=True)
+    (project / f"{cli_session_id}.jsonl").write_text("{}\n", encoding="utf-8")
+
+
+def _write_entry(
+    sessions_root: Path,
+    account: str,
+    org: str,
+    *,
+    session_id: str = LOCAL_SESSION,
+    cli_session_id: str | None = CLI_SESSION,
+    unavailable: bool = False,
+    **extra,
+) -> Path:
+    path = sessions_root / account / org / f"{session_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "sessionId": session_id,
+        "cliSessionId": cli_session_id,
+        "title": "Shared task",
+        **extra,
+    }
+    if unavailable:
+        data["transcriptUnavailable"] = True
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class TestDesktopSessionSync:
+    def test_copies_resumable_entry_and_removes_account_bound_fields(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        source = _write_entry(
+            sessions_root,
+            ACCOUNT_A,
+            ORG_A,
+            bridgeSessionIds=["old-server-id"],
+            error="out of usage credits",
+            errorAt="2026-01-01T00:00:00Z",
+        )
+
+        result = DesktopSessionSync(user_data, config_dir).sync(ACCOUNT_B, ORG_B)
+
+        assert result == DesktopSyncResult(copied=1)
+        destination = sessions_root / ACCOUNT_B / ORG_B / source.name
+        copied = json.loads(destination.read_text(encoding="utf-8"))
+        assert copied["sessionId"] == LOCAL_SESSION
+        assert copied["cliSessionId"] == CLI_SESSION
+        assert "bridgeSessionIds" not in copied
+        assert "error" not in copied
+        assert "errorAt" not in copied
+        assert json.loads(source.read_text(encoding="utf-8"))["bridgeSessionIds"] == [
+            "old-server-id"
+        ]
+
+    def test_skips_unavailable_and_missing_transcripts(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        _write_entry(sessions_root, ACCOUNT_A, ORG_A, unavailable=True)
+        _write_entry(
+            sessions_root,
+            ACCOUNT_A,
+            ORG_A,
+            session_id="local_missing-transcript",
+            cli_session_id="55555555-5555-4555-8555-555555555555",
+        )
+
+        result = DesktopSessionSync(user_data, config_dir).sync(ACCOUNT_B, ORG_B)
+
+        assert result == DesktopSyncResult(unavailable=2)
+        assert not (sessions_root / ACCOUNT_B).exists()
+
+    def test_existing_session_in_active_target_org_wins(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        _write_entry(sessions_root, ACCOUNT_A, ORG_A, title="source")
+        target = _write_entry(sessions_root, ACCOUNT_B, ORG_B, title="target")
+
+        result = DesktopSessionSync(user_data, config_dir).sync(ACCOUNT_B, ORG_B)
+
+        assert result == DesktopSyncResult(existing=1)
+        assert json.loads(target.read_text(encoding="utf-8"))["title"] == "target"
+        assert not (sessions_root / ACCOUNT_B / ORG_A / target.name).exists()
+
+    def test_copies_entry_from_another_org_of_same_account(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        source = _write_entry(sessions_root, ACCOUNT_B, ORG_A)
+
+        result = DesktopSessionSync(user_data, config_dir).sync(ACCOUNT_B, ORG_B)
+
+        assert result == DesktopSyncResult(copied=1)
+        destination = sessions_root / ACCOUNT_B / ORG_B / source.name
+        assert destination.is_file()
+        assert source.is_file()
+
+    def test_dry_run_reports_copy_without_writing(self, tmp_path):
+        user_data = tmp_path / "Claude"
+        config_dir = tmp_path / ".claude"
+        sessions_root = user_data / "claude-code-sessions"
+        _write_transcript(config_dir)
+        _write_entry(sessions_root, ACCOUNT_A, ORG_A)
+
+        result = DesktopSessionSync(user_data, config_dir).sync(
+            ACCOUNT_B, ORG_B, dry_run=True
+        )
+
+        assert result == DesktopSyncResult(copied=1)
+        assert not (sessions_root / ACCOUNT_B).exists()
+
+    def test_new_entry_writer_never_replaces_existing_file(self, tmp_path):
+        destination = tmp_path / "org" / f"{LOCAL_SESSION}.json"
+        destination.parent.mkdir()
+        destination.write_text('{"title": "keep"}', encoding="utf-8")
+
+        created = DesktopSessionSync._write_new_entry(
+            destination, {"title": "replace"}
+        )
+
+        assert created is False
+        assert json.loads(destination.read_text(encoding="utf-8")) == {
+            "title": "keep"
+        }
+
+    def test_rejects_invalid_account_uuid(self, tmp_path):
+        syncer = DesktopSessionSync(tmp_path / "Claude", tmp_path / ".claude")
+        with pytest.raises(DesktopError, match="valid account UUID"):
+            syncer.sync("not-a-uuid", ORG_B)
+
+    def test_rejects_invalid_organization_uuid(self, tmp_path):
+        syncer = DesktopSessionSync(tmp_path / "Claude", tmp_path / ".claude")
+        with pytest.raises(DesktopError, match="valid organization UUID"):
+            syncer.sync(ACCOUNT_B, "not-a-uuid")
+
+    def test_rejects_missing_desktop_index(self, tmp_path):
+        syncer = DesktopSessionSync(tmp_path / "Claude", tmp_path / ".claude")
+        with pytest.raises(DesktopError, match="session index not found"):
+            syncer.sync(ACCOUNT_B, ORG_B)
+
+
+class TestDesktopProfileStore:
+    def test_dry_run_predicts_profile_without_writing(self, tmp_path):
+        default = tmp_path / "Application Support" / "Claude"
+        (default / "claude-code-sessions").mkdir(parents=True)
+        backup = tmp_path / "backup"
+        store = DesktopProfileStore(backup, default_profile_dir=default)
+
+        profile = store.resolve(
+            ACCOUNT_B,
+            "user@example.com",
+            current_account_uuid=None,
+            current_email="",
+            current_profile_dir=default,
+            dry_run=True,
+        )
+
+        assert profile.path == backup / "desktop" / ACCOUNT_B
+        assert profile.initialized is False
+        assert not backup.exists()
+
+    def test_adopts_default_and_creates_shared_session_link(self, tmp_path):
+        default = tmp_path / "Application Support" / "Claude"
+        shared = default / "claude-code-sessions"
+        shared.mkdir(parents=True)
+        store = DesktopProfileStore(tmp_path / "backup", default_profile_dir=default)
+
+        profile = store.resolve(
+            ACCOUNT_B,
+            "user@example.com",
+            current_account_uuid=ACCOUNT_A,
+            current_email="old@example.com",
+            current_profile_dir=default,
+        )
+
+        link = profile.path / "claude-code-sessions"
+        assert link.is_symlink()
+        assert link.resolve() == shared.resolve()
+        registry = json.loads(store.registry_path.read_text(encoding="utf-8"))
+        assert registry["profiles"][ACCOUNT_A]["isDefault"] is True
+        assert registry["profiles"][ACCOUNT_B]["initialized"] is False
+
+    def test_refuses_to_replace_private_session_data(self, tmp_path):
+        default = tmp_path / "Claude"
+        (default / "claude-code-sessions").mkdir(parents=True)
+        backup = tmp_path / "backup"
+        private = backup / "desktop" / ACCOUNT_B / "claude-code-sessions"
+        private.mkdir(parents=True)
+        store = DesktopProfileStore(backup, default_profile_dir=default)
+
+        with pytest.raises(DesktopError, match="private session data"):
+            store.resolve(
+                ACCOUNT_B,
+                "user@example.com",
+                current_account_uuid=None,
+                current_email="",
+                current_profile_dir=default,
+            )
+
+    def test_marks_profile_initialized(self, tmp_path):
+        default = tmp_path / "Claude"
+        (default / "claude-code-sessions").mkdir(parents=True)
+        store = DesktopProfileStore(tmp_path / "backup", default_profile_dir=default)
+        profile = store.resolve(
+            ACCOUNT_B,
+            "user@example.com",
+            current_account_uuid=None,
+            current_email="",
+            current_profile_dir=default,
+        )
+
+        initialized = store.mark_initialized(profile)
+
+        assert initialized.initialized is True
+        stored = json.loads(store.registry_path.read_text(encoding="utf-8"))
+        assert stored["profiles"][ACCOUNT_B]["initialized"] is True
+
+        uninitialized = store.mark_uninitialized(initialized)
+
+        assert uninitialized.initialized is False
+        stored = json.loads(store.registry_path.read_text(encoding="utf-8"))
+        assert stored["profiles"][ACCOUNT_B]["initialized"] is False
+
+
+def _authenticated_profile(tmp_path: Path) -> DesktopProfile:
+    profile_dir = tmp_path / "profile"
+    profile_dir.mkdir()
+    indexed = profile_dir / "IndexedDB" / "https_claude.ai_0.indexeddb.leveldb"
+    indexed.mkdir(parents=True)
+    (indexed / "000003.log").write_bytes(b"prefix" + ACCOUNT_B.encode() + b"suffix")
+    return DesktopProfile(
+        account_uuid=ACCOUNT_B,
+        email="user@example.com",
+        path=profile_dir,
+        is_default=False,
+        initialized=False,
+    )
+
+
+class TestDesktopProfileIdentity:
+    def test_profile_storage_contains_account(self, tmp_path):
+        profile = _authenticated_profile(tmp_path)
+
+        assert DesktopManager._profile_matches_account(profile, ACCOUNT_B) is True
+        assert DesktopManager._profile_matches_account(profile, ACCOUNT_A) is False
+
+    def test_missing_account_identity_is_not_authenticated(self, tmp_path):
+        profile = DesktopProfile(
+            ACCOUNT_B,
+            "user@example.com",
+            tmp_path,
+            False,
+            False,
+        )
+        indexed = tmp_path / "IndexedDB"
+        indexed.mkdir()
+        (indexed / "data").write_text("no account here", encoding="ascii")
+
+        assert DesktopManager._profile_matches_account(profile, ACCOUNT_B) is False
+
+
+def _switcher() -> MagicMock:
+    switcher = MagicMock()
+    switcher.resolve_account.return_value = ("2", "user@example.com", ORG_B)
+    switcher.account_identity.return_value = {
+        "email": "user@example.com",
+        "organizationUuid": ORG_B,
+        "uuid": ACCOUNT_B,
+    }
+    return switcher
+
+
+class TestDesktopManager:
+    def test_launches_managed_profile_through_gui_session(self, tmp_path):
+        switcher = _switcher()
+        store = MagicMock()
+        store.default_profile_dir = tmp_path / "default"
+        manager = DesktopManager(
+            switcher, syncer=MagicMock(), profile_store=store
+        )
+        profile = DesktopProfile(
+            ACCOUNT_B, "user@example.com", tmp_path / "profile", False, True
+        )
+        completed = MagicMock(returncode=0, stderr="")
+
+        with patch.object(Path, "is_file", return_value=True), \
+             patch("claude_swap.desktop.subprocess.run", return_value=completed) as run, \
+             patch.object(manager, "_desktop_is_running", return_value=True):
+            manager._launch_desktop(profile)
+
+        run.assert_called_once_with(
+            [
+                "/usr/bin/open",
+                "-n",
+                "-b",
+                "com.anthropic.claudefordesktop",
+                "--env",
+                f"CLAUDE_USER_DATA_DIR={profile.path}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_running_profile_path_drops_ps_trailing_newline(self):
+        switcher = _switcher()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        manager = DesktopManager(
+            switcher, syncer=MagicMock(), profile_store=store
+        )
+        ps_result = MagicMock(
+            returncode=0,
+            stdout=(
+                "/Applications/Claude.app/Contents/MacOS/Claude "
+                "CLAUDE_USER_DATA_DIR=/profiles/b\n"
+            ),
+        )
+
+        with patch.object(manager, "_desktop_pids", return_value=[42]), \
+             patch("claude_swap.desktop.subprocess.run", return_value=ps_result):
+            profile = manager._running_profile_dir()
+
+        assert profile == Path("/profiles/b")
+
+    def test_dry_run_never_switches_or_touches_app(self):
+        switcher = _switcher()
+        syncer = MagicMock()
+        syncer.sync.return_value = DesktopSyncResult(copied=3, existing=2)
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        store.resolve.return_value = target
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_desktop_is_running", return_value=False), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             patch.object(manager, "_launch_desktop") as launch:
+            payload = manager.run("2", dry_run=True)
+
+        syncer.sync.assert_called_once_with(ACCOUNT_B, ORG_B, dry_run=True)
+        switcher.switch_to.assert_not_called()
+        quit_desktop.assert_not_called()
+        launch.assert_not_called()
+        assert payload["dryRun"] is True
+        assert payload["loginRequired"] is True
+        assert payload["sessions"]["copied"] == 3
+
+    def test_switches_syncs_and_relaunches(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult(copied=2)
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        store.mark_initialized.return_value = target
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             patch.object(manager, "_launch_desktop") as launch, \
+             patch.object(manager, "_wait_for_identity", return_value=True):
+            payload = manager.run("2", json_output=True)
+
+        quit_desktop.assert_called_once_with()
+        switcher.switch_to.assert_called_once_with("2", json_output=True)
+        assert syncer.sync.call_args_list == [
+            call(ACCOUNT_B, ORG_B, dry_run=True),
+            call(ACCOUNT_B, ORG_B),
+        ]
+        launch.assert_called_once_with(target)
+        store.mark_initialized.assert_called_once_with(target)
+        assert payload["loginRequired"] is False
+        assert payload["sessions"]["copied"] == 2
+
+    def test_new_profile_opens_for_one_time_login(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop"), \
+             patch.object(manager, "_launch_desktop") as launch, \
+             patch.object(manager, "_profile_matches_account", return_value=False), \
+             patch.object(manager, "_wait_for_identity") as wait:
+            payload = manager.run("2")
+
+        launch.assert_called_once_with(target)
+        wait.assert_not_called()
+        store.mark_initialized.assert_not_called()
+        assert payload["loginRequired"] is True
+
+    def test_already_active_profile_is_verified_without_switching(self):
+        switcher = _switcher()
+        syncer = MagicMock()
+        syncer.sync.return_value = DesktopSyncResult(existing=2)
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        initialized = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [target, target]
+        store.mark_initialized.return_value = initialized
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_B, "user@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/profiles/b")), \
+             patch.object(manager, "_wait_for_identity", return_value=True), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             patch.object(manager, "_launch_desktop") as launch:
+            payload = manager.run("2")
+
+        switcher.switch_to.assert_not_called()
+        quit_desktop.assert_not_called()
+        launch.assert_not_called()
+        assert payload["alreadyActive"] is True
+        assert payload["loginRequired"] is False
+
+    def test_confirms_visually_verified_active_profile(self):
+        switcher = _switcher()
+        syncer = MagicMock()
+        syncer.sync.return_value = DesktopSyncResult(existing=2)
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        initialized = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [target, target]
+        store.mark_initialized.return_value = initialized
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_B, "user@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/profiles/b")), \
+             patch.object(manager, "_wait_for_identity") as wait:
+            payload = manager.run("2", confirm_login=True)
+
+        store.mark_initialized.assert_called_once_with(target)
+        wait.assert_not_called()
+        assert payload["loginRequired"] is False
+
+    def test_refuses_non_idle_desktop_task(self):
+        switcher = _switcher()
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+        busy = ClaudeSession(
+            pid=42,
+            session_id="s",
+            cwd="/tmp/project",
+            started_at=0,
+            kind="interactive",
+            entrypoint="claude-desktop",
+            status="busy",
+        )
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[busy]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             patch.object(manager, "_launch_desktop") as launch, \
+             pytest.raises(DesktopError, match="active local task"):
+            manager.run("2")
+
+        switcher.switch_to.assert_not_called()
+        quit_desktop.assert_not_called()
+        launch.assert_not_called()
+
+    def test_refuses_locked_console_before_closing(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_console_is_unlocked", return_value=False), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             pytest.raises(DesktopError, match="Mac is locked"):
+            manager.run("2")
+
+        quit_desktop.assert_not_called()
+        switcher.switch_to.assert_not_called()
+
+    def test_console_lock_probe_reads_ioreg_plist(self):
+        unlocked = plistlib.dumps({"IOConsoleLocked": False})
+        locked = plistlib.dumps({"IOConsoleLocked": True})
+
+        with patch("claude_swap.desktop.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout=unlocked)
+            assert DesktopManager._console_is_unlocked() is True
+            run.return_value = MagicMock(returncode=0, stdout=locked)
+            assert DesktopManager._console_is_unlocked() is False
+
+    def test_relaunches_original_app_when_switch_fails(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        switcher.switch_to.side_effect = SwitchError("boom")
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop"), \
+             patch.object(manager, "_restore_original") as restore, \
+             pytest.raises(SwitchError, match="boom"):
+            manager.run("2")
+
+        restore.assert_called_once_with(
+            "1", original, was_running=True, switch_completed=False
+        )
+        syncer.sync.assert_called_once_with(ACCOUNT_B, ORG_B, dry_run=True)
+
+    def test_confirmed_profile_reuses_isolated_login_without_private_storage_probe(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {
+            "accounts": {"1": {"uuid": ACCOUNT_A}}
+        }
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, True
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop"), \
+             patch.object(manager, "_launch_desktop"), \
+             patch.object(manager, "_wait_for_identity") as wait, \
+             patch.object(manager, "_restore_original") as restore:
+            payload = manager.run("2")
+
+        wait.assert_not_called()
+        restore.assert_not_called()
+        assert payload["loginRequired"] is False
+
+    def test_refuses_untracked_current_account_before_closing(self):
+        switcher = _switcher()
+        switcher._get_sequence_data.return_value = {"accounts": {}}
+        syncer = MagicMock()
+        syncer.claude_config_dir = Path("/tmp/claude-test")
+        syncer.sync.return_value = DesktopSyncResult()
+        store = MagicMock()
+        store.default_profile_dir = Path("/default")
+        original = DesktopProfile(
+            ACCOUNT_A, "old@example.com", Path("/default"), True, True
+        )
+        target = DesktopProfile(
+            ACCOUNT_B, "user@example.com", Path("/profiles/b"), False, False
+        )
+        store.resolve.side_effect = [original, target]
+        manager = DesktopManager(switcher, syncer=syncer, profile_store=store)
+
+        with patch("claude_swap.desktop.sys.platform", "darwin"), \
+             patch.object(manager, "_blocking_sessions", return_value=[]), \
+             patch.object(manager, "_desktop_is_running", return_value=True), \
+             patch.object(manager, "_live_identity", return_value=(ACCOUNT_A, "old@example.com")), \
+             patch.object(manager, "_running_profile_dir", return_value=Path("/default")), \
+             patch.object(manager, "_quit_desktop") as quit_desktop, \
+             pytest.raises(DesktopError, match="not stored in cswap"):
+            manager.run("2")
+
+        quit_desktop.assert_not_called()
+        switcher.switch_to.assert_not_called()
+
+    def test_rejects_non_macos(self):
+        manager = DesktopManager(
+            _switcher(), syncer=MagicMock(), profile_store=MagicMock()
+        )
+        with patch("claude_swap.desktop.sys.platform", "linux"), \
+             pytest.raises(DesktopError, match="macOS-only"):
+            manager.run("2")

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -224,6 +224,7 @@ class TestListJson:
         assert acct1["active"] is True
         assert acct1["usageStatus"] == "ok"
         assert acct1["authMethod"] == "setup_token"
+        assert acct1["authMethods"] == ["setup_token"]
         assert acct1["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
 
     def test_list_payload_includes_alias(

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -197,7 +197,9 @@ class TestListJson:
         sample_sequence_data: dict, capsys,
     ):
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
-        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        active_creds = json.dumps(
+            {"claudeAiOauth": {"accessToken": "sk-ant-oat01-active"}}
+        )
         backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
         usage = {
             "five_hour": {"pct": 10.0, "resets_at": "2026-01-01T00:00:00Z",
@@ -221,6 +223,7 @@ class TestListJson:
         acct1 = next(a for a in payload["accounts"] if a["number"] == 1)
         assert acct1["active"] is True
         assert acct1["usageStatus"] == "ok"
+        assert acct1["authMethod"] == "setup_token"
         assert acct1["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
 
     def test_list_payload_includes_alias(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from claude_swap.exceptions import TransferError
+from claude_swap.credentials import AUTH_API_KEY, AUTH_SETUP_TOKEN
 from claude_swap.models import Platform
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.transfer import export_accounts, import_accounts
@@ -132,6 +133,39 @@ class TestRoundTrip:
                 # Credentials JSON parses and contains the marker
                 creds_text = dst._read_account_credentials("1", "alice@example.com")
                 assert json.loads(creds_text)["_marker"] == "alice@example.com"
+
+    def test_multiple_auth_methods_round_trip_as_one_account(self, temp_home: Path):
+        api_key = "sk-ant-api03-" + "a1b2c3d4e5" * 4
+        src = _linux_switcher(temp_home)
+        src.add_account_from_token(
+            "sk-ant-oat01-setup", email="alice@example.com"
+        )
+        src.add_account_from_token(api_key, email="alice@example.com")
+
+        out_file = temp_home / "multi-method.cswap"
+        export_accounts(src, str(out_file))
+        exported = json.loads(out_file.read_text())["accounts"]
+        assert len(exported) == 1
+        assert [item["method"] for item in exported[0]["authMethods"]] == [
+            AUTH_SETUP_TOKEN,
+            AUTH_API_KEY,
+        ]
+
+        dst_home = temp_home.parent / "dst-multi"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                import_accounts(dst, str(out_file))
+                record = dst._get_sequence_data()["accounts"]["1"]
+                assert record["authMethods"] == [AUTH_SETUP_TOKEN, AUTH_API_KEY]
+                assert record["preferredAuthMethod"] == AUTH_API_KEY
+                assert dst._read_auth_method_credentials(
+                    "1", "alice@example.com", "", AUTH_SETUP_TOKEN
+                )
+                assert dst._read_auth_method_credentials(
+                    "1", "alice@example.com", "", AUTH_API_KEY
+                ) == api_key
 
     def test_active_state_carried_but_not_applied(self, temp_home: Path):
         src = _linux_switcher(temp_home)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -638,6 +638,20 @@ class TestMiniAccountText:
         ).plain
         assert "API key" in mini_account_text(inactive, time.time()).plain
 
+    def test_multiple_auth_methods_are_grouped_on_one_account(self):
+        from claude_swap.tui.widgets import account_card_text
+
+        acc = make_account(1, auth_method="api_key")
+        acc = dataclasses.replace(
+            acc,
+            auth_methods=("browser_oauth", "setup_token", "api_key"),
+        )
+        text = account_card_text(acc, 100).plain
+        assert text.count("Claude Code") == 3
+        assert "browser OAuth" in text
+        assert "one-year setup token" in text
+        assert "API key  preferred" in text
+
     def test_seven_day_ahead_of_pace_marker(self):
         from claude_swap.tui.widgets import mini_account_text
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -77,6 +77,7 @@ def make_account(
     active: bool = False,
     switchable: bool = True,
     kind: str = "oauth",
+    auth_method: str = "browser_oauth",
     entry: UsageEntry | None = None,
     email: str | None = None,
     alias: str = "",
@@ -91,6 +92,7 @@ def make_account(
         kind=kind,
         switchable=switchable,
         usage=entry if entry is not None else make_entry(),
+        auth_method=auth_method,
         alias=alias,
         disabled=disabled,
     )
@@ -626,6 +628,16 @@ class TestUsageRows:
 
 
 class TestMiniAccountText:
+    def test_auth_method_is_visible_without_repeating_usage(self):
+        from claude_swap.tui.widgets import account_card_text, mini_account_text
+
+        active = make_account(1, active=True, auth_method="setup_token")
+        inactive = make_account(2, auth_method="api_key")
+        assert "Claude Code  one-year setup token" in account_card_text(
+            active, 100
+        ).plain
+        assert "API key" in mini_account_text(inactive, time.time()).plain
+
     def test_seven_day_ahead_of_pace_marker(self):
         from claude_swap.tui.widgets import mini_account_text
 
@@ -1709,4 +1721,3 @@ class TestThemeWiring:
             await menu_select(pilot, "theme:light")
             assert app._theme_name == "light"
             assert app.theme == "cswap-light"
-


### PR DESCRIPTION
## Summary

- Store multiple CLI login methods under one account instead of duplicating the account.
- Show usage once per account and show each saved login with its own scope, Remote Control support, and expiry.
- Preserve the current default when another login method is added.
- Add explicit method selection and `--require-capability remote-control`, which selects browser OAuth or fails before changing credentials.

## Why

One Claude account can have browser OAuth, setup-token, and API-key credentials. They share account usage but have different capabilities and lifecycles, so the account should own several selectable login methods.

## Stack

This builds on #230 and #231. It remains closed until those smaller foundational changes land.

## Validation

- 1,865 tests passed and 3 skipped, excluding five macOS locked-console cases and one pre-existing filesystem permission case.
- Focused auth, CLI, JSON, and TUI suite: 282 passed.
- P0 autoreview: clean.