### PR TITLE
feat(launch): run the Claude desktop app per account, several at once (macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ Subfolders inherit the nearest mapped ancestor. In an unmapped directory, `cswap
 
 </details>
 
+### Run several desktop apps at once (macOS)
+
+Launch the Claude desktop app for a stored account on its own profile, so several signed-in windows can run side by side — each account gets its own `Claude-a<N>` folder under `~/Library/Application Support`, separate from your normal `Claude.app` login.
+
+```bash
+cswap launch 2                  # launch (or focus, if already running) account 2
+cswap launch user@example.com   # by email
+cswap launch dev                # by alias
+cswap launch --all              # launch every managed account
+cswap launch --stop 2           # quit one account's app
+cswap launch --stop --all       # quit every launched account
+```
+
+Re-running `cswap launch` on an account that's already open brings its window to the front instead of opening a duplicate. A profile's cookies and login are never shared — copied only once, on first launch, from your default `Claude.app` profile: `claude_desktop_config.json`, extensions, and that account's own Code sidebar sessions. Each window signs in independently. macOS only.
+
 ### Interactive dashboard (TUI)
 
 Run `cswap` on its own (or `cswap tui`) for the full-screen dashboard: live usage for every account, switching, and the auto-switcher, all keyboard-driven. `cswap watch` opens it straight to the live monitor. Works on macOS, Linux, and Windows.
@@ -191,6 +206,8 @@ cswap alias 2 dev               # Give an account a short alias (usable anywhere
 cswap alias 2 --unset           # Remove an account's alias
 cswap alias                     # List all aliases
 cswap move 2 1                  # Assign an account to a slot (relocates to an empty slot, swaps if taken)
+cswap launch 2                  # Launch the desktop app for an account, one profile per account (macOS)
+cswap launch --stop 2           # Quit an account's desktop app
 cswap unclaimed                 # List stashed credential entries (slot + why they were stashed)
 cswap unclaimed --purge ID      # Drop one (deletes its bytes; recover with /login + `cswap add`)
 cswap tui                       # Interactive dashboard (also: bare `cswap`)

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -878,6 +878,124 @@ Examples:
         sys.exit(130)
 
 
+def _launch_command(argv: list[str]) -> None:
+    """Handle `cswap launch [NUM|EMAIL|ALIAS] [--all] [--stop]`. macOS only.
+
+    Pre-dispatched before the main parser is built, like `map`/`alias`/`swap`/
+    `move` (the main parser's required mutually-exclusive group can't hold a
+    positional subcommand). Guarded up front so a non-macOS run exits cleanly
+    with no traceback before anything in `launcher.py` (which is itself
+    platform-agnostic and fully mockable) is touched.
+    """
+    if sys.platform != "darwin":
+        error(
+            "cswap launch is macOS only — it launches the Claude.app desktop "
+            "app on its own profile, which relies on macOS's Application "
+            "Support layout."
+        )
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        prog=f"{_prog_name()} launch",
+        description=(
+            "Launch the Claude desktop app for a stored account on its own "
+            "profile directory, so several signed-in instances can run side "
+            "by side. Re-running on an already-running account focuses its "
+            "window instead of opening a second one."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap launch 2
+  cswap launch user@example.com
+  cswap launch dev
+  cswap launch --all
+  cswap launch --stop 2
+  cswap launch --stop --all
+        """,
+    )
+    parser.add_argument(
+        "account",
+        nargs="?",
+        metavar="NUM|EMAIL|ALIAS",
+        help="Account to launch or stop (number, email, or alias)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Launch (or stop) every managed account",
+    )
+    parser.add_argument(
+        "--stop",
+        action="store_true",
+        help="Quit the app instead of launching it",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    if args.account and args.all:
+        parser.error("give either NUM|EMAIL|ALIAS or --all, not both")
+    if not args.account and not args.all:
+        parser.error("NUM|EMAIL|ALIAS or --all is required")
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+
+        from claude_swap import launcher
+
+        if args.stop:
+            outcomes = (
+                launcher.stop_all(switcher)
+                if args.all
+                else [launcher.stop_account(switcher, args.account)]
+            )
+            for outcome in outcomes:
+                if outcome.stopped:
+                    print(
+                        f"{accent('Stopped')} Account-{outcome.account_num} "
+                        f"({outcome.email}) — pid {outcome.pid}"
+                    )
+                else:
+                    print(
+                        dimmed(
+                            f"Account-{outcome.account_num} ({outcome.email}) "
+                            "not running"
+                        )
+                    )
+            return
+
+        outcomes = (
+            launcher.launch_all(switcher)
+            if args.all
+            else [launcher.launch_account(switcher, args.account)]
+        )
+        for outcome in outcomes:
+            if outcome.focused:
+                print(
+                    f"{accent('Focused')} Account-{outcome.account_num} "
+                    f"({outcome.email}) — already running (pid {outcome.pid})"
+                )
+            else:
+                print(
+                    f"{accent('Launched')} Account-{outcome.account_num} "
+                    f"({outcome.email})"
+                )
+                if outcome.fresh:
+                    print(
+                        dimmed(
+                            f"   → new profile: sign in as {outcome.email} "
+                            "in that window"
+                        )
+                    )
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
 def _use_native_tls() -> None:
     """Route TLS trust decisions through the OS-native verifier.
 
@@ -947,6 +1065,9 @@ def main() -> None:
     if argv and argv[0] == "move":
         _move_command(argv[1:])
         return
+    if argv and argv[0] == "launch":
+        _launch_command(argv[1:])
+        return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like
     # lazygit/k9s). TTY-gated on both ends so scripts and pipes keep getting
@@ -985,6 +1106,9 @@ Commands:
   %(prog)s alias                      list all aliases
   %(prog)s swap <a> <b>               exchange two accounts' slot numbers
   %(prog)s move <a> <slot>            assign an account to a slot (swaps if taken)
+  %(prog)s launch <num|email>         launch the desktop app for an account (macOS)
+  %(prog)s launch --all               launch the desktop app for every account
+  %(prog)s launch --stop <num|email>  quit an account's desktop app
   %(prog)s auto                       auto-switch when nearing rate limits
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s unclaimed [--purge ID]     list or drop stashed credential entries

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -43,6 +43,12 @@ class SessionError(ClaudeSwitchError):
     pass
 
 
+class LauncherError(ClaudeSwitchError):
+    """Error launching or stopping the Claude desktop app (``cswap launch``)."""
+
+    pass
+
+
 class LockError(ClaudeSwitchError):
     """Error acquiring lock."""
 

--- a/src/claude_swap/launcher.py
+++ b/src/claude_swap/launcher.py
@@ -1,0 +1,192 @@
+"""Launch one Claude desktop app per cswap account, all at once (macOS only).
+
+Ports ``~/.local/bin/claude-app``: the Claude desktop app is Electron and
+takes Chromium's ``--user-data-dir``, and it does NOT call
+``requestSingleInstanceLock``. Giving each account its own profile directory
+under ``~/Library/Application Support`` therefore lets several signed-in
+Claude apps run side by side. Account identity is resolved through cswap's
+own switcher (the same path ``cswap run <num|email>`` uses) so this never
+drifts from ``cswap list`` and aliases keep working.
+
+This module has no platform guard of its own — its logic is plain path/
+subprocess plumbing that is fully testable on any OS via mocked
+``subprocess.run``. The "macOS only" refusal lives in the CLI dispatcher
+(``cli.py``), which is the one place that should ever exit the process.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from claude_swap.exceptions import LauncherError
+
+APP_PATH = Path("/Applications/Claude.app")
+_APP_BINARY_MARKER = "Claude.app/Contents/MacOS/Claude"
+
+# Copied into a new profile so a fresh instance is not bare. Cookies,
+# config.json and ant-device-registry.json are deliberately NOT copied here —
+# each profile signs in on its own, which is the whole point.
+SEED_NAMES = (
+    "claude_desktop_config.json",
+    "Claude Extensions",
+    "Claude Extensions Settings",
+)
+
+
+def support_dir() -> Path:
+    """``~/Library/Application Support``."""
+    return Path(os.path.expanduser("~")) / "Library" / "Application Support"
+
+
+def default_profile_dir() -> Path:
+    """The plain (un-swapped) Claude.app profile — seed source for new profiles."""
+    return support_dir() / "Claude"
+
+
+def profile_dir(account_num: str) -> Path:
+    """Per-account profile directory, e.g. ``Claude-a2`` for slot 2."""
+    return support_dir() / f"Claude-a{account_num}"
+
+
+@dataclass
+class LaunchOutcome:
+    """Result of launching (or focusing) one account's desktop app."""
+
+    account_num: str
+    email: str
+    focused: bool  # True: was already running, we focused it instead of relaunching
+    fresh: bool  # True: this was a brand-new profile (not signed in yet)
+    pid: int | None
+
+
+@dataclass
+class StopOutcome:
+    """Result of stopping one account's desktop app."""
+
+    account_num: str
+    email: str
+    stopped: bool
+    pid: int | None
+
+
+def running_pid(profile_path: Path) -> int | None:
+    """PID of the Claude main process using this profile, or None.
+
+    Scans ``ps`` for the app's main binary (excluding Electron helper
+    processes, which carry ``--type=``) with a matching
+    ``--user-data-dir=<profile_path>`` argument.
+    """
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,command="],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    needle = f"--user-data-dir={profile_path}"
+    for line in result.stdout.splitlines():
+        if _APP_BINARY_MARKER not in line or "--type=" in line:
+            continue
+        if needle in line:
+            return int(line.split()[0])
+    return None
+
+
+def focus(pid: int) -> None:
+    """Bring the given process's window frontmost via System Events."""
+    subprocess.run(
+        [
+            "osascript",
+            "-e",
+            'tell application "System Events" to set frontmost of '
+            f'(first process whose unix id is {pid}) to true',
+        ],
+        capture_output=True,
+        check=False,
+    )
+
+
+def seed_profile(path: Path, account_uuid: str) -> None:
+    """Create the profile directory and copy across non-secret parts.
+
+    Idempotent: an item already present in ``path`` is left untouched, so
+    calling this on an existing, already-signed-in profile is a no-op.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    default = default_profile_dir()
+    for name in SEED_NAMES:
+        src = default / name
+        dst = path / name
+        if src.exists() and not dst.exists():
+            subprocess.run(["cp", "-R", str(src), str(dst)], check=True)
+
+    if account_uuid:
+        src = default / "claude-code-sessions" / account_uuid
+        dst = path / "claude-code-sessions" / account_uuid
+        if src.is_dir() and not dst.exists():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            subprocess.run(["cp", "-R", str(src), str(dst)], check=True)
+
+
+def _require_app_installed() -> None:
+    if not APP_PATH.exists():
+        raise LauncherError(
+            f"Claude.app not found at {APP_PATH} — install it from "
+            "https://claude.ai/download before running `cswap launch`."
+        )
+
+
+def launch_account(switcher, identifier: str) -> LaunchOutcome:
+    """Launch (or focus) the desktop app for one account.
+
+    ``identifier`` is resolved through ``switcher.resolve_account`` — the
+    same resolver ``cswap run`` uses — so a slot number, email, or alias all
+    work identically here.
+    """
+    account_num, email, _org_uuid = switcher.resolve_account(identifier)
+    path = profile_dir(account_num)
+
+    pid = running_pid(path)
+    if pid is not None:
+        focus(pid)
+        return LaunchOutcome(account_num, email, focused=True, fresh=False, pid=pid)
+
+    _require_app_installed()
+
+    fresh = not path.exists()
+    identity = switcher.account_identity(account_num)
+    seed_profile(path, identity["uuid"])
+    subprocess.run(
+        ["open", "-na", str(APP_PATH), "--args", f"--user-data-dir={path}"],
+        check=True,
+    )
+    return LaunchOutcome(account_num, email, focused=False, fresh=fresh, pid=None)
+
+
+def stop_account(switcher, identifier: str) -> StopOutcome:
+    """Quit the desktop app for one account, if running."""
+    account_num, email, _org_uuid = switcher.resolve_account(identifier)
+    path = profile_dir(account_num)
+    pid = running_pid(path)
+    if pid is None:
+        return StopOutcome(account_num, email, stopped=False, pid=None)
+    subprocess.run(["kill", str(pid)], check=False)
+    return StopOutcome(account_num, email, stopped=True, pid=pid)
+
+
+def _account_numbers(switcher) -> list[str]:
+    """All managed slot numbers, in ascending order."""
+    data = switcher._get_sequence_data() or {}
+    return sorted(data.get("accounts", {}), key=int)
+
+
+def launch_all(switcher) -> list[LaunchOutcome]:
+    """Launch (or focus) every managed account."""
+    return [launch_account(switcher, num) for num in _account_numbers(switcher)]
+
+
+def stop_all(switcher) -> list[StopOutcome]:
+    """Quit every managed account's desktop app that is running."""
+    return [stop_account(switcher, num) for num in _account_numbers(switcher)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ import pytest
 
 from claude_swap import __version__
 from claude_swap import cli
+from claude_swap import launcher
 from claude_swap.credentials import ActiveCredentials
 from claude_swap.switcher import ClaudeAccountSwitcher
 
@@ -1543,3 +1544,149 @@ class TestDisableEnableDispatch:
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
         assert excinfo.value.code == 2
+
+
+class TestLaunchCommand:
+    """`cswap launch` — desktop-app launcher dispatch and the macOS gate."""
+
+    def _seeded_switcher(self, temp_home):
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"]["2"] = {
+            "email": "work@co.com",
+            "uuid": "uuid-2",
+            "organizationUuid": "",
+            "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        data["sequence"] = [2]
+        switcher._write_json(switcher.sequence_file, data)
+        return switcher
+
+    def test_launch_dispatched_from_main(self, temp_home):
+        with patch("claude_swap.cli._launch_command") as launch_fn, \
+             patch.object(sys, "argv", ["cswap", "launch", "2"]):
+            cli.main()
+        launch_fn.assert_called_once_with(["2"])
+
+    def test_non_macos_exits_cleanly_no_traceback(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with pytest.raises(SystemExit) as exc:
+            cli._launch_command(["2"])
+        assert exc.value.code == 1
+        assert "macOS only" in capsys.readouterr().err
+
+    def test_requires_account_or_all(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        with pytest.raises(SystemExit) as exc:
+            cli._launch_command([])
+        assert exc.value.code == 2
+
+    def test_rejects_account_and_all_together(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        with pytest.raises(SystemExit) as exc:
+            cli._launch_command(["2", "--all"])
+        assert exc.value.code == 2
+
+    def test_prints_launched(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        outcome = launcher.LaunchOutcome("2", "work@co.com", focused=False, fresh=False, pid=None)
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.launcher.launch_account", return_value=outcome) as launch_fn:
+            cli._launch_command(["2"])
+        launch_fn.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Launched" in out
+        assert "work@co.com" in out
+
+    def test_prints_fresh_profile_hint(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        outcome = launcher.LaunchOutcome("2", "work@co.com", focused=False, fresh=True, pid=None)
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.launcher.launch_account", return_value=outcome):
+            cli._launch_command(["2"])
+        assert "sign in as work@co.com" in capsys.readouterr().out
+
+    def test_already_running_prints_focused_not_launched(self, monkeypatch, capsys):
+        """Edge case: an already-running account must be reported as focused,
+        never as a fresh launch — the CLI must not claim a double-launch."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        outcome = launcher.LaunchOutcome("2", "work@co.com", focused=True, fresh=False, pid=54602)
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.launcher.launch_account", return_value=outcome):
+            cli._launch_command(["2"])
+        out = capsys.readouterr().out
+        assert "Focused" in out
+        assert "Launched" not in out
+
+    def test_all_launches_every_account(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        outcomes = [
+            launcher.LaunchOutcome("2", "a@co.com", focused=False, fresh=False, pid=None),
+            launcher.LaunchOutcome("3", "b@co.com", focused=False, fresh=False, pid=None),
+        ]
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.launcher.launch_all", return_value=outcomes) as launch_all_fn:
+            cli._launch_command(["--all"])
+        launch_all_fn.assert_called_once()
+        out = capsys.readouterr().out
+        assert "a@co.com" in out and "b@co.com" in out
+
+    def test_stop_prints_stopped(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        outcome = launcher.StopOutcome("2", "work@co.com", stopped=True, pid=54602)
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.launcher.stop_account", return_value=outcome) as stop_fn:
+            cli._launch_command(["--stop", "2"])
+        stop_fn.assert_called_once()
+        assert "Stopped" in capsys.readouterr().out
+
+    def test_stop_not_running_reports_cleanly(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        outcome = launcher.StopOutcome("2", "work@co.com", stopped=False, pid=None)
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.launcher.stop_account", return_value=outcome):
+            cli._launch_command(["--stop", "2"])
+        assert "not running" in capsys.readouterr().out
+
+    def test_stop_all_dispatches(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.launcher.stop_all", return_value=[]) as stop_all_fn:
+            cli._launch_command(["--stop", "--all"])
+        stop_all_fn.assert_called_once()
+
+    def test_unknown_account_error_surfaces(self, monkeypatch, capsys):
+        from claude_swap.exceptions import AccountNotFoundError
+
+        monkeypatch.setattr(sys, "platform", "darwin")
+        with patch("claude_swap.cli.ClaudeAccountSwitcher"), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch(
+                 "claude_swap.launcher.launch_account",
+                 side_effect=AccountNotFoundError("No account found with identifier: 999"),
+             ):
+            with pytest.raises(SystemExit) as exc:
+                cli._launch_command(["999"])
+        assert exc.value.code == 1
+        assert "Error" in capsys.readouterr().err
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="root guard is POSIX-only")
+    def test_refuses_root(self, temp_home, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        self._seeded_switcher(temp_home)
+        with patch("os.geteuid", return_value=0, create=True), \
+             patch.object(ClaudeAccountSwitcher, "_is_running_in_container", return_value=False):
+            with pytest.raises(SystemExit) as exc:
+                cli._launch_command(["2"])
+        assert exc.value.code == 1
+        assert "root" in capsys.readouterr().err

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,303 @@
+"""Tests for claude_swap.launcher — the `cswap launch` desktop-app helper.
+
+Fully hermetic: `subprocess.run` (ps/open/cp/kill/osascript) is always mocked
+and every account resolves through a real ClaudeAccountSwitcher seeded onto
+the isolated `temp_home` from conftest.py — never a real profile directory or
+a spawned app.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import launcher
+from claude_swap.exceptions import AccountNotFoundError, LauncherError
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+def _seeded_switcher(temp_home: Path) -> ClaudeAccountSwitcher:
+    """A real switcher with two managed accounts (slot 2 aliased 'rb', slot 3)."""
+    switcher = ClaudeAccountSwitcher()
+    switcher._setup_directories()
+    switcher._init_sequence_file()
+    data = switcher._get_sequence_data()
+    data["accounts"]["2"] = {
+        "email": "work@co.com",
+        "uuid": "uuid-2",
+        "organizationUuid": "org-2",
+        "organizationName": "",
+        "alias": "rb",
+        "added": "2024-01-01T00:00:00Z",
+    }
+    data["accounts"]["3"] = {
+        "email": "personal@co.com",
+        "uuid": "uuid-3",
+        "organizationUuid": "",
+        "organizationName": "",
+        "added": "2024-01-01T00:00:00Z",
+    }
+    data["sequence"] = [2, 3]
+    switcher._write_json(switcher.sequence_file, data)
+    return switcher
+
+
+@pytest.fixture
+def switcher(temp_home: Path) -> ClaudeAccountSwitcher:
+    return _seeded_switcher(temp_home)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_support_dir(tmp_path, monkeypatch):
+    """Redirect every profile path under launcher into a throwaway tmp_path.
+
+    Every launcher function resolves paths through support_dir(), so patching
+    it alone keeps profile_dir()/default_profile_dir() (and this test file)
+    off the real `~/Library/Application Support`.
+    """
+    fake_support = tmp_path / "Application Support"
+    fake_support.mkdir()
+    monkeypatch.setattr(launcher, "support_dir", lambda: fake_support)
+    return fake_support
+
+
+def _patch_app_path(tmp_path: Path, *, installed: bool):
+    """`Path.exists` can't be patched on a specific instance (read-only slot
+    on PosixPath), so swap the whole APP_PATH module attribute instead."""
+    app = tmp_path / "Claude.app"
+    if installed:
+        app.mkdir()
+    return patch("claude_swap.launcher.APP_PATH", app)
+
+
+def _ps_line(pid: int, profile_path: Path, *, helper: bool = False) -> str:
+    args = f"--user-data-dir={profile_path}"
+    if helper:
+        return f"{pid} {launcher._APP_BINARY_MARKER} --type=renderer {args}"
+    return f"{pid} {launcher._APP_BINARY_MARKER} {args}"
+
+
+def _ps_result(lines: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["ps"], returncode=0, stdout="\n".join(lines), stderr=""
+    )
+
+
+class TestRunningPid:
+    def test_matches_profile_by_user_data_dir(self, tmp_path):
+        path = tmp_path / "Claude-a2"
+        with patch(
+            "claude_swap.launcher.subprocess.run",
+            return_value=_ps_result([_ps_line(54602, path)]),
+        ):
+            assert launcher.running_pid(path) == 54602
+
+    def test_ignores_electron_helper_processes(self, tmp_path):
+        """A helper process (--type=renderer) must never be reported as the
+        main app — killing/focusing it would not do what the user expects."""
+        path = tmp_path / "Claude-a2"
+        with patch(
+            "claude_swap.launcher.subprocess.run",
+            return_value=_ps_result([_ps_line(99999, path, helper=True)]),
+        ):
+            assert launcher.running_pid(path) is None
+
+    def test_no_match_returns_none(self, tmp_path):
+        path = tmp_path / "Claude-a2"
+        other = tmp_path / "Claude-a3"
+        with patch(
+            "claude_swap.launcher.subprocess.run",
+            return_value=_ps_result([_ps_line(1234, other)]),
+        ):
+            assert launcher.running_pid(path) is None
+
+    def test_empty_ps_output_returns_none(self, tmp_path):
+        path = tmp_path / "Claude-a2"
+        with patch(
+            "claude_swap.launcher.subprocess.run",
+            return_value=_ps_result([]),
+        ):
+            assert launcher.running_pid(path) is None
+
+
+class TestFocus:
+    def test_focus_invokes_osascript_with_pid(self):
+        with patch("claude_swap.launcher.subprocess.run") as run:
+            launcher.focus(54602)
+        args = run.call_args[0][0]
+        assert args[0] == "osascript"
+        assert "54602" in " ".join(args)
+
+
+class TestSeedProfile:
+    def _default_profile(self, tmp_path: Path) -> Path:
+        default = tmp_path / "Application Support" / "Claude"
+        default.mkdir(parents=True)
+        return default
+
+    def test_copies_seed_items_and_session_uuid(self, tmp_path, _isolated_support_dir):
+        default = _isolated_support_dir / "Claude"
+        default.mkdir()
+        for name in launcher.SEED_NAMES:
+            (default / name).write_text("x")
+        (default / "claude-code-sessions" / "uuid-2").mkdir(parents=True)
+
+        dest = _isolated_support_dir / "Claude-a2"
+        with patch("claude_swap.launcher.subprocess.run") as run:
+            launcher.seed_profile(dest, "uuid-2")
+
+        copied_srcs = {call.args[0][2] for call in run.call_args_list}
+        for name in launcher.SEED_NAMES:
+            assert str(default / name) in copied_srcs
+        assert str(default / "claude-code-sessions" / "uuid-2") in copied_srcs
+        assert run.call_count == len(launcher.SEED_NAMES) + 1
+
+    def test_never_copies_secrets(self, tmp_path, _isolated_support_dir):
+        """Cookies / config.json / ant-device-registry.json must NEVER be
+        seeded — each profile has to sign in on its own."""
+        default = _isolated_support_dir / "Claude"
+        default.mkdir()
+        for name in launcher.SEED_NAMES:
+            (default / name).write_text("x")
+        for secret in ("Cookies", "config.json", "ant-device-registry.json"):
+            (default / secret).write_text("secret")
+
+        dest = _isolated_support_dir / "Claude-a2"
+        with patch("claude_swap.launcher.subprocess.run") as run:
+            launcher.seed_profile(dest, "")
+
+        copied_srcs = {call.args[0][2] for call in run.call_args_list}
+        for secret in ("Cookies", "config.json", "ant-device-registry.json"):
+            assert str(default / secret) not in copied_srcs
+
+    def test_existing_profile_is_not_re_seeded(self, tmp_path, _isolated_support_dir):
+        """Edge case: a profile that already has an item must not be
+        overwritten (that item would be an already-signed-in session)."""
+        default = _isolated_support_dir / "Claude"
+        default.mkdir()
+        name = launcher.SEED_NAMES[0]
+        (default / name).write_text("fresh default content")
+
+        dest = _isolated_support_dir / "Claude-a2"
+        dest.mkdir()
+        (dest / name).write_text("already there — signed in")
+
+        with patch("claude_swap.launcher.subprocess.run") as run:
+            launcher.seed_profile(dest, "")
+
+        run.assert_not_called()
+        assert (dest / name).read_text() == "already there — signed in"
+
+    def test_no_default_profile_yet_is_a_noop(self, tmp_path, _isolated_support_dir):
+        """First-ever run: no plain Claude.app profile exists to seed from."""
+        dest = _isolated_support_dir / "Claude-a2"
+        with patch("claude_swap.launcher.subprocess.run") as run:
+            launcher.seed_profile(dest, "uuid-2")
+        run.assert_not_called()
+        assert dest.is_dir()
+
+
+class TestLaunchAccount:
+    def test_launches_new_account_creates_and_seeds_profile(self, switcher, _isolated_support_dir, tmp_path):
+        path = launcher.profile_dir("2")
+        with patch("claude_swap.launcher.subprocess.run", return_value=_ps_result([])) as run, \
+             _patch_app_path(tmp_path, installed=True):
+            outcome = launcher.launch_account(switcher, "2")
+
+        assert outcome.account_num == "2"
+        assert outcome.email == "work@co.com"
+        assert outcome.focused is False
+        assert outcome.fresh is True
+        open_calls = [c for c in run.call_args_list if c.args[0][0] == "open"]
+        assert len(open_calls) == 1
+        assert f"--user-data-dir={path}" in open_calls[0].args[0]
+
+    def test_resolves_alias_through_switcher_resolver(self, switcher, _isolated_support_dir, tmp_path):
+        """`cswap launch rb` must resolve the alias — the whole point of
+        going through switcher.resolve_account rather than reading
+        sequence.json directly."""
+        with patch("claude_swap.launcher.subprocess.run", return_value=_ps_result([])), \
+             _patch_app_path(tmp_path, installed=True):
+            outcome = launcher.launch_account(switcher, "rb")
+        assert outcome.account_num == "2"
+        assert outcome.email == "work@co.com"
+
+    def test_already_running_focuses_without_double_launch(self, switcher, _isolated_support_dir):
+        """Edge case: an account already running must be focused, never
+        relaunched as a second instance."""
+        path = launcher.profile_dir("2")
+        ps_running = _ps_result([_ps_line(54602, path)])
+
+        def fake_run(cmd, *a, **k):
+            if cmd[0] == "ps":
+                return ps_running
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("claude_swap.launcher.subprocess.run", side_effect=fake_run) as run:
+            outcome = launcher.launch_account(switcher, "2")
+
+        assert outcome.focused is True
+        assert outcome.pid == 54602
+        open_calls = [c for c in run.call_args_list if c.args[0][0] == "open"]
+        assert open_calls == []
+        osascript_calls = [c for c in run.call_args_list if c.args[0][0] == "osascript"]
+        assert len(osascript_calls) == 1
+
+    def test_unknown_account_raises(self, switcher, _isolated_support_dir):
+        with pytest.raises(AccountNotFoundError):
+            launcher.launch_account(switcher, "999")
+
+    def test_missing_app_bundle_raises(self, switcher, _isolated_support_dir, tmp_path):
+        with patch("claude_swap.launcher.subprocess.run", return_value=_ps_result([])), \
+             _patch_app_path(tmp_path, installed=False):
+            with pytest.raises(LauncherError, match="Claude.app not found"):
+                launcher.launch_account(switcher, "2")
+
+
+class TestStopAccount:
+    def test_stops_running_account(self, switcher, _isolated_support_dir):
+        path = launcher.profile_dir("2")
+
+        def fake_run(cmd, *a, **k):
+            if cmd[0] == "ps":
+                return _ps_result([_ps_line(54602, path)])
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("claude_swap.launcher.subprocess.run", side_effect=fake_run) as run:
+            outcome = launcher.stop_account(switcher, "2")
+
+        assert outcome.stopped is True
+        assert outcome.pid == 54602
+        kill_calls = [c for c in run.call_args_list if c.args[0][0] == "kill"]
+        assert len(kill_calls) == 1
+        assert kill_calls[0].args[0] == ["kill", "54602"]
+
+    def test_not_running_reports_stopped_false(self, switcher, _isolated_support_dir):
+        with patch("claude_swap.launcher.subprocess.run", return_value=_ps_result([])) as run:
+            outcome = launcher.stop_account(switcher, "3")
+
+        assert outcome.stopped is False
+        assert outcome.pid is None
+        kill_calls = [c for c in run.call_args_list if c.args[0][0] == "kill"]
+        assert kill_calls == []
+
+    def test_unknown_account_raises(self, switcher, _isolated_support_dir):
+        with pytest.raises(AccountNotFoundError):
+            launcher.stop_account(switcher, "999")
+
+
+class TestLaunchAllStopAll:
+    def test_launch_all_covers_every_managed_account(self, switcher, _isolated_support_dir, tmp_path):
+        with patch("claude_swap.launcher.subprocess.run", return_value=_ps_result([])), \
+             _patch_app_path(tmp_path, installed=True):
+            outcomes = launcher.launch_all(switcher)
+        assert [o.account_num for o in outcomes] == ["2", "3"]
+
+    def test_stop_all_covers_every_managed_account(self, switcher, _isolated_support_dir):
+        with patch("claude_swap.launcher.subprocess.run", return_value=_ps_result([])):
+            outcomes = launcher.stop_all(switcher)
+        assert [o.account_num for o in outcomes] == ["2", "3"]
+        assert all(o.stopped is False for o in outcomes)


### PR DESCRIPTION
## Why

`cswap` switches which account Claude Code runs as. This adds the same idea for the desktop app, with one difference that turned out to matter: the accounts run **at the same time**, in separate windows, rather than one at a time.

The use case is having three Max accounts and wanting a Claude window open on each — reading one, working in another — without switching back and forth.

## What this adds

A macOS-only `cswap launch <num|email|alias>`:

- Launches the desktop app for that account on its own profile directory, or **focuses** the window if it is already running rather than spawning a duplicate.
- `cswap launch --all` for every managed account.
- `cswap launch --stop <N>` / `--stop --all`.
- Creates the profile on first use and seeds it with `claude_desktop_config.json`, `Claude Extensions` and that account's own `claude-code-sessions/<uuid>` subtree, so a new window is not bare.
- Account resolution goes through `switcher.resolve_account`, so slot numbers, emails and aliases all work — `cswap launch rb`.
- Non-macOS exits non-zero with a plain message, no traceback.

## How it works

Claude.app is Electron and accepts Chromium's `--user-data-dir`; the shipping app passes that switch itself. It does not call `requestSingleInstanceLock` — 0 occurrences in `app.asar` — so instances on distinct profile directories coexist. No symlinking, no quitting the app, no moving directories around.

Credentials are deliberately **not** copied between profiles: `Cookies`, `config.json` and `ant-device-registry.json` are excluded from seeding, so each profile signs in on its own. That keeps the accounts genuinely separate and means the command never touches credential material.

## Relationship to #230

#230 also targets the desktop app, and I want to be explicit that this is not meant to compete with it. They solve different problems and can coexist:

- #230's `cswap desktop <account>` **switches** one desktop app between accounts, and reconciles session indexes into the selected profile — work this PR does not do.
- `cswap launch <N>` runs several accounts **concurrently**.

I put the code in `launcher.py` rather than `desktop.py`, and used the verb `launch` rather than `desktop`, specifically so both can land without a collision. If you would rather have one desktop command overall, I am happy to rework this on top of #230 instead — say the word and I will.

One observation that may be useful there regardless of what happens to this PR: because the app honours `--user-data-dir` and holds no single-instance lock, profile selection does not require quitting the app or symlinking a directory into place. That may let #230 drop its shutdown-and-rollback path.

## Validation

- `uv run pytest` — 2117 passed, 3 failed, 3 skipped. The same 3 fail unchanged on the base commit (`test_move_accounts`, `test_real_store_guard`, `test_swap_accounts`, all in unreadable-source guards); they are not touched by this change.
- 32 new tests covering happy path, unknown account, non-macOS, missing app bundle, already-running (focuses without duplicating) and existing-profile (not re-seeded).
- Each new behaviour has a negative control: the behaviour was broken at the source, the relevant tests were observed failing for the right reason, then restored.
- Exercised live on macOS 26.6 with Claude.app 1.30096.1 over roughly an hour: three signed-in windows on three accounts concurrently; `cswap launch 3` on an already-running slot printed `Focused … (pid 46730)` and the pid did not change; `cswap launch rb` resolved through an alias to the same window; `cswap launch 99` errored cleanly.

## Scope

Does not transfer or read desktop credentials, does not modify transcripts, and does not merge Claude Chat or Cowork history. It creates local profile directories and launches the app against them. macOS only — Windows and Linux fall through to a clear error rather than a partial implementation, since I could not test them.

I have not measured behaviour on a machine where the desktop app has never been signed in at all; the first launch there simply shows the normal sign-in screen, but I have only seen that path on my own machine.
