### PR TITLE
fix(switcher): stop resync from overwriting independently acquired credentials

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -3221,6 +3221,44 @@ class ClaudeAccountSwitcher:
             retry_after_s=outcome.retry_after_s,
         )
 
+    def _backup_is_independent(self, account_num: str, backup: str) -> bool:
+        """Whether this slot's backup was acquired outside the live store.
+
+        The resync below exists for ONE shape: a backup that went stale because
+        Claude Code rotated the live credential the backup had been copied from
+        (rotation-before-collection). That makes the backup a *consumed
+        predecessor* of what is live now.
+
+        A credential that was never derived from the live store cannot be a
+        predecessor of anything in it — it belongs to a different lineage
+        entirely. Two independent grants for the same account are the case the
+        ownership probe cannot separate: it answers *whose account is this*, and
+        both answer "yours". Rotation leaves no observable link between
+        generations either, so nothing recoverable at this point distinguishes
+        them. Only a record written at acquisition time can, which is why
+        ``credentialOrigin`` exists.
+
+        Keyed by fingerprint so it self-invalidates: if the slot is later
+        re-provisioned by any derived path, the recorded fingerprint stops
+        describing the backup and this returns False — failing back to the
+        resync rather than protecting bytes the record never described.
+
+        Absent record → False, so every existing install behaves exactly as
+        before and no migration is required.
+        """
+        try:
+            data = self._get_sequence_data() or {}
+            record = (data.get("accounts") or {}).get(str(account_num)) or {}
+            origin = record.get("credentialOrigin") or {}
+            if origin.get("kind") != "independent":
+                return False
+            return bool(
+                origin.get("fingerprint")
+                and origin["fingerprint"] == oauth.credential_fingerprint(backup)
+            )
+        except Exception:
+            return False  # unreadable metadata must not block the heal
+
     def _resync_rotated_backup(
         self, account_num: str, email: str, org_uuid: str, creds: str
     ) -> None:
@@ -3265,6 +3303,8 @@ class ClaudeAccountSwitcher:
                 == oauth.credential_fingerprint(backup)
             ):
                 return  # same lineage — nothing drifted
+            if backup and self._backup_is_independent(account_num, backup):
+                return  # never derived from live — nobody's predecessor
             fp = oauth.credential_fingerprint(creds) or ""
             verdict = self._probe_verdicts.get(
                 self._lineage_key(account_num, email, fp)

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -14,7 +14,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from claude_swap import __version__
+from claude_swap import __version__, oauth
 from claude_swap.credentials import looks_like_api_key
 from claude_swap.exceptions import (
     ConfigError,
@@ -272,6 +272,13 @@ def export_accounts(
             entry["kind"] = "api_key"
         if record.get("alias"):
             entry["alias"] = record["alias"]
+        # Carry provenance across the wire. Without this the importing machine
+        # would have to guess, and "arrived via import" is not the same claim as
+        # "acquired independently" — an account captured from the live store
+        # here and imported there would be mislabelled independent, suppressing
+        # a heal it genuinely needs.
+        if record.get("credentialOrigin"):
+            entry["credentialOrigin"] = record["credentialOrigin"]
         accounts_payload.append(entry)
 
     if not accounts_payload:
@@ -432,6 +439,10 @@ def import_accounts(
                 "alias": alias,
                 "creds_text": creds_text,
                 "config_text": json.dumps(config_obj, indent=2),
+                "origin_kind": (
+                    (raw.get("credentialOrigin") or {}).get("kind")
+                    or "independent"
+                ),
             }
         )
 
@@ -552,6 +563,18 @@ def import_accounts(
             new_record["kind"] = "api_key"
         if entry.get("alias"):
             new_record["alias"] = entry["alias"]
+        # Record where this credential came from, so the rotated-backup resync
+        # can tell a consumed predecessor from an independent grant for the same
+        # account — the one case the ownership probe cannot separate. An import
+        # is independent unless the payload says otherwise (see export). The
+        # fingerprint is recomputed from the bytes actually written, so the
+        # record describes what is really in the slot.
+        origin_fp = oauth.credential_fingerprint(entry["creds_text"])
+        if origin_fp:
+            new_record["credentialOrigin"] = {
+                "kind": entry["origin_kind"],
+                "fingerprint": origin_fp,
+            }
         data["accounts"][target_num] = new_record
         if int(target_num) not in data["sequence"]:
             data["sequence"].append(int(target_num))

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -2294,6 +2294,83 @@ class TestActiveAccountRefresh:
             )
         return result, write_backup, mock_probe
 
+    # An independently acquired grant for the SAME account: a full token pair
+    # that was never derived from the live store, so it is nobody's predecessor.
+    _INDEPENDENT = json.dumps({
+        "claudeAiOauth": {
+            "accessToken": "sk-independent",
+            "refreshToken": "rt-independent",
+            "expiresAt": 9999999999000,
+        }
+    })
+
+    def test_fresh_fetch_leaves_an_independently_provisioned_backup_alone(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """Two independent grants for the same account. The ownership probe
+        affirms both — it answers *whose account is this*, not *which grant is
+        newer* — so without provenance the resync overwrites a working,
+        independently acquired refresh token that it cannot distinguish from a
+        consumed predecessor. A backup cswap never derived from the live store
+        is nobody's predecessor and must survive."""
+        sample_sequence_data["accounts"]["1"]["credentialOrigin"] = {
+            "kind": "independent",
+            "fingerprint": oauth.credential_fingerprint(self._INDEPENDENT),
+        }
+        switcher = self._switcher(sample_sequence_data)
+
+        with patch.object(
+                 switcher, "_read_credentials", return_value=self._REFRESHED
+             ), \
+             patch.object(
+                 switcher, "_read_account_credentials",
+                 return_value=self._INDEPENDENT,
+             ), \
+             patch.object(switcher, "_write_account_credentials") as write_backup, \
+             patch("claude_swap.oauth.fetch_oauth_profile",
+                   return_value=self._PROFILE_SELF), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 3}})):
+            switcher._fetch_active_usage(
+                "1", "test@example.com", self._REFRESHED
+            )
+
+        write_backup.assert_not_called()
+
+    def test_fresh_fetch_resyncs_when_the_origin_record_no_longer_describes_the_backup(
+        self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict
+    ):
+        """The origin record is keyed by fingerprint so it self-invalidates. A
+        slot re-provisioned by any derived path leaves the recorded fingerprint
+        describing a credential that is no longer there, and the marker must
+        stop applying rather than protect bytes it never described — failing
+        back to the resync, not away from it."""
+        sample_sequence_data["accounts"]["1"]["credentialOrigin"] = {
+            "kind": "independent",
+            "fingerprint": "sha256:stale-no-longer-the-backup",
+        }
+        switcher = self._switcher(sample_sequence_data)
+
+        with patch.object(
+                 switcher, "_read_credentials", return_value=self._REFRESHED
+             ), \
+             patch.object(
+                 switcher, "_read_account_credentials",
+                 return_value=self._EXPIRED,
+             ), \
+             patch.object(switcher, "_write_account_credentials") as write_backup, \
+             patch("claude_swap.oauth.fetch_oauth_profile",
+                   return_value=self._PROFILE_SELF), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 3}})):
+            switcher._fetch_active_usage(
+                "1", "test@example.com", self._REFRESHED
+            )
+
+        assert write_backup.call_args_list == [
+            call("1", "test@example.com", self._REFRESHED),
+        ]
+
     def test_fresh_foreign_probe_mismatch_skips_resync_warns_once_and_caches(
         self, temp_home: Path, mock_claude_config: Path, sample_sequence_data: dict,
         caplog,

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
+from claude_swap import oauth
 from claude_swap.exceptions import TransferError
 from claude_swap.models import Platform
 from claude_swap.switcher import ClaudeAccountSwitcher
@@ -88,6 +89,78 @@ def _seed_account(
     if data["activeAccountNumber"] is None:
         data["activeAccountNumber"] = num
     switcher._write_json(switcher.sequence_file, data)
+
+
+# ---------------------------------------------------------------------------
+# Credential provenance
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialProvenance:
+    """``credentialOrigin`` records where a slot's credential came from, so the
+    rotated-backup resync can tell a consumed predecessor from an independently
+    acquired grant for the same account — the one case the ownership probe
+    cannot separate, since it answers *whose account is this* and both answer
+    "yours"."""
+
+    def test_import_marks_the_slot_independent(self, temp_home: Path):
+        """A payload with no provenance was not derived from this machine's
+        live store, so the credential it carries cannot be a predecessor of
+        anything here."""
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com")
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+
+        dst_home = temp_home.parent / "dst-independent"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home), \
+             patch.dict(os.environ, {"HOME": str(dst_home)}):
+            dst = _linux_switcher(dst_home)
+            import_accounts(dst, str(out_file))
+            origin = (dst._get_sequence_data() or {})["accounts"]["1"][
+                "credentialOrigin"
+            ]
+            creds_text = dst._read_account_credentials("1", "alice@example.com")
+
+        assert origin["kind"] == "independent"
+        # Describes the bytes actually written, not the bytes in the payload.
+        assert origin["fingerprint"] == oauth.credential_fingerprint(creds_text)
+
+    def test_export_carries_provenance_so_import_does_not_invent_it(
+        self, temp_home: Path
+    ):
+        """Export/import moves accounts BETWEEN MACHINES, so "arrived via
+        import" is not the same claim as "acquired independently". A slot
+        captured from the live store here must stay ``derived`` there, or the
+        importing machine suppresses a heal it genuinely needs."""
+        src = _linux_switcher(temp_home)
+        _seed_account(src, 1, "alice@example.com")
+        data = src._get_sequence_data()
+        assert data is not None
+        creds_text = src._read_account_credentials("1", "alice@example.com")
+        data["accounts"]["1"]["credentialOrigin"] = {
+            "kind": "derived",
+            "fingerprint": oauth.credential_fingerprint(creds_text),
+        }
+        src._write_json(src.sequence_file, data)
+
+        out_file = temp_home / "backup.cswap"
+        export_accounts(src, str(out_file))
+        envelope = json.loads(out_file.read_text())
+        assert envelope["accounts"][0]["credentialOrigin"]["kind"] == "derived"
+
+        dst_home = temp_home.parent / "dst-derived"
+        dst_home.mkdir()
+        with patch("pathlib.Path.home", return_value=dst_home), \
+             patch.dict(os.environ, {"HOME": str(dst_home)}):
+            dst = _linux_switcher(dst_home)
+            import_accounts(dst, str(out_file))
+            origin = (dst._get_sequence_data() or {})["accounts"]["1"][
+                "credentialOrigin"
+            ]
+
+        assert origin["kind"] == "derived"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

`_resync_rotated_backup` can overwrite a slot's working refresh token with a different, unrelated one.

**Repro:**

1. Slot 1 holds an independently acquired grant for `alice@example.com`, for example one provisioned via `cswap import`.
2. The shared profile is also logged in as `alice@example.com`, holding a *different* grant.
3. Any `cswap list` usage pass overwrites slot 1's backup with the live credential and logs `Resynced account 1's backup to the rotated live credential`.

Slot 1's independent refresh token is now gone. I hit this on a real machine, not in a test.

## Why the existing guards miss it

Every guard in the function checks ownership. The token-pair check, the same-lineage early return, the profile-oracle probe, and the identity and verdict re-checks under the lock all answer one question: does this credential belong to this account?

None of them checks which grant is newer.

Two independent grants for the same account both belong to that account, so the probe affirms both. Past that point a consumed predecessor and a live independent grant are indistinguishable. Both look like "backup differs from live, same identity".

`_classify_outgoing_credential` already states the principle: *"identity proves ownership, not generation freshness"*. The resync path does not apply it.

## Why not just compare `expiresAt`

I tried that first. It does not work.

`expiresAt` is the access-token expiry. It tracks how recently a credential was refreshed, not which grant is newer. A busy live store almost always leads an idle slot. On my machine the independent slot expired at 11:44 against a live store at 17:01, so the comparison would have permitted the overwrite.

`test_expiry_after_unresynced_rotation_defers_without_verified_lineage` already says this in its docstring.

## The fix

Record where a credential came from, at acquisition time. `credentialOrigin: {kind, fingerprint}` per slot in `sequence.json`, checked before the probe.

| Decision | Reason |
|---|---|
| Absent record means `derived` | Existing installs behave exactly as today. No migration. |
| Keyed by fingerprint | A slot re-provisioned by a derived path invalidates the record and falls back to resyncing, instead of protecting bytes it never described. |
| Stored beside the credential | Backups get written into Claude Code's live store on switch, so the blob itself stays untouched. |
| `import` stamps it | A payload from elsewhere was not derived from *this* machine's live store. |
| `export` carries it forward | Export moves accounts between machines. "Arrived via import" is not the same claim as "acquired independently". The field is additive and optional, so v1 payloads round-trip both ways. |

## Tests

Four added. The two switcher tests fail on `main` and pass with the fix.

- `test_fresh_fetch_leaves_an_independently_provisioned_backup_alone` covers the bug above.
- `test_fresh_fetch_resyncs_when_the_origin_record_no_longer_describes_the_backup` proves the record self-invalidates, failing toward the resync rather than away from it.
- `test_import_marks_the_slot_independent`
- `test_export_carries_provenance_so_import_does_not_invent_it`

`1836 passed` locally on 3.12 and 3.14. One unrelated failure, `test_move_strict_clear_fails_closed_on_unreadable_dir`, fails identically on clean `main` on macOS. CI runs the full suite on Linux and Windows, so it should not appear there.

## Notes

**Not addressed, deliberately.** `backup` is read before the lock and never re-read under it, so this check inherits that existing window. Widening the locked region is a separate change.

**Smaller alternative.** If per-slot provenance is more surface than you want, a per-account `autoResync` opt-out covers the same case for much less code. I think it is worse as a default, because the people who need it are the ones who do not know the failure mode exists, but I am happy to switch.

**Context.** I found this while moving the desktop app onto its own config dir so no slot is ever active. That avoids the code path rather than fixing it, and it costs the ability to run the desktop app on a cswap-managed account.

🤖 Edited with [Claude Code](https://claude.com/claude-code)
