### PR TITLE
fix(settings): make the JSON write byte-stable — trailing newline + sorted keys

### DIFF
--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -472,7 +472,16 @@ def atomic_write_json(path: Path, data: dict) -> None:
         os.chmod(path.parent, 0o700)
     fd, tmp_path = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
     try:
-        os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
+        # sort_keys + trailing newline: the bytes must depend on the CONTENT
+        # only. This file is deployed `link: absolute`, so every write lands
+        # in a TRACKED dotfiles path — without both, the repo carries a diff
+        # that returns after each write and `git status` is never clean on any
+        # machine. Measured: the missing newline gave a permanent
+        # `\ No newline at end of file`, and insertion order moved the
+        # `ui`/`theme` block while json equality stayed True, silently
+        # reverting a sync someone had just aligned.
+        payload = json.dumps(data, indent=2, sort_keys=True) + "\n"
+        os.write(fd, payload.encode("utf-8"))
         os.close(fd)
         fd = -1
         replace_with_retry(tmp_path, str(target))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -355,3 +355,62 @@ class TestAtomicWriteThroughSymlink:
         assert (repo.stat().st_mode & 0o777) == 0o755, "foreign dir untouched"
         assert (live.stat().st_mode & 0o777) == 0o700, "our dir hardened"
         assert (tracked.stat().st_mode & 0o777) == 0o600, "file still 0600"
+
+class TestWriteIsByteStable:
+    """The written bytes must depend on the CONTENT, not on dict order or luck.
+
+    `<backup>/settings.json` is deployed `link: absolute`, so it points AT a
+    tracked file in the dotfiles repo. Every write cswap makes lands in that
+    repo. Two properties therefore decide whether `git status` is ever clean
+    on three machines: a trailing newline, and a key order that does not move.
+    """
+
+    def test_write_ends_with_a_newline(self, tmp_path):
+        """No trailing newline means a permanent `\\ No newline at end of file`
+        diff that comes back on every write, so committing it never sticks."""
+        p = tmp_path / "settings.json"
+
+        atomic_write_json(p, {"b": 1, "a": 2})
+
+        assert p.read_bytes().endswith(b"\n"), (
+            "settings.json must end with a newline; without it the dotfiles "
+            "repo carries a one-line diff that returns after every write"
+        )
+
+    def test_key_order_does_not_change_the_bytes(self, tmp_path):
+        """Same content, different insertion order -> identical bytes.
+
+        Measured 2026-08-10 on the personal mac: the `ui`/`theme` block moved
+        while `json.load` equality stayed True, so an alignment was reverted by
+        pure reordering with no value change.
+        """
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+
+        atomic_write_json(a, {"ui": {"theme": "dark"}, "schemaVersion": 1})
+        atomic_write_json(b, {"schemaVersion": 1, "ui": {"theme": "dark"}})
+
+        assert a.read_bytes() == b.read_bytes(), (
+            "insertion order must not reach the file: equal content has to "
+            "produce equal bytes or the repo diff flaps"
+        )
+
+    def test_nested_key_order_also_normalised(self, tmp_path):
+        """Sorting only the top level would leave the nested blocks flapping —
+        and `ui`/`theme` is exactly a nested block."""
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+
+        atomic_write_json(a, {"ui": {"theme": "dark", "colour": "auto"}})
+        atomic_write_json(b, {"ui": {"colour": "auto", "theme": "dark"}})
+
+        assert a.read_bytes() == b.read_bytes(), "nested order must normalise too"
+
+    def test_content_still_round_trips(self, tmp_path):
+        """Normalising the bytes must not change what is stored."""
+        p = tmp_path / "settings.json"
+        data = {"schemaVersion": 1, "ui": {"theme": "dark"}, "autoswitch": {"threshold": 90}}
+
+        atomic_write_json(p, data)
+
+        assert json.loads(p.read_text()) == data


### PR DESCRIPTION
Two properties of the settings writer reach disk, and both make a
tracked file flap.

`atomic_write_json` wrote `json.dumps(data, indent=2)`:

- **no trailing newline** — a permanent `\ No newline at end of file`
  diff that returns after every write, so committing it never sticks;
- **key order taken from the dict it was handed** — the same content
  serialises differently depending on insertion order.

That is invisible if `settings.json` is a plain local file. It is not
invisible when the deployment links it into a dotfiles repo (`link:
absolute` here), which is the normal setup for anyone syncing config
across machines: every `cswap config set` / theme change then rewrites a
tracked file.

Measured on three machines: `git status` was never clean, and separately
a cross-machine sync was reverted with **no value changed** — `json.load`
equality stayed `True` while the `ui`/`theme` block had simply moved.

Sorting is recursive, which is the point: `ui`/`theme` is a nested
block, and top-level-only sorting would leave exactly the observed case
still flapping.

The writer is shared with the autoswitch state file and the other
machine-local JSON, so those get the same stability.

## Tests

Four, each written RED first, and both halves mutation-checked —
dropping `+ "\n"` kills the newline test, dropping `sort_keys` kills
both ordering tests:

- write ends with a newline
- reordered input produces identical bytes
- nested ordering normalises too
- content still round-trips (normalising the bytes must not change what
  is stored)

Suite: 1837 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)