### PR TITLE
feat(chrome): optional Claude in Chrome extension account sync (macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,50 @@ Shows every account's 5h / 7d / spend usage and switches with a click (specific 
 
 </details>
 
+## Chrome extension sync (macOS)
+
+<details>
+<summary>Optional — also switch the "Claude in Chrome" extension's account when you switch</summary>
+
+`cswap switch` changes the account the `claude` CLI uses. This opt-in add-on also switches the account the **Claude browser extension** uses, so Claude Code's browser automation follows the same account.
+
+Two separate logins are involved, linked by account number:
+
+- **CLI** — the `claude` command's account (Keychain OAuth), managed already.
+- **Browser** — the Claude in Chrome extension's own OAuth pairing.
+
+The extension authenticates with OAuth tokens (not a cookie), held in its
+service worker's in-memory storage. Switching stores each account's tokens and,
+on a switch, injects the target account's tokens into the extension and restarts
+its service worker so it reconnects as that account. Because modern Chrome won't
+let a tool drive your everyday profile, this runs a dedicated, lean "Claude Code"
+Chrome profile alongside your normal browser (a separate window just for Claude
+Code).
+
+> **Security:** stored tokens are bearer credentials (`sk-ant-oat01-` /
+> `sk-ant-ort01-`, equivalent to a password) kept in `chrome_sessions.json`
+> (chmod 600) beside your other cswap state. Anyone with that file can act as
+> those accounts until the tokens expire.
+
+```bash
+cswap chrome setup      # guided: enable → create profile → install extension → capture accounts
+cswap chrome doctor     # what's set up + per-account coverage
+```
+
+The wizard installs the extension into the dedicated profile (one click from the Web Store), has you connect it to Claude Code, and captures each account's tokens. Other commands:
+
+```bash
+cswap chrome open              # open/focus the dedicated Claude Browser
+cswap chrome capture <n>       # store account <n>'s tokens (connect it there first)
+cswap chrome refresh <n>       # keep account <n>'s stored tokens alive (no browser)
+cswap chrome create-profile    # (re)create the dedicated profile  (--rebuild to reset)
+cswap chrome enable | disable  # turn the feature on/off
+```
+
+Once set up, `cswap switch <n>` (CLI or menu bar) flips the dedicated browser to account `<n>` too — the extension reconnects on its own, no side-panel reopen needed. A stored account's refresh token lasts about 28.5 days untouched; switching to it within that window is seamless (the extension self-refreshes an expired token), and `cswap chrome refresh <n>` (or any switch) rolls the window forward so it never lapses. Off until you turn it on (`chrome.enabled` in `settings.json`); when disabled, switching is CLI-only and behaves exactly as before.
+
+</details>
+
 ## Advanced
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -287,6 +287,17 @@ cswap chrome enable | disable  # turn the feature on/off
 
 Once set up, `cswap switch <n>` (CLI or menu bar) flips the dedicated browser to account `<n>` too — the extension reconnects on its own, no side-panel reopen needed. A stored account's refresh token lasts about 28.5 days untouched; switching to it within that window is seamless (the extension self-refreshes an expired token), and `cswap chrome refresh <n>` (or any switch) rolls the window forward so it never lapses. Off until you turn it on (`chrome.enabled` in `settings.json`); when disabled, switching is CLI-only and behaves exactly as before.
 
+#### Making a *running* session follow a switch (bridge relay)
+
+A Claude Code session binds its browser-bridge account at startup, so a switch made **while it is running** is normally not picked up until you restart it. The optional bridge relay removes that restart:
+
+```bash
+cswap chrome bridge install   # background relay via a LaunchAgent (com.claude-swap.bridge)
+cswap chrome bridge status    # is it running?  (uninstall to remove)
+```
+
+Then launch Claude Code with `LOCAL_BRIDGE=1` (e.g. `LOCAL_BRIDGE=1 claude`). Claude Code's browser bridge then connects to the local relay instead of Anthropic's; the relay forwards it to the real bridge as the **current** cswap account and re-points live when you switch — so the browser follows account changes with no restart. The extension is never modified (it stays on the real bridge and keeps auto-updating). Verified TLS to the bridge (via the system trust store); the relay listens only on `127.0.0.1`. Note: `LOCAL_BRIDGE` is an internal Claude Code flag and may change between versions.
+
 </details>
 
 ## Advanced

--- a/src/claude_swap/chrome_bridge.py
+++ b/src/claude_swap/chrome_bridge.py
@@ -1,0 +1,388 @@
+"""Local bridge relay — the browser MCP follows a switch *without a restart*.
+
+Background
+----------
+The "Claude in Chrome" extension and Claude Code pair through Anthropic's bridge
+at ``wss://bridge.claudeusercontent.com/chrome/<accountUuid>``. The account UUID
+is the *room*: both peers must resolve to the same account to see each other. A
+running Claude Code session binds that account at process start, so a mid-session
+``cswap switch`` (which swaps the Keychain credential) is *not* adopted by the
+already-open bridge connection — the browser MCP stays on the old account until
+the process restarts.
+
+Claude Code ships a native escape hatch: with the env var ``LOCAL_BRIDGE=1`` it
+connects to a plaintext ``ws://localhost:8765/chrome/dev_user_local`` with a
+tokenless connect (``{"type":"connect","client_type":"claude-code",
+"dev_user_id":"dev_user_local"}``) — account-agnostic.
+
+This module is the other half: a local relay listening on that port. It swallows
+Claude Code's tokenless local connect and originates an *authenticated* upstream
+connection to the real bridge in the **current cswap account's** room, then
+relays every frame both ways. The extension is left untouched on the real bridge
+(cswap keeps switching it via CDP, so ordinary extension updates keep working).
+When ``cswap switch`` changes the active account, the relay re-points its
+upstream to the new room while the downstream Claude Code connection stays up —
+so the browser follows the switch live, no restart.
+
+Enable by running the daemon (``cswap chrome bridge``) and launching Claude Code
+with ``LOCAL_BRIDGE=1``.
+
+Caveat: ``LOCAL_BRIDGE`` / ``dev_user_local`` are internal Claude Code dev
+features and may change between versions. macOS-only for now, like the rest of
+the Chrome sync.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import plistlib
+import select
+import shutil
+import socket
+import ssl
+import struct
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from claude_swap.chrome_session import ChromeVault, is_supported
+
+_logger = logging.getLogger("claude-swap")
+
+BRIDGE_HOST = "bridge.claudeusercontent.com"
+LOCAL_ROOM = "dev_user_local"
+_WS_MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+_ACCOUNT_POLL_SECONDS = 3.0
+
+LAUNCHD_LABEL = "com.claude-swap.bridge"
+
+
+# --------------------------------------------------------------------------- #
+# WebSocket framing (server side unmasked out; client side masked out)
+# --------------------------------------------------------------------------- #
+def _recvn(sock: socket.socket, n: int) -> bytes:
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            break
+        buf += chunk
+    return buf
+
+
+def _read_frame(sock: socket.socket):
+    """Return (opcode, payload) or None on EOF. Handles masked client frames."""
+    hdr = _recvn(sock, 2)
+    if len(hdr) < 2:
+        return None
+    op = hdr[0] & 0x0F
+    ln = hdr[1] & 0x7F
+    masked = hdr[1] & 0x80
+    if ln == 126:
+        ln = struct.unpack(">H", _recvn(sock, 2))[0]
+    elif ln == 127:
+        ln = struct.unpack(">Q", _recvn(sock, 8))[0]
+    mask = _recvn(sock, 4) if masked else b""
+    data = _recvn(sock, ln)
+    if masked and data:
+        data = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+    return op, data
+
+
+def _write_frame(sock: socket.socket, op: int, payload=b"", *, mask: bool = False) -> None:
+    if isinstance(payload, str):
+        payload = payload.encode()
+    header = bytearray([0x80 | op])
+    n = len(payload)
+    mbit = 0x80 if mask else 0
+    if n < 126:
+        header.append(mbit | n)
+    elif n < 65536:
+        header.append(mbit | 126)
+        header += struct.pack(">H", n)
+    else:
+        header.append(mbit | 127)
+        header += struct.pack(">Q", n)
+    if mask:
+        mk = os.urandom(4)
+        header += mk
+        payload = bytes(b ^ mk[i % 4] for i, b in enumerate(payload))
+    sock.sendall(bytes(header) + payload)
+
+
+# --------------------------------------------------------------------------- #
+# Current account + upstream connection
+# --------------------------------------------------------------------------- #
+def _tls_context() -> ssl.SSLContext:
+    """A verifying TLS context using the OS trust store (via truststore, a
+    project dependency) so no CA bundle wrangling — and never unverified."""
+    try:
+        import truststore
+        truststore.inject_into_ssl()
+    except Exception as e:  # noqa: BLE001
+        _logger.debug("chrome-bridge: truststore unavailable (%s); using default CAs", e)
+    return ssl.create_default_context()
+
+
+def _active_account(backup_root: Path) -> dict | None:
+    """The current cswap account's tokens+uuid, or None if unavailable."""
+    try:
+        data = json.loads((Path(backup_root) / "sequence.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    num = data.get("activeAccountNumber")
+    if num is None:
+        return None
+    session = ChromeVault(backup_root).get(str(num))
+    if session is None:
+        return None
+    return {"num": str(num), "token": session.access_token,
+            "uuid": session.account_uuid, "email": session.email}
+
+
+def _open_upstream(uuid: str, token: str, ctx: ssl.SSLContext) -> socket.socket | None:
+    """Open a verified WSS connection to the real bridge room for ``uuid`` and
+    send the authenticated claude-code connect. Returns the socket or None."""
+    try:
+        raw = socket.create_connection((BRIDGE_HOST, 443), timeout=15)
+        sock = ctx.wrap_socket(raw, server_hostname=BRIDGE_HOST)
+    except Exception as e:  # noqa: BLE001
+        _logger.warning("chrome-bridge: upstream TLS connect failed: %s", e)
+        return None
+    key = base64.b64encode(os.urandom(16)).decode()
+    path = f"/chrome/{uuid}"
+    sock.sendall((
+        f"GET {path} HTTP/1.1\r\nHost: {BRIDGE_HOST}\r\n"
+        "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+    ).encode())
+    resp = b""
+    try:
+        while b"\r\n\r\n" not in resp:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            resp += chunk
+    except OSError:
+        resp = b""
+    if b" 101 " not in resp.split(b"\r\n", 1)[0]:
+        _logger.warning("chrome-bridge: upstream handshake failed: %r", resp[:120])
+        sock.close()
+        return None
+    connect = {"type": "connect", "client_type": "claude-code",
+               "oauth_token": token, "hb_capable": True, "cancel_capable": True}
+    _write_frame(sock, 1, json.dumps(connect), mask=True)
+    return sock
+
+
+# --------------------------------------------------------------------------- #
+# Per-connection relay with live account re-pointing
+# --------------------------------------------------------------------------- #
+def _relay_connection(down: socket.socket, backup_root: Path, ctx: ssl.SSLContext) -> None:
+    # WebSocket handshake with the downstream Claude Code client.
+    req = b""
+    try:
+        while b"\r\n\r\n" not in req:
+            chunk = down.recv(4096)
+            if not chunk:
+                return
+            req += chunk
+    except OSError:
+        return
+    head = req.decode("latin1", "replace")
+    key = ""
+    for line in head.split("\r\n"):
+        if line.lower().startswith("sec-websocket-key:"):
+            key = line.split(":", 1)[1].strip()
+    accept = base64.b64encode(hashlib.sha1((key + _WS_MAGIC).encode()).digest()).decode()
+    down.sendall((
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n"
+        f"Connection: Upgrade\r\nSec-WebSocket-Accept: {accept}\r\n\r\n"
+    ).encode())
+
+    # Swallow Claude Code's tokenless local connect; we originate our own upstream.
+    first = _read_frame(down)
+    if first is None:
+        down.close()
+        return
+
+    acct = _active_account(backup_root)
+    if acct is None:
+        _logger.warning("chrome-bridge: no current cswap account with tokens; closing")
+        down.close()
+        return
+    up = _open_upstream(acct["uuid"], acct["token"], ctx)
+    if up is None:
+        down.close()
+        return
+    _logger.info("chrome-bridge: relaying Claude Code ↔ account %s (%s)",
+                 acct["num"], acct["email"] or acct["uuid"][:8])
+    cur_uuid = acct["uuid"]
+    last_poll = time.monotonic()
+
+    try:
+        while True:
+            rlist, _, _ = select.select([down, up], [], [], 1.0)
+            if down in rlist:
+                fr = _read_frame(down)
+                if fr is None:
+                    break
+                op, data = fr
+                if op == 8:  # close from Claude Code → tear the whole thing down
+                    break
+                _write_frame(up, op, data, mask=True)
+            if up in rlist:
+                fr = _read_frame(up)
+                if fr is None:
+                    # Upstream dropped — try to re-establish on the current account.
+                    up = _reopen(up, backup_root, ctx)
+                    if up is None:
+                        break
+                    cur_uuid = _active_account(backup_root)["uuid"]
+                    continue
+                op, data = fr
+                if op == 8:
+                    up = _reopen(up, backup_root, ctx)
+                    if up is None:
+                        break
+                    cur_uuid = _active_account(backup_root)["uuid"]
+                    continue
+                _write_frame(down, op, data, mask=False)
+
+            # Live re-point: if cswap switched the active account, reconnect
+            # upstream to the new room while the Claude Code side stays put.
+            now = time.monotonic()
+            if now - last_poll >= _ACCOUNT_POLL_SECONDS:
+                last_poll = now
+                acct = _active_account(backup_root)
+                if acct and acct["uuid"] != cur_uuid:
+                    _logger.info("chrome-bridge: account changed → re-pointing upstream to %s (%s)",
+                                 acct["num"], acct["email"] or acct["uuid"][:8])
+                    try:
+                        up.close()
+                    except OSError:
+                        pass
+                    up = _open_upstream(acct["uuid"], acct["token"], ctx)
+                    if up is None:
+                        break
+                    cur_uuid = acct["uuid"]
+    except Exception as e:  # noqa: BLE001
+        _logger.info("chrome-bridge: relay ended: %s", e)
+    finally:
+        for s in (down, up):
+            try:
+                s.close()
+            except (OSError, AttributeError):
+                pass
+
+
+def _reopen(old: socket.socket, backup_root: Path, ctx: ssl.SSLContext) -> socket.socket | None:
+    try:
+        old.close()
+    except OSError:
+        pass
+    acct = _active_account(backup_root)
+    if acct is None:
+        return None
+    return _open_upstream(acct["uuid"], acct["token"], ctx)
+
+
+# --------------------------------------------------------------------------- #
+# Server
+# --------------------------------------------------------------------------- #
+def serve(backup_root: Path, port: int = 8765, *, host: str = "127.0.0.1") -> None:
+    """Run the relay server (blocking). One relay thread per Claude Code client."""
+    if not is_supported():
+        _logger.info("chrome-bridge: unsupported platform; not starting")
+        return
+    ctx = _tls_context()
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind((host, port))
+    srv.listen(16)
+    _logger.info("chrome-bridge: relay listening on ws://%s:%s (LOCAL_BRIDGE=1 to use it)", host, port)
+    try:
+        while True:
+            conn, _addr = srv.accept()
+            threading.Thread(
+                target=_relay_connection, args=(conn, Path(backup_root), ctx), daemon=True
+            ).start()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        srv.close()
+
+
+# --------------------------------------------------------------------------- #
+# Persistence via a LaunchAgent (mirrors the menu bar app's setup)
+# --------------------------------------------------------------------------- #
+def is_running(port: int) -> bool:
+    """Whether something is already listening on the relay port."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        return s.connect_ex(("127.0.0.1", port)) == 0
+    finally:
+        s.close()
+
+
+def _cswap_executable() -> str:
+    """Absolute path to the ``cswap`` CLI (for the LaunchAgent ProgramArguments)."""
+    found = shutil.which("cswap")
+    if found:
+        return str(Path(found).resolve())
+    # Fall back to a console-script beside the running interpreter.
+    guess = Path(sys.executable).parent / "cswap"
+    return str(guess)
+
+
+def _launchagent_path() -> Path:
+    return Path(os.path.expanduser("~/Library/LaunchAgents")) / f"{LAUNCHD_LABEL}.plist"
+
+
+def launchd_loaded() -> bool:
+    try:
+        out = subprocess.run(["launchctl", "list"], capture_output=True, text=True, timeout=8)
+        return LAUNCHD_LABEL in out.stdout
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def install_launchagent(port: int) -> Path:
+    """Write + load the relay LaunchAgent so it runs on login and restarts on exit."""
+    plist = {
+        "Label": LAUNCHD_LABEL,
+        "ProgramArguments": [_cswap_executable(), "chrome", "bridge", "--port", str(port)],
+        "RunAtLoad": True,
+        "KeepAlive": {"SuccessfulExit": False},
+        "ThrottleInterval": 10,
+        "StandardOutPath": "/tmp/cswap-bridge.log",
+        "StandardErrorPath": "/tmp/cswap-bridge.err",
+    }
+    path = _launchagent_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(plistlib.dumps(plist))
+    uid = os.getuid()
+    # bootout an old copy first (ignore failure), then bootstrap the new one.
+    subprocess.run(["launchctl", "bootout", f"gui/{uid}/{LAUNCHD_LABEL}"],
+                   capture_output=True, text=True)
+    subprocess.run(["launchctl", "bootstrap", f"gui/{uid}", str(path)],
+                   capture_output=True, text=True)
+    return path
+
+
+def uninstall_launchagent() -> bool:
+    """Unload + remove the relay LaunchAgent. Returns True if a plist was removed."""
+    uid = os.getuid()
+    subprocess.run(["launchctl", "bootout", f"gui/{uid}/{LAUNCHD_LABEL}"],
+                   capture_output=True, text=True)
+    path = _launchagent_path()
+    if path.exists():
+        path.unlink()
+        return True
+    return False

--- a/src/claude_swap/chrome_onboard.py
+++ b/src/claude_swap/chrome_onboard.py
@@ -75,6 +75,15 @@ def print_doctor(switcher) -> None:
     else:
         print(f"  running:     {dimmed('· not running (opens on demand)')}")
 
+    from claude_swap import chrome_bridge as cbr
+    bport = settings.bridge_port
+    brun = cbr.is_running(bport)
+    bload = cbr.launchd_loaded()
+    extra = " · LaunchAgent loaded" if bload else ""
+    print(f"  bridge:      {_mark(brun or bload)} "
+          f"relay {'running' if brun else 'not running'} on {bport}{extra} "
+          f"{dimmed('(run Claude Code with LOCAL_BRIDGE=1)')}")
+
     # Per-account browser-session coverage.
     vault = cs.ChromeVault(root)
     accounts = _accounts(switcher)

--- a/src/claude_swap/chrome_onboard.py
+++ b/src/claude_swap/chrome_onboard.py
@@ -1,0 +1,190 @@
+"""Guided setup and diagnostics for the optional Chrome extension sync.
+
+Chrome sync is an opt-in add-on (like the menu bar app): cswap always switches
+the Claude Code CLI account; enabling this also switches the "Claude in Chrome"
+extension's account, via a dedicated, lean Chrome profile that runs alongside
+the user's everyday browser.
+
+``print_doctor`` is the single source of truth for "is it set up?" — it reports
+each moving part and the per-account browser-session coverage. ``run_setup`` is
+the interactive wizard that stands the whole thing up with a check after each
+step. Both are macOS-only (chrome_session.is_supported()); callers get a clear
+message elsewhere.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+from claude_swap import chrome_session as cs
+from claude_swap.printer import accent, dimmed, error, muted, yellowed
+from claude_swap.settings import load_chrome_settings, set_chrome_enabled, settings_path
+
+_OK = "✓"
+_NO = "✗"
+
+
+def _accounts(switcher) -> list[tuple[str, str, str]]:
+    """(number, email, organizationUuid) per managed account, in slot order."""
+    try:
+        data = json.loads(Path(switcher.sequence_file).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    accounts = data.get("accounts", {})
+    out: list[tuple[str, str, str]] = []
+    for num in sorted(accounts, key=lambda n: int(n) if n.isdigit() else 0):
+        acc = accounts[num]
+        out.append((num, acc.get("email", ""), acc.get("organizationUuid", "") or ""))
+    return out
+
+
+def _mark(ok: bool) -> str:
+    return accent(_OK) if ok else yellowed(_NO)
+
+
+# --------------------------------------------------------------------------- #
+# Doctor
+# --------------------------------------------------------------------------- #
+def print_doctor(switcher) -> None:
+    """Report the state of every Chrome-sync moving part + per-account coverage."""
+    root = switcher.backup_dir
+    settings = load_chrome_settings(root)
+
+    print(accent("Claude Browser sync"))
+    if not cs.is_supported():
+        print(f"  {yellowed(_NO)} not supported on this platform (macOS only)")
+        return
+    print(f"  feature:     {_mark(settings.enabled)} "
+          f"{'enabled' if settings.enabled else 'disabled — run `cswap chrome enable`'}")
+
+    udd = cs.resolve_automation_dir(settings, root)
+    prof_ok = (udd / "Default").exists()
+    ext_ok = cs.has_claude_extension(udd)
+    print(f"  profile:     {_mark(prof_ok)} {udd}")
+    print(f"  extension:   {_mark(ext_ok)} "
+          f"{'installed' if ext_ok else 'not installed — run `cswap chrome setup`'}")
+
+    running = cs.automation_chrome_running(settings.debug_port)
+    if running:
+        ident = cs.read_identity_cdp(settings.debug_port)
+        who = ident.get("email") or "(extension not connected)"
+        print(f"  running:     {accent(_OK)} port {settings.debug_port} — {who}")
+    else:
+        print(f"  running:     {dimmed('· not running (opens on demand)')}")
+
+    # Per-account browser-session coverage.
+    vault = cs.ChromeVault(root)
+    accounts = _accounts(switcher)
+    print(accent("  browser sessions (per account):"))
+    if not accounts:
+        print(f"    {dimmed('no managed accounts yet — run `cswap add`')}")
+    for num, email, _org in accounts:
+        has = vault.get(num) is not None
+        hint = "" if has else muted(f"  → connect + `cswap chrome capture {num}`")
+        print(f"    {_mark(has)} {num} {email or '(unknown)'}{hint}")
+
+    print(dimmed("\n  Note: connect the Claude Browser extension to Claude Code (and"))
+    print(dimmed("  disconnect your everyday Chrome) so browser automation uses this profile."))
+
+
+# --------------------------------------------------------------------------- #
+# Setup wizard
+# --------------------------------------------------------------------------- #
+def _confirm(prompt: str, default_yes: bool = True) -> bool:
+    suffix = "[Y/n]" if default_yes else "[y/N]"
+    try:
+        ans = input(f"{prompt} {suffix} ").strip().lower()
+    except EOFError:
+        return default_yes
+    if not ans:
+        return default_yes
+    return ans in ("y", "yes")
+
+
+def _pause(prompt: str) -> None:
+    try:
+        input(f"{prompt} {dimmed('(press Enter)')} ")
+    except EOFError:
+        pass
+
+
+def run_setup(switcher) -> int:
+    """Interactive wizard: stand up Chrome sync with a check after each step."""
+    if not cs.is_supported():
+        error("Chrome sync is macOS-only.")
+        return 1
+    if not sys.stdin.isatty():
+        error("`cswap chrome setup` needs an interactive terminal.")
+        return 1
+
+    root = switcher.backup_dir
+    print(accent("Claude Browser sync (optional)"))
+    print(
+        "cswap already switches your Claude Code CLI account. This add-on also\n"
+        "switches the Claude browser extension's account, using a dedicated, lean\n"
+        "Chrome profile that runs alongside your everyday browser.\n"
+    )
+    print(dimmed("Two logins are involved:"))
+    print(dimmed("  • CLI     — the `claude` command's account (Keychain OAuth)"))
+    print(dimmed("  • Browser — the Claude in Chrome extension's OAuth pairing\n"))
+    if not _confirm("Set it up now?", default_yes=False):
+        print(dimmed("Nothing changed. You can run `cswap chrome setup` any time."))
+        return 0
+
+    # Step 0 — enable the feature.
+    settings = load_chrome_settings(root)
+    if not settings.enabled:
+        set_chrome_enabled(root, True)
+        settings = load_chrome_settings(root)
+        print(f"[0/4] {accent(_OK)} feature enabled (settings.json chrome.enabled)")
+    udd = cs.resolve_automation_dir(settings, root)
+
+    # Step 1 — create the dedicated profile.
+    cs.ensure_automation_profile(udd)
+    cs.set_profile_display_name(udd)
+    print(f"[1/4] {accent(_OK)} profile ready at {udd}")
+
+    # Step 2 — install the extension (guided; verified by polling).
+    print("[2/4] Installing the Claude extension…")
+    print(dimmed("      A Chrome window will open on the Web Store. Click \"Add to Chrome\"."))
+    cs.launch_automation_chrome(udd, settings.debug_port, start_url=cs.CLAUDE_EXTENSION_STORE_URL)
+    for _ in range(60):
+        if cs.has_claude_extension(udd):
+            break
+        _pause("      After installing the extension,")
+        if cs.has_claude_extension(udd):
+            break
+    if cs.has_claude_extension(udd):
+        print(f"      {accent(_OK)} extension detected")
+    else:
+        print(f"      {yellowed('!')} extension not detected yet — you can finish it later")
+
+    # Step 3 — connect to Claude Code (cannot be verified from here; instruct).
+    print("[3/4] Connect to Claude Code")
+    print(dimmed("      In the Claude Browser window, connect the extension to Claude Code,"))
+    print(dimmed("      and disconnect your everyday Chrome so only this one is used."))
+    _pause("      When done,")
+
+    # Step 4 — capture each account's browser session.
+    print("[4/4] Capture each account's browser session")
+    accounts = _accounts(switcher)
+    if not accounts:
+        print(dimmed("      No managed accounts yet — add them with `cswap add`, then"))
+        print(dimmed("      `cswap chrome capture <n>` for each."))
+    sync = cs.ChromeSync(settings, root)
+    for num, email, _org in accounts:
+        print(f"      Account {num} ({email or 'unknown'}):")
+        print(dimmed("        connect the extension to this account in the Claude Browser"))
+        _pause("        then")
+        if sync.capture_from_browser(num):
+            print(f"        {accent(_OK)} captured")
+        else:
+            print(f"        {yellowed('!')} not captured (was it logged in?) "
+                  f"— retry: cswap chrome capture {num}")
+
+    print(accent("\nDone.") + f" Verify anytime with {accent('cswap chrome doctor')}.")
+    print(dimmed(f"Settings: {settings_path(root)}"))
+    return 0

--- a/src/claude_swap/chrome_session.py
+++ b/src/claude_swap/chrome_session.py
@@ -730,6 +730,7 @@ class ChromeSyncSettings:
     automation_dir: str = ""          # dedicated user-data-dir; default derived under backup_root
     source_profile: str = "Default"   # retained for settings compatibility (unused by token path)
     auto_launch: bool = True          # launch the automation Chrome on demand during a switch
+    bridge_port: int = 8765           # local bridge relay port (LOCAL_BRIDGE=1 targets this)
 
 
 def resolve_automation_dir(settings: "ChromeSyncSettings", backup_root: Path) -> Path:

--- a/src/claude_swap/chrome_session.py
+++ b/src/claude_swap/chrome_session.py
@@ -1,0 +1,952 @@
+"""Chrome extension OAuth-token capture + injection — the browser half of a switch.
+
+claude-swap switches the Claude Code CLI account (an OAuth token in the
+Keychain). This module is the optional, opt-in second half: it switches the
+account of the **"Claude in Chrome" extension** so its Claude Code pairing tracks
+the CLI account.
+
+How the extension's auth works (reverse-engineered + verified)
+--------------------------------------------------------------
+The extension does NOT authenticate by a claude.ai cookie. It runs an OAuth PKCE
+flow and stores the resulting tokens in ``chrome.storage.session`` (in-memory):
+
+- ``accessToken``  (``sk-ant-oat01-…``) — 8h lifetime on refresh.
+- ``refreshToken`` (``sk-ant-ort01-…``) — ~28.5 day lifetime, **rotates on every
+  refresh** (each refresh mints a fresh 28.5 day window).
+- ``tokenExpiry``  (ms) — when the access token expires.
+
+``chrome.storage.local`` holds ``accountUuid``. The service worker (SW) reads
+``storage.session`` **once at startup** into JS runtime memory and connects the
+bridge from there; it re-reads only when it restarts.
+
+Switching accounts (the mechanism, verified end-to-end)
+-------------------------------------------------------
+1. Inject the target account's tokens into ``storage.session`` + ``accountUuid``
+   into ``storage.local`` (via CDP, evaluating in the SW).
+2. Terminate the SW with CDP ``Target.closeTarget`` — **not**
+   ``chrome.runtime.reload()``. A runtime reload *clears* ``storage.session``
+   (losing the just-injected tokens); ``closeTarget`` *preserves* it.
+3. Wake the SW with a throwaway background ``claude.ai`` tab (closed afterwards).
+   On restart the SW reads the injected tokens and reconnects the bridge as the
+   new account. If the injected access token is expired, the SW auto-refreshes
+   via the refresh token on adoption (self-heals).
+
+Because the tokens live in in-memory session storage, capture requires the
+automation Chrome running + CDP (there is no on-disk / offline path, and no
+Keychain/openssl needed — unlike the old cookie approach).
+
+Why a dedicated Chrome profile
+------------------------------
+CDP against modern Chrome (macOS ~M136+/2025) forces a dedicated, separately
+launched profile: the default user-data-dir ignores ``--remote-debugging-port``;
+``--load-extension`` is blocked (the extension is installed once from the Web
+Store); the wake tab must be headed (Cloudflare blocks headless on claude.ai).
+
+Keep-alive
+----------
+A parked account's refresh token expires after ~28.5 days untouched. cswap can
+refresh it offline (``refresh_session`` → ``platform.claude.com/v1/oauth/token``)
+to roll the window indefinitely without opening a browser.
+
+macOS-only for now; every entry point no-ops (returns None/False, logs) on other
+platforms so callers stay unconditional.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import socket
+import struct
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+_logger = logging.getLogger("claude-swap")
+
+CHROME_APP = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+CLAUDE_EXTENSION_ID = "fcoeoabgfenejglbffodgkkbkcdhcgfn"
+CLAUDE_URL = "https://claude.ai/"
+
+# OAuth constants read from the extension bundle's production config
+# (J.production in assets/mcpPermissions-*.js). The 54511e87… client id is the
+# "development" one and is rejected by the token endpoint.
+OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+OAUTH_CLIENT_ID = "dae2cad8-15c5-43d2-9046-fcaecc135fa4"
+OAUTH_REQUESTED_EXPIRES_IN = 31536000  # what the extension asks for; server caps it
+
+# Refresh a parked account's token once it is this old, before its ~28.5 day
+# refresh-token window closes and it would need a browser re-login.
+KEEPALIVE_REFRESH_DAYS = 20
+
+
+def is_supported() -> bool:
+    """Chrome extension sync is implemented for macOS only (for now)."""
+    return sys.platform == "darwin"
+
+
+# --------------------------------------------------------------------------- #
+# Session value object — the extension's OAuth tokens + identity for one account
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ChromeSession:
+    """One account's Claude-in-Chrome OAuth tokens (+ identity for matching).
+
+    ``refresh_token`` is what makes a stored session durable: with a valid one
+    the extension self-heals even from an expired/blank access token. ``email``
+    is display-only; ``org_uuid`` backs the add-time org-match guard.
+    """
+
+    access_token: str
+    refresh_token: str = ""
+    token_expiry: int = 0       # ms epoch; access-token expiry
+    account_uuid: str = ""
+    org_uuid: str = ""
+    email: str = ""
+    captured_at: int = 0        # ms epoch; last capture/refresh (refresh-token age)
+
+    def is_usable(self) -> bool:
+        # A refresh token is the durable credential; without it a stored session
+        # cannot survive the 8h access-token lifetime.
+        return bool(self.access_token and self.refresh_token)
+
+    def to_dict(self) -> dict:
+        return {
+            "accessToken": self.access_token,
+            "refreshToken": self.refresh_token,
+            "tokenExpiry": self.token_expiry,
+            "accountUuid": self.account_uuid,
+            "orgUuid": self.org_uuid,
+            "email": self.email,
+            "capturedAt": self.captured_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ChromeSession:
+        return cls(
+            access_token=data.get("accessToken", ""),
+            refresh_token=data.get("refreshToken", ""),
+            token_expiry=int(data.get("tokenExpiry", 0) or 0),
+            account_uuid=data.get("accountUuid", ""),
+            org_uuid=data.get("orgUuid", ""),
+            email=data.get("email", ""),
+            captured_at=int(data.get("capturedAt", 0) or 0),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Minimal CDP-over-WebSocket client (pure stdlib, no websocket-client dep)
+# --------------------------------------------------------------------------- #
+class _WS:
+    """RFC6455 client: just the text-frame send/recv the CDP calls need."""
+
+    def __init__(self, url: str, timeout: float = 10.0):
+        if not url.startswith("ws://"):
+            raise ValueError(f"expected ws:// url, got {url!r}")
+        host_port, _, path = url[len("ws://"):].partition("/")
+        host, _, port = host_port.partition(":")
+        self.sock = socket.create_connection((host, int(port or 80)), timeout=timeout)
+        key = base64.b64encode(os.urandom(16)).decode()
+        self.sock.sendall(
+            (
+                f"GET /{path} HTTP/1.1\r\nHost: {host_port}\r\n"
+                "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+                f"Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+            ).encode()
+        )
+        resp = b""
+        while b"\r\n\r\n" not in resp:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                break
+            resp += chunk
+        if b" 101 " not in resp.split(b"\r\n", 1)[0]:
+            raise RuntimeError(f"WebSocket handshake failed: {resp[:80]!r}")
+        self._buf = b""
+
+    def send(self, text: str) -> None:
+        payload = text.encode()
+        header = bytearray([0x81])
+        mask = os.urandom(4)
+        n = len(payload)
+        if n < 126:
+            header.append(0x80 | n)
+        elif n < 65536:
+            header.append(0x80 | 126)
+            header += struct.pack(">H", n)
+        else:
+            header.append(0x80 | 127)
+            header += struct.pack(">Q", n)
+        header += mask
+        self.sock.sendall(bytes(header) + bytes(b ^ mask[i % 4] for i, b in enumerate(payload)))
+
+    def recv(self) -> str:
+        while True:
+            frame, self._buf = self._read_frame(self._buf)
+            if frame is not None:
+                return frame
+
+    def _read_frame(self, buf: bytes):
+        while len(buf) < 2:
+            buf += self.sock.recv(4096)
+        b1, length = buf[0], buf[1] & 0x7F
+        masked = buf[1] & 0x80
+        idx = 2
+        if length == 126:
+            while len(buf) < 4:
+                buf += self.sock.recv(4096)
+            length = struct.unpack(">H", buf[2:4])[0]
+            idx = 4
+        elif length == 127:
+            while len(buf) < 10:
+                buf += self.sock.recv(4096)
+            length = struct.unpack(">Q", buf[2:10])[0]
+            idx = 10
+        if masked:
+            idx += 4
+        while len(buf) < idx + length:
+            buf += self.sock.recv(4096)
+        payload, rest = buf[idx:idx + length], buf[idx + length:]
+        if (b1 & 0x0F) != 0x1:  # ignore non-text control frames
+            return None, rest
+        return payload.decode(errors="replace"), rest
+
+    def close(self) -> None:
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+class _CDP:
+    def __init__(self, ws_url: str):
+        self._ws = _WS(ws_url)
+        self._id = 0
+
+    def call(self, method: str, params: dict | None = None, timeout: float = 15.0) -> dict:
+        self._id += 1
+        mid = self._id
+        self._ws.send(json.dumps({"id": mid, "method": method, "params": params or {}}))
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            msg = json.loads(self._ws.recv())
+            if msg.get("id") == mid:
+                if "error" in msg:
+                    raise RuntimeError(f"{method}: {msg['error']}")
+                return msg.get("result", {})
+        raise TimeoutError(f"CDP {method} timed out")
+
+    def evaluate(self, expression: str, *, timeout: float = 15.0):
+        """Evaluate JS (awaiting a returned promise) and return the raw value."""
+        self.call("Runtime.enable")
+        res = self.call(
+            "Runtime.evaluate",
+            {"expression": expression, "awaitPromise": True, "returnByValue": True},
+            timeout=timeout,
+        )
+        return res.get("result", {}).get("value")
+
+    def close(self) -> None:
+        self._ws.close()
+
+
+def _http_json(port: int, path: str):
+    import urllib.request
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}", headers={"Host": f"127.0.0.1:{port}"}
+    )
+    return json.load(urllib.request.urlopen(req, timeout=5))
+
+
+def _list_targets(port: int) -> list[dict]:
+    for path in ("/json", "/json/list"):
+        try:
+            data = _http_json(port, path)
+            return [t for t in data if isinstance(t, dict)]
+        except Exception:
+            continue
+    return []
+
+
+def _browser_ws(port: int) -> str | None:
+    try:
+        return _http_json(port, "/json/version").get("webSocketDebuggerUrl")
+    except Exception:
+        return None
+
+
+def cdp_ready(port: int) -> bool:
+    return bool(_list_targets(port))
+
+
+def wait_cdp_ready(port: int, timeout: float = 20.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cdp_ready(port):
+            return True
+        time.sleep(0.4)
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Extension service-worker access (where the tokens live)
+# --------------------------------------------------------------------------- #
+def _sw_target(port: int) -> dict | None:
+    """The Claude extension's service-worker target, or None if not running."""
+    for t in _list_targets(port):
+        if t.get("type") == "service_worker" and CLAUDE_EXTENSION_ID in t.get("url", ""):
+            return t
+    return None
+
+
+def _eval_in_sw(port: int, expression: str, *, timeout: float = 15.0):
+    """Evaluate JS in the extension SW. Returns None if the SW isn't reachable."""
+    t = _sw_target(port)
+    if not t or not t.get("webSocketDebuggerUrl"):
+        return None
+    cdp = _CDP(t["webSocketDebuggerUrl"])
+    try:
+        return cdp.evaluate(expression, timeout=timeout)
+    finally:
+        cdp.close()
+
+
+def _create_target(port: int, url: str, *, background: bool = True) -> str | None:
+    bws = _browser_ws(port)
+    if not bws:
+        return None
+    cdp = _CDP(bws)
+    try:
+        return cdp.call("Target.createTarget", {"url": url, "background": background}).get("targetId")
+    except Exception:  # noqa: BLE001
+        return None
+    finally:
+        cdp.close()
+
+
+def _close_target(port: int, target_id: str) -> None:
+    if not target_id:
+        return
+    bws = _browser_ws(port)
+    if not bws:
+        return
+    cdp = _CDP(bws)
+    try:
+        cdp.call("Target.closeTarget", {"targetId": target_id})
+    except Exception:  # noqa: BLE001
+        pass
+    finally:
+        cdp.close()
+
+
+def _wait_for_sw(port: int, timeout: float = 12.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _sw_target(port):
+            return True
+        time.sleep(0.4)
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Capture / identity (read the extension's current tokens via CDP)
+# --------------------------------------------------------------------------- #
+_CAPTURE_JS = r"""
+(async () => {
+  const s = await chrome.storage.session.get(
+    ['accessToken', 'refreshToken', 'tokenExpiry', 'swAnalyticsProfileCache']);
+  const l = await chrome.storage.local.get(['accountUuid']);
+  const prof = (s.swAnalyticsProfileCache || {}).profile || {};
+  return JSON.stringify({
+    accessToken: s.accessToken || '',
+    refreshToken: s.refreshToken || '',
+    tokenExpiry: s.tokenExpiry || 0,
+    accountUuid: l.accountUuid || '',
+    email: (prof.account || {}).email || '',
+    orgUuid: (prof.organization || {}).uuid || '',
+  });
+})()
+"""
+
+
+def capture_tokens_cdp(port: int) -> ChromeSession | None:
+    """Capture the extension's *current* OAuth tokens from the SW via CDP.
+
+    Requires the automation Chrome running with the extension connected. Returns
+    None if the SW is unreachable or no tokens are present (not logged in).
+    """
+    raw = _eval_in_sw(port, _CAPTURE_JS)
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    session = ChromeSession(
+        access_token=data.get("accessToken", ""),
+        refresh_token=data.get("refreshToken", ""),
+        token_expiry=int(data.get("tokenExpiry", 0) or 0),
+        account_uuid=data.get("accountUuid", ""),
+        org_uuid=data.get("orgUuid", ""),
+        email=data.get("email", ""),
+        captured_at=int(time.time() * 1000),
+    )
+    return session if session.is_usable() else None
+
+
+def read_identity_cdp(port: int) -> dict:
+    """The extension's current account identity (email/accountUuid/orgUuid).
+
+    Empty dict if the SW is unreachable; empty ``email`` means the profile has
+    not been fetched yet (unauthenticated or mid-connect).
+    """
+    raw = _eval_in_sw(port, _CAPTURE_JS)
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return {
+        "email": data.get("email", ""),
+        "accountUuid": data.get("accountUuid", ""),
+        "orgUuid": data.get("orgUuid", ""),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Injection + SW restart (adopt a stored account into the running extension)
+# --------------------------------------------------------------------------- #
+def _inject_js(session: ChromeSession) -> str:
+    return (
+        "(async () => {"
+        "await chrome.storage.session.set({"
+        f"accessToken: {json.dumps(session.access_token)},"
+        f"refreshToken: {json.dumps(session.refresh_token)},"
+        f"tokenExpiry: {json.dumps(session.token_expiry)}}});"
+        f"await chrome.storage.local.set({{accountUuid: {json.dumps(session.account_uuid)}}});"
+        # Drop the cached profile so the SW re-fetches identity for the new token.
+        "await chrome.storage.session.remove('swAnalyticsProfileCache');"
+        "return 'ok';})()"
+    )
+
+
+def inject_tokens_cdp(port: int, session: ChromeSession, *, settle: float = 10.0) -> bool:
+    """Make the running extension adopt ``session``'s account.
+
+    Writes the tokens into the SW's storage, terminates the SW with
+    ``Target.closeTarget`` (which preserves ``storage.session``, unlike a runtime
+    reload), then wakes it with a throwaway background claude.ai tab so it
+    restarts, reads the injected tokens, and reconnects the bridge. The wake tab
+    is closed afterwards, so no claude.ai tab lingers. Returns True if the
+    extension came back up on the injected account.
+    """
+    if not session.is_usable():
+        return False
+    t = _sw_target(port)
+    if not t:
+        _logger.warning("chrome-sync: extension service worker not found on port %s", port)
+        return False
+    sw_id = t.get("id")
+    # 1) Write the tokens into the SW's storage.
+    if _eval_in_sw(port, _inject_js(session)) != "ok":
+        _logger.warning("chrome-sync: failed to write tokens into the extension")
+        return False
+    # 2) Terminate the SW (NOT runtime.reload → keeps storage.session).
+    _close_target(port, sw_id)
+    time.sleep(2)
+    # 3) Wake it with a background claude.ai tab so it restarts + reconnects.
+    wake_id = _create_target(port, CLAUDE_URL, background=True)
+    _wait_for_sw(port)
+    time.sleep(settle)
+    ident = read_identity_cdp(port)
+    if wake_id:
+        _close_target(port, wake_id)
+    # Adopted if the SW is back with the injected account's identity. Match by
+    # uuid when we have it (email may lag a beat behind the profile fetch).
+    ok = bool(ident) and (
+        (session.account_uuid and ident.get("accountUuid") == session.account_uuid)
+        or (session.email and ident.get("email") == session.email)
+        or bool(ident.get("email"))
+    )
+    if not ok:
+        _logger.warning("chrome-sync: extension did not adopt the injected account (got %s)",
+                        ident.get("email") or ident.get("accountUuid") or "nothing")
+    return ok
+
+
+# --------------------------------------------------------------------------- #
+# Offline token refresh (keep-alive; no browser needed)
+# --------------------------------------------------------------------------- #
+def refresh_session(session: ChromeSession, *, timeout: float = 30.0) -> ChromeSession | None:
+    """Refresh a stored session's tokens offline via the OAuth token endpoint.
+
+    Rotates the refresh token (the old one is invalidated server-side) and
+    returns an updated ChromeSession with a fresh ~28.5 day window. Uses the
+    system ``curl`` (as the old cookie path used ``openssl``) so no CA-bundle /
+    third-party HTTP dependency is needed. Returns None on any failure
+    (network, ``invalid_grant`` when the refresh token has itself expired).
+    """
+    if not session.refresh_token:
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                "curl", "-sS", "-X", "POST", OAUTH_TOKEN_URL,
+                "-H", "Content-Type: application/x-www-form-urlencoded",
+                "--data-urlencode", "grant_type=refresh_token",
+                "--data-urlencode", f"client_id={OAUTH_CLIENT_ID}",
+                "--data-urlencode", f"refresh_token={session.refresh_token}",
+                "--data-urlencode", f"expires_in={OAUTH_REQUESTED_EXPIRES_IN}",
+            ],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        data = json.loads(proc.stdout or "{}")
+    except Exception as e:  # noqa: BLE001
+        _logger.warning("chrome-sync: token refresh call failed: %s", e)
+        return None
+    if not data.get("access_token"):
+        err = (data.get("error") or {})
+        _logger.info("chrome-sync: token refresh rejected: %s",
+                     err.get("message") if isinstance(err, dict) else err or "no access_token")
+        return None
+    now = int(time.time() * 1000)
+    account = data.get("account") or {}
+    org = data.get("organization") or {}
+    return replace(
+        session,
+        access_token=data["access_token"],
+        refresh_token=data.get("refresh_token") or session.refresh_token,
+        token_expiry=now + 1000 * int(data.get("expires_in", 0) or 0),
+        account_uuid=account.get("uuid") or session.account_uuid,
+        org_uuid=org.get("uuid") or session.org_uuid,
+        email=account.get("email_address") or session.email,
+        captured_at=now,
+    )
+
+
+def _is_stale(session: ChromeSession, days: int = KEEPALIVE_REFRESH_DAYS) -> bool:
+    """Whether a stored session is old enough to refresh before its window closes."""
+    if not session.captured_at:
+        return False
+    age_days = (time.time() * 1000 - session.captured_at) / (1000 * 86400)
+    return age_days >= days
+
+
+# --------------------------------------------------------------------------- #
+# Automation profile lifecycle
+# --------------------------------------------------------------------------- #
+#: Distinct name + toolbar color for the automation profile so its Chrome
+#: window is recognizable and never confused with the user's real profile.
+AUTOMATION_PROFILE_NAME = "Claude Code (cswap)"
+AUTOMATION_THEME_COLOR = 0xFFD97757  # Claude terracotta (SkColor ARGB)
+
+#: Web Store page for the Claude extension — opened on the fresh profile so the
+#: user can install it in one click (the only manual, one-time setup step).
+CLAUDE_EXTENSION_STORE_URL = (
+    f"https://chromewebstore.google.com/detail/{CLAUDE_EXTENSION_ID}"
+)
+
+
+def ensure_automation_profile(dest_user_data_dir: Path, profile: str = "Default") -> None:
+    """Ensure the dedicated automation user-data-dir exists — **fresh, not a clone**.
+
+    A full clone of the user's profile dragged in every installed extension plus
+    GBs of state, so the second Chrome was slow. Instead this creates an empty
+    profile; the user installs only the Claude extension into it once from the
+    Web Store. Idempotent and non-destructive.
+    """
+    (Path(dest_user_data_dir) / profile).mkdir(parents=True, exist_ok=True)
+
+
+def has_claude_extension(user_data_dir: Path, profile: str = "Default") -> bool:
+    """Whether the Claude extension is installed in the automation profile yet."""
+    return (Path(user_data_dir) / profile / "Extensions" / CLAUDE_EXTENSION_ID).exists()
+
+
+def set_profile_display_name(user_data_dir: Path, profile: str = "Default",
+                             name: str = AUTOMATION_PROFILE_NAME,
+                             theme_color: int = AUTOMATION_THEME_COLOR) -> None:
+    """Set the profile's toolbar name + color so its window is recognizable.
+
+    Chrome must be closed for the change to stick (it rewrites both files on
+    exit). Best-effort; missing files (fresh profile, pre-first-launch) are
+    silently ignored — a later launch applies it once the files exist.
+    """
+    local_state = Path(user_data_dir) / "Local State"
+    try:
+        data = json.loads(local_state.read_text(encoding="utf-8"))
+        entry = data.setdefault("profile", {}).setdefault("info_cache", {}).setdefault(profile, {})
+        entry["name"] = name
+        entry["is_using_default_name"] = False
+        local_state.write_text(json.dumps(data), encoding="utf-8")
+    except (OSError, json.JSONDecodeError):
+        pass
+    prefs = Path(user_data_dir) / profile / "Preferences"
+    try:
+        data = json.loads(prefs.read_text(encoding="utf-8"))
+        data.setdefault("profile", {})["name"] = name
+        data["profile"]["using_default_name"] = False
+        theme = data.setdefault("browser", {}).setdefault("theme", {})
+        theme["user_color"] = theme_color
+        theme["is_grayscale"] = False
+        prefs.write_text(json.dumps(data), encoding="utf-8")
+    except (OSError, json.JSONDecodeError):
+        pass
+
+
+def automation_chrome_running(port: int) -> bool:
+    return cdp_ready(port)
+
+
+def launch_automation_chrome(user_data_dir: Path, port: int,
+                             profile: str = "Default",
+                             start_url: str | None = None) -> "subprocess.Popen | None":
+    """Launch the headed automation Chrome with remote debugging.
+
+    Headed (not headless) is mandatory: the wake tab hits claude.ai, which
+    Cloudflare blocks headless. ``--disable-sync`` keeps this lean, dedicated
+    profile from pulling the user's synced extensions back in. With no
+    ``start_url`` Chrome opens its normal New Tab Page. Runs alongside the user's
+    normal Chrome (separate user-data-dir). Returns None if already up on `port`.
+    """
+    if not is_supported():
+        return None
+    if automation_chrome_running(port):
+        return None
+    argv = [
+        CHROME_APP,
+        f"--user-data-dir={user_data_dir}",
+        f"--profile-directory={profile}",
+        f"--remote-debugging-port={port}",
+        "--disable-sync",
+        "--no-first-run", "--no-default-browser-check",
+        "--window-size=560,820",
+    ]
+    if start_url:
+        argv.append(start_url)
+    proc = subprocess.Popen(argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    wait_cdp_ready(port, timeout=25.0)
+    return proc
+
+
+def bring_automation_to_front(port: int) -> bool:
+    """Raise + focus the automation Chrome's window (best-effort).
+
+    The automation Chrome is a separate instance sharing the "Google Chrome"
+    app, so AppleScript ``activate`` can't target it; CDP can via a page target.
+    """
+    pages = [t for t in _list_targets(port) if t.get("type") == "page" and t.get("webSocketDebuggerUrl")]
+    if not pages:
+        return False
+    cdp = _CDP(pages[0]["webSocketDebuggerUrl"])
+    try:
+        try:
+            win = cdp.call("Browser.getWindowForTarget")
+            wid = win.get("windowId")
+            if wid is not None:
+                cdp.call("Browser.setWindowBounds",
+                         {"windowId": wid, "bounds": {"windowState": "normal"}})
+        except Exception:  # noqa: BLE001
+            pass
+        cdp.call("Page.bringToFront")
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+    finally:
+        cdp.close()
+
+
+# --------------------------------------------------------------------------- #
+# Per-account vault (chrome_sessions.json beside claude-swap's other state)
+# --------------------------------------------------------------------------- #
+class ChromeVault:
+    """Stores one ChromeSession (OAuth tokens) per account number.
+
+    Bearer tokens (``sk-ant-oat01-``/``sk-ant-ort01-``) live here in plaintext,
+    chmod 600 — the same trust model as claude-swap's own credential backups,
+    kept in a separate file (different credential type + lifecycle).
+    """
+
+    def __init__(self, backup_root: Path):
+        self._path = Path(backup_root) / "chrome_sessions.json"
+
+    def _read(self) -> dict:
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    def _write(self, data: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        if sys.platform != "win32":
+            os.chmod(self._path, 0o600)
+
+    def get(self, account_num: str) -> ChromeSession | None:
+        data = self._read().get(str(account_num))
+        if not data:
+            return None
+        session = ChromeSession.from_dict(data)
+        return session if session.is_usable() else None
+
+    def account_numbers(self) -> set[str]:
+        """Account numbers that have a usable stored session (for list markers)."""
+        return {k for k, v in self._read().items() if ChromeSession.from_dict(v).is_usable()}
+
+    def find_by_uuid(self, account_uuid: str) -> str | None:
+        """The account number whose stored session has this accountUuid, if any."""
+        if not account_uuid:
+            return None
+        for num, v in self._read().items():
+            if v.get("accountUuid") == account_uuid:
+                return num
+        return None
+
+    def put(self, account_num: str, session: ChromeSession) -> None:
+        data = self._read()
+        data[str(account_num)] = session.to_dict()
+        self._write(data)
+
+    def delete(self, account_num: str) -> None:
+        data = self._read()
+        if data.pop(str(account_num), None) is not None:
+            self._write(data)
+
+
+# --------------------------------------------------------------------------- #
+# Facade used by claude-swap's switcher (the only surface switcher.py imports)
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ChromeSyncSettings:
+    """The ``chrome`` section of settings.json (see settings.load_chrome_settings)."""
+
+    enabled: bool = False
+    debug_port: int = 9333
+    automation_dir: str = ""          # dedicated user-data-dir; default derived under backup_root
+    source_profile: str = "Default"   # retained for settings compatibility (unused by token path)
+    auto_launch: bool = True          # launch the automation Chrome on demand during a switch
+
+
+def resolve_automation_dir(settings: "ChromeSyncSettings", backup_root: Path) -> Path:
+    """The dedicated automation user-data-dir: the configured path, else a
+    default beside claude-swap's other state."""
+    return Path(settings.automation_dir) if settings.automation_dir \
+        else Path(backup_root) / "chrome-automation"
+
+
+class ChromeSync:
+    """Best-effort browser-side companion to a claude-swap account switch.
+
+    Every method swallows its own failures (logged) and returns a bool/None: a
+    dead browser or a Cloudflare hiccup must never fail the OAuth switch that
+    already committed. Construct once per switcher with the loaded settings +
+    backup_root; a no-op when disabled/unsupported.
+    """
+
+    def __init__(self, settings: ChromeSyncSettings, backup_root: Path):
+        self._s = settings
+        self._vault = ChromeVault(backup_root)
+        self._backup_root = Path(backup_root)
+
+    @property
+    def active(self) -> bool:
+        return bool(self._s.enabled) and is_supported()
+
+    def _automation_dir(self) -> Path:
+        return resolve_automation_dir(self._s, self._backup_root)
+
+    def _ensure_up(self) -> bool:
+        """Provision + launch the automation Chrome if needed; True if reachable."""
+        if automation_chrome_running(self._s.debug_port):
+            return True
+        if not self._s.auto_launch:
+            _logger.info("chrome-sync: automation Chrome not running on port %s", self._s.debug_port)
+            return False
+        try:
+            udd = self._automation_dir()
+            ensure_automation_profile(udd)
+            # Chrome is down here, so the name/color edit sticks. No-op before the
+            # first launch creates the files.
+            set_profile_display_name(udd)
+            # Until the extension is installed, land on its Web Store page so it's
+            # one click away; afterwards open the normal New Tab Page.
+            start = None if has_claude_extension(udd) else CLAUDE_EXTENSION_STORE_URL
+            launch_automation_chrome(udd, self._s.debug_port, start_url=start)
+        except Exception as e:  # noqa: BLE001
+            _logger.warning("chrome-sync: could not start automation Chrome: %s", e)
+            return False
+        return automation_chrome_running(self._s.debug_port)
+
+    def _snapshot_current(self) -> None:
+        """Re-capture the account the extension is *currently* on into its vault
+        slot, before we inject a different one.
+
+        The active account's access token rotates roughly every 8h, so its stored
+        copy goes stale; snapshotting on the way out keeps the vault fresh and
+        avoids ever re-injecting a dead token. Matched to a slot by accountUuid.
+        """
+        try:
+            current = capture_tokens_cdp(self._s.debug_port)
+            if not current:
+                return
+            num = self._vault.find_by_uuid(current.account_uuid)
+            if num:
+                self._vault.put(num, current)
+                _logger.info("chrome-sync: refreshed stored tokens for account %s (outgoing)", num)
+        except Exception as e:  # noqa: BLE001
+            _logger.info("chrome-sync: could not snapshot current account: %s", e)
+
+    def capture_for_account(self, account_num: str, expected_org_uuid: str = "") -> bool:
+        """Capture the extension's current account into the vault, with org guard.
+
+        Called from add_account. Because the tokens live in the extension's
+        in-memory storage, this reads them from the running automation Chrome via
+        CDP (there is no offline path). ``expected_org_uuid`` is the account's
+        Claude Code ``organizationUuid``; when given, the captured session's org
+        must match it, so we never store a browser login for a different account
+        than the one Claude Code is adding.
+        """
+        if not self.active:
+            return False
+        if not automation_chrome_running(self._s.debug_port):
+            _logger.info("chrome-sync: automation Chrome not running; connect this account in "
+                         "`cswap chrome open` then run `cswap chrome capture %s`", account_num)
+            return False
+        try:
+            session = capture_tokens_cdp(self._s.debug_port)
+            if session is None:
+                _logger.info("chrome-sync: no extension login to capture for account %s", account_num)
+                return False
+            if expected_org_uuid and session.org_uuid and session.org_uuid != expected_org_uuid:
+                _logger.warning(
+                    "chrome-sync: the extension is connected to org %s, which does not match "
+                    "the account being added (org %s); skipping capture. Connect this account "
+                    "in the automation Chrome, then `cswap chrome capture %s`.",
+                    session.org_uuid, expected_org_uuid, account_num,
+                )
+                return False
+            self._vault.put(account_num, session)
+            _logger.info("chrome-sync: captured extension tokens for account %s (%s)",
+                         account_num, session.email or session.account_uuid)
+            return True
+        except Exception as e:  # noqa: BLE001
+            _logger.warning("chrome-sync: capture failed for account %s: %s", account_num, e)
+            return False
+
+    # Kept for the "log into the account directly in the dedicated browser" flow;
+    # identical to capture_for_account without the org guard.
+    def capture_from_browser(self, account_num: str) -> bool:
+        if not self.active:
+            return False
+        if not automation_chrome_running(self._s.debug_port):
+            _logger.info("chrome-sync: automation Chrome not running; open it and connect first")
+            return False
+        try:
+            session = capture_tokens_cdp(self._s.debug_port)
+            if session is None:
+                _logger.info("chrome-sync: no extension login in the automation Chrome to capture")
+                return False
+            self._vault.put(account_num, session)
+            _logger.info("chrome-sync: captured account %s from browser (%s)",
+                         account_num, session.email or session.account_uuid)
+            return True
+        except Exception as e:  # noqa: BLE001
+            _logger.warning("chrome-sync: capture-from-browser failed for %s: %s", account_num, e)
+            return False
+
+    def refresh_account(self, account_num: str) -> bool:
+        """Offline-refresh a stored account's tokens (keep-alive). No browser."""
+        if not self.active:
+            return False
+        session = self._vault.get(account_num)
+        if session is None:
+            return False
+        refreshed = refresh_session(session)
+        if refreshed is None:
+            _logger.warning("chrome-sync: could not refresh account %s (refresh token expired?)",
+                            account_num)
+            return False
+        self._vault.put(account_num, refreshed)
+        _logger.info("chrome-sync: refreshed stored tokens for account %s", account_num)
+        return True
+
+    def sync_to_account(self, account_num: str) -> bool:
+        """Inject the account's stored tokens into the extension and reconnect it."""
+        if not self.active:
+            return False
+        session = self._vault.get(account_num)
+        if session is None:
+            _logger.info("chrome-sync: no stored session for account %s; skipping", account_num)
+            return False
+        try:
+            if not self._ensure_up():
+                return False
+            # Keep the outgoing account's stored tokens fresh before we overwrite.
+            self._snapshot_current()
+            # Keep-alive: refresh a long-parked token before injecting, so its
+            # (possibly expired) refresh token doesn't fail adoption.
+            if _is_stale(session):
+                refreshed = refresh_session(session)
+                if refreshed:
+                    session = refreshed
+                    self._vault.put(account_num, session)
+            ok = inject_tokens_cdp(self._s.debug_port, session)
+            if not ok:
+                # The injected tokens may be stale beyond the extension's own
+                # refresh; try an offline refresh, then re-inject once.
+                refreshed = refresh_session(session)
+                if refreshed:
+                    self._vault.put(account_num, refreshed)
+                    ok = inject_tokens_cdp(self._s.debug_port, refreshed)
+            if ok:
+                # Store whatever the extension settled on (it may have rotated the
+                # token when it reconnected), keyed to this account.
+                settled = capture_tokens_cdp(self._s.debug_port)
+                if settled and settled.account_uuid == (session.account_uuid or settled.account_uuid):
+                    self._vault.put(account_num, settled)
+                _logger.info("chrome-sync: switched browser to account %s", account_num)
+            else:
+                _logger.warning("chrome-sync: could not switch browser to account %s "
+                                "(re-login may be needed)", account_num)
+            return ok
+        except Exception as e:  # noqa: BLE001
+            _logger.warning("chrome-sync: sync failed for account %s: %s", account_num, e)
+            return False
+
+    def open_and_activate(self, account_num: str, focus: bool = False) -> bool:
+        """Ensure the automation Chrome is up and on ``account_num``.
+
+        ``focus`` (opt-in) raises the window; it defaults off so neither the
+        launcher nor a switch steals focus. When the browser is already running
+        this only ensures it's up (no re-inject), so opening it when nothing
+        changed doesn't disturb the current tab.
+        """
+        if not self.active:
+            _logger.info("chrome-sync: disabled; not opening automation Chrome")
+            return False
+        already_running = automation_chrome_running(self._s.debug_port)
+        self._ensure_up()
+        # First-run: extension not installed yet — we're parked on its Web Store
+        # page. Don't inject; let the user click "Add".
+        if not has_claude_extension(self._automation_dir()):
+            if focus:
+                bring_automation_to_front(self._s.debug_port)
+            _logger.info("chrome-sync: install the Claude extension in the opened window")
+            return False
+        # Fresh launch establishes the active account once; an already-running
+        # browser is left as-is (no re-inject).
+        ok = True if already_running else self.sync_to_account(account_num)
+        if focus:
+            bring_automation_to_front(self._s.debug_port)
+        return ok
+
+    def forget(self, account_num: str) -> None:
+        try:
+            self._vault.delete(account_num)
+        except Exception as e:  # noqa: BLE001
+            _logger.warning("chrome-sync: could not forget account %s: %s", account_num, e)

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -929,6 +929,7 @@ Examples:
   cswap chrome open             # open/focus the dedicated Claude Browser
   cswap chrome capture 3        # store account 3's tokens (connect it there first)
   cswap chrome refresh 3        # keep account 3's stored tokens alive (no browser)
+  cswap chrome bridge install   # relay so a running session follows a switch (LOCAL_BRIDGE=1)
   cswap chrome create-profile   # (re)create the dedicated Chrome profile
   cswap chrome enable | disable # turn the feature on/off
         """,
@@ -936,11 +937,17 @@ Examples:
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     sub = parser.add_subparsers(
         dest="action",
-        metavar="{setup,doctor,open,capture,refresh,create-profile,enable,disable}",
+        metavar="{setup,doctor,open,capture,refresh,bridge,create-profile,enable,disable}",
     )
     sub.add_parser("setup", help="Guided one-time setup")
     sub.add_parser("doctor", help="Report setup state and per-account coverage")
     sub.add_parser("status", help=argparse.SUPPRESS)  # alias for doctor
+    p_bridge = sub.add_parser(
+        "bridge", help="Local bridge relay so a running session follows a switch (LOCAL_BRIDGE=1)")
+    p_bridge.add_argument(
+        "op", nargs="?", choices=["run", "install", "uninstall", "status"], default="run",
+        help="run (foreground daemon), install/uninstall the LaunchAgent, or status")
+    p_bridge.add_argument("--port", type=int, default=None, help="Relay port (default: settings/8765)")
     p_open = sub.add_parser("open", help="Open the dedicated Claude Browser (launch if needed)")
     p_open.add_argument(
         "--ensure", action="store_true",
@@ -988,6 +995,38 @@ Examples:
         error("Chrome sync is macOS-only.")
         sys.exit(1)
     settings = load_chrome_settings(root)
+
+    # The bridge relay runs independently of the enable gate (LaunchAgent keeps
+    # it up), so `run` must not exit just because sync is toggled off.
+    if action == "bridge":
+        from claude_swap import chrome_bridge as cbr
+        port = args.port or settings.bridge_port
+        if args.op == "run":
+            import logging
+            h = logging.StreamHandler()
+            h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+            lg = logging.getLogger("claude-swap")
+            lg.addHandler(h)
+            lg.setLevel(logging.INFO)
+            cbr.serve(root, port)
+            return
+        if args.op == "install":
+            path = cbr.install_launchagent(port)
+            print(f"{accent('Installed')} bridge relay LaunchAgent → {path}")
+            print(dimmed(f"Launch Claude Code with LOCAL_BRIDGE=1 to route it through the relay "
+                         f"(port {port})."))
+            return
+        if args.op == "uninstall":
+            removed = cbr.uninstall_launchagent()
+            print(f"{accent('Removed') if removed else accent('No')} bridge relay LaunchAgent")
+            return
+        if args.op == "status":
+            running = cbr.is_running(port)
+            loaded = cbr.launchd_loaded()
+            print(f"bridge relay: {'running' if running else 'not running'} on port {port}; "
+                  f"LaunchAgent {'loaded' if loaded else 'not loaded'}")
+            return
+
     if not settings.enabled:
         error("Chrome sync is disabled. Run: cswap chrome enable")
         sys.exit(1)

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -903,6 +903,139 @@ def _use_native_tls() -> None:
         pass
 
 
+def _chrome_command(argv: list[str]) -> None:
+    """Handle `cswap chrome [setup|doctor|open|capture N|create-profile|enable|disable]`.
+
+    Pre-dispatched like `config`/`run`/`auto`. Drives the optional (macOS-only)
+    Chrome extension sync: a dedicated Chrome profile whose extension account
+    (OAuth tokens) follows `cswap switch`. Disabled by default — `cswap chrome
+    enable` / `cswap chrome setup` opt in; CLI account switching is unaffected.
+    """
+    from claude_swap import chrome_onboard
+    from claude_swap import chrome_session as cs
+    from claude_swap.settings import load_chrome_settings, set_chrome_enabled
+
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} chrome",
+        description=(
+            "Optional (macOS): switch the Claude browser extension's account "
+            "alongside the CLI account."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap chrome setup            # guided one-time setup
+  cswap chrome doctor           # what's set up + per-account coverage
+  cswap chrome open             # open/focus the dedicated Claude Browser
+  cswap chrome capture 3        # store account 3's tokens (connect it there first)
+  cswap chrome refresh 3        # keep account 3's stored tokens alive (no browser)
+  cswap chrome create-profile   # (re)create the dedicated Chrome profile
+  cswap chrome enable | disable # turn the feature on/off
+        """,
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    sub = parser.add_subparsers(
+        dest="action",
+        metavar="{setup,doctor,open,capture,refresh,create-profile,enable,disable}",
+    )
+    sub.add_parser("setup", help="Guided one-time setup")
+    sub.add_parser("doctor", help="Report setup state and per-account coverage")
+    sub.add_parser("status", help=argparse.SUPPRESS)  # alias for doctor
+    p_open = sub.add_parser("open", help="Open the dedicated Claude Browser (launch if needed)")
+    p_open.add_argument(
+        "--ensure", action="store_true",
+        help="Launch only if not already running; no-op if it is (for hooks)",
+    )
+    p_open.add_argument(
+        "--focus", action="store_true",
+        help="Bring the browser window to the foreground (off by default)",
+    )
+    p_cap = sub.add_parser("capture", help="Store the account the extension is connected to")
+    p_cap.add_argument("account", metavar="N", help="Account number to store the current tokens for")
+    p_ref = sub.add_parser("refresh", help="Offline-refresh a stored account's tokens (keep-alive)")
+    p_ref.add_argument("account", metavar="N", help="Account number to refresh")
+    p_cp = sub.add_parser("create-profile", help="(Re)create the dedicated Chrome profile")
+    p_cp.add_argument("--rebuild", action="store_true", help="Delete and recreate the profile")
+    sub.add_parser("enable", help="Turn Chrome sync on")
+    sub.add_parser("disable", help="Turn Chrome sync off")
+
+    args = parser.parse_args(argv)
+    action = args.action or "doctor"
+
+    switcher = ClaudeAccountSwitcher(debug=args.debug)
+    if sys.platform != "win32":
+        if os.geteuid() == 0 and not switcher._is_running_in_container():
+            error("Error: Do not run this script as root (unless running in a container)")
+            sys.exit(1)
+    root = switcher.backup_dir
+
+    if action in ("doctor", "status"):
+        chrome_onboard.print_doctor(switcher)
+        return
+    if action == "setup":
+        sys.exit(chrome_onboard.run_setup(switcher))
+    if action == "enable":
+        set_chrome_enabled(root, True)
+        print(f"{accent('Enabled')} Chrome sync. Next: {accent('cswap chrome setup')}")
+        return
+    if action == "disable":
+        set_chrome_enabled(root, False)
+        print(f"{accent('Disabled')} Chrome sync (CLI account switching is unaffected).")
+        return
+
+    # The remaining verbs act on the dedicated browser: need macOS + the feature on.
+    if not cs.is_supported():
+        error("Chrome sync is macOS-only.")
+        sys.exit(1)
+    settings = load_chrome_settings(root)
+    if not settings.enabled:
+        error("Chrome sync is disabled. Run: cswap chrome enable")
+        sys.exit(1)
+    sync = cs.ChromeSync(settings, root)
+
+    if action == "create-profile":
+        udd = cs.resolve_automation_dir(settings, root)
+        if args.rebuild and udd.exists():
+            import shutil
+            shutil.rmtree(udd, ignore_errors=True)
+        cs.ensure_automation_profile(udd)
+        cs.set_profile_display_name(udd)
+        cs.launch_automation_chrome(udd, settings.debug_port, start_url=cs.CLAUDE_EXTENSION_STORE_URL)
+        print(f"{accent('Profile ready')} at {udd}")
+        print(dimmed("Install the Claude extension in the opened window, then run `cswap chrome doctor`."))
+        return
+    if action == "open":
+        # --ensure: leave a running browser (and any in-progress session)
+        # untouched — used by a PreToolUse hook before each browser tool call.
+        if getattr(args, "ensure", False) and cs.automation_chrome_running(settings.debug_port):
+            return
+        focus = getattr(args, "focus", False)
+        data = switcher._get_sequence_data() or {}
+        active = data.get("activeAccountNumber")
+        if active is not None:
+            sync.open_and_activate(str(active), focus=focus)
+            print(f"{accent('Claude Browser')} open on account {active}")
+        else:
+            sync._ensure_up()
+            if focus:
+                cs.bring_automation_to_front(settings.debug_port)
+            print(f"{accent('Claude Browser')} open")
+        return
+    if action == "capture":
+        if sync.capture_from_browser(args.account):
+            print(f"{accent('Captured')} account {args.account} from the extension's current pairing")
+            return
+        error(f"Capture failed — open the Claude Browser and connect account {args.account} first")
+        sys.exit(1)
+    if action == "refresh":
+        if sync.refresh_account(args.account):
+            print(f"{accent('Refreshed')} stored tokens for account {args.account}")
+            return
+        error(f"Refresh failed for account {args.account} — no stored tokens, or the refresh "
+              f"token expired (re-capture: cswap chrome capture {args.account})")
+        sys.exit(1)
+
+
 def main() -> None:
     """Main entry point for the CLI."""
     force_utf8_output()
@@ -946,6 +1079,9 @@ def main() -> None:
         return
     if argv and argv[0] == "move":
         _move_command(argv[1:])
+        return
+    if argv and argv[0] == "chrome":
+        _chrome_command(argv[1:])
         return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -281,10 +281,13 @@ def format_account_label(
     alias: str | None = None,
     disabled: bool = False,
     fetched_at: float | None = None,
+    chrome_bound: bool = False,
 ) -> str:
     """Build one account row's menu label."""
     label = f"{alias}  ({email})" if alias else email
     marker = "  (disabled)" if disabled else ""
+    if chrome_bound:
+        marker += "  (chrome)"
     return f"{num}  {label}{marker}  {usage_summary(usage, now, fetched_at)}"
 
 
@@ -655,11 +658,13 @@ def run(switcher) -> int:
                 alias=self.snapshot.get("active_alias"),
             )
             self.menu.clear()
+            chrome_bound = self.switcher._chrome_bound_accounts()
             account_items = []
             for num, email, is_active, display, _last_good, alias, disabled, fetched_at in self.snapshot["accounts"]:
                 item = rumps.MenuItem(
                     format_account_label(
-                        num, email, display, alias=alias, disabled=disabled, fetched_at=fetched_at
+                        num, email, display, alias=alias, disabled=disabled,
+                        fetched_at=fetched_at, chrome_bound=str(num) in chrome_bound,
                     ),
                     callback=self._make_switch_to(num),
                 )

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -283,6 +283,7 @@ def load_chrome_settings(backup_root: Path):
         automation_dir=_str("automationDir", defaults.automation_dir),
         source_profile=_str("sourceProfile", defaults.source_profile),
         auto_launch=_bool("autoLaunch", defaults.auto_launch),
+        bridge_port=_int("bridgePort", defaults.bridge_port),
     )
 
 

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -248,6 +248,61 @@ def load_ui_settings(backup_root: Path) -> UiSettings:
     return UiSettings(theme=theme)
 
 
+def load_chrome_settings(backup_root: Path):
+    """Load the ``chrome`` section (browser-side account sync for the Claude in
+    Chrome extension); missing/corrupt file or fields → disabled defaults.
+
+    Kept standalone (like ``load_ui_settings``) rather than wired into
+    SETTING_SPECS: it is opt-in, macOS-only, and not part of the auto-switch
+    tuning surface. camelCase keys mirror the repo's other JSON artifacts. See
+    ``claude_swap.chrome_session.ChromeSyncSettings``.
+    """
+    from claude_swap.chrome_session import ChromeSyncSettings
+
+    raw = _read_raw(settings_path(backup_root))
+    section = raw.get("chrome")
+    defaults = ChromeSyncSettings()
+    if not isinstance(section, dict):
+        return defaults
+
+    def _bool(key: str, default: bool) -> bool:
+        value = section.get(key, default)
+        return value if isinstance(value, bool) else default
+
+    def _int(key: str, default: int) -> int:
+        value = section.get(key, default)
+        return value if isinstance(value, int) and not isinstance(value, bool) else default
+
+    def _str(key: str, default: str) -> str:
+        value = section.get(key, default)
+        return value if isinstance(value, str) else default
+
+    return ChromeSyncSettings(
+        enabled=_bool("enabled", defaults.enabled),
+        debug_port=_int("debugPort", defaults.debug_port),
+        automation_dir=_str("automationDir", defaults.automation_dir),
+        source_profile=_str("sourceProfile", defaults.source_profile),
+        auto_launch=_bool("autoLaunch", defaults.auto_launch),
+    )
+
+
+def set_chrome_enabled(backup_root: Path, enabled: bool) -> None:
+    """Toggle chrome.enabled in settings.json, preserving other chrome keys.
+
+    The `cswap chrome enable/disable` writer (and the setup wizard's step 0), so
+    users never hand-edit JSON to turn the optional browser-sync feature on/off.
+    """
+    path = settings_path(backup_root)
+    raw = _read_raw_for_write(path)
+    raw["schemaVersion"] = raw.get("schemaVersion", SETTINGS_SCHEMA_VERSION)
+    section = raw.get("chrome")
+    if not isinstance(section, dict):
+        section = {}
+    section["enabled"] = bool(enabled)
+    raw["chrome"] = section
+    atomic_write_json(path, raw)
+
+
 def save_settings(backup_root: Path, settings: AutoSwitchSettings) -> None:
     """Write the autoswitch section, preserving unknown keys and sections."""
     path = settings_path(backup_root)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -84,7 +84,13 @@ from claude_swap.paths import (
 )
 from claude_swap.process_detection import get_running_instances
 from claude_swap import poll_policy
-from claude_swap.settings import load_settings, parse_model_names, settings_path
+from claude_swap.chrome_session import ChromeSync
+from claude_swap.settings import (
+    load_chrome_settings,
+    load_settings,
+    parse_model_names,
+    settings_path,
+)
 from claude_swap.usage_store import (
     FetchRecord,
     UsageEntry,
@@ -326,6 +332,10 @@ class ClaudeAccountSwitcher:
         self.lock_file = self.backup_dir / ".lock"
         self._logger = setup_logging(self.backup_dir, debug=debug)
         self._usage_store = UsageStore(self.backup_dir / "cache")
+        # Browser-side companion to an account switch: syncs the Claude in Chrome
+        # extension's OAuth pairing alongside Claude Code's OAuth token.
+        # Best-effort and disabled unless settings.json's `chrome` section opts in.
+        self._chrome = ChromeSync(load_chrome_settings(self.backup_dir), self.backup_dir)
         # (settings mtime, (threshold, models)) — see _poll_policy_inputs.
         self._poll_inputs_cache: tuple[float | None, tuple[float, tuple[str, ...]]] | None = None
         self._poll_inputs_override: tuple[float, tuple[str, ...]] | None = None
@@ -3413,6 +3423,11 @@ class ClaudeAccountSwitcher:
         data["lastUpdated"] = get_timestamp()
 
         self._write_json(self.sequence_file, data)
+        # Best-effort: if the dedicated Claude Browser is up and its extension is
+        # connected to this same account, capture its OAuth tokens too. The org
+        # guard ensures a browser connected to a different account isn't stored
+        # here; otherwise this no-ops and the user runs `cswap chrome capture N`.
+        self._chrome.capture_for_account(account_num, organization_uuid)
         tag = self._get_display_tag(current_email, organization_name, organization_uuid)
         self._logger.info(f"Added account {account_num}: {current_email} (org: {organization_uuid or 'personal'})")
         if migrate_from:
@@ -5140,6 +5155,23 @@ class ClaudeAccountSwitcher:
             payload["unclaimedCredentials"] = sorted(unclaimed)
         return payload
 
+    def _chrome_bound_accounts(self) -> set[str]:
+        """Account numbers that have a stored Claude browser session.
+
+        Empty unless the optional Chrome sync feature is enabled, so the
+        ``(chrome)`` marker in list/status/menu bar only appears for users who
+        opted in. Best-effort — any failure yields an empty set (no marker).
+        """
+        try:
+            from claude_swap.chrome_session import ChromeVault
+            from claude_swap.settings import load_chrome_settings
+
+            if not load_chrome_settings(self.backup_dir).enabled:
+                return set()
+            return ChromeVault(self.backup_dir).account_numbers()
+        except Exception:  # noqa: BLE001 - a display marker must never break listing
+            return set()
+
     def list_accounts(
         self,
         show_token_status: bool = False,
@@ -5175,6 +5207,7 @@ class ClaudeAccountSwitcher:
             return self._build_list_payload(accounts_info, entries)
 
         seq_data = self._get_sequence_data() or {}
+        chrome_bound = self._chrome_bound_accounts()
         print(bolded("Accounts:"))
         for i, (num, email, org_name, org_uuid, is_active, _, alias) in enumerate(accounts_info):
             tag = self._get_display_tag(email, org_name, org_uuid)
@@ -5184,6 +5217,8 @@ class ClaudeAccountSwitcher:
                 markers += f" {bold_accent('(active)')}"
             if self._disabled_from_data(seq_data, str(num)):
                 markers += f" {muted('(disabled)')}"
+            if str(num) in chrome_bound:
+                markers += f" {muted('(chrome)')}"
             print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")
@@ -5335,9 +5370,13 @@ class ClaudeAccountSwitcher:
         if account_num:
             tag = self._get_display_tag(current_email, org_name, current_org_uuid)
             total = len(data.get("accounts", {}))
+            chrome_mark = (
+                f" {muted('(chrome)')}"
+                if str(account_num) in self._chrome_bound_accounts() else ""
+            )
             print(
                 f"{bolded('Status:')} {accent(f'Account-{account_num}')} "
-                f"({current_email} {muted(f'[{tag}]')})"
+                f"({current_email} {muted(f'[{tag}]')}){chrome_mark}"
             )
             print(f"  {dimmed(f'Total managed accounts: {total}')}")
             entry = self._active_account_usage(
@@ -6847,6 +6886,9 @@ class ClaudeAccountSwitcher:
             target_email,
             data["accounts"][target_account].get("organizationUuid", ""),
         )
+        # Best-effort browser sync, after the lock releases (CDP/network is safe
+        # here). Never affects the already-committed OAuth switch above.
+        self._chrome.sync_to_account(target_account)
         return {"from": from_ref, "to": to_ref, "warnings": warnings_out}
 
     def _print_switch_followup(self) -> None:

--- a/tests/test_chrome_bridge.py
+++ b/tests/test_chrome_bridge.py
@@ -1,0 +1,76 @@
+"""Tests for the local bridge relay's platform-independent pieces.
+
+The live relay path (a real LOCAL_BRIDGE Claude Code client + Anthropic's bridge)
+is exercised manually; here we cover WebSocket framing, current-account
+resolution from cswap state, and the LaunchAgent identity.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+
+from claude_swap import chrome_bridge as cb
+from claude_swap import chrome_session as cs
+
+
+def test_frame_roundtrip_masked_and_unmasked():
+    a, b = socket.socketpair()
+    try:
+        # client->server frames are masked; the reader must unmask them
+        cb._write_frame(a, 1, json.dumps({"type": "connect"}), mask=True)
+        op, data = cb._read_frame(b)
+        assert op == 1
+        assert json.loads(data) == {"type": "connect"}
+        # server->client frames are unmasked
+        cb._write_frame(a, 1, "hello", mask=False)
+        op, data = cb._read_frame(b)
+        assert op == 1 and data == b"hello"
+    finally:
+        a.close()
+        b.close()
+
+
+def test_frame_roundtrip_large_payload():
+    a, b = socket.socketpair()
+    try:
+        payload = "x" * 70000  # forces the 8-byte extended length path
+        # write from a thread — 70KB exceeds the socketpair buffer, so the
+        # sender must be able to block while the reader drains concurrently.
+        t = threading.Thread(target=cb._write_frame, args=(a, 1, payload), kwargs={"mask": True})
+        t.start()
+        op, data = cb._read_frame(b)
+        t.join(5)
+        assert op == 1 and data.decode() == payload
+    finally:
+        a.close()
+        b.close()
+
+
+def test_active_account_reads_sequence_and_vault(tmp_path):
+    (tmp_path / "sequence.json").write_text(json.dumps({"activeAccountNumber": 2}))
+    cs.ChromeVault(tmp_path).put("2", cs.ChromeSession(
+        access_token="at", refresh_token="rt", account_uuid="uuid-2", email="two@x"))
+    acct = cb._active_account(tmp_path)
+    assert acct == {"num": "2", "token": "at", "uuid": "uuid-2", "email": "two@x"}
+
+
+def test_active_account_none_when_missing(tmp_path):
+    assert cb._active_account(tmp_path) is None  # no sequence.json
+    (tmp_path / "sequence.json").write_text(json.dumps({"activeAccountNumber": 1}))
+    assert cb._active_account(tmp_path) is None  # active account has no stored tokens
+
+
+def test_is_running_false_on_closed_port():
+    # pick a port nothing listens on
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    assert cb.is_running(port) is False
+
+
+def test_launchd_label_stable():
+    assert cb.LAUNCHD_LABEL == "com.claude-swap.bridge"
+    assert cb._launchagent_path().name == "com.claude-swap.bridge.plist"

--- a/tests/test_chrome_session.py
+++ b/tests/test_chrome_session.py
@@ -1,0 +1,219 @@
+"""Tests for the optional Chrome extension sync (platform-independent logic).
+
+Covers the token value object, the per-account vault, the settings.json
+``chrome`` section, the disabled no-op contract, the add-time org-match guard,
+and the keep-alive staleness check. The browser/CDP paths (macOS + a live
+Chrome + the OAuth endpoint) are exercised manually, not here.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import sys
+import time
+from pathlib import Path
+
+from claude_swap import chrome_session as cs
+from claude_swap.settings import load_chrome_settings, set_chrome_enabled
+
+
+def _session(**kw) -> cs.ChromeSession:
+    base = {"access_token": "at", "refresh_token": "rt"}
+    base.update(kw)
+    return cs.ChromeSession(**base)
+
+
+def test_chrome_session_roundtrip():
+    s = _session(token_expiry=123, account_uuid="acc", org_uuid="org", email="e@x", captured_at=9)
+    assert s.is_usable()
+    d = s.to_dict()
+    assert d == {
+        "accessToken": "at", "refreshToken": "rt", "tokenExpiry": 123,
+        "accountUuid": "acc", "orgUuid": "org", "email": "e@x", "capturedAt": 9,
+    }
+    assert cs.ChromeSession.from_dict(d) == s
+    # A session needs BOTH tokens to be durable (refresh token is what survives).
+    assert not cs.ChromeSession(access_token="at").is_usable()
+    assert not cs.ChromeSession(access_token="", refresh_token="rt").is_usable()
+
+
+def test_vault_roundtrip(tmp_path):
+    vault = cs.ChromeVault(tmp_path)
+    assert vault.get("1") is None
+    s = _session(account_uuid="u1")
+    vault.put("1", s)
+    assert vault.get("1") == s
+    if sys.platform != "win32":
+        mode = stat.S_IMODE((tmp_path / "chrome_sessions.json").stat().st_mode)
+        assert mode == 0o600
+    vault.delete("1")
+    assert vault.get("1") is None
+
+
+def test_vault_ignores_unusable_stored_session(tmp_path):
+    (tmp_path / "chrome_sessions.json").write_text(json.dumps({"1": {"accessToken": "at"}}))
+    assert cs.ChromeVault(tmp_path).get("1") is None
+
+
+def test_vault_account_numbers(tmp_path):
+    vault = cs.ChromeVault(tmp_path)
+    assert vault.account_numbers() == set()
+    vault.put("1", _session())
+    vault.put("3", _session())
+    # a stored-but-unusable entry (no refresh token) is not counted
+    raw = json.loads((tmp_path / "chrome_sessions.json").read_text())
+    raw["9"] = {"accessToken": "at"}
+    (tmp_path / "chrome_sessions.json").write_text(json.dumps(raw))
+    assert vault.account_numbers() == {"1", "3"}
+
+
+def test_vault_find_by_uuid(tmp_path):
+    vault = cs.ChromeVault(tmp_path)
+    vault.put("1", _session(account_uuid="uuid-a"))
+    vault.put("2", _session(account_uuid="uuid-b"))
+    assert vault.find_by_uuid("uuid-b") == "2"
+    assert vault.find_by_uuid("nope") is None
+    assert vault.find_by_uuid("") is None
+
+
+def test_is_stale():
+    now = time.time() * 1000
+    fresh = _session(captured_at=int(now))
+    old = _session(captured_at=int(now - cs.KEEPALIVE_REFRESH_DAYS * 86400 * 1000 - 1000))
+    assert not cs._is_stale(fresh)
+    assert cs._is_stale(old)
+    # unknown capture time never forces a refresh
+    assert not cs._is_stale(_session(captured_at=0))
+
+
+def test_resolve_automation_dir(tmp_path):
+    assert cs.resolve_automation_dir(cs.ChromeSyncSettings(), tmp_path) == tmp_path / "chrome-automation"
+    custom = cs.ChromeSyncSettings(automation_dir="/tmp/foo")
+    assert cs.resolve_automation_dir(custom, tmp_path) == Path("/tmp/foo")
+
+
+def test_load_chrome_settings_defaults(tmp_path):
+    s = load_chrome_settings(tmp_path)
+    assert s.enabled is False
+    assert s.debug_port == 9333
+    assert s.source_profile == "Default"
+    assert s.auto_launch is True
+
+
+def test_load_chrome_settings_values(tmp_path):
+    (tmp_path / "settings.json").write_text(json.dumps({"chrome": {
+        "enabled": True, "debugPort": 9401, "sourceProfile": "Profile 1", "autoLaunch": False}}))
+    s = load_chrome_settings(tmp_path)
+    assert s.enabled is True
+    assert s.debug_port == 9401
+    assert s.source_profile == "Profile 1"
+    assert s.auto_launch is False
+
+
+def test_load_chrome_settings_ignores_bad_types(tmp_path):
+    (tmp_path / "settings.json").write_text(json.dumps({"chrome": {
+        "enabled": "yes", "debugPort": "nope"}}))  # wrong types → defaults
+    s = load_chrome_settings(tmp_path)
+    assert s.enabled is False
+    assert s.debug_port == 9333
+
+
+def test_set_chrome_enabled_roundtrip_and_preserves_keys(tmp_path):
+    set_chrome_enabled(tmp_path, True)
+    assert load_chrome_settings(tmp_path).enabled is True
+    set_chrome_enabled(tmp_path, False)
+    assert load_chrome_settings(tmp_path).enabled is False
+
+    (tmp_path / "settings.json").write_text(json.dumps({
+        "autoswitch": {"threshold": 80},
+        "chrome": {"enabled": False, "debugPort": 9999},
+    }))
+    set_chrome_enabled(tmp_path, True)
+    raw = json.loads((tmp_path / "settings.json").read_text())
+    assert raw["chrome"]["enabled"] is True
+    assert raw["chrome"]["debugPort"] == 9999          # other chrome keys kept
+    assert raw["autoswitch"]["threshold"] == 80        # other sections kept
+
+
+def test_chromesync_noop_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(cs, "is_supported", lambda: True)
+    sync = cs.ChromeSync(cs.ChromeSyncSettings(enabled=False), tmp_path)
+    assert sync.active is False
+    assert sync.capture_for_account("1") is False
+    assert sync.sync_to_account("1") is False
+    assert sync.capture_from_browser("1") is False
+    assert sync.refresh_account("1") is False
+    assert sync.open_and_activate("1") is False
+
+
+def test_chromesync_noop_when_unsupported(tmp_path, monkeypatch):
+    monkeypatch.setattr(cs, "is_supported", lambda: False)
+    sync = cs.ChromeSync(cs.ChromeSyncSettings(enabled=True), tmp_path)
+    assert sync.active is False
+
+
+def test_capture_for_account_rejects_org_mismatch(tmp_path, monkeypatch):
+    monkeypatch.setattr(cs, "is_supported", lambda: True)
+    monkeypatch.setattr(cs, "automation_chrome_running", lambda *a, **k: True)
+    monkeypatch.setattr(
+        cs, "capture_tokens_cdp",
+        lambda *a, **k: _session(account_uuid="acc", org_uuid="ORG-A"),
+    )
+    sync = cs.ChromeSync(cs.ChromeSyncSettings(enabled=True), tmp_path)
+
+    # Mismatched org → not stored (the extension is connected to a different account).
+    assert sync.capture_for_account("1", expected_org_uuid="ORG-B") is False
+    assert cs.ChromeVault(tmp_path).get("1") is None
+
+    # Matching org → stored.
+    assert sync.capture_for_account("1", expected_org_uuid="ORG-A") is True
+    assert cs.ChromeVault(tmp_path).get("1").org_uuid == "ORG-A"
+
+    # No expected org supplied → best-effort store.
+    assert sync.capture_for_account("2") is True
+
+
+def test_capture_for_account_none_when_no_login(tmp_path, monkeypatch):
+    monkeypatch.setattr(cs, "is_supported", lambda: True)
+    monkeypatch.setattr(cs, "automation_chrome_running", lambda *a, **k: True)
+    monkeypatch.setattr(cs, "capture_tokens_cdp", lambda *a, **k: None)
+    sync = cs.ChromeSync(cs.ChromeSyncSettings(enabled=True), tmp_path)
+    assert sync.capture_for_account("1", expected_org_uuid="ORG") is False
+
+
+def test_capture_for_account_needs_running_browser(tmp_path, monkeypatch):
+    monkeypatch.setattr(cs, "is_supported", lambda: True)
+    monkeypatch.setattr(cs, "automation_chrome_running", lambda *a, **k: False)
+    sync = cs.ChromeSync(cs.ChromeSyncSettings(enabled=True), tmp_path)
+    # Tokens live in the running extension's memory; no browser → nothing to capture.
+    assert sync.capture_for_account("1") is False
+
+
+def test_refresh_account_updates_vault(tmp_path, monkeypatch):
+    monkeypatch.setattr(cs, "is_supported", lambda: True)
+    vault = cs.ChromeVault(tmp_path)
+    vault.put("1", _session(access_token="old", refresh_token="rt-old", account_uuid="acc"))
+
+    def fake_refresh(session, **k):
+        return cs.ChromeSession(
+            access_token="new", refresh_token="rt-new",
+            account_uuid=session.account_uuid, captured_at=42,
+        )
+
+    monkeypatch.setattr(cs, "refresh_session", fake_refresh)
+    sync = cs.ChromeSync(cs.ChromeSyncSettings(enabled=True), tmp_path)
+    assert sync.refresh_account("1") is True
+    stored = vault.get("1")
+    assert stored.access_token == "new"
+    assert stored.refresh_token == "rt-new"
+
+
+def test_refresh_account_failure_keeps_old(tmp_path, monkeypatch):
+    monkeypatch.setattr(cs, "is_supported", lambda: True)
+    vault = cs.ChromeVault(tmp_path)
+    vault.put("1", _session(access_token="old", refresh_token="rt-old"))
+    monkeypatch.setattr(cs, "refresh_session", lambda *a, **k: None)
+    sync = cs.ChromeSync(cs.ChromeSyncSettings(enabled=True), tmp_path)
+    assert sync.refresh_account("1") is False
+    assert vault.get("1").access_token == "old"   # unchanged


### PR DESCRIPTION
## What

Adds an **opt-in, macOS-only** feature that switches the *Claude in Chrome*
extension's account alongside the CLI account. When enabled, `cswap switch` (and
the menu bar) also flips the account the extension is paired to, so Claude Code's
browser automation follows the same account.

Disabled by default — when off, cswap behaves exactly as before (CLI-only), and
non-macOS platforms no-op.

## How it works (OAuth tokens, not a cookie)

The extension authenticates with **OAuth tokens** — `accessToken`
(`sk-ant-oat01-`), `refreshToken` (`sk-ant-ort01-`), `tokenExpiry` — held in its
service worker's **in-memory** `chrome.storage.session`. `accountUuid` lives in
`chrome.storage.local`. The service worker reads these once at startup and
connects the bridge from there.

Switching an account therefore means:

1. Inject the target account's tokens into the SW's storage (via CDP, evaluating
   in the service worker).
2. Terminate the SW with CDP `Target.closeTarget` — **not**
   `chrome.runtime.reload()`. A runtime reload *clears* `storage.session`
   (losing the just-injected tokens); `closeTarget` *preserves* it.
3. Wake the SW with a throwaway background `claude.ai` tab (closed afterwards),
   so it restarts, reads the injected tokens, and reconnects as the new account.
   If the injected access token is expired, the SW auto-refreshes via the refresh
   token on adoption (self-heals).

Because the tokens live in in-memory session storage, capture requires the
automation Chrome running + CDP (there is no on-disk/offline path, and — unlike a
cookie approach — no Keychain/openssl/SQLite is involved at all).

## Why a dedicated Chrome profile

CDP against modern Chrome (macOS ~M136+/2025) forces a dedicated, separately
launched profile:

1. The **default user-data-dir ignores `--remote-debugging-port`** → switching
   must run in a *separate* `--user-data-dir` instance.
2. **`--load-extension` is blocked** → the Claude extension is installed once
   from the Web Store into the dedicated profile.
3. The wake tab hits claude.ai, which **Cloudflare blocks headless** → the
   automation Chrome runs headed.

Full rationale lives in the `chrome_session` module docstring.

## Token lifetimes & keep-alive

- `accessToken` ~8h; the extension refreshes it transparently.
- `refreshToken` ~28.5 days, **rotating on every refresh**. This is the real
  parking limit: switching to an account within ~28.5 days is seamless; past
  that its refresh token expires and it needs a browser re-login.
- `cswap chrome refresh <n>` (and every switch) refreshes a stored token offline
  via `platform.claude.com/v1/oauth/token`, rolling the window forward so a
  parked account never lapses — no browser needed.

## Commands

- `cswap chrome setup` — guided one-time setup (create profile → install
  extension → connect + capture each account)
- `cswap chrome doctor` — setup state + per-account coverage
- `cswap chrome open [--ensure] [--focus]` / `capture <n>` / `refresh <n>`
  / `create-profile [--rebuild]` / `enable` / `disable`
- `cswap chrome bridge install | status | uninstall | run` — local relay so a
  *running* session follows a switch (see below)

A `(chrome)` marker in `list` / `status` / the menu bar flags accounts that have
stored tokens.

## Making a *running* session follow a switch (bridge relay)

The token swap above re-pairs the **extension**, but a Claude Code session binds
its own bridge account at process start — so a switch made *while it is running*
was only picked up after restarting it.

The extension and Claude Code pair through Anthropic's bridge at
`wss://bridge.claudeusercontent.com/chrome/<accountUuid>`; the UUID is the
**room**, and both peers must resolve to the same one to see each other. Claude
Code ships an escape hatch: with `LOCAL_BRIDGE=1` it connects to a plaintext
`ws://localhost:8765/chrome/dev_user_local` with a tokenless connect —
account-agnostic.

`chrome_bridge` is the other half: a local relay on that port. It accepts Claude
Code's tokenless local connect, originates an *authenticated* upstream
connection to the real bridge in the **current cswap account's** room, and
relays frames both ways. On `cswap switch` it re-points that upstream to the new
room while the downstream connection stays up — so the browser follows the
switch live, no restart.

```bash
cswap chrome bridge install     # background relay via a LaunchAgent (com.claude-swap.bridge)
cswap chrome bridge status      # running? on which port     (also: run, uninstall)
LOCAL_BRIDGE=1 claude           # route this session through the relay
```

- The **extension is never modified** by this path — it stays on the real
  bridge and keeps auto-updating; only Claude Code's side is re-pointed.
- Verified TLS upstream (system trust store); the relay listens on `127.0.0.1`
  only, and runs independently of the `chrome.enabled` gate (the LaunchAgent
  keeps it up across logins).
- `cswap chrome doctor` reports relay + LaunchAgent state alongside the rest.
- Caveat: `LOCAL_BRIDGE` / `dev_user_local` are internal Claude Code dev
  features and may change between versions — hence opt-in, and harmless when
  unused.

## Design / safety

- **Opt-in**: gated on `chrome.enabled` in `settings.json`; `ChromeSync` is a
  no-op when disabled or on non-macOS. The switch/add hooks are best-effort and
  never fail the OAuth switch that already committed.
- **Freshness**: on every switch the outgoing account's tokens are re-captured
  (the active token rotates ~8h), matched to a vault slot by `accountUuid`.
- **Capture guard**: on `cswap add`, tokens are stored only if the extension's
  org matches the account Claude Code is adding.
- **Security**: stored tokens are bearer credentials (password-equivalent) in
  `chrome_sessions.json`, chmod 600, beside the existing backup root.
- **No new dependencies**: pure-stdlib CDP client; the offline refresh uses the
  system `curl` (as the old path used `openssl`).

## Browser behavior (non-intrusive)

- **No focus stealing**: the window is never raised automatically;
  `cswap chrome open --focus` is opt-in.
- **No lingering claude.ai tab**: the wake tab is a throwaway *background* tab
  that is closed afterwards, leaving the dedicated browser on a normal New Tab
  Page, ready for Claude Code to drive.
- `cswap chrome open` on an already-running browser only ensures it's up (no
  re-inject).

## Testing

- `tests/test_chrome_session.py` (18 tests): token value object, vault
  (incl. `find_by_uuid`), settings load/toggle, disabled/unsupported no-op, the
  add-time org guard, keep-alive staleness, and offline-refresh vault update.
- `tests/test_chrome_bridge.py` (6 tests): WebSocket frame round-trip (masked,
  unmasked, and the 8-byte extended-length path), active-account resolution from
  the sequence file + vault (and the `None` case), the closed-port liveness
  probe, and a stable launchd label.
- Full suite otherwise green; 3 pre-existing, environment-specific failures are
  unrelated to this change (they reproduce unchanged on `main`).
- Verified end-to-end on macOS: A→B→A account flips through the `ChromeSync`
  facade, confirmed by the extension's reported identity and by Claude Code's
  `list_connected_browsers` following the switch.
- Bridge relay verified **without restarting the session**: with `LOCAL_BRIDGE=1`,
  a mid-session `cswap switch` moved `cswap chrome doctor`'s reported identity to
  the other account, and `list_connected_browsers` kept returning the browser on
  a fresh connection in the new room.

## Notes

- macOS-only for now; other platforms no-op with a clear message. The token
  mechanism itself is portable (no macOS-specific crypto); a Linux/Windows launch
  path is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

