### PR TITLE
auto: authoritative reset override bridge (opt-in, one-directional clamp)

### DIFF
--- a/src/claude_swap/authoritative_reset.py
+++ b/src/claude_swap/authoritative_reset.py
@@ -1,0 +1,115 @@
+"""Authoritative rate-limit reset overrides — opt-in bridge for worker-observed resets.
+
+cswap derives every window reset time from the ``/api/oauth/usage`` endpoint
+(:func:`oauth.build_usage_result`). A poller has no other source, but the
+*authoritative* current-window reset is the one Claude Code itself prints in its
+rate-limit message ("resets 6:50pm") — a value only the worker actually running
+Claude Code ever observes. When the usage endpoint reports a reset later than the
+true current-window reset (observed 2026-08: once a window is fully spent the
+endpoint can return the *next* window's reset), an all-accounts-exhausted auto
+loop sleeps to that too-late time and idles past the real reset.
+
+This module lets an external worker that DOES see the authoritative reset feed it
+in through a small JSON file. The clamp is deliberately **one-directional**: an
+authoritative reset only ever pulls a window's reset *earlier*, never later — so a
+stale or wrong override can shorten an over-wait but can never extend a wait or
+hide a real limit. Absent file / missing entry / unparsable value = exact
+pre-existing behavior (fail-open).
+
+The caller reads this file and passes the parsed dict to
+:func:`oauth.try_fetch_usage_for_account` as ``authoritative_resets``; this
+module owns only the (tolerant) reader and the pure clamp. File format::
+
+    {
+      "<account-email>": {"five_hour": "<iso8601>", "seven_day": "<iso8601>"},
+      ...
+    }
+
+Any window key may be omitted; unknown keys are ignored.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+_logger = logging.getLogger("claude-swap")
+
+# usage-dict window key -> override key (same names; explicit so a rename of one
+# side can't silently desync the other).
+_WINDOW_KEYS = (("five_hour", "five_hour"), ("seven_day", "seven_day"))
+
+
+def read_authoritative_resets(path: str | None) -> dict[str, dict]:
+    """Load the override file as ``{email: {window: iso}}``; ``{}`` on any failure.
+
+    Fail-open by contract: a missing, unreadable, or malformed file must never
+    break a usage fetch — it just means "no overrides this pass". Only the outer
+    shape is validated here; per-window parsing/comparison happens in
+    :func:`clamp_account_resets` so one bad entry can't discard the rest.
+    """
+    if not path:
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError) as e:
+        _logger.debug("authoritative reset file unreadable (%s): %r", path, e)
+        return {}
+    if not isinstance(data, dict):
+        _logger.debug("authoritative reset file is not an object: %s", path)
+        return {}
+    return {
+        email: windows
+        for email, windows in data.items()
+        if isinstance(email, str) and isinstance(windows, dict)
+    }
+
+
+def _parse(iso: object) -> datetime | None:
+    """Parse an ISO-8601 string to an aware UTC datetime, or None."""
+    if not isinstance(iso, str) or not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def clamp_account_resets(
+    usage: dict | None, overrides: dict | None, now: datetime | None = None
+) -> dict | None:
+    """Return ``usage`` with window resets pulled earlier by authoritative overrides.
+
+    For each 5h/7d window present in ``usage``, if ``overrides`` carries an
+    authoritative reset for that window that is in the future AND strictly
+    earlier than the endpoint's ``resets_at`` (or the endpoint sent none),
+    replace it. Never moves a reset later. Pure: returns the same object when
+    nothing changes, else a shallow copy with the affected window dicts replaced.
+    """
+    if not isinstance(usage, dict) or not isinstance(overrides, dict):
+        return usage
+    now = now or datetime.now(timezone.utc)
+    result: dict | None = None
+    for win_key, ovr_key in _WINDOW_KEYS:
+        window = usage.get(win_key)
+        if not isinstance(window, dict):
+            continue
+        auth = _parse(overrides.get(ovr_key))
+        if auth is None or auth <= now:
+            continue  # no override, or already elapsed — nothing to clamp to
+        current = _parse(window.get("resets_at"))
+        if current is not None and current <= auth:
+            continue  # endpoint value is already at/earlier than authoritative
+        if result is None:
+            result = dict(usage)
+        new_window = dict(window)
+        new_window["resets_at"] = auth.isoformat()
+        # Stale countdown/clock would misrender until the next fetch; drop them so
+        # oauth.fresh_reset_strings recomputes from the new resets_at at render.
+        new_window.pop("countdown", None)
+        new_window.pop("clock", None)
+        result[win_key] = new_window
+    return result if result is not None else usage

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -610,6 +610,7 @@ def try_fetch_usage_for_account(
     is_active: bool,
     persist_credentials: Callable[[str, str, str], None] | None = None,
     refresh_via: Callable[[str, str, str], RefreshOutcome] | None = None,
+    authoritative_resets: dict | None = None,
 ) -> UsageOutcome:
     """Fetch usage for an account, refreshing expired tokens for inactive accounts only.
 
@@ -619,8 +620,22 @@ def try_fetch_usage_for_account(
     freshest copy under the slot lock, persists via fingerprint CAS, and
     never consumes a superseded snapshot. ``persist_credentials`` is then
     unused for the refresh (the gate persists internally).
+
+    ``authoritative_resets`` (opt-in) maps ``{email: {window: iso}}`` of
+    worker-observed authoritative resets; when given, this account's windows are
+    clamped earlier by :func:`authoritative_reset.clamp_account_resets` (never
+    later). Default None = exact pre-existing behavior.
     """
     context = f"for account {account_num}"  # no email: paste-safe for public issues
+
+    def _built(data: dict) -> dict | None:
+        """Normalize the raw response, then clamp with any authoritative override."""
+        usage = build_usage_result(data)
+        if authoritative_resets:
+            from claude_swap.authoritative_reset import clamp_account_resets
+            usage = clamp_account_resets(usage, authoritative_resets.get(email))
+        return usage
+
     oauth = extract_oauth_data(credentials)
     access_token = oauth.get("accessToken") if oauth else None
     if not access_token:
@@ -671,7 +686,7 @@ def try_fetch_usage_for_account(
 
     try:
         data = request_usage_data(access_token)
-        return UsageOutcome(build_usage_result(data))
+        return UsageOutcome(_built(data))
     except urllib.error.HTTPError as e:
         kind, retry_after = _classify_usage_error(e)
         if (
@@ -720,7 +735,7 @@ def try_fetch_usage_for_account(
 
         try:
             data = request_usage_data(new_token)
-            return UsageOutcome(build_usage_result(data))
+            return UsageOutcome(_built(data))
         except Exception as retry_error:
             kind, retry_after = _classify_usage_error(retry_error)
             _log_usage_failure(context + " after refresh", retry_error, kind, retry_after)

--- a/tests/test_authoritative_reset.py
+++ b/tests/test_authoritative_reset.py
@@ -1,0 +1,79 @@
+"""Tests for the authoritative_reset override bridge."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from claude_swap import authoritative_reset as ar
+
+NOW = datetime(2026, 8, 11, 18, 0, tzinfo=timezone.utc)
+
+
+def _iso(minutes: int) -> str:
+    return (NOW + timedelta(minutes=minutes)).isoformat()
+
+
+class TestReadAuthoritativeResets:
+    def test_none_path(self):
+        assert ar.read_authoritative_resets(None) == {}
+
+    def test_missing_file(self, tmp_path):
+        assert ar.read_authoritative_resets(str(tmp_path / "nope.json")) == {}
+
+    def test_malformed_json(self, tmp_path):
+        p = tmp_path / "b.json"
+        p.write_text("{not json", encoding="utf-8")
+        assert ar.read_authoritative_resets(str(p)) == {}
+
+    def test_non_object_top_level(self, tmp_path):
+        p = tmp_path / "arr.json"
+        p.write_text("[1, 2]", encoding="utf-8")
+        assert ar.read_authoritative_resets(str(p)) == {}
+
+    def test_valid_and_filters_bad_entries(self, tmp_path):
+        p = tmp_path / "ok.json"
+        p.write_text(json.dumps({
+            "a@x.com": {"five_hour": _iso(69)},
+            "bad": "not-a-dict",  # dropped
+        }), encoding="utf-8")
+        out = ar.read_authoritative_resets(str(p))
+        assert out == {"a@x.com": {"five_hour": _iso(69)}}
+
+
+class TestClampAccountResets:
+    def test_pulls_earlier(self):
+        usage = {"five_hour": {"pct": 100.0, "resets_at": _iso(210)}}  # 21:30
+        out = ar.clamp_account_resets(usage, {"five_hour": _iso(69)}, NOW)  # 19:09
+        assert out["five_hour"]["resets_at"] == _iso(69)
+        # stale render fields dropped so they recompute from the new reset
+        assert "countdown" not in out["five_hour"]
+        assert usage["five_hour"]["resets_at"] == _iso(210)  # input untouched
+
+    def test_never_moves_later(self):
+        usage = {"five_hour": {"pct": 100.0, "resets_at": _iso(30)}}
+        out = ar.clamp_account_resets(usage, {"five_hour": _iso(200)}, NOW)
+        assert out is usage  # no change → same object
+
+    def test_fills_missing_endpoint_reset(self):
+        usage = {"seven_day": {"pct": 95.0}}
+        out = ar.clamp_account_resets(usage, {"seven_day": _iso(120)}, NOW)
+        assert out["seven_day"]["resets_at"] == _iso(120)
+
+    def test_ignores_elapsed_override(self):
+        usage = {"five_hour": {"pct": 100.0, "resets_at": _iso(210)}}
+        out = ar.clamp_account_resets(usage, {"five_hour": _iso(-10)}, NOW)
+        assert out is usage
+
+    def test_no_overrides_is_noop(self):
+        usage = {"five_hour": {"pct": 100.0, "resets_at": _iso(210)}}
+        assert ar.clamp_account_resets(usage, None, NOW) is usage
+        assert ar.clamp_account_resets(usage, {}, NOW) is usage
+
+    def test_unparsable_override_ignored(self):
+        usage = {"five_hour": {"pct": 100.0, "resets_at": _iso(210)}}
+        out = ar.clamp_account_resets(usage, {"five_hour": "garbage"}, NOW)
+        assert out is usage
+
+    def test_none_usage(self):
+        assert ar.clamp_account_resets(None, {"five_hour": _iso(10)}, NOW) is None


### PR DESCRIPTION
Closes #244 (proposal — see issue for the problem writeup and open questions).

## What

Opt-in bridge letting a worker that observes the **authoritative** rate-limit
reset (the "resets 6:50pm" text Claude Code prints — never visible to the usage
endpoint) feed it to cswap, so an all-accounts-exhausted `auto` loop doesn't idle
past the real reset when `/api/oauth/usage` returns the next window's `resets_at`.

## How

- `authoritative_reset.py` — tolerant `read_authoritative_resets(path)` + pure
  `clamp_account_resets(usage, overrides, now)`.
- `oauth.try_fetch_usage_for_account(..., authoritative_resets=None)` — when
  given `{email: {window: iso}}`, clamps this account's 5h/7d windows after the
  fetch. Default `None` = exact pre-existing behavior.

**One-directional by design:** the clamp only pulls a reset *earlier*, never
later — a stale/wrong override can shorten an over-wait but can never extend a
wait or hide a real limit. Fail-open on missing/malformed file or entry.

## Scope / open question

Deliberately just the self-contained core + opt-in param — no settings key or
`auto`-loop file-read wired yet, so this changes nothing by default. Happy to add
the wiring (env var / `AutoSwitchSettings` field / read in the auto loop) whichever
way you prefer.

## Tests

`tests/test_authoritative_reset.py` — 12 cases (earlier-only clamp, fills a
missing endpoint reset, ignores elapsed/unparsable/no override, input untouched).
`pytest tests/test_authoritative_reset.py tests/test_oauth.py` → 120 passed.
