### PR TITLE
Add "Change alias" to the menu bar, preserving typed capitalization

### DIFF
--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -678,6 +678,7 @@ def run(switcher) -> int:
                 self._add_menu(rumps),
                 self._disable_menu(rumps),
                 self._remove_menu(rumps),
+                self._alias_item(rumps),
                 rumps.MenuItem("Refresh current credentials", callback=self.on_refresh_creds),
                 self._history_menu(rumps),
                 None,
@@ -685,6 +686,58 @@ def run(switcher) -> int:
                 rumps.MenuItem("Refresh now", callback=self.on_refresh_now),
                 rumps.MenuItem("Quit", callback=self.on_quit),
             ]
+
+        def _active_account(self):
+            """Return the active account tuple from the snapshot, or None."""
+            for entry in self.snapshot["accounts"]:
+                if entry[2]:  # is_active
+                    return entry
+            return None
+
+        def _alias_item(self, rumps):
+            """Rename the CURRENT account. Label carries the alias so the
+            scope is obvious without opening the dialog."""
+            active = self._active_account()
+            if active is None:
+                item = rumps.MenuItem("Change alias…", callback=None)
+                return item
+            alias = active[5]
+            label = f"Change alias ({alias})…" if alias else "Set alias…"
+            return rumps.MenuItem(label, callback=self.on_change_alias)
+
+        def on_change_alias(self, _sender):
+            # A menu-bar (accessory) app isn't the active app, so a modal
+            # rumps.Window can render black/blank until we bring the app
+            # forward. Same guard as on_add_token.
+            import AppKit
+            AppKit.NSApplication.sharedApplication().activateIgnoringOtherApps_(True)
+
+            active = self._active_account()
+            if active is None:
+                rumps.alert(title="claude-swap", message="No active account to rename.")
+                return
+            num, email, _is_active, _display, _last_good, alias, _disabled, _fetched_at = active
+
+            win = rumps.Window(
+                title="Change alias",
+                message=(
+                    f"Alias for {email}\n\n"
+                    "Capitalization is kept as typed; switching stays "
+                    "case-insensitive."
+                ),
+                default_text=alias or "",
+                ok="Save", cancel="Cancel", dimensions=(320, 24),
+            )
+            resp = win.run()
+            if resp.clicked != 1:
+                return
+            text = resp.text.strip()
+            if not text or text == (alias or ""):
+                return
+            # preserve_case: the whole point of doing this from the menu is to
+            # keep the typed spelling, which `cswap alias` lowercases.
+            if self._guard(lambda: self.switcher.set_alias(num, text, preserve_case=True)):
+                self.refresh_async()
 
         def _add_menu(self, rumps):
             menu = rumps.MenuItem("Add account")

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -967,12 +967,24 @@ class ClaudeAccountSwitcher:
             record.get("organizationUuid", "") or "",
         )
 
-    def set_alias(self, identifier: str, alias: str) -> tuple[str, str]:
+    def set_alias(
+        self, identifier: str, alias: str, *, preserve_case: bool = False
+    ) -> tuple[str, str]:
         """Set (or rename) the alias for the account matching identifier.
 
         ``identifier`` is a slot number, email, or existing alias (so a
         typo'd alias can be corrected with ``cswap alias <old> <new>`` as
-        well as by number/email). Returns ``(account_num, normalized_alias)``.
+        well as by number/email). Returns ``(account_num, stored_alias)``.
+
+        ``preserve_case`` stores the alias with the capitalization the caller
+        typed instead of the lowercased form. The alias is still validated
+        through ``normalize_alias`` (empty / purely-numeric / leading-dash are
+        rejected exactly as before) and uniqueness is still checked
+        case-insensitively — only the stored spelling differs. This is safe
+        because every lookup path lowercases both sides (see
+        ``_find_account_by_alias``), so ``SR``, ``sr`` and ``Sr`` all continue
+        to resolve to the same account. The CLI leaves this off, so
+        ``cswap alias`` behaviour is unchanged.
 
         Raises:
             AccountNotFoundError: identifier doesn't match any account.
@@ -984,6 +996,7 @@ class ClaudeAccountSwitcher:
             normalized = normalize_alias(alias)
         except ValueError as e:
             raise ValidationError(str(e)) from e
+        stored = alias.strip() if preserve_case else normalized
 
         self._get_sequence_data_migrated()
         account_num = self._resolve_account_identifier(identifier)
@@ -1000,10 +1013,10 @@ class ClaudeAccountSwitcher:
         if conflict is not None:
             raise ConfigError(f"Alias '{normalized}' is already used by account {conflict}")
 
-        record["alias"] = normalized
+        record["alias"] = stored
         data["lastUpdated"] = get_timestamp()
         self._write_json(self.sequence_file, data)
-        return account_num, normalized
+        return account_num, stored
 
     def unset_alias(self, identifier: str) -> str:
         """Clear the alias for the account matching identifier.

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -415,6 +415,40 @@ class TestAliasCommand:
         data = switcher._get_sequence_data()
         assert data["accounts"]["2"]["alias"] == "dev"
 
+    def test_set_alias_preserve_case_keeps_typed_spelling(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+
+        _, stored = switcher.set_alias("2", "DevBox", preserve_case=True)
+
+        assert stored == "DevBox"
+        data = switcher._get_sequence_data()
+        assert data["accounts"]["2"]["alias"] == "DevBox"
+
+    def test_preserved_case_alias_still_resolves_case_insensitively(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """A capitalized alias must stay usable as an identifier in any case."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        switcher.set_alias("2", "DevBox", preserve_case=True)
+
+        for spelling in ("devbox", "DEVBOX", "DevBox"):
+            assert switcher._resolve_account_identifier(spelling) == "2"
+
+    def test_set_alias_preserve_case_still_rejects_duplicates(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """Uniqueness is case-insensitive, so case alone can't dodge a clash."""
+        switcher = ClaudeAccountSwitcher()
+        self._write(switcher, sample_sequence_data)
+        switcher.set_alias("1", "dev")
+
+        with pytest.raises(ConfigError):
+            switcher.set_alias("2", "DEV", preserve_case=True)
+
     def test_set_alias_by_email(self, temp_home: Path, sample_sequence_data: dict):
         switcher = ClaudeAccountSwitcher()
         self._write(switcher, sample_sequence_data)


### PR DESCRIPTION
## What

Adds a **Change alias…** item to the menu bar, which renames the currently active account and keeps the capitalization you type.

## Why

The menu bar can switch, add, remove and disable accounts — but not rename one. Aliases are CLI-only today.

There's a second, smaller thing behind it. `normalize_alias()` lowercases, so an alias can only ever be *stored* lowercase — while every lookup already compares case-insensitively (`_find_account_by_alias` lowercases both sides). The stored spelling is purely cosmetic, so the lowercasing costs display quality and buys nothing.

That matters because the menu bar prints the stored value verbatim. Anyone wanting `Bispoke` / `SR` rather than `bispoke` / `sr` in their menu bar has to hand-edit `sequence.json`, and the next `cswap alias` silently reverts it.

## How

`set_alias()` gains a keyword-only `preserve_case=False`:

- the alias is **still validated** through `normalize_alias` — empty, purely-numeric and leading-dash rejected exactly as before
- uniqueness is **still checked case-insensitively**, so case alone can't dodge a clash
- only the *stored spelling* changes

The CLI leaves the flag off, so **`cswap alias` behaviour is unchanged**. The menu bar passes `preserve_case=True`.

UI details:

- the item carries the current alias — **Change alias (Bispoke)…**, or **Set alias…** when unset — so scope is clear without opening it
- greys out when no account is active
- dialog is pre-filled with the current alias; cancelling or submitting an unchanged value writes nothing
- `activateIgnoringOtherApps_` before the modal, matching `on_add_token` (accessory apps render a blank window otherwise)

## Tests

Three added to `TestAliases`:

- `test_set_alias_preserve_case_keeps_typed_spelling`
- `test_preserved_case_alias_still_resolves_case_insensitively` — `devbox` / `DEVBOX` / `DevBox` all resolve
- `test_set_alias_preserve_case_still_rejects_duplicates`

The existing `test_set_alias_normalizes_to_lowercase` still passes unchanged, which is the guard that the CLI path didn't move.

`2088 passed`. Three failures in `test_move_accounts`, `test_real_store_guard` and `test_swap_accounts` are **pre-existing** — they fail identically on a clean checkout of the same commit, and are unrelated to aliases.

## Notes

The menu-bar callback itself isn't unit-tested, matching the existing `test_menubar.py`, which covers the pure `format_*` helpers rather than rumps callbacks. Happy to add coverage if you'd like it.
