### PR TITLE
fix(credentials): a failed strict clear must not destroy the material it aborted on

### DIFF
--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -963,10 +963,12 @@ class CredentialStore:
         never serve them. The best-effort variant remains right for
         post-commit cleanup, where a failure only leaks an unreferenced file.
         """
-        # Best-effort sweep first: same cruft cleanup (legacy alias, .prev,
-        # quiet Keychain) a normal delete performs.
-        self._delete_account_credentials(account_num, email)
-        # Then assure the served key really is gone, propagating failures.
+        # Strict deletes of the served backends first, propagating failures: a
+        # clear that is going to fail must fail *before* the key's material is
+        # destroyed, so an aborted transaction leaves the original readable.
+        # (The best-effort sweep used to run first, and on macOS it deleted
+        # the Keychain copy with errors swallowed — a later file failure then
+        # aborted a clear that had already half-destroyed the key.)
         # Unconditional unlink: exists() returns False on an inaccessible
         # directory, which would fail open here — missing is fine
         # (missing_ok), permission/I/O errors must abort the commit.
@@ -979,6 +981,9 @@ class CredentialStore:
                 f"Could not clear stored credentials for slot {account_num} "
                 f"({email}) — aborting before commit: {e}"
             ) from e
+        # Then the same cruft cleanup (legacy alias, .prev, quiet Keychain) a
+        # normal delete performs — pure cleanup once the served key is gone.
+        self._delete_account_credentials(account_num, email)
         # Final belt: catches any backend view the deletes above missed.
         if self._read_account_credentials(account_num, email):
             raise CredentialError(

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1297,6 +1297,7 @@ class ClaudeAccountSwitcher:
 
         src_dir = self._session_dir(num_src, email)
         dst_dir = self._session_dir(target, email)
+        wrote_target = False
         try:
             # Move the session profile to the account's new slot key, best
             # effort: a profile that cannot be moved is pruned below with the
@@ -1316,11 +1317,19 @@ class ClaudeAccountSwitcher:
             # must not adopt stale material leaked under the target key by an
             # earlier crash. The old key is cleared only after the commit
             # below, so the records never point at missing material.
+            # ``wrote_target`` gates the failure cleanup: only a write can
+            # leave half-written strays. A failed *clear* must leave the
+            # target key exactly as fail-closed found it — cleanup after it
+            # would re-run the delete best-effort, destroying on one backend
+            # (Keychain) the pre-existing material whose failed removal on
+            # the other (file) just aborted the move.
             if creds:
+                wrote_target = True
                 self._write_account_credentials(target, email, creds)
             else:
                 self._delete_account_credentials_strict(target, email)
             if config:
+                wrote_target = True
                 self._write_account_config(target, email, config)
             else:
                 self._delete_config_backup(target, email)
@@ -1343,10 +1352,12 @@ class ClaudeAccountSwitcher:
         except BaseException:
             # Pre-commit failure: the records still point at num_src and its
             # keys are untouched — drop any strays written under the target
-            # key and put the session profile back, best effort.
+            # key (only when a write ran; see ``wrote_target`` above) and put
+            # the session profile back, best effort.
             try:
-                self._delete_account_credentials(target, email)
-                self._delete_config_backup(target, email)
+                if wrote_target:
+                    self._delete_account_credentials(target, email)
+                    self._delete_config_backup(target, email)
                 if dst_dir.exists() and not src_dir.exists():
                     os.replace(dst_dir, src_dir)
             except Exception as e:


### PR DESCRIPTION
On macOS, an aborted swap/move can leave a slot's credential half-destroyed. Two causes, same shape:

1. `_delete_account_credentials_strict` runs the best-effort sweep (which deletes the Keychain copy with errors swallowed) *before* the strict, error-propagating deletes. So when the file-side delete fails, the operation aborts — but the Keychain copy is already gone. The fix flips the order: strict deletes first, cruft sweep only after they succeed.

2. `_relocate_locked`'s pre-commit failure cleanup always deleted "strays written under the target key", even when the failure happened in the clear step before anything was written — destroying pre-existing target material on the Keychain backend that the failed clear had left intact on the file backend. Cleanup is now gated on a write having actually started (`wrote_target`).

No new tests needed — the existing suite already pins the correct behavior and fails on current main, but only on macOS (the Keychain backend is what gets destroyed, so Linux CI stays green):

```
pytest tests/test_move_accounts.py -k fails_closed_on_unreadable_dir
# AssertionError: assert '' == 'stale-foreign'
```

Full suite green on macOS with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)