### PR TITLE
fix(credentials): stop pairing one profile's identity with another profile's credential

### DIFF
--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -38,10 +38,74 @@ from claude_swap.models import Platform
 from claude_swap.paths import (
     get_claude_config_home,
     get_credentials_path,
+    get_default_claude_config_home,
     get_global_config_path,
 )
 
 _logger = logging.getLogger("claude-swap")
+
+
+def _active_profile_is_default() -> bool:
+    """Whether the active config home is the default profile's.
+
+    ``CLAUDE_CONFIG_DIR`` pointed at the default profile is still the default
+    profile, so this keys on where the path resolves rather than on the
+    variable being set. Resolution also collapses symlinks, which is how a
+    profile reached through one shows up as itself.
+
+    Unresolvable paths answer False: treating an unknown profile as the default
+    is what licenses reading another account's credential, and that is the
+    failure this guards.
+    """
+    try:
+        return (
+            get_claude_config_home().resolve()
+            == get_default_claude_config_home().resolve()
+        )
+    except Exception:
+        return False
+
+
+def _active_oauth_keychain_services() -> list[str]:
+    """Keychain services holding the OAuth credential for the active environment.
+
+    Resolved exactly the way :meth:`ClaudeAccountSwitcher._read_capture_credentials`
+    resolves it, so the active read and the capture read agree about which
+    profile's store they are looking at. Claude (2.1.220
+    ``getMacOsKeychainStorageServiceName``) sources secure storage from
+    ``CLAUDE_SECURESTORAGE_CONFIG_DIR`` when that is *defined*, else
+    ``CLAUDE_CONFIG_DIR``; defined-but-empty selects the *default* secure store,
+    whose item is the unsuffixed one.
+
+    Returned in try-order rather than as a single name for one case: an explicit
+    ``CLAUDE_CONFIG_DIR`` naming the default profile. Claude hashes the exported
+    string, so it would write a *suffixed* item there, but a user who has always
+    used the default profile may only have the unsuffixed one. Capture handles
+    that with the same fallback (``_same_directory`` → ``_read_credentials``).
+    A defined ``CLAUDE_SECURESTORAGE_CONFIG_DIR`` gets no fallback: it names the
+    only store claude will read for this environment, so a miss means claude
+    sees a logged-out profile and reaching into another store would report a
+    credential claude is not using.
+    """
+    # Local import: session imports from this module, so a top-level import
+    # would close the cycle. _read_capture_credentials does the same.
+    from claude_swap.session import keychain_service_name
+
+    secure_env = os.environ.get("CLAUDE_SECURESTORAGE_CONFIG_DIR")
+    if secure_env is not None:
+        if not secure_env:
+            return [CLAUDE_CODE_KEYCHAIN_SERVICE]
+        return [keychain_service_name(secure_env)]
+
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if not config_dir:
+        return [CLAUDE_CODE_KEYCHAIN_SERVICE]
+
+    services = [keychain_service_name(config_dir)]
+    if _active_profile_is_default():
+        services.append(CLAUDE_CODE_KEYCHAIN_SERVICE)
+    return services
+
 
 # Service name for per-account backup credentials now managed via the ``security``
 # CLI on macOS. Deliberately distinct from KEYRING_SERVICE so old keyring items and
@@ -446,7 +510,31 @@ class CredentialStore:
         return self._read_active_credentials().value
 
     def _read_active_oauth_keychain(self) -> tuple[str | None, bool]:
-        """Read the active OAuth Keychain item with a bounded retry.
+        """Read the active profile's OAuth Keychain item(s).
+
+        Reads the item(s) :func:`_active_oauth_keychain_services` resolves for
+        the current environment, in order, stopping at the first hit. Only the
+        explicit-``CLAUDE_CONFIG_DIR``-names-the-default-profile case yields
+        more than one; see that function for why.
+
+        Returns ``(value, failed)`` exactly as before: ``value`` is the
+        credential string, or ``None`` when every item was absent (rc-44) or the
+        Keychain was unreadable. ``failed`` is True only for unreadable.
+
+        An unreadable Keychain stops the walk. It is a property of the Keychain,
+        not of the item, so a second service name cannot fare better — and
+        ``_kc_call`` has already flipped routing to file mode by then.
+        """
+        for service in _active_oauth_keychain_services():
+            value, failed = self._read_one_oauth_keychain(service)
+            if value:
+                return value, False
+            if failed:
+                return None, True
+        return None, False
+
+    def _read_one_oauth_keychain(self, service: str) -> tuple[str | None, bool]:
+        """Read one OAuth Keychain item with a bounded retry.
 
         Returns ``(value, failed)``. ``value`` is the credential string, or
         ``None`` when the item is absent (rc-44) or unreadable. ``failed`` is True
@@ -460,7 +548,7 @@ class CredentialStore:
             try:
                 value = self._kc_call(
                     macos_keychain.get_password,
-                    CLAUDE_CODE_KEYCHAIN_SERVICE,
+                    service,
                     macos_keychain.keychain_account_name(),
                 )
                 return value, False
@@ -495,6 +583,26 @@ class CredentialStore:
         """
         keychain_failed = False
         # 1. OAuth Keychain (macOS, when usable), with a bounded retry.
+        #
+        # READ THE ITEM FOR *THIS* PROFILE, NOT THE FIXED NAME.
+        # CLAUDE_CODE_KEYCHAIN_SERVICE is a fixed name, but Claude Code stores
+        # only the DEFAULT profile's credential under it: with CLAUDE_CONFIG_DIR
+        # set it scopes the item to that config dir under a hashed service name.
+        # Reading the fixed name from a custom profile therefore returns a
+        # credential belonging to a different account, while the identity read
+        # one layer up (paths.get_claude_config_home, which does honor
+        # CLAUDE_CONFIG_DIR) reports the custom profile's. Pairing an identity
+        # with another account's token is silent, and every consumer of this
+        # read inherits it.
+        #
+        # REDIRECTED, NOT SKIPPED. Skipping the keychain under a custom profile
+        # would leave macOS mostly blind: claude writes rotations keychain-only
+        # there, so the step-2 plaintext file frequently does not exist at all
+        # and a logged-in profile would render as "no credentials" — trading a
+        # wrong answer for a missing one. The hashed name is not a guess in this
+        # codebase either: session.keychain_service_name codifies claude's
+        # derivation (pinned against its source) and the delete, session-read
+        # and capture paths already depend on it.
         if self._use_keychain():
             val, keychain_failed = self._read_active_oauth_keychain()
             # THIS read's own verdict, kept so a later success on some OTHER
@@ -546,8 +654,25 @@ class CredentialStore:
         macOS Keychain "Claude Code" (when usable) first, then ``~/.claude.json``
         ``primaryApiKey`` — mirroring Claude Code's
         ``getApiKeyFromConfigOrMacOSKeychain``.
+
+        The Keychain half is default-profile-only. Unlike the OAuth item above
+        this one is gated rather than redirected, because there is no codified
+        derivation to redirect it *to*: ``session.keychain_service_name`` covers
+        the credentials item, and claude's managed-key service name under a
+        custom profile is not pinned anywhere in this repo. Guessing it is the
+        thing the OAuth half can avoid and this half cannot.
+
+        Gating matches what capture already does.
+        ``_read_capture_credentials`` ends on "only this profile's own
+        ``primaryApiKey`` — never the unsuffixed 'Claude Code' Keychain item,
+        which belongs to the default profile and would answer for a login that
+        is not the one being added". Same item, same conclusion; this makes the
+        read side agree with the capture side instead of contradicting it.
+
+        ``primaryApiKey`` below is read from the active profile's own config and
+        stays, so a custom profile with a managed key is still found.
         """
-        if self._use_keychain():
+        if _active_profile_is_default() and self._use_keychain():
             try:
                 val = self._kc_call(
                     macos_keychain.get_password,

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,273 @@
+"""``CredentialStore``: the active-credential read must stay on one profile.
+
+The identity read honors ``CLAUDE_CONFIG_DIR`` (``paths.get_claude_config_home``)
+while the Keychain read used a hardcoded service name that does not. Pairing one
+profile's identity with another profile's credential is silent, and every
+consumer of the active read inherits it.
+
+The fix resolves the Keychain item the way claude does for the same environment
+(``session.keychain_service_name``, the same derivation ``delete``, the
+session read and capture already use) rather than skipping the Keychain under a
+custom profile. Skipping would trade a wrong answer for a missing one: claude
+writes rotations keychain-only on macOS, so a custom profile frequently has no
+plaintext file at all and would render as "no credentials" while logged in.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from claude_swap.credentials import (
+    CLAUDE_CODE_KEYCHAIN_SERVICE,
+    CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
+    CredentialStore,
+)
+from claude_swap.models import Platform
+from claude_swap.session import keychain_service_name
+
+
+class _Host:
+    """Minimal ``_StoreHost``: data only, read at call time."""
+
+    def __init__(self, credentials_dir: Path):
+        self.platform = Platform.MACOS
+        self.credentials_dir = credentials_dir
+        self._logger = logging.getLogger("test")
+
+
+DEFAULT_PROFILE_CREDS = json.dumps({
+    "claudeAiOauth": {
+        "accessToken": "sk-default-profile",
+        "refreshToken": "rt-default-profile",
+        "expiresAt": 9999999999000,
+    }
+})
+
+CUSTOM_PROFILE_CREDS = json.dumps({
+    "claudeAiOauth": {
+        "accessToken": "sk-custom-profile",
+        "refreshToken": "rt-custom-profile",
+        "expiresAt": 9999999999000,
+    }
+})
+
+SECURE_PROFILE_CREDS = json.dumps({
+    "claudeAiOauth": {
+        "accessToken": "sk-secure-profile",
+        "refreshToken": "rt-secure-profile",
+        "expiresAt": 9999999999000,
+    }
+})
+
+
+def _keychain(mapping: dict[str, str], seen: list[str]):
+    """A fake Keychain: only the listed services exist, and record every probe.
+
+    Anything unlisted returns ``None``, which is claude's rc-44 "absent item"
+    signal — the case that legitimately falls through to the plaintext file.
+    """
+
+    def fake_get_password(service: str, account: str):
+        seen.append(service)
+        return mapping.get(service)
+
+    return fake_get_password
+
+
+class TestActiveReadStaysOnOneProfile:
+    def test_custom_config_dir_does_not_return_the_default_keychain_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The hardcoded ``Claude Code-credentials`` item belongs to the DEFAULT
+        profile. Under a custom ``CLAUDE_CONFIG_DIR`` it must never answer, or
+        the store hands back one account's token against another's identity."""
+        custom = tmp_path / "custom-profile"
+        custom.mkdir()
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+        monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "claude_swap.macos_keychain.get_password",
+            _keychain(
+                {
+                    CLAUDE_CODE_KEYCHAIN_SERVICE: DEFAULT_PROFILE_CREDS,
+                    CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE: "sk-ant-api-default",
+                },
+                seen,
+            ),
+        )
+
+        result = CredentialStore(_Host(tmp_path / "backups"))._read_active_credentials()
+
+        assert CLAUDE_CODE_KEYCHAIN_SERVICE not in seen, (
+            f"read the default profile's OAuth item: {seen}"
+        )
+        assert CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE not in seen, (
+            f"read the default profile's managed-key item: {seen}"
+        )
+        assert result.value != DEFAULT_PROFILE_CREDS
+        assert not result.value
+
+    def test_custom_config_dir_reads_its_own_hashed_keychain_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The regression a plain skip would introduce.
+
+        On macOS claude writes rotations keychain-only, so a live custom profile
+        commonly has a hashed item and NO plaintext file. Skipping the Keychain
+        would report "no credentials" for a profile that is logged in; the
+        redirect returns the profile's real credential."""
+        custom = tmp_path / "custom-profile"
+        custom.mkdir()  # deliberately no .credentials.json
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+        monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "claude_swap.macos_keychain.get_password",
+            _keychain(
+                {
+                    keychain_service_name(str(custom)): CUSTOM_PROFILE_CREDS,
+                    CLAUDE_CODE_KEYCHAIN_SERVICE: DEFAULT_PROFILE_CREDS,
+                },
+                seen,
+            ),
+        )
+
+        result = CredentialStore(_Host(tmp_path / "backups"))._read_active_credentials()
+
+        assert result.value == CUSTOM_PROFILE_CREDS
+        assert seen == [keychain_service_name(str(custom))]
+
+    def test_custom_config_dir_falls_back_to_its_own_credentials_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """An ABSENT hashed item (rc 44) is claude's own signal to read the
+        plaintext seed — and that file is unambiguously this profile's."""
+        custom = tmp_path / "custom-profile"
+        custom.mkdir()
+        (custom / ".credentials.json").write_text(
+            CUSTOM_PROFILE_CREDS, encoding="utf-8"
+        )
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+        monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "claude_swap.macos_keychain.get_password",
+            _keychain({CLAUDE_CODE_KEYCHAIN_SERVICE: DEFAULT_PROFILE_CREDS}, seen),
+        )
+
+        store = CredentialStore(_Host(tmp_path / "backups"))
+        assert store._read_active_credentials().value == CUSTOM_PROFILE_CREDS
+        assert CLAUDE_CODE_KEYCHAIN_SERVICE not in seen
+
+    def test_default_profile_still_reads_the_unsuffixed_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The common case is unchanged. With no ``CLAUDE_CONFIG_DIR`` the
+        unsuffixed item IS this profile's credential."""
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "claude_swap.macos_keychain.get_password",
+            _keychain({CLAUDE_CODE_KEYCHAIN_SERVICE: DEFAULT_PROFILE_CREDS}, seen),
+        )
+
+        store = CredentialStore(_Host(tmp_path / "backups"))
+        assert store._read_active_credentials().value == DEFAULT_PROFILE_CREDS
+        assert seen == [CLAUDE_CODE_KEYCHAIN_SERVICE]
+
+    def test_config_dir_equal_to_the_default_falls_back_to_the_unsuffixed_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Setting ``CLAUDE_CONFIG_DIR`` to the default profile explicitly is not
+        a custom profile. Claude hashes the exported string, so the hashed name
+        is tried first, but a user who has always used the default profile may
+        only have the unsuffixed item — so that fallback must remain."""
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        default = tmp_path / ".claude"
+        default.mkdir()
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(default))
+        monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "claude_swap.macos_keychain.get_password",
+            _keychain({CLAUDE_CODE_KEYCHAIN_SERVICE: DEFAULT_PROFILE_CREDS}, seen),
+        )
+
+        store = CredentialStore(_Host(tmp_path / "backups"))
+        assert store._read_active_credentials().value == DEFAULT_PROFILE_CREDS
+        assert seen == [
+            keychain_service_name(str(default)),
+            CLAUDE_CODE_KEYCHAIN_SERVICE,
+        ]
+
+
+class TestSecureStorageOverride:
+    """``CLAUDE_SECURESTORAGE_CONFIG_DIR`` takes precedence when *defined*.
+
+    Claude 2.1.220+ resolves secure storage from it and only falls back to
+    ``CLAUDE_CONFIG_DIR`` when it is undefined. ``_read_capture_credentials``
+    already reads it this way; the active read has to agree, or the two disagree
+    about which profile they are looking at.
+    """
+
+    def test_defined_and_empty_selects_the_default_store(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Defined-but-empty means the DEFAULT secure store, even with a custom
+        ``CLAUDE_CONFIG_DIR``. Here the unsuffixed item is the correct read, so
+        a guard keyed only on ``CLAUDE_CONFIG_DIR`` would wrongly return
+        nothing."""
+        custom = tmp_path / "custom-profile"
+        custom.mkdir()
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+        monkeypatch.setenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", "")
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "claude_swap.macos_keychain.get_password",
+            _keychain({CLAUDE_CODE_KEYCHAIN_SERVICE: DEFAULT_PROFILE_CREDS}, seen),
+        )
+
+        store = CredentialStore(_Host(tmp_path / "backups"))
+        assert store._read_active_credentials().value == DEFAULT_PROFILE_CREDS
+        assert seen == [CLAUDE_CODE_KEYCHAIN_SERVICE]
+
+    def test_defined_and_set_selects_that_stores_hashed_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A defined, non-empty value names the only store claude will read."""
+        custom = tmp_path / "custom-profile"
+        custom.mkdir()
+        secure = tmp_path / "secure-profile"
+        secure.mkdir()
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+        monkeypatch.setenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", str(secure))
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "claude_swap.macos_keychain.get_password",
+            _keychain(
+                {
+                    keychain_service_name(str(secure)): SECURE_PROFILE_CREDS,
+                    keychain_service_name(str(custom)): CUSTOM_PROFILE_CREDS,
+                    CLAUDE_CODE_KEYCHAIN_SERVICE: DEFAULT_PROFILE_CREDS,
+                },
+                seen,
+            ),
+        )
+
+        store = CredentialStore(_Host(tmp_path / "backups"))
+        assert store._read_active_credentials().value == SECURE_PROFILE_CREDS
+        assert seen == [keychain_service_name(str(secure))]


### PR DESCRIPTION
## The bug

The active-credential read resolves its Keychain item from a fixed service name. The identity read one layer up (`paths.get_claude_config_home`) honors `CLAUDE_CONFIG_DIR`. Under a custom profile those two land in different profiles, so the store reports one account's identity paired with another account's token.

Nothing surfaces. There is no error, no warning, and no mismatch anyone can see, because each half is individually correct.

## Repro

1. Log in normally, so the default profile holds account A.
2. `export CLAUDE_CONFIG_DIR=~/some-other-profile` and log in there as account B.
3. Run `cswap list`.

Before this PR the identity reads B from the custom profile's `.claude.json`, while the credential reads A out of the unsuffixed Keychain item. The token belongs to A. The label says B.

## Who this affects

Users who set `CLAUDE_CONFIG_DIR` themselves. Claude Code does not set it (checked against 2.1.227); the spawn path only propagates it when it is already set.

Affected consumers are the ones that go through `_read_active_credentials`: `list`, `--status`, usage collection, `token_dead`, and switch reads.

**Not** `cswap add`. That consequence was already fixed by #190 (`9c6fc24`, plus `253877c` and `521075f`), which routed capture through `_read_capture_credentials`. All three are ancestors of this branch, so the mislabeled-slot outcome no longer reproduces on it.

## The fix

Resolve the Keychain item the way claude resolves it for the same environment, rather than assuming the default profile's.

Resolution mirrors `_read_capture_credentials` exactly, so the read side and the capture side cannot disagree about which profile they are looking at:

| Environment | Item read |
|---|---|
| Neither variable set | Unsuffixed `Claude Code-credentials` |
| `CLAUDE_CONFIG_DIR` set to a custom profile | That dir's hashed item |
| `CLAUDE_CONFIG_DIR` set to the default profile | Hashed item, then unsuffixed as fallback |
| `CLAUDE_SECURESTORAGE_CONFIG_DIR` defined and empty | Unsuffixed, whatever `CLAUDE_CONFIG_DIR` says |
| `CLAUDE_SECURESTORAGE_CONFIG_DIR` defined and set | That dir's hashed item, no fallback |

Two asymmetries in that table are deliberate:

- An explicit `CLAUDE_CONFIG_DIR` naming the default profile falls back to the unsuffixed item. Claude hashes the exported string and would write a suffixed item, but a user who has always used the default profile may only have the unsuffixed one.
- A defined `CLAUDE_SECURESTORAGE_CONFIG_DIR` gets no fallback. It names the only store claude will read for that environment, so a miss means claude sees a logged-out profile. Reaching into another store would report a credential claude is not using.

`session.keychain_service_name` supplies the derivation, which is the same one `delete_macos_keychain_entry`, `read_session_credentials` and `_read_capture_credentials` already depend on.

### Why redirect and not skip

An earlier version of this PR skipped the Keychain entirely under a custom profile and relied on the plaintext fallback. That is worse, not safer.

On macOS claude writes rotations keychain-only, so a live custom profile frequently has a hashed item and no `.credentials.json` at all. Measured on two such profiles: hashed item present, plaintext file absent in both. Skipping would render a logged-in profile as "no credentials", trading a wrong answer for a missing one.

### What is gated rather than redirected

The managed-key Keychain read (`Claude Code`) is skipped under a custom profile instead of redirected. `session.keychain_service_name` covers the credentials item; claude's managed-key service name under a custom profile is not pinned anywhere in this repo, so redirecting it would be a guess. Capture already reached the same conclusion about the same item.

`primaryApiKey` is read from the active profile's own config and is unaffected, so a custom profile with a managed key still resolves.

## Known scope limit

This changes reads only. Flows that both read and write (the usage refresh, switch) now read the profile's own item but still write the fixed-name item via `_write_oauth_credentials`. That split does not exist before this PR, since both sides previously hit the same item.

Writes are deliberately out of scope: the write-side clobber predates this PR and the provenance gates from #117 and #196 cap the damage. Worth fixing separately.

## Behavior when nothing is set

Unchanged. With no `CLAUDE_CONFIG_DIR` the unsuffixed item is this profile's credential and is still what gets read, on the same code path as before. The retry, timeout and degraded/unavailable classification in `_read_active_oauth_keychain` are untouched; the per-item retry moved into `_read_one_oauth_keychain` and the outer method keeps its signature.

## Tests

7 tests in `tests/test_credentials.py`, none of which touch a real Keychain, so they run on every platform.

- A custom profile never returns the default profile's OAuth or managed-key item.
- A custom profile whose credential exists **only** as a hashed Keychain item is read correctly. This is the case a skip would break.
- A custom profile falls back to its own `.credentials.json` when the hashed item is absent (rc 44, claude's own signal to read the file).
- No `CLAUDE_CONFIG_DIR` still reads the unsuffixed item.
- `CLAUDE_CONFIG_DIR` pointing at the default profile tries hashed, then unsuffixed.
- `CLAUDE_SECURESTORAGE_CONFIG_DIR` defined-but-empty selects the default store even under a custom `CLAUDE_CONFIG_DIR`.
- `CLAUDE_SECURESTORAGE_CONFIG_DIR` defined and set selects that store's hashed item and does not fall back.

Full suite on the rebased tree: 2085 passed, 3 skipped.

Branch is rebased onto current `main` (`9f62506`, post #196).
