### PR TITLE
fix(usage-store): stop retaining and resurrecting usage rows for slots that leave the managed set

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -325,7 +325,9 @@ class ClaudeAccountSwitcher:
         self.credentials_dir = self.backup_dir / "credentials"
         self.lock_file = self.backup_dir / ".lock"
         self._logger = setup_logging(self.backup_dir, debug=debug)
-        self._usage_store = UsageStore(self.backup_dir / "cache")
+        self._usage_store = UsageStore(
+            self.backup_dir / "cache", roster_path=self.sequence_file
+        )
         # (settings mtime, (threshold, models)) — see _poll_policy_inputs.
         self._poll_inputs_cache: tuple[float | None, tuple[float, tuple[str, ...]]] | None = None
         self._poll_inputs_override: tuple[float, tuple[str, ...]] | None = None
@@ -917,7 +919,12 @@ class ClaudeAccountSwitcher:
         del data["accounts"][d_num]
         self._write_json(self.sequence_file, data)
         self._prune_mappings(d_email, d_org)
-        self._usage_store.drop([d_num])
+        try:
+            self._usage_store.drop([d_num])
+        except Exception as e:
+            self._logger.error(
+                f"Stale ring-usage cache row left under displaced key {d_num}: {e}"
+            )
 
     def _vacate_migrated_slot(self, migrate_from: str) -> None:
         """Free the OLD slot number after the same identity moves to a new
@@ -933,7 +940,13 @@ class ClaudeAccountSwitcher:
             data["sequence"].remove(int(migrate_from))
         del data["accounts"][migrate_from]
         self._write_json(self.sequence_file, data)
-        self._usage_store.drop([migrate_from])
+        try:
+            self._usage_store.drop([migrate_from])
+        except Exception as e:
+            self._logger.error(
+                "Stale ring-usage cache row left under migrated key "
+                f"{migrate_from}: {e}"
+            )
 
     def _read_account_config(self, account_num: str, email: str) -> str:
         """Read account config from backup."""

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1631,6 +1631,12 @@ class ClaudeAccountSwitcher:
             self._logger.error(
                 f"Stale backup left under old key {num_src} ({email}): {e}"
             )
+        try:
+            self._usage_store.drop([num_src])
+        except Exception as e:
+            self._logger.error(
+                f"Stale ring-usage cache row left under old key {num_src}: {e}"
+            )
         if creds:
             # Any .prev retained while overwriting a stale target key holds
             # that stale material, not this account's history.
@@ -3377,6 +3383,7 @@ class ClaudeAccountSwitcher:
             del data["accounts"][d_num]
             self._write_json(self.sequence_file, data)
             self._prune_mappings(d_email, d_org)
+            self._usage_store.drop([d_num])
 
         if migrate_from:
             data = self._get_sequence_data()
@@ -3386,6 +3393,7 @@ class ClaudeAccountSwitcher:
                 data["sequence"].remove(int(migrate_from))
             del data["accounts"][migrate_from]
             self._write_json(self.sequence_file, data)
+            self._usage_store.drop([migrate_from])
 
         # Store backups
         self._write_account_credentials(account_num, current_email, current_creds)
@@ -3583,6 +3591,7 @@ class ClaudeAccountSwitcher:
             del data["accounts"][d_num]
             self._write_json(self.sequence_file, data)
             self._prune_mappings(d_email, d_org)
+            self._usage_store.drop([d_num])
 
         if migrate_from:
             data = self._get_sequence_data()
@@ -3592,6 +3601,7 @@ class ClaudeAccountSwitcher:
                 data["sequence"].remove(int(migrate_from))
             del data["accounts"][migrate_from]
             self._write_json(self.sequence_file, data)
+            self._usage_store.drop([migrate_from])
 
         self._write_account_credentials(account_num, email, credentials)
         self._write_account_config(account_num, email, config)
@@ -3714,6 +3724,7 @@ class ClaudeAccountSwitcher:
         print(f"{accent('Removed')} Account-{account_num} ({email})")
 
         self._prune_mappings(email, account_info.get("organizationUuid", ""))
+        self._usage_store.drop([account_num])
 
     def _build_accounts_info(self) -> list[tuple[int, str, str, str, bool, str, str]]:
         """Build per-account (num, email, org_name, org_uuid, is_active, creds, alias).

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -904,6 +904,37 @@ class ClaudeAccountSwitcher:
         if pruned:
             print(dimmed(f"Removed {pruned} directory mapping(s) for this account"))
 
+    def _vacate_displaced_slot(self, displace_slot: tuple[str, str, str]) -> None:
+        """Free a slot occupied by a DIFFERENT account so a new one can take
+        it: delete its backup files, drop it from the account table, and
+        prune its directory mappings and ring-usage cache row. Shared by
+        add_account and add_account_from_token's identical overwrite path."""
+        d_num, d_email, d_org = displace_slot
+        self._delete_account_files(d_num, d_email)
+        data = self._get_sequence_data()
+        if int(d_num) in data["sequence"]:
+            data["sequence"].remove(int(d_num))
+        del data["accounts"][d_num]
+        self._write_json(self.sequence_file, data)
+        self._prune_mappings(d_email, d_org)
+        self._usage_store.drop([d_num])
+
+    def _vacate_migrated_slot(self, migrate_from: str) -> None:
+        """Free the OLD slot number after the same identity moves to a new
+        one: delete its backup files, drop it from the account table, and
+        drop its ring-usage cache row (keyed by slot number, so migration
+        leaves it behind even though the identity-keyed directory mappings
+        need no pruning here). Shared by add_account and
+        add_account_from_token's identical migration path."""
+        data = self._get_sequence_data()
+        old_email = data["accounts"][migrate_from].get("email", "")
+        self._delete_account_files(migrate_from, old_email)
+        if int(migrate_from) in data["sequence"]:
+            data["sequence"].remove(int(migrate_from))
+        del data["accounts"][migrate_from]
+        self._write_json(self.sequence_file, data)
+        self._usage_store.drop([migrate_from])
+
     def _read_account_config(self, account_num: str, email: str) -> str:
         """Read account config from backup."""
         config_file = self.configs_dir / f".claude-config-{account_num}-{email}.json"
@@ -1732,7 +1763,7 @@ class ClaudeAccountSwitcher:
         """
         accounts_info = self._build_accounts_info()
         return self._collect_usage_entries(
-            accounts_info, fetch=fetch, scheduled=scheduled
+            accounts_info, fetch=fetch, scheduled=scheduled, reconcile=True
         )
 
     def accounts_snapshot(self, fetch: set[str] | None = None) -> AccountsSnapshot:
@@ -1747,7 +1778,9 @@ class ClaudeAccountSwitcher:
         this pass.
         """
         accounts_info = self._build_accounts_info()
-        entries = self._collect_usage_entries(accounts_info, fetch=fetch)
+        entries = self._collect_usage_entries(
+            accounts_info, fetch=fetch, reconcile=True
+        )
         seq_data = self._get_sequence_data() or {}
         active_number: str | None = None
         accounts: list[AccountSnapshot] = []
@@ -3375,25 +3408,10 @@ class ClaudeAccountSwitcher:
 
         # Now safe to perform destructive cleanup (new account data is in memory)
         if displace_slot:
-            d_num, d_email, d_org = displace_slot
-            self._delete_account_files(d_num, d_email)
-            data = self._get_sequence_data()
-            if int(d_num) in data["sequence"]:
-                data["sequence"].remove(int(d_num))
-            del data["accounts"][d_num]
-            self._write_json(self.sequence_file, data)
-            self._prune_mappings(d_email, d_org)
-            self._usage_store.drop([d_num])
+            self._vacate_displaced_slot(displace_slot)
 
         if migrate_from:
-            data = self._get_sequence_data()
-            old_email = data["accounts"][migrate_from].get("email", "")
-            self._delete_account_files(migrate_from, old_email)
-            if int(migrate_from) in data["sequence"]:
-                data["sequence"].remove(int(migrate_from))
-            del data["accounts"][migrate_from]
-            self._write_json(self.sequence_file, data)
-            self._usage_store.drop([migrate_from])
+            self._vacate_migrated_slot(migrate_from)
 
         # Store backups
         self._write_account_credentials(account_num, current_email, current_creds)
@@ -3583,25 +3601,10 @@ class ClaudeAccountSwitcher:
             account_num = str(self._get_next_account_number())
 
         if displace_slot:
-            d_num, d_email, d_org = displace_slot
-            self._delete_account_files(d_num, d_email)
-            data = self._get_sequence_data()
-            if int(d_num) in data["sequence"]:
-                data["sequence"].remove(int(d_num))
-            del data["accounts"][d_num]
-            self._write_json(self.sequence_file, data)
-            self._prune_mappings(d_email, d_org)
-            self._usage_store.drop([d_num])
+            self._vacate_displaced_slot(displace_slot)
 
         if migrate_from:
-            data = self._get_sequence_data()
-            old_email = data["accounts"][migrate_from].get("email", "")
-            self._delete_account_files(migrate_from, old_email)
-            if int(migrate_from) in data["sequence"]:
-                data["sequence"].remove(int(migrate_from))
-            del data["accounts"][migrate_from]
-            self._write_json(self.sequence_file, data)
-            self._usage_store.drop([migrate_from])
+            self._vacate_migrated_slot(migrate_from)
 
         self._write_account_credentials(account_num, email, credentials)
         self._write_account_config(account_num, email, config)
@@ -4605,6 +4608,7 @@ class ClaudeAccountSwitcher:
         fetch: set[str] | None = None,
         *,
         scheduled: bool = False,
+        reconcile: bool = False,
     ) -> dict[str, UsageEntry]:
         """Store-backed usage collection: one :class:`UsageEntry` per account.
 
@@ -4621,12 +4625,24 @@ class ClaudeAccountSwitcher:
         the same plan. A failed fetch only updates the entry's error/backoff
         fields, so the last-good measurement keeps being served
         (stale-on-error).
+
+        ``reconcile=True`` (BC-18973) additionally sweeps ``usage.json`` for
+        rows outside ``accounts_info`` before reading it, so a slot orphaned
+        before per-removal pruning existed (or by any write path that missed
+        it) still converges to the managed set. Safe here specifically
+        because ``accounts_info`` is this call's own snapshot of the *whole*
+        table — never set this on a caller that passes a filtered or
+        single-account ``accounts_info`` (e.g. ``_active_account_usage``),
+        or the sweep would delete perfectly healthy rows it simply wasn't
+        told about.
         """
         store = self._usage_store
         identities = {
             str(num): (email, org_uuid or "")
             for num, email, _org_name, org_uuid, _active, _creds, _alias in accounts_info
         }
+        if reconcile:
+            store.reconcile(identities)
         info_by_num = {str(info[0]): info for info in accounts_info}
         # Scoped-window models so the 429-stale trust bound honors per-model
         # (e.g. Fable) resets, matching the poll planner's window view.
@@ -4888,7 +4904,7 @@ class ClaudeAccountSwitcher:
     def _usage_by_account(self) -> dict[str, dict | str | None]:
         """Map account number → decision-grade usage value for managed accounts."""
         accounts_info = self._build_accounts_info()
-        entries = self._collect_usage_entries(accounts_info)
+        entries = self._collect_usage_entries(accounts_info, reconcile=True)
         return {num: entry.decision_value() for num, entry in entries.items()}
 
     def _warn_inert_models(
@@ -5180,7 +5196,9 @@ class ClaudeAccountSwitcher:
             return None
 
         accounts_info = self._build_accounts_info()
-        entries = self._collect_usage_entries(accounts_info, fetch=fetch)
+        entries = self._collect_usage_entries(
+            accounts_info, fetch=fetch, reconcile=True
+        )
 
         if json_output:
             return self._build_list_payload(accounts_info, entries)

--- a/src/claude_swap/transfer.py
+++ b/src/claude_swap/transfer.py
@@ -544,9 +544,16 @@ def import_accounts(
         # previous auth verdict is no longer authoritative, so lift any
         # dead-token quarantine on this slot (mirrors add_account / the
         # add-token paths). This clears for both "imported" and "overwrote":
-        # account removal doesn't prune usage.json, so re-importing a removed
-        # identity into the same slot would otherwise stay quarantined and
-        # never re-fetch to prove the imported token — issue #138.
+        # "overwrote" replaces a still-managed slot's credentials in place,
+        # without going through remove_account, so its usage row (and any
+        # dead-token strike on it) survives untouched and must be cleared
+        # here explicitly — issue #138. ("imported" onto a slot number
+        # freed by a genuine removal no longer needs this for the same
+        # reason: BC-18973 made remove_account drop that row outright, so
+        # there is nothing left to quarantine the re-import. This call
+        # still runs unconditionally for that outcome too, since it is a
+        # no-op on a slot with no strike and cheap to keep uniform across
+        # both outcomes.)
         switcher._usage_store.clear_dead_token(
             [target_num], {target_num: (entry["email"], entry["org_uuid"])}
         )

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -843,9 +843,15 @@ class UsageStore:
       docstring before calling it.
     """
 
-    def __init__(self, cache_dir: Path, clock: Callable[[], float] = time.time):
+    def __init__(
+        self,
+        cache_dir: Path,
+        clock: Callable[[], float] = time.time,
+        roster_path: Path | None = None,
+    ):
         self.path = cache_dir / "usage.json"
         self._lock_path = cache_dir / ".usage.lock"
+        self._roster_path = roster_path
         self.clock = clock
 
     # -- raw I/O ------------------------------------------------------------
@@ -878,6 +884,29 @@ class UsageStore:
 
     def _fresh_row(self, identity: Identity) -> dict:
         return {"email": identity[0], "organizationUuid": identity[1]}
+
+    def _is_current_roster_identity(self, num: str, identity: Identity) -> bool:
+        """Whether ``num`` still names ``identity`` in the managed roster.
+
+        Switcher-owned stores provide a roster path so an in-flight collector
+        cannot cross a completed remove or slot reuse. Standalone stores omit
+        it and retain the generic identity-guarded behavior.
+        """
+        if self._roster_path is None:
+            return True
+        try:
+            data = json.loads(self._roster_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return True
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return False
+        accounts = data.get("accounts") if isinstance(data, dict) else None
+        account = accounts.get(num) if isinstance(accounts, dict) else None
+        return (
+            isinstance(account, dict)
+            and account.get("email") == identity[0]
+            and (account.get("organizationUuid") or "") == identity[1]
+        )
 
     # -- read model -----------------------------------------------------------
 
@@ -1037,6 +1066,8 @@ class UsageStore:
             rows = self._read_rows()
             for num in nums:
                 identity = identities[num]
+                if not self._is_current_roster_identity(num, identity):
+                    continue
                 row = rows.get(num)
                 if not self._matches(row, identity):
                     rows[num] = row = self._fresh_row(identity)
@@ -1126,6 +1157,10 @@ class UsageStore:
             rows = self._read_rows()
             for num in outcomes:
                 identity = identities[num]
+                if claims is not None and not self._is_current_roster_identity(
+                    num, identity
+                ):
+                    continue
                 row = rows.get(num)
                 expected: str | None = None
                 if claims is not None:

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -1177,6 +1177,33 @@ class UsageStore:
 
         self._mutate(identities, nums, apply)
 
+    def drop(self, nums: Iterable[str]) -> int:
+        """Delete stored rows for slots that have permanently left the
+        managed set (removed, displaced, migrated, or moved away from — see
+        the callers in switcher.py, one per table mutation that frees a slot
+        number for good).
+
+        Unconditional on identity: a freed slot's row is stale regardless of
+        what it currently holds — the identity it recorded is gone, or (a
+        reused slot number) the next fetch's identity-guarded write already
+        replaces it. Without this, a removed account's row keeps reading as
+        an unpolled, unknown account to any consumer of the raw file forever
+        (ring-watcher, most notably: it has no in-band "managed" signal of
+        its own and must trust the stored rows as-is). Returns the count of
+        rows actually removed.
+        """
+        nums = list(nums)
+        if not nums:
+            return 0
+        with self._lock():
+            rows = self._read_rows()
+            doomed = [num for num in nums if num in rows]
+            for num in doomed:
+                del rows[num]
+            if doomed:
+                self._write_rows(rows)
+        return len(doomed)
+
 
 def _num_or_none(value: object) -> float | None:
     return float(value) if isinstance(value, (int, float)) else None

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -818,12 +818,29 @@ class UsageStore:
     """The ``cache/usage.json`` table. All writes go read-modify-write under
     ``cache/.usage.lock``; reads are lock-free (writes are atomic replaces).
 
-    Every method takes the caller's current ``identities`` map (slot number →
-    ``(email, organizationUuid)``) and only ever touches rows for those slots:
-    a row whose stored identity differs is invisible to reads and replaced on
-    write, so slot reuse never serves the previous account's usage. Rows for
-    slots outside the map are left alone (callers like ``--status`` operate
-    on a single slot).
+    Every read/fetch/plan method takes the caller's current ``identities``
+    map (slot number → ``(email, organizationUuid)``) and only ever touches
+    rows for those slots: a row whose stored identity differs is invisible
+    to reads and replaced on write, so slot reuse never serves the previous
+    account's usage. Rows for slots outside the map are left alone (callers
+    like ``--status`` operate on a single slot) — this is the general rule,
+    and it is safe precisely because these methods never need to know
+    whether a slot they weren't told about is still managed.
+
+    Two methods are the deliberate exception, both existing solely to keep
+    ``usage.json`` from accumulating rows for accounts no longer managed at
+    all (BC-18973 — orphaned rows are invisible to cswap's own identity
+    guard but not to a consumer with no such guard, e.g. ring-watcher,
+    which reads the raw file directly):
+
+    - :meth:`drop` takes bare slot numbers (``nums``, no identity check) and
+      deletes exactly those rows — for a caller that already knows, by
+      construction, that a specific slot was just freed for good.
+    - :meth:`reconcile` takes an ``identities`` map like every other method,
+      but inverts the rule above: it deletes every row NOT in the map,
+      instead of leaving rows outside it alone. Callers MUST pass their
+      complete current managed set here, never a subset — see its own
+      docstring before calling it.
     """
 
     def __init__(self, cache_dir: Path, clock: Callable[[], float] = time.time):
@@ -1198,6 +1215,54 @@ class UsageStore:
         with self._lock():
             rows = self._read_rows()
             doomed = [num for num in nums if num in rows]
+            for num in doomed:
+                del rows[num]
+            if doomed:
+                self._write_rows(rows)
+        return len(doomed)
+
+    def reconcile(self, identities: dict[str, Identity]) -> int:
+        """Delete every stored row whose slot number is not a key in
+        ``identities`` — the retroactive counterpart to :meth:`drop`.
+
+        ``drop()`` only reaches rows for slot numbers its caller names
+        explicitly, at the moment a slot is freed. It cannot reach a row
+        that was already orphaned before that per-removal pruning existed
+        (BC-18973's original gap: accounts removed by an older release, or
+        by any write path that missed a ``drop()`` call). This sweep closes
+        that gap by comparing against the caller's live view of the whole
+        table instead of a specific slot list, so the cache converges to
+        the managed set on its own the next time a caller with the full
+        picture runs — no migration step, no touching the file by hand.
+
+        ``identities`` MUST be the caller's COMPLETE current managed set,
+        fresh off the account table (e.g. every slot in
+        ``Switcher._build_accounts_info()``'s return) — never a subset. A
+        row for a slot simply not mentioned in a partial or single-account
+        map looks identical, from here, to a genuinely orphaned one; this
+        method cannot tell the difference and would delete perfectly
+        healthy, still-managed rows a caller only forgot to list. Contrast
+        every other method on this class, whose ``identities``/``nums``
+        arguments may safely be a subset — this is the one exception, and
+        callers must build it accordingly (see ``Switcher.
+        _collect_usage_entries``'s ``reconcile`` parameter).
+
+        An empty ``identities`` is treated as "not a real reading" rather
+        than "zero managed accounts" and is always a no-op: a transient
+        failure reading the account table (a corrupt or momentarily
+        unreadable ``sequence.json``) must never be able to read as "prune
+        everything" and wipe the entire cache. The true empty-table case
+        loses nothing by waiting for the next reconciling call once the
+        table is readable again — an unreconciled row is merely stale, the
+        harm this guard avoids is irreversible.
+
+        Returns the count of rows actually removed.
+        """
+        if not identities:
+            return 0
+        with self._lock():
+            rows = self._read_rows()
+            doomed = [num for num in rows if num not in identities]
             for num in doomed:
                 del rows[num]
             if doomed:

--- a/tests/test_move_accounts.py
+++ b/tests/test_move_accounts.py
@@ -1,5 +1,6 @@
 """Tests for `cswap move` (ClaudeAccountSwitcher.move_account)."""
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -15,6 +16,7 @@ from claude_swap.exceptions import (
 )
 from claude_swap.models import Platform
 from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.usage_store import FetchRecord, UsageStore
 
 
 class TestMoveAccount:
@@ -483,6 +485,29 @@ class TestMoveAccount:
 
         with pytest.raises(ValidationError, match="out of range"):
             switcher.move_account("2", "151")
+
+    # -- BC-18973: the vacated source slot must not linger in usage.json --
+
+    def test_move_drops_the_old_slot_usage_row(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """Moving frees ``num_src`` for good (it leaves the accounts table
+        entirely — ``del data["accounts"][num_src]``), so its ring-usage
+        cache row must go with it; otherwise it sits in usage.json forever,
+        indistinguishable from a real never-polled managed account to a
+        reader with no identity guard (ring-watcher; BC-18955/BC-18973)."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        UsageStore(switcher.backup_dir / "cache").record(
+            {"2": FetchRecord(usage={"five_hour": {"pct": 50.0}})},
+            {"2": ("account2@example.com", "")},
+        )
+        raw_path = switcher.backup_dir / "cache" / "usage.json"
+        assert "2" in json.loads(raw_path.read_text())["accounts"]
+
+        switcher.move_account("2", "5")
+
+        assert "2" not in json.loads(raw_path.read_text())["accounts"]
 
 
 class TestMoveUnreadableSourceIsNotAbsent:

--- a/tests/test_swap_accounts.py
+++ b/tests/test_swap_accounts.py
@@ -1,5 +1,6 @@
 """Tests for `cswap swap` (ClaudeAccountSwitcher.swap_accounts)."""
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -13,6 +14,7 @@ from claude_swap.exceptions import (
     ValidationError,
 )
 from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.usage_store import FetchRecord, UsageStore
 
 
 class TestSwapAccounts:
@@ -436,6 +438,33 @@ class TestSwapAccounts:
         moved = switcher._session_dir("2", "account1@example.com")
         assert (moved / "marker.txt").read_text() == "history-of-account-one"
         assert not session_a.exists()
+
+    def test_swap_does_not_drop_usage_rows_for_still_managed_slots(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """Scope guard for BC-18973's fix: unlike remove/displace/migrate/
+        move, a swap never frees a slot NUMBER — both numbers stay in the
+        accounts table, just holding each other's identity. Their usage
+        rows must survive (self-healing via the identity guard on next
+        write, same as any slot reuse) rather than being wiped by an
+        over-eager drop()."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        UsageStore(switcher.backup_dir / "cache").record(
+            {
+                "1": FetchRecord(usage={"five_hour": {"pct": 10.0}}),
+                "2": FetchRecord(usage={"five_hour": {"pct": 20.0}}),
+            },
+            {"1": ("account1@example.com", ""), "2": ("account2@example.com", "")},
+        )
+
+        switcher.swap_accounts("1", "2")
+
+        raw = json.loads(
+            (switcher.backup_dir / "cache" / "usage.json").read_text()
+        )["accounts"]
+        assert "1" in raw
+        assert "2" in raw
 
 
 class TestSwapUnreadableSourceIsNotAbsent:

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -8255,6 +8255,109 @@ class TestRemoveAccountPrunesMappings:
         assert switcher.slot_for_directory(str(temp_home)) == ("5", "a@x.com")
 
 
+class TestSlotVacatePrunesUsageStore:
+    """BC-18973: a slot that leaves cswap's managed set for good (removed,
+    displaced by an overwrite, or migrated to a new number) must not leave
+    its row behind in usage.json — orphaned rows there are invisible to
+    cswap's own identity-guarded reads but not to a tool that reads the raw
+    file directly (ring-watcher; see BC-18955/BC-18973), where they read as
+    permanently unpolled managed accounts and block ring-wide confirmation.
+
+    Each test reads the raw file exactly as such a tool would (plain JSON,
+    no identity matching) rather than through ``UsageStore.entries()``,
+    since entries() already hides a mismatched row and would pass even if
+    the row were merely orphaned rather than actually removed.
+    """
+
+    @staticmethod
+    def _raw_usage_accounts(switcher) -> dict:
+        path = switcher.backup_dir / "cache" / "usage.json"
+        if not path.exists():
+            return {}
+        return json.loads(path.read_text(encoding="utf-8")).get("accounts", {})
+
+    def _config_switcher(self, temp_home, email):
+        config = {
+            "oauthAccount": {
+                "emailAddress": email,
+                "accountUuid": "uuid-" + email,
+                "organizationUuid": "",
+                "organizationName": "",
+            }
+        }
+        (temp_home / ".claude.json").write_text(json.dumps(config))
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        return switcher
+
+    def test_remove_account_drops_the_usage_row(self, temp_home, monkeypatch):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["1"] = {
+            "email": "a@x.com",
+            "uuid": "u1",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [1]
+        switcher._write_json(switcher.sequence_file, data)
+
+        UsageStore(switcher.backup_dir / "cache").record(
+            {"1": FetchRecord(usage={"five_hour": {"pct": 50.0}})},
+            {"1": ("a@x.com", "")},
+        )
+        assert "1" in self._raw_usage_accounts(switcher)
+
+        monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+        switcher.remove_account("1")
+
+        assert "1" not in self._raw_usage_accounts(switcher)
+
+    # NOTE on the displace-slot path (add_account/add_account_from_token
+    # overwriting an occupied target slot): the displaced slot number IS the
+    # target slot, which the same call immediately rewrites via
+    # ``clear_dead_token`` right after — that call's own identity mismatch
+    # already forces a fresh row there, independent of the ``drop()`` this
+    # fix adds at the point of displacement. So the happy path can't
+    # discriminate the two — a black-box test asserting the row's final
+    # state passes whether or not the extra drop() runs. It stays in source
+    # for the narrow window it does cover (a crash between the displacement
+    # and that follow-up write, which the "safe to perform destructive
+    # cleanup" comment there says is not otherwise guarded), verified by
+    # code review rather than by a test that can't tell the difference.
+
+    def test_slot_migration_drops_the_old_slot_usage_row(self, temp_home):
+        """Moving an account to another slot (same identity, new number)
+        drops the vacated slot's row — unlike directory mappings (identity-
+        keyed, so migration needs no pruning there), usage rows are keyed by
+        slot number, so the OLD number is now a stray key. Mirrors
+        TestRemoveAccountPrunesMappings.test_slot_migration_keeps_mappings."""
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+
+        switcher = self._config_switcher(temp_home, "a@x.com")
+        with patch.object(switcher, "_read_active_credentials", return_value=ActiveCredentials(fake_creds, False)), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account()  # lands in slot 1
+
+        UsageStore(switcher.backup_dir / "cache").record(
+            {"1": FetchRecord(usage={"five_hour": {"pct": 50.0}})},
+            {"1": ("a@x.com", "")},
+        )
+        assert "1" in self._raw_usage_accounts(switcher)
+
+        with patch.object(switcher, "_read_active_credentials", return_value=ActiveCredentials(fake_creds, False)), \
+             patch.object(switcher, "_write_account_credentials"), \
+             patch.object(switcher, "_delete_account_credentials"):
+            switcher.add_account(slot=5)  # same identity, new slot
+
+        assert "1" not in self._raw_usage_accounts(switcher)
+
+
 class TestSwitchRemoveGatesAcceptAlias:
     """Regression: switch_to/remove_account must accept an alias identifier
     instead of rejecting it with 'Invalid email format' before resolution."""

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -8357,6 +8357,50 @@ class TestSlotVacatePrunesUsageStore:
 
         assert "1" not in self._raw_usage_accounts(switcher)
 
+    @pytest.mark.parametrize("entrypoint", ["capture", "token"])
+    @pytest.mark.parametrize("vacate_kind", ["displaced", "migrated"])
+    def test_add_completes_when_post_commit_usage_drop_fails(
+        self, temp_home, entrypoint, vacate_kind
+    ):
+        """Cache hygiene is best-effort once vacating the roster is committed."""
+        new_email = "new@x.com"
+        old_email = "old@x.com" if vacate_kind == "displaced" else new_email
+        old_slot = "5" if vacate_kind == "displaced" else "1"
+        target_slot = 5
+        switcher = self._config_switcher(temp_home, new_email)
+        data = switcher._get_sequence_data()
+        data["accounts"][old_slot] = {
+            "email": old_email,
+            "uuid": "old-uuid",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [int(old_slot)]
+        switcher._write_json(switcher.sequence_file, data)
+
+        fake_creds = json.dumps({"claudeAiOauth": {"accessToken": "tok"}})
+        with patch.object(switcher, "_delete_account_files"), patch.object(
+            switcher, "_write_account_credentials"
+        ), patch.object(switcher, "_write_account_config"), patch.object(
+            switcher._usage_store,
+            "drop",
+            side_effect=OSError("injected usage cache write failure"),
+        ), patch.object(
+            switcher, "_read_active_credentials",
+            return_value=ActiveCredentials(fake_creds, False),
+        ):
+            if entrypoint == "capture":
+                switcher.add_account(slot=target_slot, assume_yes=True)
+            else:
+                switcher.add_account_from_token(
+                    "token", new_email, slot=target_slot, assume_yes=True
+                )
+
+        data = switcher._get_sequence_data()
+        assert data["accounts"][str(target_slot)]["email"] == new_email
+        assert data["sequence"] == [target_slot]
+
 
 class TestReconcilesPreExistingOrphans:
     """BC-18973 rework: independent review found the forward-only drop()

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -8358,6 +8358,82 @@ class TestSlotVacatePrunesUsageStore:
         assert "1" not in self._raw_usage_accounts(switcher)
 
 
+class TestReconcilesPreExistingOrphans:
+    """BC-18973 rework: independent review found the forward-only drop()
+    calls above can never reach a row orphaned BEFORE this hygiene existed
+    (the ticket's own reported slots 10, 11, 13-18) — no future remove,
+    displace, migrate, or move will ever name a slot number nobody manages
+    anymore, so drop() alone leaves those rows stuck forever. A normal
+    full-managed-set read (list/status/TUI/auto) must reconcile the cache
+    against the account table instead, while leaving a genuinely managed,
+    never-polled account's row alone — ring-watcher's ``unknown_accounts``
+    must still contain exactly those, never fewer.
+    """
+
+    def test_list_accounts_reconciles_a_pre_existing_orphan_row(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        # A row for a slot number no add/remove/move/migrate in this test
+        # ever touched -- exactly the shape of the 8 slots this ticket
+        # found live: cache data outliving a removal from before per-slot
+        # pruning shipped at all.
+        UsageStore(switcher.backup_dir / "cache").record(
+            {"10": FetchRecord(usage={"five_hour": {"pct": 90.0}})},
+            {"10": ("orphan@x.com", "")},
+        )
+        # A genuinely managed account that simply hasn't been polled yet.
+        UsageStore(switcher.backup_dir / "cache").claim(
+            ["2"], {"2": ("account2@example.com", "")}
+        )
+
+        raw_path = switcher.backup_dir / "cache" / "usage.json"
+        assert set(json.loads(raw_path.read_text())["accounts"]) == {"10", "2"}
+
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        with patch.object(
+            switcher, "_read_active_credentials",
+            return_value=ActiveCredentials(active_creds, False),
+        ), patch.object(switcher, "_read_account_credentials", return_value="{}"):
+            switcher.list_accounts(fetch=set())
+
+        raw = json.loads(raw_path.read_text())["accounts"]
+        assert "10" not in raw, "pre-existing orphan must be reconciled away"
+        assert "2" in raw, "a genuinely managed, never-polled row must survive"
+
+    def test_single_slot_status_lookup_never_triggers_reconciliation(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """`_active_account_usage` (the `--status` single-slot path) only
+        ever builds a one-account view, never the full table -- it must
+        default `reconcile=False`, or a status check on slot 1 would sweep
+        away every other account's perfectly healthy row."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_json(switcher.sequence_file, sample_sequence_data)
+
+        UsageStore(switcher.backup_dir / "cache").record(
+            {"2": FetchRecord(usage={"five_hour": {"pct": 50.0}})},
+            {"2": ("account2@example.com", "")},
+        )
+        raw_path = switcher.backup_dir / "cache" / "usage.json"
+        assert "2" in json.loads(raw_path.read_text())["accounts"]
+
+        active_creds = json.dumps({"claudeAiOauth": {"accessToken": "sk-active"}})
+        with patch.object(
+            switcher, "_read_active_credentials",
+            return_value=ActiveCredentials(active_creds, False),
+        ):
+            switcher._active_account_usage("1", "account1@example.com", "")
+
+        assert "2" in json.loads(raw_path.read_text())["accounts"], (
+            "a single-slot status lookup must never sweep other accounts' rows"
+        )
+
+
 class TestSwitchRemoveGatesAcceptAlias:
     """Regression: switch_to/remove_account must accept an alias identifier
     instead of rejecting it with 'Invalid email format' before resolution."""

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -1737,3 +1737,75 @@ class TestDrop:
     def test_drop_reports_only_rows_actually_present(self, store):
         store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
         assert store.drop(["1", "9"]) == 1
+
+
+class TestReconcile:
+    """BC-18973 rework: drop() only ever reaches a slot its caller already
+    knows was just freed. A row orphaned before that per-removal pruning
+    existed (or by any write path that missed it — e.g. the 8 slots
+    reported live in this ticket) can't be reached that way at all, since
+    no future removal will ever name a slot number nobody manages anymore.
+    reconcile() is the retroactive sweep: given the caller's whole current
+    managed set, delete anything not in it.
+    """
+
+    def test_reconcile_removes_a_row_outside_identities(self, store):
+        store.record({"9": FetchRecord(usage=USAGE)}, {"9": ("orphan@x.com", "")})
+
+        removed = store.reconcile(IDENT)  # IDENT only knows "1" and "2"
+
+        assert removed == 1
+        assert "9" not in store._read_rows()
+
+    def test_reconciled_row_is_gone_even_to_a_reader_with_no_identity_guard(self, store):
+        """Discriminating check, as with drop(): read the file exactly as
+        ring-watcher does (raw JSON, no identity matching)."""
+        store.record({"9": FetchRecord(usage=USAGE)}, {"9": ("orphan@x.com", "")})
+        store.reconcile(IDENT)
+
+        raw = json.loads(store.path.read_text(encoding="utf-8"))
+        assert "9" not in raw["accounts"]
+
+    def test_reconcile_keeps_a_genuinely_managed_never_polled_row(self, store):
+        """The discriminating half of the fix: a row for a slot that IS in
+        ``identities`` but has never been successfully fetched (claimed,
+        no ``lastGood`` yet) must survive — it is a real managed account
+        ring-watcher is right to call unknown, not an orphan."""
+        store.claim(["1"], IDENT)
+        assert store.entries(IDENT)["1"].last_good is None  # genuinely unpolled
+
+        removed = store.reconcile(IDENT)
+
+        assert removed == 0
+        assert "1" in store._read_rows()
+        assert store.entries(IDENT)["1"].last_good is None
+
+    def test_reconcile_keeps_managed_rows_and_drops_orphans_together(self, store):
+        store.record(
+            {"1": FetchRecord(usage=USAGE), "9": FetchRecord(usage=USAGE)},
+            {"1": IDENT["1"], "9": ("orphan@x.com", "")},
+        )
+
+        removed = store.reconcile(IDENT)
+
+        assert removed == 1
+        rows = store._read_rows()
+        assert "1" in rows
+        assert "9" not in rows
+
+    def test_reconcile_with_empty_identities_is_a_safe_noop(self, store):
+        """A blank managed-set reading (e.g. a momentarily unreadable
+        sequence.json) must never be mistaken for "zero accounts, prune
+        everything" — that would wipe the whole cache on a transient glitch."""
+        store.record(
+            {"1": FetchRecord(usage=USAGE), "2": FetchRecord(usage=USAGE)}, IDENT
+        )
+
+        removed = store.reconcile({})
+
+        assert removed == 0
+        assert set(store._read_rows()) == {"1", "2"}
+
+    def test_reconcile_returns_zero_when_nothing_is_orphaned(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        assert store.reconcile(IDENT) == 0

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -1682,3 +1682,58 @@ class TestStruckFingerprintHygiene:
         )
         store.clear_dead_token(["1"], ident)
         assert store.entries(ident)["1"].struck_fingerprint is None
+
+
+class TestDrop:
+    """BC-18973: a slot freed for good (account removed, displaced, migrated,
+    or moved away from) must not leave its row sitting in usage.json forever.
+
+    Identity-guarded reads (``entries()``) already hide a mismatched row from
+    cswap itself, but a tool with no access to that guard — ring-watcher,
+    which reads the raw file directly and has no in-band "managed" signal of
+    its own (BC-18955/BC-18973) — sees the orphaned row exactly as if it were
+    a real, never-polled managed account. These tests assert the row is
+    physically gone from the raw file, not merely hidden from entries().
+    """
+
+    def test_drop_removes_the_row_from_the_raw_file(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        assert "1" in store._read_rows()
+
+        removed = store.drop(["1"])
+
+        assert removed == 1
+        assert "1" not in store._read_rows()
+
+    def test_dropped_row_is_gone_even_to_a_reader_with_no_identity_guard(self, store):
+        """The discriminating check: read the file exactly as ring-watcher
+        does (raw JSON, no identity matching) rather than through
+        ``entries()``, which would already hide a mismatched row and could
+        pass even if the row were merely orphaned, not actually deleted."""
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        store.drop(["1"])
+
+        raw = json.loads(store.path.read_text(encoding="utf-8"))
+        assert "1" not in raw["accounts"]
+
+    def test_drop_missing_slot_is_a_noop(self, store):
+        assert store.drop(["9"]) == 0
+        assert not store.path.exists()
+
+    def test_drop_empty_list_is_a_noop(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        mtime_before = store.path.stat().st_mtime_ns
+
+        assert store.drop([]) == 0
+        assert store.path.stat().st_mtime_ns == mtime_before
+
+    def test_drop_leaves_other_rows_untouched(self, store):
+        store.record(
+            {"1": FetchRecord(usage=USAGE), "2": FetchRecord(usage=USAGE)}, IDENT
+        )
+        store.drop(["1"])
+        assert store.entries(IDENT)["2"].last_good == USAGE
+
+    def test_drop_reports_only_rows_actually_present(self, store):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        assert store.drop(["1", "9"]) == 1

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -1738,10 +1738,10 @@ class TestDrop:
         store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
         assert store.drop(["1", "9"]) == 1
 
-    def test_stale_collector_cannot_recreate_a_removed_roster_slot(
+    def test_stale_reserve_cannot_recreate_a_removed_roster_slot(
         self, tmp_path, clock
     ):
-        """Removal after snapshot construction fences later reserve/record."""
+        """Removal after snapshot construction fences a later reserve."""
         sequence_path = tmp_path / "sequence.json"
         sequence_path.write_text(
             json.dumps(
@@ -1768,13 +1768,56 @@ class TestDrop:
         store.drop(["2"])
 
         claims = store.reserve(["2"], stale_snapshot, respect_plans=False)
+
+        assert claims == {}
+        assert "2" not in store._read_rows()
+
+    def test_fenced_record_rejects_a_claim_after_roster_identity_reuse(
+        self, tmp_path, clock
+    ):
+        """A claim won before slot reuse cannot persist its stale result."""
+        sequence_path = tmp_path / "sequence.json"
+        sequence_path.write_text(
+            json.dumps(
+                {
+                    "sequence": [2],
+                    "accounts": {
+                        "2": {"email": "b@x.com", "organizationUuid": "org-2"}
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        store = UsageStore(
+            tmp_path / "cache", clock=clock, roster_path=sequence_path
+        )
+        stale_snapshot = {"2": IDENT["2"]}
+        claims = store.reserve(["2"], stale_snapshot, respect_plans=False)
+        assert set(claims) == {"2"}  # the fetch starts while still managed
+
+        # Reuse commits before the in-flight fetch returns. Model failed
+        # best-effort cache cleanup by deliberately retaining the old claim.
+        sequence_path.write_text(
+            json.dumps(
+                {
+                    "sequence": [2],
+                    "accounts": {
+                        "2": {
+                            "email": "replacement@x.com",
+                            "organizationUuid": "",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
         accepted = store.record(
             {"2": FetchRecord(usage=USAGE)}, stale_snapshot, claims
         )
 
-        assert claims == {}
         assert accepted == set()
-        assert "2" not in store._read_rows()
+        assert "lastGood" not in store._read_rows()["2"]
 
 
 class TestReconcile:

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -1738,6 +1738,44 @@ class TestDrop:
         store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
         assert store.drop(["1", "9"]) == 1
 
+    def test_stale_collector_cannot_recreate_a_removed_roster_slot(
+        self, tmp_path, clock
+    ):
+        """Removal after snapshot construction fences later reserve/record."""
+        sequence_path = tmp_path / "sequence.json"
+        sequence_path.write_text(
+            json.dumps(
+                {
+                    "sequence": [2],
+                    "accounts": {
+                        "2": {"email": "b@x.com", "organizationUuid": "org-2"}
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        store = UsageStore(
+            tmp_path / "cache", clock=clock, roster_path=sequence_path
+        )
+        stale_snapshot = {"2": IDENT["2"]}
+        store.record({"2": FetchRecord(usage=USAGE)}, stale_snapshot)
+
+        # The collector retains stale_snapshot while the roster mutation and
+        # cache cleanup complete in another process.
+        sequence_path.write_text(
+            json.dumps({"sequence": [], "accounts": {}}), encoding="utf-8"
+        )
+        store.drop(["2"])
+
+        claims = store.reserve(["2"], stale_snapshot, respect_plans=False)
+        accepted = store.record(
+            {"2": FetchRecord(usage=USAGE)}, stale_snapshot, claims
+        )
+
+        assert claims == {}
+        assert accepted == set()
+        assert "2" not in store._read_rows()
+
 
 class TestReconcile:
     """BC-18973 rework: drop() only ever reaches a slot its caller already


### PR DESCRIPTION
## Problem

`usage.json` rows are keyed by slot number, and nothing ever deleted a row. When an account left the managed set (removed, displaced by an overwrite, migrated, or moved), its row stayed in the cache forever. cswap's own reads are identity-guarded, so this is invisible to cswap itself — but external consumers reading the raw file see orphaned rows as real, permanently-unpolled accounts.

On one affected machine this had accumulated 8 orphaned slots that could never clear.

## Fix

- `UsageStore.drop(nums)` — deletes rows for slot numbers, under the store's existing file lock. Called at every site in `switcher.py` that frees a slot number for good: `remove_account`, displacement and migration cleanup in both `add_account` entry points, and `move_account`'s vacated source slot. `swap_accounts` deliberately does not drop (a swap never frees a slot; a guard test pins this so the fix can't widen into data loss).
- `UsageStore.reconcile(identities)` — retroactive sweep: given the caller's complete current managed set, deletes every stored row not in it. Wired at exactly the four call sites that pass a fresh, complete account snapshot; deliberately not the single-slot status path (guard-tested). An empty identity set is treated as "account table unreadable" and is always a no-op, so a transient read glitch can never wipe the cache.
- Failure containment: the displacement/migration cleanup helpers catch and log `drop()` failures after the roster commit (same pattern `move_account` already used), so a cache-maintenance failure can never strand an add/migrate operation between destructive cleanup and replacement install.
- Race fencing: `reserve()` and fenced `record()` revalidate roster membership under the usage lock, so a collector holding a stale account snapshot cannot recreate a row for a slot that was removed or reused mid-flight.

## Tests

- 20+ new tests covering: raw-file row removal for every slot-freeing path, swap preservation, empty-set no-op, never-polled managed-row preservation, single-slot status isolation, failure injection through both add entry points (displacement and migration), and deterministic stale-collector interleavings for both the reserve-time and record-time fences.
- Each regression test was red-proofed: temporarily reverting the specific production change it guards makes it fail; restoring passes.
- Full suite: 2105 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)