### PR TITLE
feat(auth): group login methods by account

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ cswap list --json                   # all accounts with usage/quota
 cswap status --json                 # current active account
 cswap switch --strategy best --json # switch, then report the result
 cswap switch 2 --json
+cswap switch 2 --auth-method setup-token
+cswap switch 2 --require-capability remote-control
 ```
 
 <details>
@@ -298,7 +300,18 @@ cswap switch 2 --json
   "schemaVersion": 1,
   "activeAccountNumber": 2,
   "accounts": [
-    { "number": 2, "email": "you@example.com", "active": true, "usageStatus": "ok",
+    { "number": 2, "email": "you@example.com", "active": true,
+      "authMethod": "setup_token", "authScope": "inference_only",
+      "supportsRemoteControl": false, "authExpiresAt": "2027-01-02T03:04:05Z",
+      "authMethods": ["browser_oauth", "setup_token"],
+      "authMethodDetails": [
+        { "method": "browser_oauth", "scope": "full",
+          "supportsRemoteControl": true },
+        { "method": "setup_token", "scope": "inference_only",
+          "supportsRemoteControl": false, "expiresAt": "2027-01-02T03:04:05Z",
+          "default": true }
+      ],
+      "usageStatus": "ok",
       "usage": { "fiveHour": { "pct": 25.0, "resetsAt": "2026-06-22T23:29:59Z" },
                  "sevenDay": { "pct": 16.0, "resetsAt": "2026-06-26T17:59:59Z" } } }
   ]
@@ -309,7 +322,22 @@ Every payload carries a `schemaVersion` (currently `1`); on a handled error stdo
 
 Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
 
-An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
+Each account row carries additive authentication metadata. `authMethod` is
+`browser_oauth`, `setup_token`, `api_key`, or `unknown`; `authScope` is `full`,
+`inference_only`, or `unknown`; and `supportsRemoteControl` reports whether the
+login can start Remote Control. Setup-token rows also carry their actual
+`authExpiresAt` when the credential includes one. Browser OAuth is the full
+Claude Code login. Setup tokens and API keys are inference-only and cannot start
+Remote Control. `authMethods` lists every stored login, while
+`authMethodDetails` reports the capability and expiry of each one. The human
+list and TUI group these logins under one account and show usage once. Use
+`cswap switch N --auth-method setup-token` (or `browser-oauth` / `api-key`) to
+choose a specific default. Adding another login method does not silently change
+the current default. Use `--require-capability remote-control` when a command
+needs Remote Control; cswap selects browser OAuth or fails before changing the
+active login with instructions to run `claude auth login`. An account row also
+carries an additive `alias` field once one is set with `cswap alias` (e.g.
+`"alias": "dev"`); accounts without one simply omit the key.
 
 Weekly windows (`sevenDay` and per-model `scoped` entries — never `fiveHour`) additively carry pace fields once the week is ~a day old: `expectedPct` (where usage would sit if spread evenly across the week) and `aheadOfPace` (`true` when meaningfully above that — the same signal the human views show as an `(ahead)`/`(ahead of pace)` marker). `projectedExhaustionAt`/`willLastToReset` extrapolate the current rate into an ETA to 100% and a yes/no "will it last to the reset"; they stay `--json`-only since a linear projection is too rough to present as fact in the UI.
 
@@ -334,12 +362,16 @@ cswap add-token --email user@example.com     # optional label override
 
 `--email` is optional; omitted values use `setup-token-{slot}@token.local`
 (or `api-key-{slot}@token.local` for API keys). No Anthropic API calls are made.
+When that email already exists, cswap adds or refreshes the login method under
+the existing account instead of creating a duplicate slot. Browser OAuth,
+setup-token, and API-key credentials can therefore coexist under one account.
+The newest method becomes preferred. Export and import carry every method.
 
 **API-key accounts.** An `sk-ant-api...` value registers a managed API-key account
 (the kind Claude Code uses after `/login` with a key) rather than an OAuth
-setup-token. It switches like any other account; since API keys have no subscription
-quota, they show no usage and the usage-aware `switch` strategies never skip them as
-rate-limited.
+setup-token. It switches like any other login. A standalone API-key account has
+no subscription quota to fetch. If the same account also has OAuth, cswap uses
+that OAuth child for the single account-level usage measurement.
 
 ## Uninstall
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -944,6 +944,8 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s switch --strategy best           # pick the account with most quota left
   %(prog)s switch --strategy next-available # rotate, skipping rate-limited accounts
   %(prog)s switch user@example.com
+  %(prog)s switch user@example.com --auth-method setup-token
+  %(prog)s switch user@example.com --require-capability remote-control
   %(prog)s list --token-status
   %(prog)s list --json
   %(prog)s add --slot 3                      # add to a specific slot
@@ -1032,6 +1034,22 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             "Overwrite existing accounts during import; with 'switch <num|email>', "
             "activate the stored credentials without backing up the current "
             "login first"
+        ),
+    )
+    parser.add_argument(
+        "--auth-method",
+        choices=["browser-oauth", "setup-token", "api-key"],
+        help=(
+            "Claude Code login method to activate with "
+            "'switch <num|email>'; defaults to the account's preferred method"
+        ),
+    )
+    parser.add_argument(
+        "--require-capability",
+        choices=["remote-control"],
+        help=(
+            "Select a login that supports this Claude Code feature with "
+            "'switch <num|email>'; fails before switching when none is stored"
         ),
     )
     parser.add_argument(
@@ -1194,6 +1212,14 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.force and not (args.import_ or args.switch_to):
         parser.error("--force can only be used with 'import' or 'switch <num|email>'")
 
+    if args.auth_method is not None and not args.switch_to:
+        parser.error("--auth-method can only be used with 'switch <num|email>'")
+
+    if args.require_capability is not None and not args.switch_to:
+        parser.error(
+            "--require-capability can only be used with 'switch <num|email>'"
+        )
+
     if args.full and not args.export:
         parser.error("--full can only be used with 'export'")
 
@@ -1266,9 +1292,12 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
                 payload["models"] = list(models)
                 payload["modelSource"] = model_source
         elif args.switch_to:
-            payload = switcher.switch_to(
-                args.switch_to, json_output=args.json, force=args.force
-            )
+            kwargs = {"json_output": args.json, "force": args.force}
+            if args.auth_method is not None:
+                kwargs["auth_method"] = args.auth_method
+            if args.require_capability is not None:
+                kwargs["required_capability"] = args.require_capability
+            payload = switcher.switch_to(args.switch_to, **kwargs)
         elif args.status:
             payload = switcher.status(json_output=args.json)
         elif args.purge:

--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -24,6 +24,7 @@ import os
 import sys
 import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple, Protocol
 
@@ -111,6 +112,137 @@ def _credential_object(credentials: str | None) -> dict | None:
     except (json.JSONDecodeError, TypeError):
         return None
     return data if isinstance(data, dict) else None
+
+
+AUTH_BROWSER_OAUTH = "browser_oauth"
+AUTH_SETUP_TOKEN = "setup_token"
+AUTH_API_KEY = "api_key"
+AUTH_UNKNOWN = "unknown"
+
+AUTH_SCOPE_FULL = "full"
+AUTH_SCOPE_INFERENCE_ONLY = "inference_only"
+AUTH_SCOPE_UNKNOWN = "unknown"
+
+AUTH_CAPABILITY_REMOTE_CONTROL = "remote_control"
+
+AUTH_METHOD_LABELS = {
+    AUTH_BROWSER_OAUTH: "browser OAuth",
+    AUTH_SETUP_TOKEN: "setup token",
+    AUTH_API_KEY: "API key",
+    AUTH_UNKNOWN: "unknown login",
+}
+
+AUTH_SCOPE_LABELS = {
+    AUTH_SCOPE_FULL: "full access",
+    AUTH_SCOPE_INFERENCE_ONLY: "inference only",
+    AUTH_SCOPE_UNKNOWN: "scope unknown",
+}
+
+
+class AuthMetadata(NamedTuple):
+    """Safe display metadata derived from one credential value."""
+
+    method: str
+    scope: str
+    supports_remote_control: bool | None
+    expires_at: str | None
+
+
+def classify_auth_method(credentials: str | None) -> str:
+    """Classify one stored Claude Code credential without exposing its value.
+
+    Browser OAuth carries a refresh token. A setup token is a standalone
+    ``sk-ant-oat`` access token with no refresh token. Managed API keys use the
+    raw ``sk-ant-api`` form. Anything else stays explicitly unknown rather than
+    being guessed from account metadata.
+    """
+    if looks_like_api_key(credentials):
+        return AUTH_API_KEY
+    data = _credential_object(credentials)
+    if data is None:
+        return AUTH_UNKNOWN
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return AUTH_UNKNOWN
+    if oauth.get("refreshToken"):
+        return AUTH_BROWSER_OAUTH
+    access_token = oauth.get("accessToken")
+    if isinstance(access_token, str) and access_token.startswith("sk-ant-oat"):
+        return AUTH_SETUP_TOKEN
+    return AUTH_UNKNOWN
+
+
+def auth_method_label(method: str) -> str:
+    """Return the human label for a classified authentication method."""
+    return AUTH_METHOD_LABELS.get(method, AUTH_METHOD_LABELS[AUTH_UNKNOWN])
+
+
+def auth_scope_label(scope: str) -> str:
+    """Return the human label for an authentication scope."""
+    return AUTH_SCOPE_LABELS.get(scope, AUTH_SCOPE_LABELS[AUTH_SCOPE_UNKNOWN])
+
+
+def auth_method_supports_capability(method: str, capability: str) -> bool:
+    """Whether a login method can satisfy one explicit Claude Code feature."""
+    if capability == AUTH_CAPABILITY_REMOTE_CONTROL:
+        return method == AUTH_BROWSER_OAUTH
+    return False
+
+
+def auth_metadata(credentials: str | None) -> AuthMetadata:
+    """Describe method, scope, capabilities, and stable expiry for display.
+
+    Browser OAuth is Claude Code's full login. Setup tokens and managed API
+    keys are inference-only and cannot start Remote Control. Browser OAuth's
+    access-token expiry is intentionally hidden because its refresh token
+    renews that value; a setup token has no refresh token, so its actual expiry
+    is useful operator information.
+    """
+    method = classify_auth_method(credentials)
+    scope = {
+        AUTH_BROWSER_OAUTH: AUTH_SCOPE_FULL,
+        AUTH_SETUP_TOKEN: AUTH_SCOPE_INFERENCE_ONLY,
+        AUTH_API_KEY: AUTH_SCOPE_INFERENCE_ONLY,
+    }.get(method, AUTH_SCOPE_UNKNOWN)
+    supports_remote_control = {
+        AUTH_BROWSER_OAUTH: True,
+        AUTH_SETUP_TOKEN: False,
+        AUTH_API_KEY: False,
+    }.get(method)
+    expires_at = None
+    if method == AUTH_SETUP_TOKEN:
+        data = _credential_object(credentials)
+        oauth = data.get("claudeAiOauth") if isinstance(data, dict) else None
+        value = oauth.get("expiresAt") if isinstance(oauth, dict) else None
+        if isinstance(value, (int, float)) and value > 0:
+            try:
+                expires_at = (
+                    datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+                    .isoformat(timespec="seconds")
+                    .replace("+00:00", "Z")
+                )
+            except (OverflowError, OSError, ValueError):
+                expires_at = None
+    return AuthMetadata(method, scope, supports_remote_control, expires_at)
+
+
+def auth_metadata_summary(
+    metadata: AuthMetadata, *, include_remote_control: bool = True,
+    include_expiry: bool = True,
+) -> str:
+    """Return one concise human line for authentication metadata."""
+    parts = [
+        auth_method_label(metadata.method),
+        auth_scope_label(metadata.scope),
+    ]
+    if include_remote_control:
+        if metadata.supports_remote_control is True:
+            parts.append("Remote Control")
+        elif metadata.supports_remote_control is False:
+            parts.append("no Remote Control")
+    if include_expiry and metadata.expires_at:
+        parts.append(f"expires {metadata.expires_at[:10]}")
+    return " · ".join(parts)
 
 
 # The credential object's siblings of claudeAiOauth are not uniformly owned:

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -219,6 +219,12 @@ def account_row(
     usage_fetched_at: float | None = None,
     usage_age_s: float | None = None,
     last_good_usage: dict | None = None,
+    auth_method: str | None = None,
+    auth_methods: list[str] | None = None,
+    auth_scope: str | None = None,
+    auth_supports_remote_control: bool | None = None,
+    auth_expires_at: str | None = None,
+    auth_method_details: list[dict] | None = None,
     alias: str = "",
     disabled: bool = False,
 ) -> dict:
@@ -234,6 +240,17 @@ def account_row(
         "usageStatus": status,
         "usage": usage,
     }
+    if auth_method is not None:
+        row["authMethod"] = auth_method
+    if auth_methods is not None:
+        row["authMethods"] = auth_methods
+    if auth_scope is not None:
+        row["authScope"] = auth_scope
+        row["supportsRemoteControl"] = auth_supports_remote_control
+    if auth_expires_at is not None:
+        row["authExpiresAt"] = auth_expires_at
+    if auth_method_details is not None:
+        row["authMethodDetails"] = auth_method_details
     if alias:
         row["alias"] = alias
     # Additive field: present only when the slot is held out of rotation, so

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -121,6 +121,17 @@ class AccountInfo:
 
 
 @dataclass(frozen=True)
+class AuthMethodSnapshot:
+    """Safe display metadata for one stored Claude Code login method."""
+
+    method: str
+    scope: str
+    supports_remote_control: bool | None
+    expires_at: str | None
+    is_default: bool = False
+
+
+@dataclass(frozen=True)
 class AccountSnapshot:
     """One managed account as seen by interactive UIs (the TUI).
 
@@ -138,6 +149,12 @@ class AccountSnapshot:
     kind: str  # "oauth" | "api_key"
     switchable: bool
     usage: UsageEntry
+    auth_method: str = "unknown"
+    auth_methods: tuple[str, ...] = ()
+    auth_scope: str = "unknown"
+    auth_supports_remote_control: bool | None = None
+    auth_expires_at: str | None = None
+    auth_method_details: tuple[AuthMethodSnapshot, ...] = ()
     alias: str = ""
     disabled: bool = False  # held out of auto-rotation (still a valid explicit target)
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -40,10 +41,21 @@ from claude_swap.json_output import (
     usage_freshness_fields,
 )
 from claude_swap.credentials import (  # noqa: F401  (constants re-exported for migrations/tests)
+    AUTH_API_KEY,
+    AUTH_BROWSER_OAUTH,
+    AUTH_CAPABILITY_REMOTE_CONTROL,
+    AUTH_METHOD_LABELS,
+    AUTH_SETUP_TOKEN,
+    AUTH_UNKNOWN,
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     SECURITY_SERVICE,
     ActiveCredentials,
     CredentialStore,
+    auth_method_label,
+    auth_method_supports_capability,
+    auth_metadata,
+    auth_metadata_summary,
+    classify_auth_method,
     looks_like_api_key,
     merge_shared_credential_fields,
     shared_credential_fields,
@@ -53,6 +65,7 @@ from claude_swap.logging_config import setup_logging
 from claude_swap.models import (
     AccountSnapshot,
     AccountsSnapshot,
+    AuthMethodSnapshot,
     Platform,
     SwitchTransaction,
     get_timestamp,
@@ -333,6 +346,11 @@ class ClaudeAccountSwitcher:
         self._probe_verdicts: dict[
             tuple[str, str, str, str, str, str], bool
         ] = {}
+        # Populated by _build_accounts_info. An active account may use an API
+        # key while its account-level quota is fetched through a stored OAuth
+        # child. Those credentials must follow the inactive, backup-safe fetch
+        # path so a refresh never replaces the live API-key login.
+        self._usage_backup_slots: set[str] = set()
 
         # Run any pending one-time data migrations (e.g. relocating Windows
         # backup credentials out of Credential Manager into files). Imported
@@ -612,7 +630,253 @@ class ClaudeAccountSwitcher:
             self._invalidate_session_credentials(account_num, email)
 
     def _read_account_credentials(self, account_num: str, email: str) -> str:
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(str(account_num), {})
+        raw = record.get("authMethods")
+        preferred = record.get("preferredAuthMethod")
+        if isinstance(raw, list) and preferred in raw:
+            key = self._auth_method_storage_key(
+                email,
+                record.get("organizationUuid", "") or "",
+                preferred,
+            )
+            credentials = self._store._read_account_credentials(key, email)
+            if credentials:
+                return credentials
         return self._store._read_account_credentials(account_num, email)
+
+    @staticmethod
+    def _auth_method_storage_key(
+        email: str, organization_uuid: str, auth_method: str
+    ) -> str:
+        """Stable, non-secret backup key for one account login method.
+
+        Method backups must follow an account through slot moves and swaps, so
+        they are keyed by the account identity rather than its mutable slot.
+        The email remains part of the existing backup key for diagnostics; the
+        digest prevents organization UUIDs and separators from entering file or
+        Keychain account names.
+        """
+        identity = f"{email}\0{organization_uuid or ''}".encode("utf-8")
+        digest = hashlib.sha256(identity).hexdigest()[:20]
+        return f"auth-{digest}-{auth_method}"
+
+    def _account_auth_methods(
+        self,
+        account_num: str,
+        *,
+        credentials: str | None = None,
+        data: dict | None = None,
+    ) -> tuple[str, ...]:
+        """Return stored login methods, including legacy single-method slots."""
+        data = data if data is not None else (self._get_sequence_data() or {})
+        record = data.get("accounts", {}).get(str(account_num), {})
+        raw = record.get("authMethods")
+        if isinstance(raw, list):
+            methods = tuple(
+                method for method in AUTH_METHOD_LABELS
+                if method != AUTH_UNKNOWN and method in raw
+            )
+            if methods:
+                return methods
+        if credentials is None:
+            credentials = self._read_account_credentials(
+                str(account_num), record.get("email", "")
+            )
+        method = classify_auth_method(credentials)
+        return (method,) if method != AUTH_UNKNOWN else ()
+
+    def _preferred_auth_method(
+        self,
+        account_num: str,
+        *,
+        credentials: str | None = None,
+        data: dict | None = None,
+    ) -> str:
+        """Return the account's default Claude Code login method."""
+        data = data if data is not None else (self._get_sequence_data() or {})
+        record = data.get("accounts", {}).get(str(account_num), {})
+        methods = self._account_auth_methods(
+            account_num, credentials=credentials, data=data
+        )
+        preferred = record.get("preferredAuthMethod")
+        if preferred in methods:
+            return preferred
+        return methods[0] if methods else AUTH_UNKNOWN
+
+    def _auth_method_snapshots(
+        self,
+        account_num: str,
+        email: str,
+        organization_uuid: str,
+        *,
+        credentials: str | None = None,
+        data: dict | None = None,
+    ) -> tuple[AuthMethodSnapshot, ...]:
+        """Return safe display metadata for every login stored by an account."""
+        data = data if data is not None else (self._get_sequence_data() or {})
+        methods = self._account_auth_methods(
+            account_num, credentials=credentials, data=data
+        )
+        default = self._preferred_auth_method(
+            account_num, credentials=credentials, data=data
+        )
+        details = []
+        for method in methods:
+            if classify_auth_method(credentials) == method:
+                method_credentials = credentials or ""
+            else:
+                method_credentials = self._read_auth_method_credentials(
+                    account_num, email, organization_uuid, method
+                )
+            metadata = auth_metadata(method_credentials)
+            details.append(
+                AuthMethodSnapshot(
+                    method=method,
+                    scope=metadata.scope,
+                    supports_remote_control=metadata.supports_remote_control,
+                    expires_at=metadata.expires_at,
+                    is_default=method == default,
+                )
+            )
+        return tuple(details)
+
+    def _read_auth_method_credentials(
+        self, account_num: str, email: str, organization_uuid: str, auth_method: str
+    ) -> str:
+        """Read one child login method, with legacy preferred-backup fallback."""
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(str(account_num), {})
+        raw = record.get("authMethods")
+        if not isinstance(raw, list):
+            primary = self._read_account_credentials(account_num, email)
+            if classify_auth_method(primary) in {auth_method, AUTH_UNKNOWN}:
+                return primary
+            return ""
+        primary = self._store._read_account_credentials(account_num, email)
+        methods = self._account_auth_methods(
+            account_num, credentials=primary, data=data
+        )
+        if auth_method not in methods:
+            return ""
+        key = self._auth_method_storage_key(email, organization_uuid, auth_method)
+        credentials = self._store._read_account_credentials(key, email)
+        if credentials:
+            return credentials
+        preferred = self._preferred_auth_method(
+            account_num, credentials=primary, data=data
+        )
+        if auth_method == preferred:
+            primary = self._store._read_account_credentials(account_num, email)
+            if classify_auth_method(primary) == auth_method:
+                return primary
+        return ""
+
+    def _write_auth_method_secret(
+        self, email: str, organization_uuid: str, auth_method: str, credentials: str
+    ) -> None:
+        """Write one child login secret without slot-session side effects."""
+        key = self._auth_method_storage_key(email, organization_uuid, auth_method)
+        self._store._write_account_credentials(key, email, credentials)
+
+    def _delete_auth_method_secrets(self, record: dict) -> None:
+        email = record.get("email", "")
+        org_uuid = record.get("organizationUuid", "") or ""
+        raw = record.get("authMethods")
+        if not isinstance(raw, list):
+            return
+        for method in raw:
+            if method in AUTH_METHOD_LABELS and method != AUTH_UNKNOWN:
+                key = self._auth_method_storage_key(email, org_uuid, method)
+                self._store._delete_account_credentials(key, email)
+
+    def _set_account_auth_methods(
+        self,
+        data: dict,
+        account_num: str,
+        methods: list[str],
+        preferred: str,
+    ) -> None:
+        """Persist a canonical method list and its preferred child."""
+        ordered = [
+            method for method in AUTH_METHOD_LABELS
+            if method != AUTH_UNKNOWN and method in methods
+        ]
+        if preferred not in ordered:
+            raise ValidationError(f"Unknown login method: {preferred}")
+        record = data["accounts"][str(account_num)]
+        record["authMethods"] = ordered
+        record["preferredAuthMethod"] = preferred
+        if preferred == AUTH_API_KEY:
+            record["kind"] = "api_key"
+        else:
+            record.pop("kind", None)
+
+    def _store_account_auth_method(
+        self,
+        data: dict,
+        account_num: str,
+        credentials: str,
+        *,
+        make_default: bool = False,
+        auth_method: str | None = None,
+    ) -> str:
+        """Add or refresh one child login method for an existing account.
+
+        The first time an account gains a second method, its legacy primary
+        backup is copied into child storage before the new secret is written.
+        The primary backup remains a compatibility pointer to the preferred
+        method, so existing switch, usage, session, and auto-rotation paths keep
+        one account-level credential source. Adding or refreshing a method keeps
+        the current default unless ``make_default`` is explicit.
+        """
+        record = data["accounts"][str(account_num)]
+        email = record.get("email", "")
+        org_uuid = record.get("organizationUuid", "") or ""
+        primary = self._read_account_credentials(str(account_num), email)
+        methods = list(
+            self._account_auth_methods(
+                account_num, credentials=primary, data=data
+            )
+        )
+        if not isinstance(record.get("authMethods"), list):
+            old_method = classify_auth_method(primary)
+            if old_method != AUTH_UNKNOWN and primary:
+                self._write_auth_method_secret(
+                    email, org_uuid, old_method, primary
+                )
+
+        method = auth_method or classify_auth_method(credentials)
+        if method == AUTH_UNKNOWN:
+            raise ValidationError("Unsupported Claude Code login credential")
+        self._write_auth_method_secret(email, org_uuid, method, credentials)
+        if method not in methods:
+            methods.append(method)
+
+        current_preferred = self._preferred_auth_method(
+            account_num, credentials=primary, data=data
+        )
+        selected = (
+            method
+            if make_default or current_preferred == AUTH_UNKNOWN
+            else current_preferred
+        )
+        selected_credentials = (
+            credentials
+            if selected == method
+            else self._read_auth_method_credentials(
+                account_num, email, org_uuid, selected
+            )
+        )
+        if not selected_credentials:
+            raise CredentialReadError(
+                f"No stored credentials for {auth_method_label(selected)}"
+            )
+        self._write_account_credentials(
+            str(account_num), email, selected_credentials
+        )
+        self._set_account_auth_methods(data, str(account_num), methods, selected)
+        return method
 
     def _write_account_credentials(
         self, account_num: str, email: str, credentials: str
@@ -623,6 +887,18 @@ class ClaudeAccountSwitcher:
         so ``_post_backup_write`` (the session-invalidation chokepoint) runs exactly
         once and only after a successful write.
         """
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(str(account_num), {})
+        methods = record.get("authMethods")
+        if isinstance(methods, list):
+            method = classify_auth_method(credentials)
+            if method in methods:
+                self._write_auth_method_secret(
+                    email,
+                    record.get("organizationUuid", "") or "",
+                    method,
+                    credentials,
+                )
         self._store._write_account_credentials(account_num, email, credentials)
         self._post_backup_write(account_num, email)
 
@@ -1484,6 +1760,27 @@ class ClaudeAccountSwitcher:
             n = str(num)
             if is_active:
                 active_number = n
+            preferred = self._preferred_auth_method(
+                n, credentials=_creds, data=seq_data
+            )
+            details = self._auth_method_snapshots(
+                n,
+                email,
+                org_uuid,
+                credentials=_creds,
+                data=seq_data,
+            )
+            fallback = auth_metadata(_creds)
+            selected = next(
+                (detail for detail in details if detail.method == preferred),
+                AuthMethodSnapshot(
+                    fallback.method,
+                    fallback.scope,
+                    fallback.supports_remote_control,
+                    fallback.expires_at,
+                    True,
+                ),
+            )
             accounts.append(
                 AccountSnapshot(
                     number=n,
@@ -1494,6 +1791,13 @@ class ClaudeAccountSwitcher:
                     kind=self._account_kind(n),
                     switchable=self._account_is_switchable(n),
                     usage=entries[n],
+                    auth_method=preferred,
+                    auth_methods=tuple(detail.method for detail in details)
+                    or (selected.method,),
+                    auth_scope=selected.scope,
+                    auth_supports_remote_control=selected.supports_remote_control,
+                    auth_expires_at=selected.expires_at,
+                    auth_method_details=details or (selected,),
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, n),
                 )
@@ -2026,34 +2330,6 @@ class ClaudeAccountSwitcher:
                 "'cswap --add-token sk-ant-api...' instead of --add-account."
             )
 
-    def _reject_cross_kind_collision(self, email: str, is_api_key: bool) -> None:
-        """Reject registering a token whose (email, personal-org) already exists as
-        the *other* kind.
-
-        Identity is matched on ``(email, organizationUuid)`` only, so two slots
-        sharing an email across kinds (one OAuth, one API key) could not be told
-        apart at switch time. Rather than thread ``kind`` through the whole identity
-        system, refuse the collision and point the user at a distinct ``--email``.
-        The default ``…@token.local`` labels never collide; this only guards a forced
-        ``--email``.
-        """
-        data = self._get_sequence_data()
-        if not data:
-            return
-        slot = self._find_account_slot(data, email, "")
-        if slot is None:
-            return
-        existing_kind = self._account_kind(slot)
-        new_kind = "api_key" if is_api_key else "oauth"
-        if existing_kind != new_kind:
-            existing_label = "API-key" if existing_kind == "api_key" else "OAuth"
-            new_label = "API-key" if is_api_key else "OAuth"
-            raise ValidationError(
-                f"'{email}' already exists as an {existing_label} account "
-                f"(slot {slot}); cannot add it as an {new_label} account. "
-                f"Pass a distinct --email."
-            )
-
     @staticmethod
     def _get_display_tag(email: str, org_name: str, org_uuid: str) -> str:
         """Return display tag for an account's org context."""
@@ -2258,7 +2534,12 @@ class ClaudeAccountSwitcher:
             except PermissionError:
                 raise ConfigError("Permission denied reading Claude config")
 
-            self._write_account_credentials(account_num, current_email, current_creds)
+            self._store_account_auth_method(
+                seq,
+                account_num,
+                current_creds,
+                auth_method=AUTH_BROWSER_OAUTH,
+            )
             self._write_account_config(account_num, current_email, current_config)
             self._usage_store.clear_dead_token(
                 [account_num], {account_num: (current_email, current_org_uuid)}
@@ -2377,6 +2658,10 @@ class ClaudeAccountSwitcher:
         # Now safe to perform destructive cleanup (new account data is in memory)
         if displace_slot:
             d_num, d_email, d_org = displace_slot
+            displaced = (self._get_sequence_data() or {}).get("accounts", {}).get(
+                d_num, {}
+            )
+            self._delete_auth_method_secrets(displaced)
             self._delete_account_files(d_num, d_email)
             data = self._get_sequence_data()
             if int(d_num) in data["sequence"]:
@@ -2394,13 +2679,6 @@ class ClaudeAccountSwitcher:
             del data["accounts"][migrate_from]
             self._write_json(self.sequence_file, data)
 
-        # Store backups
-        self._write_account_credentials(account_num, current_email, current_creds)
-        self._write_account_config(account_num, current_email, current_config)
-        self._usage_store.clear_dead_token(
-            [account_num], {account_num: (current_email, organization_uuid)}
-        )
-
         # Update sequence.json
         data = self._get_sequence_data()
         data["accounts"][account_num] = {
@@ -2410,6 +2688,16 @@ class ClaudeAccountSwitcher:
             "organizationName": organization_name,
             "added": get_timestamp(),
         }
+        self._store_account_auth_method(
+            data,
+            account_num,
+            current_creds,
+            auth_method=AUTH_BROWSER_OAUTH,
+        )
+        self._write_account_config(account_num, current_email, current_config)
+        self._usage_store.clear_dead_token(
+            [account_num], {account_num: (current_email, organization_uuid)}
+        )
         carried_alias = alias if alias is not None else existing_alias
         if carried_alias:
             data["accounts"][account_num]["alias"] = carried_alias
@@ -2433,7 +2721,7 @@ class ClaudeAccountSwitcher:
         slot: int | None = None,
         assume_yes: bool = False,
     ) -> None:
-        """Register a raw OAuth setup-token or managed API key as a new account.
+        """Register a raw setup-token or managed API key under an account.
 
         Useful for headless servers or when the token is received from another
         machine, without needing a prior Claude Code login on this machine. The
@@ -2447,7 +2735,8 @@ class ClaudeAccountSwitcher:
             email: Email address to associate with the account. When omitted,
                    defaults to ``setup-token-{slot}@token.local`` (or
                    ``api-key-{slot}@token.local`` for API keys) since these tokens
-                   carry no real email metadata.
+                   carry no real email metadata. An existing personal account
+                   with the same email gains or refreshes this login method.
             slot:  Slot number to use; auto-assigned when ``None``.
             assume_yes: Skip the occupied-slot overwrite prompt (callers with
                    their own confirmation UI, e.g. the TUI, confirm first).
@@ -2481,11 +2770,6 @@ class ClaudeAccountSwitcher:
             label = "api-key" if is_api_key else "setup-token"
             email = f"{label}-{slot}@token.local"
 
-        # Don't silently overwrite/convert an existing account of the other kind:
-        # identity is matched on (email, org) only, so an api-key and an OAuth
-        # account sharing an email would be indistinguishable at switch time.
-        self._reject_cross_kind_collision(email, is_api_key)
-
         # Build the credential payload by kind: a managed key is stored raw; an
         # OAuth setup-token is wrapped in Claude Code's credential JSON. The
         # synthesized config is identical for both (no real org metadata).
@@ -2515,7 +2799,12 @@ class ClaudeAccountSwitcher:
                 raise ConfigError(
                     f"Existing account metadata for {email} is inconsistent"
                 )
-            self._write_account_credentials(account_num, email, credentials)
+            method = self._store_account_auth_method(
+                seq,
+                account_num,
+                credentials,
+                auth_method=AUTH_API_KEY if is_api_key else AUTH_SETUP_TOKEN,
+            )
             self._write_account_config(account_num, email, config)
             # A refreshed credential invalidates any dead-token quarantine on this
             # slot (mirrors ``add_account``); otherwise the stale strike row keeps
@@ -2526,7 +2815,7 @@ class ClaudeAccountSwitcher:
             )
             seq["lastUpdated"] = get_timestamp()
             self._write_json(self.sequence_file, seq)
-            kind_label = "API key" if is_api_key else "token"
+            kind_label = "API key" if method == AUTH_API_KEY else "token"
             self._logger.info(f"Updated {kind_label} for account {account_num}: {email}")
             print(
                 f"{accent(f'Updated {kind_label}')} for Account {account_num} "
@@ -2582,6 +2871,10 @@ class ClaudeAccountSwitcher:
 
         if displace_slot:
             d_num, d_email, d_org = displace_slot
+            displaced = (self._get_sequence_data() or {}).get("accounts", {}).get(
+                d_num, {}
+            )
+            self._delete_auth_method_secrets(displaced)
             self._delete_account_files(d_num, d_email)
             data = self._get_sequence_data()
             if int(d_num) in data["sequence"]:
@@ -2599,14 +2892,6 @@ class ClaudeAccountSwitcher:
             del data["accounts"][migrate_from]
             self._write_json(self.sequence_file, data)
 
-        self._write_account_credentials(account_num, email, credentials)
-        self._write_account_config(account_num, email, config)
-        # Reusing/overwriting a slot with a fresh credential lifts any dead-token
-        # quarantine carried by that slot's prior lineage (mirrors ``add_account``).
-        self._usage_store.clear_dead_token(
-            [account_num], {account_num: (email, "")}
-        )
-
         data = self._get_sequence_data()
         record = {
             "email": email,
@@ -2615,16 +2900,26 @@ class ClaudeAccountSwitcher:
             "organizationName": "",
             "added": get_timestamp(),
         }
-        if is_api_key:
-            record["kind"] = "api_key"
         data["accounts"][account_num] = record
+        method = self._store_account_auth_method(
+            data,
+            account_num,
+            credentials,
+            auth_method=AUTH_API_KEY if is_api_key else AUTH_SETUP_TOKEN,
+        )
+        self._write_account_config(account_num, email, config)
+        # Reusing/overwriting a slot with a fresh credential lifts any dead-token
+        # quarantine carried by that slot's prior lineage (mirrors ``add_account``).
+        self._usage_store.clear_dead_token(
+            [account_num], {account_num: (email, "")}
+        )
         if int(account_num) not in data["sequence"]:
             data["sequence"].append(int(account_num))
             data["sequence"].sort()
         data["lastUpdated"] = get_timestamp()
 
         self._write_json(self.sequence_file, data)
-        source_label = "API key" if is_api_key else "token"
+        source_label = auth_method_label(method)
         self._logger.info(f"Added account {account_num} from {source_label}: {email}")
         if migrate_from:
             print(f"{dimmed(f'Moved from slot {migrate_from} → {slot}')}")
@@ -2707,6 +3002,7 @@ class ClaudeAccountSwitcher:
                 return
 
         # Remove backup files
+        self._delete_auth_method_secrets(account_info)
         self._delete_account_files(account_num, email)
 
         # Update sequence.json
@@ -2738,6 +3034,7 @@ class ClaudeAccountSwitcher:
             active_num = self._find_account_slot(data, current_email, current_org_uuid)
 
         accounts_info: list[tuple[int, str, str, str, bool, str, str]] = []
+        self._usage_backup_slots = set()
         # Reset each build; set below only when the active slot's OAuth Keychain
         # read failed with no fallback. Read by _static_usage_sentinel (main
         # thread writes it here before the fetch pool starts → no data race).
@@ -2756,6 +3053,25 @@ class ClaudeAccountSwitcher:
                 self._active_keychain_unavailable = active.keychain_unavailable
             else:
                 creds = self._read_account_credentials(str(num), email)
+
+            methods = self._account_auth_methods(
+                str(num), credentials=creds, data=data
+            )
+            live_method = classify_auth_method(creds)
+            oauth_methods = [
+                method
+                for method in (AUTH_BROWSER_OAUTH, AUTH_SETUP_TOKEN)
+                if method in methods
+            ]
+            if oauth_methods and live_method not in oauth_methods:
+                usage_method = oauth_methods[0]
+                stored_oauth = self._read_auth_method_credentials(
+                    str(num), email, org_uuid, usage_method
+                )
+                if stored_oauth:
+                    creds = stored_oauth
+                    if is_active:
+                        self._usage_backup_slots.add(str(num))
 
             accounts_info.append((num, email, org_name, org_uuid, is_active, creds, alias))
         return accounts_info
@@ -3392,7 +3708,7 @@ class ClaudeAccountSwitcher:
         # The active/default account owns the live credential — route it
         # through the locked-refresh path (refreshes an expired token under
         # Claude Code's own lock protocol, owner or not).
-        if is_active:
+        if is_active and str(num) not in self._usage_backup_slots:
             return self._fetch_active_usage(str(num), email, creds, org_uuid)
 
         def persist(acct_num: str, acct_email: str, new_creds: str) -> None:
@@ -3881,7 +4197,7 @@ class ClaudeAccountSwitcher:
         active_num: int | None = None
         accounts = []
         seq_data = self._get_sequence_data() or {}
-        for num, email, org_name, org_uuid, is_active, _, alias in accounts_info:
+        for num, email, org_name, org_uuid, is_active, creds, alias in accounts_info:
             if is_active:
                 active_num = num
             entry = entries[str(num)]
@@ -3889,6 +4205,30 @@ class ClaudeAccountSwitcher:
             # recent enough to act on (≤ STALE_OK_S), else unavailable. Showing
             # older measurements is a human-display affordance only — scripts
             # keying on usageStatus == "ok" must not act on arbitrarily old data.
+            preferred = self._preferred_auth_method(
+                str(num), credentials=creds, data=seq_data
+            )
+            methods = self._account_auth_methods(
+                str(num), credentials=creds, data=seq_data
+            )
+            details = self._auth_method_snapshots(
+                str(num),
+                email,
+                org_uuid,
+                credentials=creds,
+                data=seq_data,
+            )
+            fallback = auth_metadata(creds)
+            selected = next(
+                (detail for detail in details if detail.method == preferred),
+                AuthMethodSnapshot(
+                    fallback.method,
+                    fallback.scope,
+                    fallback.supports_remote_control,
+                    fallback.expires_at,
+                    True,
+                ),
+            )
             accounts.append(
                 account_row(
                     num, email, org_name, org_uuid, is_active,
@@ -3896,6 +4236,25 @@ class ClaudeAccountSwitcher:
                     usage_fetched_at=entry.fetched_at,
                     usage_age_s=entry.age_s,
                     last_good_usage=entry.last_good,
+                    auth_method=preferred,
+                    auth_methods=list(methods or (preferred,)),
+                    auth_scope=selected.scope,
+                    auth_supports_remote_control=selected.supports_remote_control,
+                    auth_expires_at=selected.expires_at,
+                    auth_method_details=[
+                        {
+                            "method": detail.method,
+                            "scope": detail.scope,
+                            "supportsRemoteControl": detail.supports_remote_control,
+                            **(
+                                {"expiresAt": detail.expires_at}
+                                if detail.expires_at
+                                else {}
+                            ),
+                            **({"default": True} if detail.is_default else {}),
+                        }
+                        for detail in details
+                    ],
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, str(num)),
                 )
@@ -3954,7 +4313,7 @@ class ClaudeAccountSwitcher:
 
         seq_data = self._get_sequence_data() or {}
         print(bolded("Accounts:"))
-        for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
+        for i, (num, email, org_name, org_uuid, is_active, creds, alias) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
             label = f"{accent(alias)} ({email})" if alias else email
             markers = ""
@@ -3963,6 +4322,37 @@ class ClaudeAccountSwitcher:
             if self._disabled_from_data(seq_data, str(num)):
                 markers += f" {muted('(disabled)')}"
             print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
+            preferred = self._preferred_auth_method(
+                str(num), credentials=creds, data=seq_data
+            )
+            details = self._auth_method_snapshots(
+                str(num),
+                email,
+                org_uuid,
+                credentials=creds,
+                data=seq_data,
+            )
+            if not details:
+                auth = auth_metadata(creds)
+                details = (
+                    AuthMethodSnapshot(
+                        auth.method,
+                        auth.scope,
+                        auth.supports_remote_control,
+                        auth.expires_at,
+                        True,
+                    ),
+                )
+            for detail in details:
+                marker = (
+                    " · default"
+                    if detail.method == preferred and len(details) > 1
+                    else ""
+                )
+                print(
+                    f"     {dimmed('Claude Code:')} "
+                    f"{muted(auth_metadata_summary(detail) + marker)}"
+                )
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
 
@@ -4597,13 +4987,20 @@ class ClaudeAccountSwitcher:
         )
 
     def switch_to(
-        self, identifier: str, json_output: bool = False, force: bool = False
+        self,
+        identifier: str,
+        json_output: bool = False,
+        force: bool = False,
+        auth_method: str | None = None,
+        required_capability: str | None = None,
     ) -> dict | None:
         """Switch to specific account.
 
         ``force`` activates the target's stored credentials directly, skipping
         both the already-active no-op guard and the backup-current step —
         the recovery path for a live login gone stale (e.g. after --import).
+        ``required_capability`` selects a login that supports the requested
+        Claude Code feature and fails before mutation when none is stored.
         """
         if not self.sequence_file.exists():
             raise ConfigError("No accounts are managed yet")
@@ -4654,6 +5051,59 @@ class ClaudeAccountSwitcher:
         if target_account not in data.get("accounts", {}):
             raise AccountNotFoundError(f"Account-{target_account} does not exist")
 
+        requested_method = auth_method.replace("-", "_") if auth_method else None
+        capability = (
+            required_capability.replace("-", "_")
+            if required_capability
+            else None
+        )
+        if capability not in {None, AUTH_CAPABILITY_REMOTE_CONTROL}:
+            raise ValidationError(
+                f"Unsupported Claude Code capability: {required_capability}"
+            )
+        target_email = data["accounts"][target_account].get("email", "")
+        target_primary = self._read_account_credentials(
+            target_account, target_email
+        )
+        available_methods = self._account_auth_methods(
+            target_account, credentials=target_primary, data=data
+        )
+        if requested_method is not None and requested_method not in available_methods:
+            available = ", ".join(auth_method_label(m) for m in available_methods)
+            raise ValidationError(
+                f"Account-{target_account} has no {auth_method_label(requested_method)} "
+                f"login. Available: {available or 'none'}"
+            )
+        default_method = self._preferred_auth_method(
+            target_account, credentials=target_primary, data=data
+        )
+        if requested_method is not None:
+            selected_method = requested_method
+        elif capability is not None:
+            ordered_methods = (default_method,) + tuple(
+                method for method in available_methods if method != default_method
+            )
+            selected_method = next(
+                (
+                    method
+                    for method in ordered_methods
+                    if auth_method_supports_capability(method, capability)
+                ),
+                AUTH_UNKNOWN,
+            )
+        else:
+            selected_method = default_method
+
+        if capability is not None and not auth_method_supports_capability(
+            selected_method, capability
+        ):
+            if capability == AUTH_CAPABILITY_REMOTE_CONTROL:
+                raise ValidationError(
+                    f"Remote Control requires browser OAuth for Account-"
+                    f"{target_account}. Run 'claude auth login', then "
+                    f"'cswap add --slot {target_account}'."
+                )
+
         # Short-circuit a no-op before mutating (issue #79). A self-switch
         # would first back up the live credentials into the target slot —
         # destroying a freshly imported backup with a possibly stale login —
@@ -4670,11 +5120,19 @@ class ClaudeAccountSwitcher:
             identity = self._get_current_account()
             if identity is not None:
                 cur_slot = self._find_account_slot(data, identity[0], identity[1])
-                if cur_slot == target_account:
+                current_preferred = self._preferred_auth_method(
+                    target_account, credentials=target_primary, data=data
+                )
+                method_change = selected_method != current_preferred
+                if cur_slot == target_account and not method_change:
                     action, provenance = self._self_switch_action(
                         target_account, identity[0]
                     )
-                if cur_slot == target_account and action != "reconcile":
+                if (
+                    cur_slot == target_account
+                    and not method_change
+                    and action != "reconcile"
+                ):
                     email = (
                         data.get("accounts", {}).get(target_account, {}).get("email", "")
                     )
@@ -4697,12 +5155,14 @@ class ClaudeAccountSwitcher:
                         message=f"Already on Account-{target_account} ({email})",
                     )
 
-        op = self._perform_switch(
-            target_account,
-            emit_output=not json_output,
-            force_activate=force,
-            provenance=provenance,
-        )
+        switch_kwargs = {
+            "emit_output": not json_output,
+            "force_activate": force,
+            "provenance": provenance,
+        }
+        if selected_method != AUTH_UNKNOWN:
+            switch_kwargs["target_auth_method"] = selected_method
+        op = self._perform_switch(target_account, **switch_kwargs)
         result = self._switch_result_from_op(op, "direct") if json_output else None
         # A forced self-activation really rewrote the live credentials from the
         # stored backup — "already-active" would misdescribe that mutation.
@@ -5027,6 +5487,7 @@ class ClaudeAccountSwitcher:
         emit_output: bool = True,
         force_activate: bool = False,
         provenance: dict | None = None,
+        target_auth_method: str | None = None,
     ) -> dict:
         """Perform the actual account switch with transaction support.
 
@@ -5094,6 +5555,11 @@ class ClaudeAccountSwitcher:
             active_account = data.get("activeAccountNumber")
             current_account = str(active_account) if active_account is not None else None
             target_email = data["accounts"][target_account]["email"]
+            target_record = data["accounts"][target_account]
+            target_org_uuid = target_record.get("organizationUuid", "") or ""
+            target_method = target_auth_method or self._preferred_auth_method(
+                target_account, data=data
+            )
             to_ref = account_ref(int(target_account), target_email)
             current_identity = self._get_current_account()
             if current_identity is not None:
@@ -5122,8 +5588,11 @@ class ClaudeAccountSwitcher:
                     from_ref = account_ref(None, current_identity[0])
                 else:
                     from_ref = account_ref(int(current_account), current_identity[0])
-                target_creds = self._read_account_credentials(
-                    target_account, target_email
+                target_creds = self._read_auth_method_credentials(
+                    target_account,
+                    target_email,
+                    target_org_uuid,
+                    target_method,
                 )
                 target_config = self._read_account_config(target_account, target_email)
                 if not target_creds:
@@ -5230,6 +5699,16 @@ class ClaudeAccountSwitcher:
                         self._write_json(config_path, target_config_data)
                     config_written = True
 
+                    target_methods = self._account_auth_methods(
+                        target_account, credentials=target_creds, data=data
+                    )
+                    if target_method in target_methods:
+                        self._set_account_auth_methods(
+                            data,
+                            target_account,
+                            list(target_methods),
+                            target_method,
+                        )
                     data["activeAccountNumber"] = int(target_account)
                     data["lastUpdated"] = get_timestamp()
                     self._write_json(self.sequence_file, data)
@@ -5446,9 +5925,24 @@ class ClaudeAccountSwitcher:
                             acct["uuid"] = resolved["uuid"]
                     self._logger.info(f"Backed up account {current_account}")
 
+                outgoing_method = classify_auth_method(original_creds)
+                outgoing_methods = self._account_auth_methods(
+                    current_account, credentials=original_creds, data=data
+                )
+                if outgoing_method in outgoing_methods:
+                    self._set_account_auth_methods(
+                        data,
+                        current_account,
+                        list(outgoing_methods),
+                        outgoing_method,
+                    )
+
                 # Step 2: Retrieve target account
-                target_creds = self._read_account_credentials(
-                    target_account, target_email
+                target_creds = self._read_auth_method_credentials(
+                    target_account,
+                    target_email,
+                    target_org_uuid,
+                    target_method,
                 )
                 target_config = self._read_account_config(target_account, target_email)
 
@@ -5487,6 +5981,16 @@ class ClaudeAccountSwitcher:
                 self._logger.info("Updated config file")
 
                 # Step 5: Update sequence state
+                target_methods = self._account_auth_methods(
+                    target_account, credentials=target_creds, data=data
+                )
+                if target_method in target_methods:
+                    self._set_account_auth_methods(
+                        data,
+                        target_account,
+                        list(target_methods),
+                        target_method,
+                    )
                 data["activeAccountNumber"] = int(target_account)
                 data["lastUpdated"] = get_timestamp()
                 self._write_json(self.sequence_file, data)
@@ -5627,6 +6131,17 @@ class ClaudeAccountSwitcher:
                 nums = [account_num]
                 if str(account_num) != "None":
                     nums.append("None")
+                raw_methods = account_info.get("authMethods")
+                if isinstance(raw_methods, list):
+                    nums.extend(
+                        self._auth_method_storage_key(
+                            email,
+                            account_info.get("organizationUuid", "") or "",
+                            method,
+                        )
+                        for method in raw_methods
+                        if method in AUTH_METHOD_LABELS and method != AUTH_UNKNOWN
+                    )
                 usernames = [f"account-{num}-{email}" for num in nums]
 
                 # .enc files (Linux/WSL/Windows always; macOS fallback copies).

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -15,7 +15,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from claude_swap import __version__
-from claude_swap.credentials import looks_like_api_key
+from claude_swap.credentials import (
+    AUTH_API_KEY,
+    AUTH_BROWSER_OAUTH,
+    AUTH_SETUP_TOKEN,
+    classify_auth_method,
+    looks_like_api_key,
+)
 from claude_swap.exceptions import (
     ConfigError,
     CredentialReadError,
@@ -29,6 +35,11 @@ if TYPE_CHECKING:
 
 
 FORMAT_VERSION = 1
+_TRANSFER_AUTH_METHODS = {
+    AUTH_BROWSER_OAUTH,
+    AUTH_SETUP_TOKEN,
+    AUTH_API_KEY,
+}
 
 _PLATFORM_TAG = {
     Platform.MACOS: "macos",
@@ -160,6 +171,33 @@ def _slim_credentials(creds_obj: dict) -> dict:
     return {"claudeAiOauth": creds_obj["claudeAiOauth"]}
 
 
+def _credentials_payload(credentials: str, label: str, full: bool) -> Any:
+    """Serialize one login secret using the existing transfer representation."""
+    if looks_like_api_key(credentials):
+        return credentials.strip()
+    payload = _parse_payload(credentials, label)
+    return payload if full else _slim_credentials(payload)
+
+
+def _imported_credentials_text(value: Any, method: str, email: str) -> str:
+    """Validate and normalize one imported login method secret."""
+    if method == AUTH_API_KEY:
+        if not (isinstance(value, str) and looks_like_api_key(value)):
+            raise TransferError(
+                f"API-key credentials for {email} must be a raw sk-ant-api… string"
+            )
+        return value.strip()
+    if not isinstance(value, dict):
+        raise TransferError(f"credentials for {email} must be a JSON object")
+    text = json.dumps(value)
+    classified = classify_auth_method(text)
+    if classified != method:
+        raise TransferError(
+            f"credentials for {email} do not match auth method {method}"
+        )
+    return text
+
+
 def export_accounts(
     switcher: ClaudeAccountSwitcher,
     destination: str,
@@ -225,6 +263,19 @@ def export_accounts(
             if not config_path.exists():
                 raise ConfigError("Claude config file not found")
             config_text = config_path.read_text(encoding="utf-8")
+            if isinstance(record.get("authMethods"), list):
+                preferred = switcher._preferred_auth_method(
+                    num, data=sequence_data
+                )
+                if classify_auth_method(creds_text) != preferred:
+                    creds_text = switcher._read_auth_method_credentials(
+                        num, email, org_uuid, preferred
+                    )
+                    if not creds_text:
+                        raise CredentialReadError(
+                            f"no stored {preferred} credentials found for "
+                            f"account {num} ({email})"
+                        )
         else:
             creds_text = switcher._read_account_credentials(num, email)
             config_text = switcher._read_account_config(num, email)
@@ -248,16 +299,13 @@ def export_accounts(
         if not full:
             config_obj = _slim_config(config_obj, f"config for {email}")
 
-        # API-key accounts store the credential as a raw ``sk-ant-api…`` string,
-        # not OAuth JSON — carry it verbatim (and tag the kind) so the JSON parse
-        # below doesn't choke and import can restore it as-is.
+        # Keep the v1 preferred credential fields for older importers. Accounts
+        # with child login methods add an optional list below; usage and identity
+        # remain account-owned and are not duplicated per method.
         is_api_key = looks_like_api_key(creds_text)
-        if is_api_key:
-            creds_payload: Any = creds_text.strip()
-        else:
-            creds_payload = _parse_payload(creds_text, f"credentials for {email}")
-            if not full:
-                creds_payload = _slim_credentials(creds_payload)
+        creds_payload = _credentials_payload(
+            creds_text, f"credentials for {email}", full
+        )
         entry: dict[str, Any] = {
             "number": int(num),
             "email": email,
@@ -270,6 +318,38 @@ def export_accounts(
         }
         if is_api_key:
             entry["kind"] = "api_key"
+        stored_methods = record.get("authMethods")
+        if isinstance(stored_methods, list):
+            preferred = switcher._preferred_auth_method(
+                num, credentials=creds_text, data=sequence_data
+            )
+            method_entries: list[dict[str, Any]] = []
+            for method in switcher._account_auth_methods(
+                num, credentials=creds_text, data=sequence_data
+            ):
+                method_creds = (
+                    creds_text
+                    if method == preferred
+                    else switcher._read_auth_method_credentials(
+                        num, email, org_uuid, method
+                    )
+                )
+                if not method_creds:
+                    raise CredentialReadError(
+                        f"no stored {method} credentials found for account {num} ({email})"
+                    )
+                method_entries.append(
+                    {
+                        "method": method,
+                        "credentials": _credentials_payload(
+                            method_creds,
+                            f"{method} credentials for {email}",
+                            full,
+                        ),
+                    }
+                )
+            entry["authMethods"] = method_entries
+            entry["preferredAuthMethod"] = preferred
         if record.get("alias"):
             entry["alias"] = record["alias"]
         accounts_payload.append(entry)
@@ -383,20 +463,51 @@ def import_accounts(
         if not isinstance(config_obj, dict):
             raise TransferError(f"config for {email} must be a JSON object")
         # API-key accounts carry the credential as a raw string; OAuth accounts
-        # carry a JSON object.
+        # carry a JSON object. Optional child methods are additive to format v1.
         is_api_key = raw.get("kind") == "api_key" or isinstance(creds_obj, str)
         if is_api_key:
-            if not (isinstance(creds_obj, str) and looks_like_api_key(creds_obj)):
-                raise TransferError(
-                    f"API-key credentials for {email} must be a raw sk-ant-api… string"
-                )
-            creds_text = creds_obj.strip()
+            preferred_method = AUTH_API_KEY
+            creds_text = _imported_credentials_text(
+                creds_obj, preferred_method, email
+            )
         else:
             if not isinstance(creds_obj, dict):
                 raise TransferError(
                     f"credentials for {email} must be a JSON object"
                 )
             creds_text = json.dumps(creds_obj)
+            preferred_method = classify_auth_method(creds_text)
+            if preferred_method not in _TRANSFER_AUTH_METHODS:
+                # Legacy exports may use an old OAuth object shape that cannot
+                # be classified locally. Version 1 accepted it as OAuth.
+                preferred_method = AUTH_BROWSER_OAUTH
+
+        method_credentials: dict[str, str] = {}
+        raw_methods = raw.get("authMethods")
+        if raw_methods is not None:
+            if not isinstance(raw_methods, list) or not raw_methods:
+                raise TransferError(
+                    f"authMethods for {email} must be a non-empty list"
+                )
+            for child in raw_methods:
+                if not isinstance(child, dict):
+                    raise TransferError(f"authMethods for {email} must contain objects")
+                method = child.get("method")
+                if method not in _TRANSFER_AUTH_METHODS:
+                    raise TransferError(
+                        f"unsupported auth method for {email}: {method!r}"
+                    )
+                if method in method_credentials:
+                    raise TransferError(f"duplicate auth method for {email}: {method}")
+                method_credentials[method] = _imported_credentials_text(
+                    child.get("credentials"), method, email
+                )
+            preferred_method = raw.get("preferredAuthMethod")
+            if preferred_method not in method_credentials:
+                raise TransferError(
+                    f"preferredAuthMethod for {email} must name an imported auth method"
+                )
+            creds_text = method_credentials[preferred_method]
         key = (email, org_uuid)
         if key in seen_keys:
             raise TransferError(
@@ -428,7 +539,9 @@ def import_accounts(
                 "org_name": raw.get("organizationName", "") or "",
                 "uuid": raw.get("uuid", "") or "",
                 "added": raw.get("added") or get_timestamp(),
-                "kind": "api_key" if is_api_key else "oauth",
+                "kind": "api_key" if preferred_method == AUTH_API_KEY else "oauth",
+                "preferred_method": preferred_method,
+                "method_credentials": method_credentials,
                 "alias": alias,
                 "creds_text": creds_text,
                 "config_text": json.dumps(config_obj, indent=2),
@@ -528,6 +641,10 @@ def import_accounts(
         switcher._write_account_config(
             target_num, entry["email"], entry["config_text"]
         )
+        for method, method_creds in entry["method_credentials"].items():
+            switcher._write_auth_method_secret(
+                entry["email"], entry["org_uuid"], method, method_creds
+            )
         # Every successful import write introduces credential material whose
         # previous auth verdict is no longer authoritative, so lift any
         # dead-token quarantine on this slot (mirrors add_account / the
@@ -550,6 +667,9 @@ def import_accounts(
         }
         if entry["kind"] == "api_key":
             new_record["kind"] = "api_key"
+        if entry["method_credentials"]:
+            new_record["authMethods"] = list(entry["method_credentials"])
+            new_record["preferredAuthMethod"] = entry["preferred_method"]
         if entry.get("alias"):
             new_record["alias"] = entry["alias"]
         data["accounts"][target_num] = new_record

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -15,6 +15,10 @@ from rich.text import Text
 from textual.widgets import ListItem, Static
 
 from claude_swap import pace
+from claude_swap.credentials import (
+    AuthMetadata,
+    auth_metadata_summary,
+)
 from claude_swap.json_output import USAGE_API_KEY
 from claude_swap.models import AccountSnapshot
 from claude_swap.usage_store import STALE_OK_S
@@ -186,6 +190,21 @@ def account_card_text(
     if age:
         text.append(f"   {age}", style=palette.muted)
 
+    details = acc.auth_method_details or (
+        AuthMetadata(
+            acc.auth_method,
+            acc.auth_scope,
+            acc.auth_supports_remote_control,
+            acc.auth_expires_at,
+        ),
+    )
+    for detail in details:
+        text.append("\n    ")
+        text.append("Claude Code  ", style=palette.muted)
+        text.append(auth_metadata_summary(detail), style=palette.foreground)
+        if len(details) > 1 and detail.method == acc.auth_method:
+            text.append(" · default", style=palette.muted)
+
     sentinel = acc.usage.sentinel
     if sentinel is not None:
         text.append("\n    ")
@@ -255,6 +274,26 @@ def mini_account_text(
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.disabled:
         text.append("  (disabled)", style=palette.muted)
+    details = acc.auth_method_details or (
+        AuthMetadata(
+            acc.auth_method,
+            acc.auth_scope,
+            acc.auth_supports_remote_control,
+            acc.auth_expires_at,
+        ),
+    )
+    labels = ", ".join(
+        auth_metadata_summary(
+            detail,
+            include_remote_control=False,
+            include_expiry=False,
+        )
+        for detail in details
+    )
+    text.append(
+        f"  · {labels}",
+        style=palette.muted,
+    )
     text.append("   ")
 
     sentinel = acc.usage.sentinel

--- a/tests/test_api_key_accounts.py
+++ b/tests/test_api_key_accounts.py
@@ -1,7 +1,7 @@
 """Tests for managed API-key (``/login`` key) account support.
 
-Covers kind detection, ``--add-token`` auto-detection, the cross-kind collision
-guard, the ``add_account`` live-key guard, kind+platform-aware active credential
+Covers kind detection, ``--add-token`` auto-detection, account-owned login methods,
+the ``add_account`` live-key guard, kind+platform-aware active credential
 read/write with OAuth↔API-key mutual exclusion, the "API key — no quota" usage
 display, the ``cswap run`` session guard, and export/import of raw keys.
 """
@@ -9,6 +9,7 @@ display, the ``cswap run`` session guard, and export/import of raw keys.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -16,9 +17,16 @@ import pytest
 from claude_swap import macos_keychain
 from claude_swap import session as session_mod
 from claude_swap.credentials import (
+    AUTH_API_KEY,
+    AUTH_BROWSER_OAUTH,
+    AUTH_SCOPE_FULL,
+    AUTH_SCOPE_INFERENCE_ONLY,
+    AUTH_SETUP_TOKEN,
     CLAUDE_CODE_KEYCHAIN_SERVICE,
     CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
     approved_form,
+    auth_metadata,
+    classify_auth_method,
     looks_like_api_key,
 )
 from claude_swap.exceptions import SessionError, ValidationError
@@ -62,6 +70,47 @@ def _read_global_config() -> dict:
 
 
 class TestKindDetection:
+    def test_classifies_every_supported_auth_method(self):
+        expires_at = int(
+            datetime(2027, 1, 2, 3, 4, 5, tzinfo=timezone.utc).timestamp()
+            * 1000
+        )
+        browser = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat01-browser",
+                    "refreshToken": "refresh",
+                    "expiresAt": expires_at,
+                }
+            }
+        )
+        setup = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat01-setup",
+                    "expiresAt": expires_at,
+                }
+            }
+        )
+        assert classify_auth_method(browser) == AUTH_BROWSER_OAUTH
+        assert classify_auth_method(setup) == AUTH_SETUP_TOKEN
+        assert classify_auth_method(API_KEY) == AUTH_API_KEY
+
+        browser_info = auth_metadata(browser)
+        assert browser_info.scope == AUTH_SCOPE_FULL
+        assert browser_info.supports_remote_control is True
+        assert browser_info.expires_at is None
+
+        setup_info = auth_metadata(setup)
+        assert setup_info.scope == AUTH_SCOPE_INFERENCE_ONLY
+        assert setup_info.supports_remote_control is False
+        assert setup_info.expires_at == "2027-01-02T03:04:05Z"
+
+        api_key_info = auth_metadata(API_KEY)
+        assert api_key_info.scope == AUTH_SCOPE_INFERENCE_ONLY
+        assert api_key_info.supports_remote_control is False
+        assert api_key_info.expires_at is None
+
     def test_api_key_detected(self):
         assert looks_like_api_key(API_KEY) is True
 
@@ -120,18 +169,187 @@ class TestAddTokenApiKey:
         assert s._read_account_credentials("1", "me@example.com") == OTHER_KEY
 
 
-class TestCrossKindCollision:
-    def test_api_key_rejected_when_email_is_oauth(self, temp_home: Path):
+class TestAccountAuthMethods:
+    def test_browser_oauth_joins_existing_setup_token_account(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token(
+            "sk-ant-oat01-setup", email="dup@example.com"
+        )
+        (temp_home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "oauthAccount": {
+                        "emailAddress": "dup@example.com",
+                        "accountUuid": "account-1",
+                        "organizationUuid": None,
+                        "organizationName": None,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        get_credentials_path().parent.mkdir(parents=True, exist_ok=True)
+        get_credentials_path().write_text(OAUTH_JSON, encoding="utf-8")
+
+        s.add_account()
+
+        record = s._get_sequence_data()["accounts"]["1"]
+        assert record["authMethods"] == [AUTH_BROWSER_OAUTH, AUTH_SETUP_TOKEN]
+        assert record["preferredAuthMethod"] == AUTH_SETUP_TOKEN
+
+    def test_api_key_and_setup_token_share_one_account(self, temp_home: Path):
         s = _linux_switcher()
         s.add_account_from_token("sk-ant-oat01-abc", email="dup@example.com")
-        with pytest.raises(ValidationError, match="already exists as an OAuth account"):
-            s.add_account_from_token(API_KEY, email="dup@example.com")
+        s.add_account_from_token(API_KEY, email="dup@example.com")
 
-    def test_oauth_rejected_when_email_is_api_key(self, temp_home: Path):
+        data = s._get_sequence_data()
+        record = data["accounts"]["1"]
+        assert len(data["accounts"]) == 1
+        assert record["authMethods"] == [AUTH_SETUP_TOKEN, AUTH_API_KEY]
+        assert record["preferredAuthMethod"] == AUTH_SETUP_TOKEN
+        assert s._read_auth_method_credentials(
+            "1", "dup@example.com", "", AUTH_SETUP_TOKEN
+        )
+        assert s._read_auth_method_credentials(
+            "1", "dup@example.com", "", AUTH_API_KEY
+        ) == API_KEY
+
+    def test_explicit_method_switch_updates_preference(self, temp_home: Path):
         s = _linux_switcher()
         s.add_account_from_token(API_KEY, email="dup@example.com")
-        with pytest.raises(ValidationError, match="already exists as an API-key account"):
-            s.add_account_from_token("sk-ant-oat01-abc", email="dup@example.com")
+        s.add_account_from_token("sk-ant-oat01-abc", email="dup@example.com")
+
+        s.switch_to("1", force=True, auth_method="api-key")
+        s.switch_to("1", auth_method="setup-token")
+
+        record = s._get_sequence_data()["accounts"]["1"]
+        assert record["preferredAuthMethod"] == AUTH_SETUP_TOKEN
+        assert classify_auth_method(
+            s._read_account_credentials("1", "dup@example.com")
+        ) == AUTH_SETUP_TOKEN
+
+    def test_usage_stays_account_level_when_api_key_is_also_stored(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token(
+            "sk-ant-oat01-setup", email="dup@example.com"
+        )
+        s.add_account_from_token(API_KEY, email="dup@example.com")
+
+        info = s._build_accounts_info()
+        snapshot = s.accounts_snapshot(fetch=set())
+
+        assert classify_auth_method(info[0][5]) == AUTH_SETUP_TOKEN
+        assert len(snapshot.accounts) == 1
+        assert snapshot.accounts[0].auth_method == AUTH_SETUP_TOKEN
+        assert snapshot.accounts[0].auth_methods == (
+            AUTH_SETUP_TOKEN,
+            AUTH_API_KEY,
+        )
+        assert snapshot.accounts[0].usage.sentinel != USAGE_API_KEY
+
+    def test_remote_control_requirement_selects_browser_oauth(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token(
+            "sk-ant-oat01-setup", email="dup@example.com"
+        )
+        (temp_home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "oauthAccount": {
+                        "emailAddress": "dup@example.com",
+                        "accountUuid": "account-1",
+                        "organizationUuid": None,
+                        "organizationName": None,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        get_credentials_path().parent.mkdir(parents=True, exist_ok=True)
+        get_credentials_path().write_text(OAUTH_JSON, encoding="utf-8")
+        s.add_account()
+
+        assert (
+            s._get_sequence_data()["accounts"]["1"]["preferredAuthMethod"]
+            == AUTH_SETUP_TOKEN
+        )
+        s.switch_to("1", force=True, auth_method="setup-token")
+
+        s.switch_to("1", required_capability="remote-control")
+
+        record = s._get_sequence_data()["accounts"]["1"]
+        assert record["preferredAuthMethod"] == AUTH_BROWSER_OAUTH
+        assert classify_auth_method(s._read_credentials()) == AUTH_BROWSER_OAUTH
+
+    def test_remote_control_requirement_rejects_inference_only_account(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token(
+            "sk-ant-oat01-setup", email="dup@example.com"
+        )
+
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "Remote Control requires browser OAuth for Account-1.*"
+                "claude auth login.*cswap add --slot 1"
+            ),
+        ):
+            s.switch_to("1", required_capability="remote-control")
+
+        record = s._get_sequence_data()["accounts"]["1"]
+        assert record["preferredAuthMethod"] == AUTH_SETUP_TOKEN
+
+    def test_active_api_key_uses_oauth_backup_without_replacing_live_login(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        s.add_account_from_token(
+            "sk-ant-oat01-setup", email="dup@example.com"
+        )
+        s.add_account_from_token(API_KEY, email="dup@example.com")
+        s.switch_to("1", force=True, auth_method="api-key")
+
+        info = s._build_accounts_info()
+
+        assert info[0][4] is True
+        assert classify_auth_method(info[0][5]) == AUTH_SETUP_TOKEN
+        assert "1" in s._usage_backup_slots
+        assert s._read_credentials() == API_KEY
+
+    def test_method_secrets_follow_slot_move_and_delete_with_account(
+        self, temp_home: Path
+    ):
+        s = _linux_switcher()
+        email = "dup@example.com"
+        s.add_account_from_token("sk-ant-oat01-setup", email=email)
+        s.add_account_from_token(API_KEY, email=email)
+
+        s.move_account("1", "3")
+
+        assert s._read_auth_method_credentials(
+            "3", email, "", AUTH_SETUP_TOKEN
+        )
+        assert s._read_auth_method_credentials(
+            "3", email, "", AUTH_API_KEY
+        ) == API_KEY
+        keys = [
+            s._auth_method_storage_key(email, "", method)
+            for method in (AUTH_SETUP_TOKEN, AUTH_API_KEY)
+        ]
+
+        s.remove_account("3", assume_yes=True)
+
+        assert all(
+            not s._store._read_account_credentials(key, email) for key in keys
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -314,6 +314,63 @@ class TestCLI:
             "2", json_output=False, force=False
         )
 
+    def test_switch_to_forwards_auth_method(self):
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(
+                 sys,
+                 "argv",
+                 ["claude-swap", "switch", "2", "--auth-method", "setup-token"],
+             ), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.switch_to.assert_called_once_with(
+            "2",
+            json_output=False,
+            force=False,
+            auth_method="setup-token",
+        )
+
+    def test_switch_to_forwards_required_capability(self):
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(
+                 sys,
+                 "argv",
+                 [
+                     "claude-swap",
+                     "switch",
+                     "2",
+                     "--require-capability",
+                     "remote-control",
+                 ],
+             ), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.switch_to.assert_called_once_with(
+            "2",
+            json_output=False,
+            force=False,
+            required_capability="remote-control",
+        )
+
+    def test_required_capability_requires_switch_target(self, capsys):
+        with patch.object(
+            sys,
+            "argv",
+            ["claude-swap", "list", "--require-capability", "remote-control"],
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+
+        assert excinfo.value.code == 2
+        assert (
+            "--require-capability can only be used with 'switch <num|email>'"
+            in capsys.readouterr().err
+        )
+
     def test_export_and_import_are_mutually_exclusive(self):
         """--export and --import cannot be combined."""
         result = subprocess.run(

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -197,7 +197,18 @@ class TestListJson:
         sample_sequence_data: dict, capsys,
     ):
         sample_sequence_data["accounts"]["1"]["email"] = "test@example.com"
-        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        expires_at = int(
+            datetime(2027, 1, 2, 3, 4, 5, tzinfo=timezone.utc).timestamp()
+            * 1000
+        )
+        active_creds = json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat01-active",
+                    "expiresAt": expires_at,
+                }
+            }
+        )
         backup_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-backup"}})
         usage = {
             "five_hour": {"pct": 10.0, "resets_at": "2026-01-01T00:00:00Z",
@@ -221,6 +232,20 @@ class TestListJson:
         acct1 = next(a for a in payload["accounts"] if a["number"] == 1)
         assert acct1["active"] is True
         assert acct1["usageStatus"] == "ok"
+        assert acct1["authMethod"] == "setup_token"
+        assert acct1["authMethods"] == ["setup_token"]
+        assert acct1["authScope"] == "inference_only"
+        assert acct1["supportsRemoteControl"] is False
+        assert acct1["authExpiresAt"] == "2027-01-02T03:04:05Z"
+        assert acct1["authMethodDetails"] == [
+            {
+                "method": "setup_token",
+                "scope": "inference_only",
+                "supportsRemoteControl": False,
+                "expiresAt": "2027-01-02T03:04:05Z",
+                "default": True,
+            }
+        ]
         assert acct1["usage"]["fiveHour"]["resetsAt"] == "2026-01-01T00:00:00Z"
 
     def test_list_payload_includes_alias(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from claude_swap.exceptions import TransferError
+from claude_swap.credentials import AUTH_API_KEY, AUTH_SETUP_TOKEN
 from claude_swap.models import Platform
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.transfer import export_accounts, import_accounts
@@ -132,6 +133,39 @@ class TestRoundTrip:
                 # Credentials JSON parses and contains the marker
                 creds_text = dst._read_account_credentials("1", "alice@example.com")
                 assert json.loads(creds_text)["_marker"] == "alice@example.com"
+
+    def test_multiple_auth_methods_round_trip_as_one_account(self, temp_home: Path):
+        api_key = "sk-ant-api03-" + "a1b2c3d4e5" * 4
+        src = _linux_switcher(temp_home)
+        src.add_account_from_token(
+            "sk-ant-oat01-setup", email="alice@example.com"
+        )
+        src.add_account_from_token(api_key, email="alice@example.com")
+
+        out_file = temp_home / "multi-method.cswap"
+        export_accounts(src, str(out_file))
+        exported = json.loads(out_file.read_text())["accounts"]
+        assert len(exported) == 1
+        assert [item["method"] for item in exported[0]["authMethods"]] == [
+            AUTH_SETUP_TOKEN,
+            AUTH_API_KEY,
+        ]
+
+        dst_home = temp_home.parent / "dst-multi"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home):
+            with patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = _linux_switcher(dst_home)
+                import_accounts(dst, str(out_file))
+                record = dst._get_sequence_data()["accounts"]["1"]
+                assert record["authMethods"] == [AUTH_SETUP_TOKEN, AUTH_API_KEY]
+                assert record["preferredAuthMethod"] == AUTH_SETUP_TOKEN
+                assert dst._read_auth_method_credentials(
+                    "1", "alice@example.com", "", AUTH_SETUP_TOKEN
+                )
+                assert dst._read_auth_method_credentials(
+                    "1", "alice@example.com", "", AUTH_API_KEY
+                ) == api_key
 
     def test_active_state_carried_but_not_applied(self, temp_home: Path):
         src = _linux_switcher(temp_home)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -21,7 +21,7 @@ import pytest
 
 from claude_swap.autoswitch import NoSwitchEvent, SwitchEvent
 from claude_swap.json_output import USAGE_API_KEY, USAGE_TOKEN_EXPIRED
-from claude_swap.models import AccountSnapshot, AccountsSnapshot
+from claude_swap.models import AccountSnapshot, AccountsSnapshot, AuthMethodSnapshot
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui import data as tui_data
 from claude_swap.usage_store import UsageEntry
@@ -77,6 +77,10 @@ def make_account(
     active: bool = False,
     switchable: bool = True,
     kind: str = "oauth",
+    auth_method: str = "browser_oauth",
+    auth_scope: str = "full",
+    auth_supports_remote_control: bool | None = True,
+    auth_expires_at: str | None = None,
     entry: UsageEntry | None = None,
     email: str | None = None,
     alias: str = "",
@@ -91,6 +95,10 @@ def make_account(
         kind=kind,
         switchable=switchable,
         usage=entry if entry is not None else make_entry(),
+        auth_method=auth_method,
+        auth_scope=auth_scope,
+        auth_supports_remote_control=auth_supports_remote_control,
+        auth_expires_at=auth_expires_at,
         alias=alias,
         disabled=disabled,
     )
@@ -611,8 +619,8 @@ class TestUsageRows:
         )
         acc = make_account(1, active=True, entry=entry)
 
-        wide = account_card_text(acc, 100).plain
-        assert wide.count(" · ") == 3
+        wide_lines = account_card_text(acc, 100).plain.splitlines()
+        assert sum(" · " in line for line in wide_lines if "resets" in line) == 3
 
         mid_lines = account_card_text(acc, 78).plain.splitlines()
         spend_line = next(line for line in mid_lines if "$12.50" in line)
@@ -621,11 +629,63 @@ class TestUsageRows:
             if "resets" in line and "$12.50" not in line:
                 assert " · " in line
 
-        narrow = account_card_text(acc, 40).plain
-        assert " · " not in narrow
+        narrow_lines = account_card_text(acc, 40).plain.splitlines()
+        assert all(" · " not in line for line in narrow_lines if "resets" in line)
 
 
 class TestMiniAccountText:
+    def test_auth_method_is_visible_without_repeating_usage(self):
+        from claude_swap.tui.widgets import account_card_text, mini_account_text
+
+        active = make_account(
+            1,
+            active=True,
+            auth_method="setup_token",
+            auth_scope="inference_only",
+            auth_supports_remote_control=False,
+            auth_expires_at="2027-01-02T03:04:05Z",
+        )
+        inactive = make_account(
+            2,
+            auth_method="api_key",
+            auth_scope="inference_only",
+            auth_supports_remote_control=False,
+        )
+        full = account_card_text(active, 100).plain
+        assert (
+            "Claude Code  setup token · inference only · no Remote Control "
+            "· expires 2027-01-02"
+        ) in full
+        assert "API key · inference only" in mini_account_text(
+            inactive, time.time()
+        ).plain
+
+    def test_multiple_auth_methods_are_grouped_on_one_account(self):
+        from claude_swap.tui.widgets import account_card_text
+
+        acc = make_account(1, auth_method="api_key")
+        acc = dataclasses.replace(
+            acc,
+            auth_methods=("browser_oauth", "setup_token", "api_key"),
+            auth_method_details=(
+                AuthMethodSnapshot("browser_oauth", "full", True, None),
+                AuthMethodSnapshot(
+                    "setup_token",
+                    "inference_only",
+                    False,
+                    "2027-01-02T03:04:05Z",
+                ),
+                AuthMethodSnapshot(
+                    "api_key", "inference_only", False, None, True
+                ),
+            ),
+        )
+        text = account_card_text(acc, 100).plain
+        assert text.count("Claude Code") == 3
+        assert "browser OAuth · full access · Remote Control" in text
+        assert "setup token · inference only · no Remote Control" in text
+        assert "API key · inference only · no Remote Control · default" in text
+
     def test_seven_day_ahead_of_pace_marker(self):
         from claude_swap.tui.widgets import mini_account_text
 
@@ -1709,4 +1769,3 @@ class TestThemeWiring:
             await menu_select(pilot, "theme:light")
             assert app._theme_name == "light"
             assert app.theme == "cswap-light"
-


### PR DESCRIPTION
## Summary

- Store browser OAuth, setup-token, and API-key logins under one Claude account.
- Show each login method, scope, Remote Control support, and setup-token expiry in the CLI list, TUI, and JSON output.
- Keep usage at the account level.
- Preserve the current default when another login method is added.
- Allow explicit method selection and capability-based switching with `--require-capability remote-control`.

## Why

A Claude account can have several CLI credentials with different capabilities and lifecycles. Treating each credential as a separate account duplicates the identity and usage display, while hiding which login can perform a requested workflow.

The account now owns its login methods. Normal switching uses the saved default. Capability-based switching selects a compatible method or fails before changing credentials.

## Authentication model

| Login method | Scope | Remote Control |
| --- | --- | --- |
| Browser OAuth | Full | Yes |
| Setup token | Inference only | No |
| API key | Inference only | No |

## Validation

Validated independently on two Apple Silicon macOS 26 hosts:

- Full suite on each host: 1,845 passed and 3 skipped. The remaining permission-semantics test fails identically on current upstream `main`.
- Focused auth, CLI, JSON, transfer, and TUI suite on each host, serially: 355 passed.
- Built and installed the release wheel on each host.
- Ran a real terminal-scoped Claude request through a saved setup token on each host. Global account state and `sequence.json` remained unchanged.
- Exercised the native macOS Keychain backend with disposable credentials: method grouping, default preservation, Remote Control selection, fail-before-mutation rejection, slot moves, export/import, and complete cleanup.
- Changed-file syntax lint, secret scan, and final P0 autoreview: clean.

Supersedes #231 and #232.