### PR TITLE
feat: multi-provider support, with Codex (ChatGPT) as the second provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,29 +182,43 @@ cswap also switches [Codex](https://github.com/openai/codex) accounts, under a
 nothing you already type changes.
 
 ```bash
-cswap codex list                # accounts + 5h/weekly usage
-cswap codex list --token-status # token expiry diagnostics (never the token)
-cswap codex switch 2            # activate a stored account
-cswap codex add                 # store the account you are logged in as
-cswap codex login               # run `codex login`, then store the result
+cswap codex list                     # accounts + 5h/weekly usage
+cswap codex list --token-status      # token expiry (never prints the token)
+cswap codex list --json              # machine-readable
+cswap codex status                   # the account codex is running as
+cswap codex switch                   # rotate to the next account
+cswap codex switch 2                 # or by number / email / alias
+cswap codex switch --strategy best   # jump to the most quota left
+cswap codex add                      # store the account you are logged in as
+cswap codex login                    # run `codex login`, then store it
 cswap codex alias 2 work
-cswap codex disable 2           # hold it out of auto-rotation
+cswap codex disable 2                # hold it out of auto-rotation
+cswap codex swap 1 2                 # exchange slot numbers
+cswap codex move 3 1                 # assign a slot (swaps if taken)
+cswap codex export ~/codex.json      # back up (contains live tokens)
+cswap codex import ~/codex.json
+cswap codex purge                    # drop cswap's copies; your login stays
 ```
 
-If you already use [`codex-auth`](https://github.com/Loongphy/codex-auth), your
-accounts are imported automatically the first time you run a `cswap codex`
-command. `~/.codex/accounts/` is left untouched, so you can keep using that tool
-or go back to it.
+Every command mirrors its Claude counterpart — `cswap codex status` prints the
+same block as `cswap status`, and `--json` returns the same envelope, so a
+script that reads one reads the other.
+
+**Coming from `codex-auth`?** Your accounts are imported automatically the first
+time you run any `cswap codex` command. `~/.codex/accounts/` is left completely
+untouched, so you can keep using that tool or go back to it. Re-run the import
+by hand with `cswap codex import-codex-auth`.
 
 > [!IMPORTANT]
 > Switching rewrites `~/.codex/auth.json`. A codex session that is **already
 > running** keeps its old account until you restart it — cswap warns you and
 > names the running PIDs. This applies to automatic switching too: it only
-> affects the next session you start.
+> affects the next session you start. For seamless switching without a restart,
+> see the [`codext`](https://github.com/Loongphy/codext) fork of the Codex CLI.
 
 Codex accounts appear in the dashboard and the macOS menu bar alongside your
-Claude ones, and `cswap auto` rotates both. Two extra settings tune the Codex
-side:
+Claude ones (tagged `⟨codex⟩`), and `cswap auto` rotates both providers in one
+process. Two extra settings tune the Codex side:
 
 ```bash
 cswap config set autoswitch.codexThreshold 85   # 0 = use autoswitch.threshold
@@ -213,6 +227,28 @@ cswap config set autoswitch.codexEnabled false  # leave Codex out of `cswap auto
 
 `autoswitch.includeApiKeyAccounts` applies to Claude only: a Codex API-key login
 reports no usage, so there is nothing for a threshold to compare.
+
+<details>
+<summary>Where Codex data is stored</summary>
+
+Accounts live in cswap's own store, a sibling of the Claude one — not in
+`~/.codex/accounts/`:
+
+| What | Where |
+|---|---|
+| Slot registry (no secrets) | `<cswap data dir>/codex/sequence.json` |
+| Credentials, macOS | Keychain, service `claude-swap-codex` |
+| Credentials, Linux/Windows | `<cswap data dir>/codex/credentials/`, mode 0600 |
+| Usage cache | `<cswap data dir>/codex/cache/` |
+
+Credentials are keyed by account identity rather than slot number, so `swap` and
+`move` only rewrite the registry and never move a secret.
+
+`cswap codex export` writes real OAuth tokens — an export you cannot log in with
+is not a backup. The file is created private (0600) and says so in a `warning`
+field. Treat it like a password.
+
+</details>
 
 ### Other commands
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Multi-account switcher for Claude Code. Easily switch between multiple Claude accounts without logging out, or let it switch for you before you hit a rate limit. Track usage for every account in a live dashboard, and run accounts in parallel. Works with both the Claude Code CLI and the VS Code extension.
 
+Also switches **Codex (ChatGPT)** accounts — see [Codex accounts](#codex-chatgpt-accounts).
+
 ## Installation
 
 ### Using uv (recommended)
@@ -172,6 +174,42 @@ cswap add
 ```
 
 This will update the stored credentials without creating a duplicate.
+
+### Codex (ChatGPT) accounts
+
+cswap also switches [Codex](https://github.com/openai/codex) accounts, under a
+`codex` namespace. Bare `cswap list` / `cswap switch` keep meaning Claude, so
+nothing you already type changes.
+
+```bash
+cswap codex list                # accounts + 5h/weekly usage
+cswap codex list --token-status # token expiry diagnostics (never the token)
+cswap codex switch 2            # activate a stored account
+cswap codex add                 # store the account you are logged in as
+cswap codex login               # run `codex login`, then store the result
+cswap codex alias 2 work
+cswap codex disable 2           # hold it out of auto-rotation
+```
+
+If you already use [`codex-auth`](https://github.com/Loongphy/codex-auth), your
+accounts are imported automatically the first time you run a `cswap codex`
+command. `~/.codex/accounts/` is left untouched, so you can keep using that tool
+or go back to it.
+
+> [!IMPORTANT]
+> Switching rewrites `~/.codex/auth.json`. A codex session that is **already
+> running** keeps its old account until you restart it — cswap warns you and
+> names the running PIDs. This applies to automatic switching too: it only
+> affects the next session you start.
+
+Codex accounts appear in the dashboard and the macOS menu bar alongside your
+Claude ones, and `cswap auto` rotates both. Two extra settings tune the Codex
+side:
+
+```bash
+cswap config set autoswitch.codexThreshold 85   # 0 = use autoswitch.threshold
+cswap config set autoswitch.codexEnabled false  # leave Codex out of `cswap auto`
+```
 
 ### Other commands
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ cswap config set autoswitch.codexThreshold 85   # 0 = use autoswitch.threshold
 cswap config set autoswitch.codexEnabled false  # leave Codex out of `cswap auto`
 ```
 
+`autoswitch.includeApiKeyAccounts` applies to Claude only: a Codex API-key login
+reports no usage, so there is nothing for a threshold to compare.
+
 ### Other commands
 
 ```bash

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -947,6 +947,11 @@ def main() -> None:
     if argv and argv[0] == "move":
         _move_command(argv[1:])
         return
+    if argv and argv[0] == "codex":
+        from claude_swap.cli_codex import codex_command
+
+        codex_command(argv[1:])
+        return
 
     # Bare `cswap` in an interactive terminal opens the TUI dashboard (like
     # lazygit/k9s). TTY-gated on both ends so scripts and pipes keep getting
@@ -986,6 +991,7 @@ Commands:
   %(prog)s swap <a> <b>               exchange two accounts' slot numbers
   %(prog)s move <a> <slot>            assign an account to a slot (swaps if taken)
   %(prog)s auto                       auto-switch when nearing rate limits
+  %(prog)s codex <cmd>                manage Codex (ChatGPT) accounts
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s unclaimed [--purge ID]     list or drop stashed credential entries
   %(prog)s export <path>              export accounts

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import sys
+import threading
 
 from claude_swap import __version__, paths, printer
 from claude_swap.exceptions import ClaudeSwitchError
@@ -705,8 +706,26 @@ Defaults live in settings.json in the backup root; flags override them.
             dry_run=args.dry_run,
         )
 
+        # Codex rides along in this same process as its own small engine — the
+        # user asked for one `cswap auto` driving both providers, and two small
+        # engines beat genericizing the 1700-line Claude tick. Absent Codex
+        # accounts this is a no-op the user never sees.
+        codex_auto = _codex_auto_engine(settings)
+
+        def run_codex_tick() -> None:
+            if codex_auto is None:
+                return
+            tick = codex_auto.tick(dry_run=args.dry_run)
+            if tick.outcome in ("switched", "error") or args.dry_run:
+                if args.json:
+                    print(json.dumps({"event": "codex", **tick.__dict__}, default=list))
+                else:
+                    print(tick.human())
+
         if args.once:
-            sys.exit(engine.tick().value)
+            outcome = engine.tick()
+            run_codex_tick()
+            sys.exit(outcome.value)
 
         # Loop mode: SIGTERM (systemd stop) exits the loop cleanly.
         signal.signal(signal.SIGTERM, lambda *_: engine.stop())
@@ -718,7 +737,32 @@ Defaults live in settings.json in the backup root; flags override them.
                     f"{' (dry-run)' if args.dry_run else ''} — Ctrl-C to stop"
                 )
             )
-        sys.exit(engine.run_loop())
+        # Codex ticks on its own daemon thread at the same interval rather than
+        # inside the Claude engine's loop: the engine gets no new hook, no new
+        # failure mode, and a slow Codex fetch can never delay a Claude switch.
+        codex_thread = None
+        if codex_auto is not None:
+            codex_stop = threading.Event()
+
+            def codex_loop() -> None:
+                while not codex_stop.wait(settings.interval_seconds):
+                    try:
+                        run_codex_tick()
+                    except Exception:
+                        # A Codex problem must never take down `cswap auto`.
+                        pass
+
+            codex_thread = threading.Thread(
+                target=codex_loop, name="codex-auto", daemon=True
+            )
+            codex_thread.start()
+
+        try:
+            code = engine.run_loop()
+        finally:
+            if codex_thread is not None:
+                codex_stop.set()
+        sys.exit(code)
     except ClaudeSwitchError as e:
         if args.json:
             print(json.dumps(error_envelope(e)))
@@ -731,6 +775,32 @@ Defaults live in settings.json in the backup root; flags override them.
             file=sys.stderr if args.json else sys.stdout,
         )
         sys.exit(130)
+
+
+
+def _codex_auto_engine(settings):
+    """A Codex auto-switcher, or None when this machine has no Codex accounts.
+
+    Returning None rather than an idle engine is what keeps a Claude-only
+    install exactly as it was: no extra work per tick, no extra output, nothing
+    new in `cswap auto`'s log.
+    """
+    if not getattr(settings, "codex_enabled", True):
+        return None
+    try:
+        from claude_swap.providers.registry import codex_is_present
+
+        if not codex_is_present():
+            return None
+        from claude_swap.codex.autoswitch import CodexAutoSwitcher
+
+        threshold = getattr(settings, "codex_threshold", 0.0) or settings.threshold
+        return CodexAutoSwitcher(
+            threshold=threshold, hysteresis_pct=settings.hysteresis_pct
+        )
+    except Exception:
+        # A broken Codex store must never stop the Claude auto loop starting.
+        return None
 
 
 def _config_command(argv: list[str]) -> None:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -1074,13 +1074,18 @@ Commands:
 Codex (ChatGPT) accounts — the commands above stay Claude-only:
   %(prog)s codex list                 list Codex accounts and usage
   %(prog)s codex status               show the account codex is running as
+  %(prog)s codex switch               rotate to the next Codex account
   %(prog)s codex switch <num|email>   switch to a specific Codex account
   %(prog)s codex add                  store the current Codex login
   %(prog)s codex login                run `codex login`, then store it
   %(prog)s codex remove <num|email>   remove a Codex account
   %(prog)s codex alias <num> <name>   set a short alias (--unset to clear)
   %(prog)s codex disable|enable <n>   hold out of / return to auto-rotation
-  %(prog)s codex import               re-run the codex-auth import
+  %(prog)s codex swap <a> <b>         exchange two Codex slot numbers
+  %(prog)s codex move <a> <slot>      assign a Codex account to a slot
+  %(prog)s codex export <path>        export Codex accounts
+  %(prog)s codex import <path>        import Codex accounts
+  %(prog)s codex purge                remove all cswap Codex data
   %(prog)s codex --help               full Codex help
 
 Aliases: ls=list  rm=remove  update=upgrade""",

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -1061,7 +1061,6 @@ Commands:
   %(prog)s swap <a> <b>               exchange two accounts' slot numbers
   %(prog)s move <a> <slot>            assign an account to a slot (swaps if taken)
   %(prog)s auto                       auto-switch when nearing rate limits
-  %(prog)s codex <cmd>                manage Codex (ChatGPT) accounts
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s unclaimed [--purge ID]     list or drop stashed credential entries
   %(prog)s export <path>              export accounts
@@ -1071,6 +1070,18 @@ Commands:
   %(prog)s menubar                    macOS menu bar app
   %(prog)s upgrade                    self-upgrade to latest
   %(prog)s purge                      remove all claude-swap data
+
+Codex (ChatGPT) accounts — the commands above stay Claude-only:
+  %(prog)s codex list                 list Codex accounts and usage
+  %(prog)s codex status               show the account codex is running as
+  %(prog)s codex switch <num|email>   switch to a specific Codex account
+  %(prog)s codex add                  store the current Codex login
+  %(prog)s codex login                run `codex login`, then store it
+  %(prog)s codex remove <num|email>   remove a Codex account
+  %(prog)s codex alias <num> <name>   set a short alias (--unset to clear)
+  %(prog)s codex disable|enable <n>   hold out of / return to auto-rotation
+  %(prog)s codex import               re-run the codex-auth import
+  %(prog)s codex --help               full Codex help
 
 Aliases: ls=list  rm=remove  update=upgrade""",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1085,6 +1096,8 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s run 2 -- --resume                 # forward args after '--' to claude
   %(prog)s auto --once                       # single auto-switch tick (cron-friendly)
   %(prog)s config set autoswitch.threshold 80
+  %(prog)s codex list --token-status         # Codex token expiry (never the token)
+  %(prog)s codex list --json --skip-api      # machine-readable, no network
 
 The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep working.
         """,

--- a/src/claude_swap/cli_codex.py
+++ b/src/claude_swap/cli_codex.py
@@ -1,0 +1,250 @@
+"""``cswap codex ...`` — the Codex provider's command surface.
+
+A namespace rather than a ``--provider`` flag: bare ``cswap switch`` and
+``cswap list`` keep meaning Claude, so every script and every habit built on the
+existing CLI is untouched. Nothing in this module changes an existing command.
+
+Dispatched from ``cli.main`` alongside the other pre-dispatch handlers
+(``run``/``auto``/``config``/``map``), for the same reason they are: a
+positional subcommand cannot coexist with the main parser's mutually-exclusive
+flag group.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+
+from claude_swap.codex.registry_import import import_codex_auth_registry
+from claude_swap.codex.switcher import CodexSwitcher
+from claude_swap.exceptions import ClaudeSwitchError
+from claude_swap.printer import dimmed, error, warning
+
+
+def _auto_import() -> None:
+    """Import codex-auth's accounts the first time, once.
+
+    Automatic because an explicit command the user has to discover means they
+    run ``cswap codex list``, see nothing, and conclude cswap is broken. The
+    source tree is left untouched, so this is reversible.
+    """
+    result = import_codex_auth_registry(only_if_empty=True)
+    if result.unsupported_schema is not None:
+        warning(
+            f"codex-auth registry uses schema {result.unsupported_schema}, which this "
+            "version of cswap does not understand — not importing."
+        )
+        return
+    if result.imported:
+        print(
+            dimmed(
+                f"Imported {result.imported} Codex account(s) from {result.source} "
+                "(the original is left untouched)."
+            )
+        )
+    if result.skipped:
+        print(dimmed(f"Skipped {result.skipped} account(s) with no usable auth file."))
+
+
+def _usage_summary(usage: dict | None) -> str:
+    if not usage:
+        return ""
+    parts = []
+    for key, label in (("five_hour", "5h"), ("seven_day", "7d")):
+        window = usage.get(key)
+        if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)):
+            parts.append(f"{label} {window['pct']:.0f}%")
+    return "  ".join(parts)
+
+
+def _print_list(switcher: CodexSwitcher, *, as_json: bool, skip_api: bool) -> None:
+    numbers = None if skip_api else set(switcher.account_numbers())
+    snap = switcher.accounts_snapshot(fetch=numbers)
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "provider": "codex",
+                    "activeNumber": snap.active_number,
+                    "accounts": [
+                        {
+                            "number": a.number,
+                            "email": a.email,
+                            "workspace": a.org_name,
+                            "alias": a.alias,
+                            "active": a.is_active,
+                            "disabled": a.disabled,
+                            "kind": a.kind,
+                            "usage": a.usage.last_good,
+                            "sentinel": a.usage.sentinel,
+                        }
+                        for a in snap.accounts
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    if not snap.accounts:
+        print("No Codex accounts. Run 'cswap codex add' or 'cswap codex login'.")
+        return
+
+    for a in snap.accounts:
+        marker = "*" if a.is_active else " "
+        alias = f" ({a.alias})" if a.alias else ""
+        state = " [disabled]" if a.disabled else ""
+        usage = a.usage.sentinel or _usage_summary(a.usage.last_good)
+        suffix = f"  {usage}" if usage else ""
+        print(f"{marker} {a.number}. {a.email} [{a.display_tag}]{alias}{state}{suffix}")
+
+
+def _do_login(args) -> None:
+    """Run ``codex login``, then capture the account it produced."""
+    binary = shutil.which("codex")
+    if not binary:
+        error(
+            "The 'codex' CLI is not on PATH. Install it, or run 'cswap codex add' "
+            "after logging in another way."
+        )
+        sys.exit(1)
+
+    cmd = [binary, "login"]
+    if args.device_auth:
+        cmd.append("--device-auth")
+    # shell=False, and the resolved absolute path: a shell function named
+    # `codex` is a common setup (one that injects
+    # --dangerously-bypass-approvals-and-sandbox is in the wild), and inheriting
+    # it would run this login under flags cswap never chose.
+    result = subprocess.run(cmd, shell=False)
+    if result.returncode != 0:
+        error("codex login did not complete.")
+        sys.exit(result.returncode)
+
+    slot = CodexSwitcher().add_account(alias=args.alias or "")
+    print(f"Added Codex account {slot.number}: {slot.display_label}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cswap codex",
+        description="Multi-account switcher for the Codex CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Commands:
+  list                    list managed Codex accounts
+  status                  show the account the codex CLI is currently using
+  switch <num|email>      activate a stored account
+  add                     store the account you are currently logged in as
+  login [--device-auth]   run 'codex login', then store the result
+  remove <num|email>      forget an account
+  alias <num|email> NAME  set a short alias  (--unset to clear)
+  disable|enable <t>      hold an account out of / return it to auto-rotation
+  import                  re-run the codex-auth import
+
+Switching rewrites ~/.codex/auth.json. A codex session that is already running
+keeps its old account until you restart it.
+        """,
+    )
+    sub = parser.add_subparsers(dest="verb", required=True)
+
+    p_list = sub.add_parser("list", help="List managed Codex accounts")
+    p_list.add_argument("--json", action="store_true", help="Machine-readable output")
+    p_list.add_argument("--skip-api", action="store_true", help="Do not fetch usage")
+
+    sub.add_parser("status", help="Show the currently active Codex account")
+
+    p_switch = sub.add_parser("switch", help="Activate a stored account")
+    p_switch.add_argument("account", metavar="NUM|EMAIL|ALIAS")
+
+    p_add = sub.add_parser("add", help="Store the current Codex login")
+    p_add.add_argument("--alias", metavar="NAME", default="")
+
+    p_login = sub.add_parser("login", help="Run 'codex login', then store the account")
+    p_login.add_argument("--device-auth", action="store_true")
+    p_login.add_argument("--alias", metavar="NAME", default="")
+
+    p_remove = sub.add_parser("remove", help="Forget an account")
+    p_remove.add_argument("account", metavar="NUM|EMAIL|ALIAS")
+    p_remove.add_argument("-y", "--yes", action="store_true")
+
+    p_alias = sub.add_parser("alias", help="Set or clear an account alias")
+    p_alias.add_argument("account", metavar="NUM|EMAIL")
+    p_alias.add_argument("name", nargs="?", default="")
+    p_alias.add_argument("--unset", action="store_true")
+
+    for verb, holding in (("disable", True), ("enable", False)):
+        p = sub.add_parser(
+            verb,
+            help=("Hold out of auto-rotation" if holding else "Return to auto-rotation"),
+        )
+        p.add_argument("account", metavar="NUM|EMAIL|ALIAS")
+
+    sub.add_parser("import", help="Re-run the codex-auth registry import")
+    return parser
+
+
+def codex_command(argv: list[str]) -> None:
+    """Entry point for ``cswap codex ...``."""
+    args = _build_parser().parse_args(argv)
+
+    try:
+        if args.verb == "import":
+            result = import_codex_auth_registry()
+            print(f"Imported {result.imported}, skipped {result.skipped}.")
+            return
+
+        _auto_import()
+        switcher = CodexSwitcher()
+
+        if args.verb == "list":
+            _print_list(switcher, as_json=args.json, skip_api=args.skip_api)
+        elif args.verb == "status":
+            number = switcher.current_account_number()
+            if number is None:
+                print("No managed Codex account is active.")
+            else:
+                _num, _email, label = switcher.resolve_account(number)
+                print(f"Active Codex account {number}: {label}")
+        elif args.verb == "switch":
+            result = switcher.switch_to(args.account)
+            print(f"Switched to Codex account {result.number}: {result.email}")
+            if result.running_pids:
+                pids = ", ".join(str(p) for p in result.running_pids)
+                warning(
+                    f"codex is running (pid {pids}) — restart it for the new "
+                    "account to take effect."
+                )
+        elif args.verb == "add":
+            slot = switcher.add_account(alias=args.alias)
+            print(f"Added Codex account {slot.number}: {slot.display_label}")
+        elif args.verb == "login":
+            _do_login(args)
+        elif args.verb == "remove":
+            switcher.remove_account(args.account, assume_yes=args.yes)
+            print(f"Removed Codex account {args.account}")
+        elif args.verb == "alias":
+            if args.unset or not args.name:
+                number = switcher.unset_alias(args.account)
+                print(f"Cleared alias for Codex account {number}")
+            else:
+                number, alias = switcher.set_alias(args.account, args.name)
+                print(f"Codex account {number} is now '{alias}'")
+        elif args.verb in ("disable", "enable"):
+            switcher.set_account_disabled(args.account, args.verb == "disable")
+            print(f"Codex account {args.account} {args.verb}d")
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except ValueError as e:
+        # normalize_alias rejects bad aliases with ValueError; that is user
+        # input, not a bug.
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)

--- a/src/claude_swap/cli_codex.py
+++ b/src/claude_swap/cli_codex.py
@@ -83,7 +83,8 @@ def _print_list(
     skip_api: bool,
     token_status: bool = False,
 ) -> None:
-    numbers = None if skip_api else set(switcher.account_numbers())
+    # None = every account eligible; an empty set = no network at all.
+    numbers: set[str] | None = set() if skip_api else None
     snap = switcher.accounts_snapshot(fetch=numbers)
 
     if as_json:

--- a/src/claude_swap/cli_codex.py
+++ b/src/claude_swap/cli_codex.py
@@ -178,18 +178,45 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Commands:
-  list                    list managed Codex accounts
+  list [--json] [--skip-api] [--token-status]
+                          list managed Codex accounts and their usage
   status                  show the account the codex CLI is currently using
-  switch <num|email>      activate a stored account
-  add                     store the account you are currently logged in as
-  login [--device-auth]   run 'codex login', then store the result
-  remove <num|email>      forget an account
+  switch <num|email|alias>
+                          activate a stored account
+  add [--alias NAME]      store the account you are currently logged in as
+  login [--device-auth] [--alias NAME]
+                          run 'codex login', then store the result
+  remove <num|email> [-y] forget an account and delete its credentials
   alias <num|email> NAME  set a short alias  (--unset to clear)
-  disable|enable <t>      hold an account out of / return it to auto-rotation
+  disable|enable <target> hold an account out of / return it to auto-rotation
   import                  re-run the codex-auth import
 
-Switching rewrites ~/.codex/auth.json. A codex session that is already running
-keeps its old account until you restart it.
+Examples:
+  cswap codex list                    5h / weekly usage per account
+  cswap codex list --skip-api         cached only, no network
+  cswap codex list --token-status     token expiry (never prints the token)
+  cswap codex list --json             machine-readable
+  cswap codex switch work             by alias
+  cswap codex disable 2               keep it out of `cswap auto` rotation
+
+Auto-switching:
+  Codex rides along in `cswap auto`, which rotates both providers. Tune it with
+  `cswap config set autoswitch.codexThreshold 85` (0 = inherit
+  autoswitch.threshold) or turn it off with `autoswitch.codexEnabled false`.
+  autoswitch.includeApiKeyAccounts is Claude-only: a Codex API-key login
+  reports no usage, so a threshold has nothing to compare.
+
+Notes:
+  Bare `cswap list` / `cswap switch` still mean Claude — nothing you already
+  type changes.
+
+  Switching rewrites ~/.codex/auth.json. A codex session that is ALREADY
+  RUNNING keeps its old account until you restart it; cswap warns you and names
+  the running PIDs. This applies to automatic switching too — it only affects
+  the next session you start.
+
+  If you use codex-auth, your accounts are imported automatically on the first
+  `cswap codex` command. ~/.codex/accounts/ is left untouched.
         """,
     )
     sub = parser.add_subparsers(dest="verb", required=True)

--- a/src/claude_swap/cli_codex.py
+++ b/src/claude_swap/cli_codex.py
@@ -19,6 +19,11 @@ import subprocess
 import sys
 
 from claude_swap.codex.registry_import import import_codex_auth_registry
+from claude_swap.codex.transfer import (
+    export_codex_accounts,
+    import_codex_accounts,
+    purge_codex_data,
+)
 from claude_swap.codex.switcher import CodexSwitcher
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.printer import dimmed, error, warning
@@ -180,24 +185,36 @@ def _build_parser() -> argparse.ArgumentParser:
 Commands:
   list [--json] [--skip-api] [--token-status]
                           list managed Codex accounts and their usage
-  status                  show the account the codex CLI is currently using
+  status [--json]         show the account the codex CLI is currently using
+  switch                  rotate to the next account
   switch <num|email|alias>
-                          activate a stored account
+                          activate a specific account
+  switch --strategy best  jump to the account with the most quota left
   add [--alias NAME]      store the account you are currently logged in as
   login [--device-auth] [--alias NAME]
                           run 'codex login', then store the result
   remove <num|email> [-y] forget an account and delete its credentials
   alias <num|email> NAME  set a short alias  (--unset to clear)
   disable|enable <target> hold an account out of / return it to auto-rotation
-  import                  re-run the codex-auth import
+  swap <a> <b>            exchange two accounts' slot numbers
+  move <target> <slot>    assign an account to a slot (swaps if taken)
+  export <path>           export accounts (with tokens) to a file; '-' = stdout
+  import <path>           import accounts from a file; '-' = stdin
+  purge                   remove all cswap Codex data (your login is untouched)
+  import-codex-auth       re-run the one-time codex-auth registry import
 
 Examples:
   cswap codex list                    5h / weekly usage per account
   cswap codex list --skip-api         cached only, no network
   cswap codex list --token-status     token expiry (never prints the token)
   cswap codex list --json             machine-readable
+  cswap codex switch                  rotate to the next account
   cswap codex switch work             by alias
+  cswap codex switch --strategy best  most quota left
+  cswap codex status --json           machine-readable status
   cswap codex disable 2               keep it out of `cswap auto` rotation
+  cswap codex swap 1 2                exchange slot numbers
+  cswap codex export ~/codex.json     back up accounts (contains live tokens)
 
 Auto-switching:
   Codex rides along in `cswap auto`, which rotates both providers. Tune it with
@@ -230,10 +247,18 @@ Notes:
         help="Show token expiry diagnostics (never the token itself)",
     )
 
-    sub.add_parser("status", help="Show the currently active Codex account")
+    p_status = sub.add_parser("status", help="Show the currently active Codex account")
+    p_status.add_argument("--json", action="store_true", help="Machine-readable output")
 
-    p_switch = sub.add_parser("switch", help="Activate a stored account")
-    p_switch.add_argument("account", metavar="NUM|EMAIL|ALIAS")
+    p_switch = sub.add_parser(
+        "switch", help="Activate a stored account (bare: rotate to the next one)"
+    )
+    p_switch.add_argument("account", nargs="?", metavar="NUM|EMAIL|ALIAS")
+    p_switch.add_argument(
+        "--strategy",
+        choices=("best",),
+        help="Pick the target by remaining quota instead of rotating",
+    )
 
     p_add = sub.add_parser("add", help="Store the current Codex login")
     p_add.add_argument("--alias", metavar="NAME", default="")
@@ -258,7 +283,28 @@ Notes:
         )
         p.add_argument("account", metavar="NUM|EMAIL|ALIAS")
 
-    sub.add_parser("import", help="Re-run the codex-auth registry import")
+    p_swap = sub.add_parser("swap", help="Exchange two accounts' slot numbers")
+    p_swap.add_argument("first", metavar="A")
+    p_swap.add_argument("second", metavar="B")
+
+    p_move = sub.add_parser("move", help="Assign an account to a slot (swaps if taken)")
+    p_move.add_argument("account", metavar="NUM|EMAIL|ALIAS")
+    p_move.add_argument("slot", metavar="SLOT")
+
+    p_export = sub.add_parser("export", help="Export accounts to a file ('-' for stdout)")
+    p_export.add_argument("path", metavar="PATH")
+    p_export.add_argument("--account", metavar="NUM|EMAIL", help="Export just one account")
+
+    p_import = sub.add_parser("import", help="Import accounts from a file ('-' for stdin)")
+    p_import.add_argument("path", metavar="PATH")
+    p_import.add_argument("--force", action="store_true", help="Overwrite existing accounts")
+
+    p_purge = sub.add_parser("purge", help="Remove all cswap Codex data")
+    p_purge.add_argument("-y", "--yes", action="store_true")
+
+    sub.add_parser(
+        "import-codex-auth", help="Re-run the one-time codex-auth registry import"
+    )
     return parser
 
 
@@ -267,7 +313,7 @@ def codex_command(argv: list[str]) -> None:
     args = _build_parser().parse_args(argv)
 
     try:
-        if args.verb == "import":
+        if args.verb == "import-codex-auth":
             result = import_codex_auth_registry()
             print(f"Imported {result.imported}, skipped {result.skipped}.")
             return
@@ -283,14 +329,16 @@ def codex_command(argv: list[str]) -> None:
                 token_status=args.token_status,
             )
         elif args.verb == "status":
-            number = switcher.current_account_number()
-            if number is None:
-                print("No managed Codex account is active.")
-            else:
-                _num, _email, label = switcher.resolve_account(number)
-                print(f"Active Codex account {number}: {label}")
+            payload = switcher.status(json_output=args.json)
+            if payload is not None:
+                print(json.dumps(payload, indent=2))
         elif args.verb == "switch":
-            result = switcher.switch_to(args.account)
+            if args.strategy == "best":
+                result = switcher.switch_best()
+            elif args.account is None:
+                result = switcher.rotate()
+            else:
+                result = switcher.switch_to(args.account)
             print(f"Switched to Codex account {result.number}: {result.email}")
             if result.running_pids:
                 pids = ", ".join(str(p) for p in result.running_pids)
@@ -316,6 +364,26 @@ def codex_command(argv: list[str]) -> None:
         elif args.verb in ("disable", "enable"):
             switcher.set_account_disabled(args.account, args.verb == "disable")
             print(f"Codex account {args.account} {args.verb}d")
+        elif args.verb == "swap":
+            a, b = switcher.swap_accounts(args.first, args.second)
+            print(f"Swapped Codex slots {a} and {b}")
+        elif args.verb == "move":
+            src, dst, swapped = switcher.move_account(args.account, args.slot)
+            if src == dst:
+                print(f"Codex account is already in slot {dst}")
+            elif swapped:
+                print(f"Moved Codex account {src} to slot {dst} (swapped with its occupant)")
+            else:
+                print(f"Moved Codex account {src} to slot {dst}")
+        elif args.verb == "export":
+            count = export_codex_accounts(switcher, args.path, account=args.account)
+            if args.path != "-":
+                print(f"Exported {count} Codex account(s) to {args.path}")
+        elif args.verb == "import":
+            count = import_codex_accounts(switcher, args.path, force=args.force)
+            print(f"Imported {count} Codex account(s)")
+        elif args.verb == "purge":
+            purge_codex_data(assume_yes=args.yes)
     except ClaudeSwitchError as e:
         error(f"Error: {e}")
         sys.exit(1)

--- a/src/claude_swap/cli_codex.py
+++ b/src/claude_swap/cli_codex.py
@@ -60,34 +60,59 @@ def _usage_summary(usage: dict | None) -> str:
     return "  ".join(parts)
 
 
-def _print_list(switcher: CodexSwitcher, *, as_json: bool, skip_api: bool) -> None:
+def _relative(seconds: float | None) -> str:
+    """A compact human duration, e.g. "6d 4h", "12m", "expired"."""
+    if seconds is None:
+        return "unknown"
+    if seconds <= 0:
+        return "expired"
+    days, rem = divmod(int(seconds), 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes = rem // 60
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def _print_list(
+    switcher: CodexSwitcher,
+    *,
+    as_json: bool,
+    skip_api: bool,
+    token_status: bool = False,
+) -> None:
     numbers = None if skip_api else set(switcher.account_numbers())
     snap = switcher.accounts_snapshot(fetch=numbers)
 
     if as_json:
-        print(
-            json.dumps(
+        payload = {
+            "provider": "codex",
+            "activeNumber": snap.active_number,
+            "accounts": [
                 {
-                    "provider": "codex",
-                    "activeNumber": snap.active_number,
-                    "accounts": [
-                        {
-                            "number": a.number,
-                            "email": a.email,
-                            "workspace": a.org_name,
-                            "alias": a.alias,
-                            "active": a.is_active,
-                            "disabled": a.disabled,
-                            "kind": a.kind,
-                            "usage": a.usage.last_good,
-                            "sentinel": a.usage.sentinel,
-                        }
-                        for a in snap.accounts
-                    ],
-                },
-                indent=2,
-            )
-        )
+                    "number": a.number,
+                    "email": a.email,
+                    "workspace": a.org_name,
+                    "alias": a.alias,
+                    "active": a.is_active,
+                    "disabled": a.disabled,
+                    "kind": a.kind,
+                    "usage": a.usage.last_good,
+                    "sentinel": a.usage.sentinel,
+                    "fetchedAt": a.usage.fetched_at,
+                    "ageSeconds": a.usage.age_s,
+                    "plan": (a.usage.last_good or {}).get("plan"),
+                }
+                for a in snap.accounts
+            ],
+        }
+        if token_status:
+            payload["tokenStatus"] = [
+                switcher.token_status(a.number) for a in snap.accounts
+            ]
+        print(json.dumps(payload, indent=2))
         return
 
     if not snap.accounts:
@@ -101,6 +126,22 @@ def _print_list(switcher: CodexSwitcher, *, as_json: bool, skip_api: bool) -> No
         usage = a.usage.sentinel or _usage_summary(a.usage.last_good)
         suffix = f"  {usage}" if usage else ""
         print(f"{marker} {a.number}. {a.email} [{a.display_tag}]{alias}{state}{suffix}")
+
+        if token_status:
+            st = switcher.token_status(a.number)
+            if st["state"] != "oauth":
+                print(dimmed(f"      token: {st['state']}"))
+            else:
+                due = "refresh due" if st["refreshDue"] else "valid"
+                rt = "" if st["hasRefreshToken"] else ", NO refresh token"
+                last = st["lastRefresh"] or "never"
+                print(
+                    dimmed(
+                        f"      token: {due}, expires in "
+                        f"{_relative(st['expiresInSeconds'])}{rt}; "
+                        f"last refresh {last}"
+                    )
+                )
 
 
 def _do_login(args) -> None:
@@ -155,6 +196,11 @@ keeps its old account until you restart it.
     p_list = sub.add_parser("list", help="List managed Codex accounts")
     p_list.add_argument("--json", action="store_true", help="Machine-readable output")
     p_list.add_argument("--skip-api", action="store_true", help="Do not fetch usage")
+    p_list.add_argument(
+        "--token-status",
+        action="store_true",
+        help="Show token expiry diagnostics (never the token itself)",
+    )
 
     sub.add_parser("status", help="Show the currently active Codex account")
 
@@ -202,7 +248,12 @@ def codex_command(argv: list[str]) -> None:
         switcher = CodexSwitcher()
 
         if args.verb == "list":
-            _print_list(switcher, as_json=args.json, skip_api=args.skip_api)
+            _print_list(
+                switcher,
+                as_json=args.json,
+                skip_api=args.skip_api,
+                token_status=args.token_status,
+            )
         elif args.verb == "status":
             number = switcher.current_account_number()
             if number is None:

--- a/src/claude_swap/codex/__init__.py
+++ b/src/claude_swap/codex/__init__.py
@@ -1,0 +1,9 @@
+"""Codex (ChatGPT) provider.
+
+Manages ``~/.codex`` accounts the way the Claude side manages ``~/.claude``.
+Semantics — endpoint contracts, registry schema, plan naming, grouped
+account-name refresh — follow Loongphy/codex-auth; none of its code is reused
+(it is Zig).
+"""
+
+from __future__ import annotations

--- a/src/claude_swap/codex/auth_file.py
+++ b/src/claude_swap/codex/auth_file.py
@@ -1,0 +1,195 @@
+"""Read and write ``~/.codex/auth.json``, and derive an account identity from it.
+
+The live file is the authority on which Codex account is active. The codex CLI
+refreshes its own tokens and writes them back here, so a session that is still
+open on account A can overwrite this file *after* cswap has switched to B. Any
+"which account is active" answer derived from cswap's own registry alone would
+therefore be wrong; it is derived from this file instead, and the mismatch is
+what capture-on-switch repairs.
+
+Identity resolution follows codex-auth's rules so imported records and
+cswap-captured records key identically:
+
+1. ``tokens.account_id`` when present — the value the codex CLI itself uses.
+2. else the JWT's ``chatgpt_account_id``.
+3. else an organization id from the JWT's ``organizations[]``, preferring
+   ``is_default``, falling back to the first non-empty id. Phone-login auth
+   files carry only this.
+
+Nothing here verifies a token's signature: that is the server's job, and cswap
+only needs the claims to know whose token it is holding.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from claude_swap.codex.paths import get_live_auth_path
+
+#: Namespaced claim block the ChatGPT tokens carry their account context in.
+AUTH_CLAIM = "https://api.openai.com/auth"
+
+
+@dataclass(frozen=True)
+class CodexIdentity:
+    """Who an ``auth.json`` payload belongs to."""
+
+    account_id: str
+    user_id: str
+    email: str
+    plan: str
+    is_api_key: bool = False
+
+    @property
+    def account_key(self) -> str:
+        """Stable identity key, byte-identical to codex-auth's."""
+        return account_key(self.user_id, self.account_id)
+
+    @property
+    def is_identifiable(self) -> bool:
+        """Whether this identity can be matched to a stored slot.
+
+        An API-key login, or a payload whose account context could not be
+        resolved at all, has no key to match on — it is a real login but not a
+        *managed* one until it is explicitly added.
+        """
+        return bool(self.account_id)
+
+
+def account_key(user_id: str, account_id: str) -> str:
+    """Join a user and account id into codex-auth's record key."""
+    return f"{user_id}::{account_id}"
+
+
+def file_key(key: str) -> str:
+    """Encode an account key for use as a filename or Keychain account.
+
+    Unpadded base64url, matching codex-auth's snapshot filenames — verified
+    against a real ``<key>.auth.json`` on disk.
+    """
+    return base64.urlsafe_b64encode(key.encode()).decode().rstrip("=")
+
+
+def _decode_jwt_claims(token: object) -> dict | None:
+    """Decode a JWT's payload segment without verifying it."""
+    if not isinstance(token, str):
+        return None
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    seg = parts[1]
+    try:
+        raw = base64.urlsafe_b64decode(seg + "=" * (-len(seg) % 4))
+        claims = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    return claims if isinstance(claims, dict) else None
+
+
+def _org_fallback(auth_claims: dict) -> str:
+    """Pick an organization id when no account id is present."""
+    orgs = auth_claims.get("organizations")
+    if not isinstance(orgs, list):
+        return ""
+    for org in orgs:
+        if isinstance(org, dict) and org.get("is_default") and org.get("id"):
+            return str(org["id"])
+    for org in orgs:
+        if isinstance(org, dict) and org.get("id"):
+            return str(org["id"])
+    return ""
+
+
+def parse_identity(payload: object) -> CodexIdentity | None:
+    """Derive a :class:`CodexIdentity` from an ``auth.json`` payload."""
+    if not isinstance(payload, dict):
+        return None
+
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        # An API-key login has no OAuth tokens at all. It is a real, listable
+        # account — it simply has no usage and nothing to refresh — so it gets
+        # an identity rather than a parse failure.
+        if payload.get("auth_mode") == "apikey" or payload.get("OPENAI_API_KEY"):
+            return CodexIdentity("", "", "", "", is_api_key=True)
+        return None
+
+    claims = _decode_jwt_claims(tokens.get("id_token")) or _decode_jwt_claims(
+        tokens.get("access_token")
+    )
+    if claims is None:
+        return None
+
+    auth_claims = claims.get(AUTH_CLAIM)
+    if not isinstance(auth_claims, dict):
+        auth_claims = {}
+
+    account_id = tokens.get("account_id") or auth_claims.get("chatgpt_account_id") or ""
+    if not account_id:
+        account_id = _org_fallback(auth_claims)
+
+    return CodexIdentity(
+        account_id=str(account_id),
+        user_id=str(auth_claims.get("chatgpt_user_id") or ""),
+        email=str(claims.get("email") or ""),
+        plan=str(auth_claims.get("chatgpt_plan_type") or ""),
+        is_api_key=payload.get("auth_mode") == "apikey",
+    )
+
+
+def read_live_payload() -> dict | None:
+    """Read the live ``auth.json``, or None when absent/unreadable/torn."""
+    path = get_live_auth_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        # A torn write is transient — the next pass re-reads. Never fatal.
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def read_live_identity() -> CodexIdentity | None:
+    """Identity of whoever is currently logged in to the codex CLI."""
+    payload = read_live_payload()
+    return parse_identity(payload) if payload is not None else None
+
+
+def access_token_expiry(payload: object) -> float | None:
+    """The access token's ``exp`` claim as a POSIX timestamp, or None."""
+    if not isinstance(payload, dict):
+        return None
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+    claims = _decode_jwt_claims(tokens.get("access_token"))
+    if not claims:
+        return None
+    exp = claims.get("exp")
+    return float(exp) if isinstance(exp, (int, float)) else None
+
+
+def write_live_auth(payload: dict) -> Path:
+    """Write ``payload`` to the live ``auth.json``, atomically.
+
+    An existing file keeps its current mode: it belongs to the codex CLI, which
+    created it, and a switch has no business re-permissioning it. A file we
+    create from scratch is private (0600), because the snapshot it came from is.
+    """
+    path = get_live_auth_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing_mode: int | None = None
+    if path.exists() and sys.platform != "win32":
+        existing_mode = os.stat(path).st_mode & 0o777
+
+    tmp = path.with_name(path.name + ".cswap.tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    if sys.platform != "win32":
+        os.chmod(tmp, existing_mode if existing_mode is not None else 0o600)
+    os.replace(tmp, path)
+    return path

--- a/src/claude_swap/codex/autoswitch.py
+++ b/src/claude_swap/codex/autoswitch.py
@@ -1,0 +1,153 @@
+"""Auto-switching for Codex, run alongside the Claude engine by ``cswap auto``.
+
+Deliberately **not** a genericized ``AutoSwitchEngine``. That engine is ~1700
+lines of tick built around Claude specifics — per-model scoped windows, setup
+tokens, session profiles, credential quarantine, the consume-gate — and
+abstracting it to fit a second provider would be a rewrite of the most
+load-bearing code in the project, for a provider that needs almost none of it.
+Two small engines in one process give the user what they asked for (one
+``cswap auto``, both providers) at a fraction of the risk.
+
+What Codex actually needs is small: read every account's usage, and if the
+active one is at or over the threshold, move to whichever candidate has the most
+headroom. Cadence, backoff and freshness are already handled by the usage cache.
+
+**The honest caveat, and why it is surfaced rather than hidden.** A Codex switch
+rewrites ``~/.codex/auth.json``, but a codex session already running holds its
+tokens in memory and keeps using the old account until restarted. So an
+automatic switch here only helps the *next* session. When running codex
+processes are detected the engine says so in its event stream rather than
+switching silently and letting the user believe they moved.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from claude_swap.codex.switcher import CodexSwitcher
+from claude_swap.exceptions import ClaudeSwitchError
+from claude_swap.models import AccountSnapshot
+
+_logger = logging.getLogger(__name__)
+
+
+def binding_pct(account: AccountSnapshot) -> float | None:
+    """The utilization that decides this account's fate: the worst window.
+
+    Codex has no per-model windows, so this is just max(5h, weekly) over
+    whichever windows the account actually reports.
+    """
+    usage = account.usage.last_good
+    if not isinstance(usage, dict):
+        return None
+    pcts = [
+        float(window["pct"])
+        for key in ("five_hour", "seven_day")
+        if isinstance(window := usage.get(key), dict)
+        and isinstance(window.get("pct"), (int, float))
+    ]
+    return max(pcts) if pcts else None
+
+
+@dataclass(frozen=True)
+class CodexTick:
+    """What one Codex auto-switch tick decided, and why."""
+
+    outcome: str  # "ok" | "switched" | "blocked" | "no-accounts" | "error"
+    detail: str = ""
+    switched_to: str | None = None
+    running_pids: tuple[int, ...] = ()
+
+    def human(self) -> str:
+        base = f"codex: {self.detail}" if self.detail else f"codex: {self.outcome}"
+        if self.running_pids:
+            pids = ", ".join(str(p) for p in self.running_pids)
+            base += f" — restart codex (pid {pids}) for it to take effect"
+        return base
+
+
+class CodexAutoSwitcher:
+    """Threshold rotation for Codex accounts."""
+
+    def __init__(
+        self,
+        switcher: CodexSwitcher | None = None,
+        *,
+        threshold: float = 90.0,
+        hysteresis_pct: float = 10.0,
+    ) -> None:
+        self.switcher = switcher or CodexSwitcher()
+        self.threshold = threshold
+        self.hysteresis_pct = hysteresis_pct
+
+    def tick(self, *, dry_run: bool = False) -> CodexTick:
+        """One decision pass. Never raises."""
+        try:
+            snapshot = self.switcher.accounts_snapshot(fetch=None)
+        except Exception as e:
+            _logger.debug("codex auto tick failed: %s", type(e).__name__)
+            return CodexTick("error", f"snapshot failed ({type(e).__name__})")
+
+        rotatable = set(self.switcher.switchable_account_numbers())
+        accounts = [a for a in snapshot.accounts if a.number in rotatable]
+        if not accounts:
+            return CodexTick("no-accounts", "no rotatable accounts")
+
+        active = next((a for a in accounts if a.is_active), None)
+        if active is None:
+            return CodexTick("ok", "no managed account active")
+
+        active_pct = binding_pct(active)
+        if active_pct is None:
+            # No measurement is not the same as no usage: switching on unknown
+            # data would move the user for no established reason.
+            return CodexTick("ok", f"account {active.number} usage unknown")
+
+        if active_pct < self.threshold:
+            return CodexTick(
+                "ok", f"account {active.number} at {active_pct:.0f}% (below threshold)"
+            )
+
+        best, best_pct = None, None
+        for candidate in accounts:
+            if candidate.number == active.number:
+                continue
+            pct = binding_pct(candidate)
+            if pct is None or pct >= self.threshold:
+                continue
+            # Must beat the active account by the hysteresis margin, or two
+            # accounts hovering at the line would ping-pong every tick.
+            if pct > active_pct - self.hysteresis_pct:
+                continue
+            if best_pct is None or pct < best_pct:
+                best, best_pct = candidate, pct
+
+        if best is None:
+            return CodexTick(
+                "blocked",
+                f"account {active.number} at {active_pct:.0f}% and no better candidate",
+            )
+
+        if dry_run:
+            return CodexTick(
+                "ok",
+                f"would switch {active.number} ({active_pct:.0f}%) -> "
+                f"{best.number} ({best_pct:.0f}%)",
+            )
+
+        try:
+            result = self.switcher.switch_to(best.number)
+        except ClaudeSwitchError as e:
+            return CodexTick("error", f"switch failed: {e}")
+
+        return CodexTick(
+            "switched",
+            f"switched {active.number} ({active_pct:.0f}%) -> "
+            f"{best.number} ({best_pct:.0f}%)",
+            switched_to=best.number,
+            # The switch already detected them; an EMPTY list means nothing was
+            # running, not that nobody looked. An `or` fallback here re-ran the
+            # real process table — inside unit tests, too.
+            running_pids=tuple(result.running_pids),
+        )

--- a/src/claude_swap/codex/oauth.py
+++ b/src/claude_swap/codex/oauth.py
@@ -1,0 +1,182 @@
+"""Refresh Codex access tokens.
+
+codex-auth does not do this — it leaves refresh to the codex CLI and renders the
+resulting HTTP status in its usage column. cswap refreshes, because autoswitch
+has to compare accounts that nobody has opened in hours, and a stale token
+answers 401 instead of a percentage.
+
+Endpoint, client id and error shape were established empirically against the
+live endpoint using a deliberately invalid refresh token (2026-08-16):
+
+- ``POST https://auth.openai.com/oauth/token`` accepts a **JSON** body.
+- ``client_id=app_EMoamEEZ73f0CkXaXp7hrann``. A public OAuth client identifier
+  shipped inside the publicly distributed ``codex`` binary — it identifies the
+  app, it does not authenticate it, and it is not a secret. (The binary also
+  contains ``app_69a1d78e929881919bba0dbda1f6436d``, which this endpoint rejects
+  with ``invalid_client``; it belongs to something else. Do not "fix" the id
+  back to it.)
+- Failures answer **401**, not 400, and the body is **nested**:
+  ``{"error": {"code": "token_expired", "message": ..., "type": ...}}`` — not
+  RFC 6749's flat ``{"error": "invalid_grant"}``. Both shapes are parsed, since
+  the flat one is what the standard specifies and this endpoint is undocumented.
+
+Nothing here is documented by OpenAI, so every failure mode degrades rather than
+raises: the account renders its status and drops out of autoswitch candidacy,
+and the rest of cswap keeps working.
+
+**The active account is never refreshed from a stored snapshot.** The codex CLI
+holds its own copy of that same refresh token and keeps ``auth.json`` current;
+refreshing our copy in parallel risks invalidating whichever token the server
+rotates away from, and that is a logout. Callers must pass the *live* payload
+for the active account, and snapshots only for inactive ones — see
+``switcher.CodexSwitcher._payload_for_usage``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from claude_swap.codex.auth_file import access_token_expiry
+
+_logger = logging.getLogger(__name__)
+
+OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+
+#: Public OAuth client of the Codex CLI. Verified against the live endpoint —
+#: see the module docstring before changing it.
+OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+OAUTH_SCOPE = "openid profile email offline_access"
+
+#: Refresh this far before nominal expiry. A token that expires mid-request is
+#: indistinguishable from a revoked one at the call site.
+EXPIRY_MARGIN_S = 120.0
+
+#: Server verdicts that will not improve by retrying. ``token_expired`` is this
+#: endpoint's wording for a dead *refresh* token: the account needs a fresh
+#: login, and retrying only wastes requests. Anything not listed here stays
+#: transient — a misclassified transient costs one retry, a misclassified
+#: permanent quarantines a live account.
+PERMANENT_ERRORS = frozenset({"invalid_grant", "invalid_client", "token_expired"})
+
+
+@dataclass(frozen=True)
+class RefreshOutcome:
+    """Result of one refresh attempt.
+
+    ``kind`` is None on success. ``"transient"`` means try again later;
+    everything else is a verdict about this account that will not improve by
+    retrying.
+    """
+
+    payload: dict | None = None
+    kind: str | None = None
+
+
+def needs_refresh(payload: object, *, now: float | None = None) -> bool:
+    """Whether this payload's access token is expired or about to be."""
+    exp = access_token_expiry(payload)
+    if exp is None:
+        # No readable expiry: treat as needing refresh. A pointless refresh
+        # costs one request; a skipped one costs a blank usage row.
+        return True
+    return exp - (now if now is not None else time.time()) <= EXPIRY_MARGIN_S
+
+
+def _error_code(body: str) -> str | None:
+    """Extract the server's error code from either body shape.
+
+    This endpoint nests it (``{"error": {"code": ...}}``); RFC 6749 puts a bare
+    string there. Undocumented endpoints change, so both are read.
+    """
+    try:
+        err = json.loads(body).get("error")
+    except (ValueError, AttributeError):
+        return None
+    if isinstance(err, str):
+        return err
+    if isinstance(err, dict):
+        code = err.get("code") or err.get("type")
+        return code if isinstance(code, str) else None
+    return None
+
+
+def try_refresh(payload: object, timeout_s: float = 10.0) -> RefreshOutcome:
+    """Exchange a refresh token for a fresh access token.
+
+    Returns the updated payload; persisting it is the caller's job, and the
+    caller must do so *immediately and under the store lock* — a rotated
+    refresh token that is never written down is an account lost.
+    """
+    if not isinstance(payload, dict):
+        return RefreshOutcome(kind="transient")
+
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        if payload.get("auth_mode") == "apikey" or payload.get("OPENAI_API_KEY"):
+            return RefreshOutcome(kind="not_applicable")
+        return RefreshOutcome(kind="transient")
+
+    refresh_token = tokens.get("refresh_token")
+    if not refresh_token:
+        return RefreshOutcome(kind="no_refresh_token")
+
+    body = json.dumps(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": OAUTH_CLIENT_ID,
+            "scope": OAUTH_SCOPE,
+        }
+    ).encode()
+
+    try:
+        req = urllib.request.Request(
+            OAUTH_TOKEN_URL,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "claude-swap/1.0",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode(errors="replace") if hasattr(e, "read") else ""
+        # Log the status and the server's code only. The request body carries a
+        # refresh token and the response can echo request context; neither
+        # belongs in a log file users paste into public issues.
+        code = _error_code(raw)
+        _logger.debug("Codex token refresh failed: http-%s (%s)", e.code, code)
+        if e.code in (400, 401, 403) and code in PERMANENT_ERRORS:
+            return RefreshOutcome(kind=code)
+        return RefreshOutcome(kind="transient")
+    except Exception as e:
+        _logger.debug("Codex token refresh failed: %s", type(e).__name__)
+        return RefreshOutcome(kind="transient")
+
+    if not isinstance(data, dict) or not data.get("access_token"):
+        # A 200 that carries no token is not a success; treating it as one would
+        # persist a payload with a stale access token and a possibly-spent
+        # refresh token.
+        return RefreshOutcome(kind="transient")
+
+    updated = dict(payload)
+    new_tokens = dict(tokens)
+    new_tokens["access_token"] = data["access_token"]
+    if data.get("id_token"):
+        new_tokens["id_token"] = data["id_token"]
+    # Absent means "keep using the one you have" (RFC 6749 §6). Overwriting it
+    # with None would destroy the account's only way back.
+    if data.get("refresh_token"):
+        new_tokens["refresh_token"] = data["refresh_token"]
+    updated["tokens"] = new_tokens
+    updated["last_refresh"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return RefreshOutcome(payload=updated)

--- a/src/claude_swap/codex/paths.py
+++ b/src/claude_swap/codex/paths.py
@@ -1,0 +1,74 @@
+"""Path resolution for Codex config and for cswap's own Codex store.
+
+Two distinct roots, deliberately kept apart:
+
+- ``~/.codex`` (or ``$CODEX_HOME``) is the *codex CLI's* directory. cswap reads
+  and writes exactly one file in it, ``auth.json``, and reads codex-auth's
+  ``accounts/registry.json`` once at import time. Nothing else in there is ours.
+- ``<cswap backup root>/codex/`` is cswap's own store, a sibling of the existing
+  Claude ``configs/``/``credentials/``. Keeping it under the same root means the
+  existing purge, backup-root migration and the tests' real-store write guard all
+  cover Codex data for free.
+
+``CODEX_HOME`` mirrors the codex CLI's own env var; resolving it the same way is
+what makes cswap and codex agree on which file is live.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from claude_swap.paths import get_backup_root
+
+
+def get_codex_home() -> Path:
+    """Return the Codex config home (``CODEX_HOME`` or ``~/.codex``)."""
+    env = os.environ.get("CODEX_HOME")
+    if env:
+        return Path(env)
+    return Path.home() / ".codex"
+
+
+def get_live_auth_path() -> Path:
+    """Return the live ``auth.json`` the codex CLI reads and writes."""
+    return get_codex_home() / "auth.json"
+
+
+def get_codex_auth_registry_path() -> Path:
+    """Return codex-auth's registry, read once during the one-time import."""
+    return get_codex_home() / "accounts" / "registry.json"
+
+
+def get_codex_auth_accounts_dir() -> Path:
+    """Return codex-auth's snapshot directory (read-only for cswap)."""
+    return get_codex_home() / "accounts"
+
+
+def get_codex_store_root() -> Path:
+    """Return cswap's own Codex store root."""
+    return get_backup_root() / "codex"
+
+
+def get_codex_sequence_path() -> Path:
+    """Return the slot registry (slot -> account_key and metadata)."""
+    return get_codex_store_root() / "sequence.json"
+
+
+def get_codex_credentials_dir() -> Path:
+    """Return the on-disk snapshot directory (non-macOS, and macOS fallback)."""
+    return get_codex_store_root() / "credentials"
+
+
+def get_codex_cache_dir() -> Path:
+    """Return the usage-cache directory backing ``UsageStore``."""
+    return get_codex_store_root() / "cache"
+
+
+def get_codex_lock_path() -> Path:
+    """Return cswap's Codex lock file.
+
+    Separate from the Claude lock on purpose: a Codex switch and a Claude
+    switch touch disjoint files and must never block each other.
+    """
+    return get_codex_store_root() / ".lock"

--- a/src/claude_swap/codex/plans.py
+++ b/src/claude_swap/codex/plans.py
@@ -1,0 +1,21 @@
+"""Codex plan-tier naming.
+
+codex-auth's schema v4 renamed the tiers to final product semantics. Records
+imported from an older registry — and the ``plan_type`` the usage API returns —
+are normalized through here so one Business account never displays as
+Enterprise in one view and Business in another.
+"""
+
+from __future__ import annotations
+
+#: v4's renames, applied as ONE lookup. Applied sequentially, a legacy ``team``
+#: would pass through ``business`` and land on ``enterprise`` — every Business
+#: account mislabelled one tier up.
+_RENAMES = {"team": "business", "business": "enterprise"}
+
+
+def normalize_plan(plan: object) -> str:
+    """Map a stored or reported plan tier onto v4's final semantics."""
+    if not isinstance(plan, str) or not plan:
+        return ""
+    return _RENAMES.get(plan, plan)

--- a/src/claude_swap/codex/processes.py
+++ b/src/claude_swap/codex/processes.py
@@ -1,0 +1,83 @@
+"""Detect running ``codex`` processes.
+
+A Codex switch rewrites ``auth.json``, but a codex session already running has
+its tokens in memory — it keeps using the old account until restarted. Silently
+switching under a live session is this feature's biggest trap, so a switch that
+finds running processes says so and names their PIDs.
+
+Unlike ``process_detection`` on the Claude side, this cannot read session PID
+files: Claude Code writes ``~/.claude/sessions/{pid}.json`` and codex writes no
+equivalent liveness record (``~/.codex/sessions/`` holds rollout transcripts,
+which outlive the process that wrote them). So the process table is the only
+honest source.
+
+Matching is on the executable's *name*, never a substring of the whole path: a
+directory called ``codex-notes`` would otherwise produce a restart warning on
+every switch, and a warning that fires wrongly is one users learn to ignore.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+
+_logger = logging.getLogger(__name__)
+
+#: Executable names that mean "a Codex session is running". ``codext`` is the
+#: seamless-switching fork; it is still a session worth reporting.
+_CODEX_EXECUTABLES = frozenset({"codex", "codext"})
+
+#: Process listing is advisory — a switch must not stall on it.
+_TIMEOUT_S = 5
+
+
+def _list_processes() -> list[tuple[int, str]]:
+    """Return ``(pid, command path)`` for every visible process."""
+    if sys.platform == "win32":
+        out = subprocess.run(
+            ["tasklist", "/FO", "CSV", "/NH"],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        ).stdout
+        rows: list[tuple[int, str]] = []
+        for line in out.splitlines():
+            parts = [p.strip('"') for p in line.split('","')]
+            if len(parts) >= 2 and parts[1].isdigit():
+                rows.append((int(parts[1]), parts[0]))
+        return rows
+
+    out = subprocess.run(
+        ["ps", "-axo", "pid=,comm="],
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_S,
+    ).stdout
+    rows = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        pid, _, comm = line.partition(" ")
+        if pid.isdigit():
+            rows.append((int(pid), comm.strip()))
+    return rows
+
+
+def _executable_name(command: str) -> str:
+    """The bare executable name of a command path, without a ``.exe`` suffix."""
+    name = command.replace("\\", "/").rsplit("/", 1)[-1]
+    return name[:-4] if name.lower().endswith(".exe") else name
+
+
+def running_codex_pids() -> list[int]:
+    """PIDs of running codex sessions. Never raises."""
+    try:
+        rows = _list_processes()
+    except Exception as e:
+        # If the listing fails we lose a warning, not a switch.
+        _logger.debug("codex process detection failed: %s", type(e).__name__)
+        return []
+    return [pid for pid, cmd in rows if _executable_name(cmd) in _CODEX_EXECUTABLES]

--- a/src/claude_swap/codex/registry_import.py
+++ b/src/claude_swap/codex/registry_import.py
@@ -1,0 +1,142 @@
+"""One-time import of codex-auth's accounts into cswap's own store.
+
+Read-only against ``~/.codex/accounts/``: cswap never writes that tree. The
+user keeps a working codex-auth install and can go back to it — the price is
+that the two stores diverge after the import, which is the accepted cost of
+owning our own format.
+
+Schema support mirrors codex-auth's own history:
+
+- ``version = 2``  email-keyed, no ``account_key`` — nothing to key a snapshot
+  by, so rows are counted as skipped rather than guessed at.
+- ``schema_version = 3`` and ``4`` record-key-based; identical account layout.
+  v4 renamed the plan tiers, and v3 rows are normalized to v4 semantics on the
+  way in so a Business account does not display as Enterprise.
+
+An unknown, newer schema is refused outright. Misreading a format we do not
+know would corrupt the user's account list; reporting "too new" costs them
+nothing but an upgrade.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+from claude_swap.codex import paths as cpaths
+from claude_swap.codex.auth_file import file_key
+from claude_swap.codex.plans import normalize_plan
+from claude_swap.codex.store import CodexStore
+
+_logger = logging.getLogger(__name__)
+
+#: Highest ``schema_version`` this importer understands.
+MAX_SCHEMA = 4
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    """What one import pass did."""
+
+    imported: int = 0
+    skipped: int = 0
+    source: str | None = None
+    unsupported_schema: int | None = None
+
+    @property
+    def did_anything(self) -> bool:
+        return self.imported > 0
+
+
+def _load_registry() -> dict | None:
+    path = cpaths.get_codex_auth_registry_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _rows(data: dict) -> list[dict]:
+    """Normalize the accounts container to a list of row dicts.
+
+    v3/v4 store a list; the v2 loader stored an email-keyed dict.
+    """
+    accounts = data.get("accounts")
+    if isinstance(accounts, list):
+        return [r for r in accounts if isinstance(r, dict)]
+    if isinstance(accounts, dict):
+        return [r for r in accounts.values() if isinstance(r, dict)]
+    return []
+
+
+def import_codex_auth_registry(*, only_if_empty: bool = False) -> ImportResult:
+    """Import codex-auth's accounts. Safe to call repeatedly.
+
+    ``only_if_empty`` is what the automatic first-run path passes: it makes the
+    call a no-op once cswap has any Codex slot of its own, so an import can
+    never overwrite accounts the user has since added or renamed here.
+    """
+    store = CodexStore()
+    if only_if_empty and store.slots():
+        return ImportResult(source=None)
+
+    data = _load_registry()
+    if data is None:
+        return ImportResult(source=None)
+
+    schema = data.get("schema_version") or data.get("version") or 2
+    if not isinstance(schema, int) or schema > MAX_SCHEMA:
+        _logger.warning(
+            "codex-auth registry uses schema %s, newer than this cswap understands "
+            "(max %s); not importing",
+            schema,
+            MAX_SCHEMA,
+        )
+        return ImportResult(
+            unsupported_schema=schema if isinstance(schema, int) else None
+        )
+
+    accounts_dir = cpaths.get_codex_auth_accounts_dir()
+    imported = skipped = 0
+
+    for row in _rows(data):
+        key = row.get("account_key")
+        if not isinstance(key, str) or not key:
+            skipped += 1
+            continue
+
+        snapshot_path = accounts_dir / f"{file_key(key)}.auth.json"
+        try:
+            payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            # The registry row outlived its auth file. Costs this one account.
+            skipped += 1
+            continue
+        if not isinstance(payload, dict):
+            skipped += 1
+            continue
+
+        store.upsert_slot(
+            key,
+            email=str(row.get("email") or ""),
+            plan=normalize_plan(row.get("plan")),
+            workspace_name=str(row.get("account_name") or ""),
+            auth_mode=str(row.get("auth_mode") or "chatgpt"),
+        )
+        alias = row.get("alias")
+        if isinstance(alias, str) and alias:
+            store.set_alias(key, alias)
+        store.write_snapshot(key, payload)
+        imported += 1
+
+    active = data.get("active_account_key")
+    if isinstance(active, str) and active and store.slot_for_key(active):
+        store.set_active(active)
+
+    return ImportResult(
+        imported=imported,
+        skipped=skipped,
+        source=str(cpaths.get_codex_auth_registry_path()),
+    )

--- a/src/claude_swap/codex/store.py
+++ b/src/claude_swap/codex/store.py
@@ -201,6 +201,32 @@ class CodexStore:
         self.delete_snapshot(account_key)
         return True
 
+    def renumber(self, mapping: dict[str, str]) -> None:
+        """Reassign slot numbers: ``{account_key: new_number}``, atomically.
+
+        Only ``sequence.json`` moves. Snapshots are keyed by ``account_key``
+        precisely so renumbering never has to touch a secret — the whole reason
+        this store does not key them by slot.
+        """
+        if not mapping:
+            return
+        data = self._read()
+        accounts = data["accounts"]
+        rows = {
+            row.get("account_key"): (num, row)
+            for num, row in accounts.items()
+            if isinstance(row, dict)
+        }
+        for key in mapping:
+            if key not in rows:
+                raise KeyError(f"unknown account_key: {key}")
+        for key, new_number in mapping.items():
+            old_number, _row = rows[key]
+            accounts.pop(old_number, None)
+        for key, new_number in mapping.items():
+            accounts[str(new_number)] = rows[key][1]
+        self._write(data)
+
     def set_active(self, account_key: str | None) -> None:
         """Record cswap's *intent*. The live auth.json remains the authority on
         what is actually active — see ``auth_file.read_live_identity``."""

--- a/src/claude_swap/codex/store.py
+++ b/src/claude_swap/codex/store.py
@@ -1,0 +1,286 @@
+"""cswap's own Codex account store: slot registry plus credential snapshots.
+
+Two pieces with different lifetimes and different security postures:
+
+- ``sequence.json`` — non-secret metadata (slot number, email, plan, alias,
+  workspace name, disabled flag) keyed by slot number, each row naming its
+  ``account_key``.
+- the snapshot store — one ``auth.json`` payload per account, keyed by
+  ``account_key``, in the macOS Keychain or in 0600 files elsewhere.
+
+Snapshots are keyed by ``account_key`` rather than slot number on purpose. Slot
+numbers are a presentation concern that a future ``cswap codex swap``/``move``
+will renumber; the account key never changes. Keying secrets by a mutable
+number turns that feature into a data migration.
+
+Slot numbers are not compacted when an account is removed: renumbering would
+silently repoint every alias and every number a user has memorised. The gap is
+left, and the next add reuses the lowest free number — the same rule the Claude
+side follows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from claude_swap import macos_keychain
+from claude_swap.codex import paths as cpaths
+from claude_swap.codex.auth_file import file_key
+from claude_swap.models import get_timestamp
+
+#: Keychain service for Codex snapshots. Distinct from the Claude side's so a
+#: purge or an audit can tell the two apart at a glance.
+KEYCHAIN_SERVICE = "claude-swap-codex"
+
+
+@dataclass
+class CodexSlot:
+    """One managed Codex account as stored (no secrets in here)."""
+
+    number: str
+    account_key: str
+    email: str = ""
+    plan: str = ""
+    workspace_name: str = ""
+    alias: str = ""
+    added: str = ""
+    disabled: bool = False
+    auth_mode: str = "chatgpt"
+
+    @property
+    def display_label(self) -> str:
+        """``email [workspace]`` — mirrors ``AccountInfo.display_label``."""
+        tag = self.workspace_name or "personal"
+        return f"{self.email} [{tag}]"
+
+    def to_dict(self) -> dict:
+        return {
+            "account_key": self.account_key,
+            "email": self.email,
+            "plan": self.plan,
+            "workspaceName": self.workspace_name,
+            "alias": self.alias,
+            "added": self.added,
+            "disabled": self.disabled,
+            "authMode": self.auth_mode,
+        }
+
+    @classmethod
+    def from_dict(cls, number: str, data: dict) -> CodexSlot:
+        return cls(
+            number=number,
+            account_key=data.get("account_key", ""),
+            email=data.get("email", "") or "",
+            plan=data.get("plan", "") or "",
+            workspace_name=data.get("workspaceName", "") or "",
+            alias=data.get("alias", "") or "",
+            added=data.get("added", "") or "",
+            disabled=bool(data.get("disabled", False)),
+            auth_mode=data.get("authMode", "chatgpt") or "chatgpt",
+        )
+
+
+class CodexStore:
+    """Reads and writes the Codex slot registry and snapshot store."""
+
+    def __init__(self) -> None:
+        self._sequence_path = cpaths.get_codex_sequence_path()
+        self._credentials_dir = cpaths.get_codex_credentials_dir()
+
+    # ---- slot registry -------------------------------------------------
+
+    def _read(self) -> dict:
+        try:
+            data = json.loads(self._sequence_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            # A missing file is the normal fresh-install case; a corrupt one is
+            # a torn write. Both degrade to "no accounts" rather than making
+            # every cswap command raise.
+            return {"accounts": {}, "activeAccountKey": None}
+        if not isinstance(data, dict):
+            return {"accounts": {}, "activeAccountKey": None}
+        if not isinstance(data.get("accounts"), dict):
+            data["accounts"] = {}
+        data.setdefault("activeAccountKey", None)
+        return data
+
+    def _write(self, data: dict) -> None:
+        self._sequence_path.parent.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(self._sequence_path.parent, 0o700)
+        data["lastUpdated"] = get_timestamp()
+        tmp = self._sequence_path.with_name(self._sequence_path.name + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        if sys.platform != "win32":
+            os.chmod(tmp, 0o600)
+        os.replace(tmp, self._sequence_path)
+
+    def slots(self) -> list[CodexSlot]:
+        """Every managed slot, ordered by slot number."""
+        accounts = self._read()["accounts"]
+        out = [
+            CodexSlot.from_dict(num, row)
+            for num, row in accounts.items()
+            if isinstance(row, dict) and str(num).isdigit()
+        ]
+        out.sort(key=lambda s: int(s.number))
+        return out
+
+    def slot_for_key(self, account_key: str) -> CodexSlot | None:
+        for slot in self.slots():
+            if slot.account_key == account_key:
+                return slot
+        return None
+
+    def _next_free_number(self, accounts: dict) -> str:
+        taken = {int(n) for n in accounts if str(n).isdigit()}
+        n = 1
+        while n in taken:
+            n += 1
+        return str(n)
+
+    def upsert_slot(
+        self,
+        account_key: str,
+        *,
+        email: str = "",
+        plan: str = "",
+        workspace_name: str = "",
+        auth_mode: str = "chatgpt",
+    ) -> CodexSlot:
+        """Create or update the slot for ``account_key``; returns it."""
+        data = self._read()
+        accounts = data["accounts"]
+
+        for num, row in accounts.items():
+            if isinstance(row, dict) and row.get("account_key") == account_key:
+                row["email"] = email or row.get("email", "")
+                row["plan"] = plan or row.get("plan", "")
+                if workspace_name:
+                    row["workspaceName"] = workspace_name
+                row["authMode"] = auth_mode
+                self._write(data)
+                return CodexSlot.from_dict(num, row)
+
+        number = self._next_free_number(accounts)
+        slot = CodexSlot(
+            number=number,
+            account_key=account_key,
+            email=email,
+            plan=plan,
+            workspace_name=workspace_name,
+            added=get_timestamp(),
+            auth_mode=auth_mode,
+        )
+        accounts[number] = slot.to_dict()
+        self._write(data)
+        return slot
+
+    def remove_slot(self, account_key: str) -> bool:
+        """Forget a slot and its snapshot. Returns whether anything was removed."""
+        data = self._read()
+        accounts = data["accounts"]
+        target = next(
+            (
+                num
+                for num, row in accounts.items()
+                if isinstance(row, dict) and row.get("account_key") == account_key
+            ),
+            None,
+        )
+        if target is None:
+            return False
+        del accounts[target]
+        if data.get("activeAccountKey") == account_key:
+            data["activeAccountKey"] = None
+        self._write(data)
+        self.delete_snapshot(account_key)
+        return True
+
+    def set_active(self, account_key: str | None) -> None:
+        """Record cswap's *intent*. The live auth.json remains the authority on
+        what is actually active — see ``auth_file.read_live_identity``."""
+        data = self._read()
+        data["activeAccountKey"] = account_key
+        self._write(data)
+
+    def active_key(self) -> str | None:
+        return self._read().get("activeAccountKey")
+
+    def active_number(self) -> str | None:
+        key = self.active_key()
+        if not key:
+            return None
+        slot = self.slot_for_key(key)
+        return slot.number if slot else None
+
+    def set_alias(self, account_key: str, alias: str) -> None:
+        self._mutate(account_key, "alias", alias)
+
+    def set_disabled(self, account_key: str, disabled: bool) -> None:
+        self._mutate(account_key, "disabled", bool(disabled))
+
+    def set_workspace_name(self, account_key: str, name: str) -> None:
+        self._mutate(account_key, "workspaceName", name)
+
+    def _mutate(self, account_key: str, field_name: str, value: object) -> None:
+        data = self._read()
+        for row in data["accounts"].values():
+            if isinstance(row, dict) and row.get("account_key") == account_key:
+                row[field_name] = value
+                self._write(data)
+                return
+
+    # ---- snapshot store ------------------------------------------------
+
+    def _use_keychain(self) -> bool:
+        return sys.platform == "darwin"
+
+    def _snapshot_path(self, account_key: str) -> Path:
+        return self._credentials_dir / f"{file_key(account_key)}.json"
+
+    def write_snapshot(self, account_key: str, payload: dict) -> None:
+        """Persist one account's ``auth.json`` payload."""
+        blob = json.dumps(payload)
+        if self._use_keychain():
+            macos_keychain.set_password(KEYCHAIN_SERVICE, file_key(account_key), blob)
+            return
+        self._credentials_dir.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(self._credentials_dir, 0o700)
+        path = self._snapshot_path(account_key)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(blob, encoding="utf-8")
+        if sys.platform != "win32":
+            os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+
+    def read_snapshot(self, account_key: str) -> dict | None:
+        """Read one account's stored payload, or None when absent/corrupt."""
+        if self._use_keychain():
+            blob = macos_keychain.get_password(KEYCHAIN_SERVICE, file_key(account_key))
+        else:
+            try:
+                blob = self._snapshot_path(account_key).read_text(encoding="utf-8")
+            except OSError:
+                blob = None
+        if not blob:
+            return None
+        try:
+            data = json.loads(blob)
+        except ValueError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def delete_snapshot(self, account_key: str) -> None:
+        if self._use_keychain():
+            macos_keychain.delete_password(KEYCHAIN_SERVICE, file_key(account_key))
+            return
+        try:
+            self._snapshot_path(account_key).unlink()
+        except OSError:
+            pass

--- a/src/claude_swap/codex/switcher.py
+++ b/src/claude_swap/codex/switcher.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass, field
 from claude_swap.codex import paths as cpaths
 from claude_swap.codex.auth_file import (
     CodexIdentity,
+    access_token_expiry,
     parse_identity,
     read_live_payload,
     write_live_auth,
@@ -49,6 +50,7 @@ from claude_swap.codex.oauth import needs_refresh, try_refresh
 from claude_swap.codex.processes import running_codex_pids
 from claude_swap.codex.store import CodexSlot, CodexStore
 from claude_swap.codex.usage_cache import CodexUsageCache
+from claude_swap.codex.workspaces import refresh_workspace_names
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.locking import FileLock, LockError
 from claude_swap.models import AccountSnapshot, AccountsSnapshot, normalize_alias
@@ -193,11 +195,21 @@ class CodexSwitcher:
         if not wanted:
             return self._cache.entries(slots)
 
+        def payload_for(slot: CodexSlot) -> dict | None:
+            return self._payload_for_usage(slot, active)
+
         refreshed = self._cache.refresh(
-            wanted,
-            payload_for=lambda slot: self._payload_for_usage(slot, active),
-            active_number=active,
+            wanted, payload_for=payload_for, active_number=active
         )
+
+        # Workspace names ride along with a usage fetch rather than getting
+        # their own pass: they change approximately never, and the grouped-scope
+        # rules mean most users never issue this request at all.
+        try:
+            refresh_workspace_names(self._store, payload_for=payload_for)
+        except Exception as e:  # pragma: no cover - defensive
+            # A missing workspace name is cosmetic and must never fail a listing.
+            _logger.debug("codex workspace refresh failed: %s", type(e).__name__)
         # Slots the caller did not ask about still render from cache.
         entries = self._cache.entries(slots)
         entries.update(refreshed)
@@ -206,8 +218,10 @@ class CodexSwitcher:
     def accounts_snapshot(self, fetch: set[str] | None = None) -> AccountsSnapshot:
         """One coherent pass over every managed Codex account."""
         active = self.current_account_number()
+        usage = self._usage_for(self._store.slots(), fetch, active)
+        # Re-read: a fetching pass may have filled in workspace names, and the
+        # rows must show what the store holds now, not what it held before.
         slots = self._store.slots()
-        usage = self._usage_for(slots, fetch, active)
         rows: list[AccountSnapshot] = []
 
         for slot in slots:
@@ -371,6 +385,33 @@ class CodexSwitcher:
             for s in self._store.slots()
             if not s.disabled and s.auth_mode != "apikey"
         ]
+
+    def token_status(self, identifier: str) -> dict:
+        """Diagnostics for one slot's stored token. Never returns token material.
+
+        Deliberately reports only derived facts — when it expires, whether a
+        refresh is due, when it last refreshed. The token itself is what these
+        diagnostics exist to avoid making people paste into an issue.
+        """
+        slot = self._slot_or_raise(identifier)
+        payload = self._store.read_snapshot(slot.account_key)
+        if payload is None:
+            return {"number": slot.number, "state": "no credentials"}
+        if slot.auth_mode == "apikey":
+            return {"number": slot.number, "state": "api key"}
+
+        tokens = payload.get("tokens") or {}
+        exp = access_token_expiry(payload)
+        now = time.time()
+        return {
+            "number": slot.number,
+            "state": "oauth",
+            "expiresAt": exp,
+            "expiresInSeconds": (exp - now) if exp is not None else None,
+            "refreshDue": needs_refresh(payload, now=now),
+            "hasRefreshToken": bool(tokens.get("refresh_token")),
+            "lastRefresh": payload.get("last_refresh"),
+        }
 
     def account_numbers(self) -> list[str]:
         """Every managed slot number, rotation-eligible or not.

--- a/src/claude_swap/codex/switcher.py
+++ b/src/claude_swap/codex/switcher.py
@@ -52,6 +52,7 @@ from claude_swap.codex.usage import fetch_usage
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.locking import FileLock, LockError
 from claude_swap.models import AccountSnapshot, AccountsSnapshot, normalize_alias
+from claude_swap.printer import dimmed, warning
 from claude_swap.usage_store import UsageEntry
 
 _logger = logging.getLogger(__name__)
@@ -307,7 +308,29 @@ class CodexSwitcher:
         )
 
     def remove_account(self, identifier: str, assume_yes: bool = False) -> None:
+        """Forget an account and delete its stored credentials.
+
+        Prompts unless ``assume_yes``, mirroring the Claude side (whose TUI
+        collects confirmation before calling and passes True). Removal deletes
+        the Keychain item too, so an unprompted destructive verb here would
+        diverge from its sibling for no reason.
+        """
         slot = self._slot_or_raise(identifier)
+
+        if slot.number == self.current_account_number():
+            warning(
+                f"Warning: Codex account {slot.number} ({slot.email}) is currently active"
+            )
+
+        if not assume_yes:
+            confirm = input(
+                f"Are you sure you want to permanently remove "
+                f"Codex account {slot.number} ({slot.email})? [y/N] "
+            )
+            if confirm.lower() != "y":
+                print(dimmed("Cancelled"))
+                return
+
         self._store.remove_slot(slot.account_key)
 
     def set_alias(self, identifier: str, alias: str) -> tuple[str, str]:

--- a/src/claude_swap/codex/switcher.py
+++ b/src/claude_swap/codex/switcher.py
@@ -181,17 +181,24 @@ class CodexSwitcher:
     def _usage_for(
         self, slots: list[CodexSlot], fetch: set[str] | None, active: str | None
     ) -> dict[str, UsageEntry]:
-        """Usage for every slot, refreshing only those asked for and due.
+        """Usage for every slot, refreshing those eligible and due.
 
-        The cache decides what a "due" fetch is (serve TTL, poll plan, backoff,
-        cross-process lease). This method's only job is to hand it the payload
-        rule — which is where the never-refresh-the-active-account invariant
-        lives, so the cache never has to know about it.
+        ``fetch`` carries the Claude side's documented semantics, which the TUI
+        and every other shared consumer rely on: **None makes every account
+        eligible**, and a set restricts which accounts *may* be fetched this
+        pass (so an empty set means "no network at all"). Getting this backwards
+        is invisible from the CLI, which always passes an explicit set — and
+        would make the dashboard silently never refresh Codex usage.
+
+        The cache decides what a "due" fetch actually is (serve TTL, poll plan,
+        backoff, cross-process lease). This method's only job is to hand it the
+        payload rule — which is where the never-refresh-the-active-account
+        invariant lives, so the cache never has to know about it.
         """
         if not slots:
             return {}
 
-        wanted = [s for s in slots if fetch is not None and s.number in fetch]
+        wanted = [s for s in slots if fetch is None or s.number in fetch]
         if not wanted:
             return self._cache.entries(slots)
 

--- a/src/claude_swap/codex/switcher.py
+++ b/src/claude_swap/codex/switcher.py
@@ -25,11 +25,11 @@ and a CLI switch in another terminal are concurrent by construction, and an
 interleaved capture/write would put one account's tokens in another's slot. The
 lock is the Codex store's own, so it never contends with a Claude switch.
 
-**Stage 1 does not cache usage.** Every fetch here is a live request; the
-``UsageStore`` + ``poll_policy`` integration (TTL, backoff, 429 handling, age
-display) lands in Stage 2. Until then ``cswap codex list`` costs one request per
-account — fine for a handful of accounts and a human at a terminal, not fine for
-an auto loop. Autoswitch must not ship before that caching does.
+Usage goes through ``CodexUsageCache``, which is this provider's adapter onto
+the same ``UsageStore`` + ``poll_policy`` machinery the Claude side uses: serve
+TTL, cross-process fetch leases, failure backoff, 429 handling and an adaptive
+cadence. Two consecutive ``cswap codex list`` calls therefore cost one round of
+requests, not two.
 """
 
 from __future__ import annotations
@@ -48,7 +48,7 @@ from claude_swap.codex.auth_file import (
 from claude_swap.codex.oauth import needs_refresh, try_refresh
 from claude_swap.codex.processes import running_codex_pids
 from claude_swap.codex.store import CodexSlot, CodexStore
-from claude_swap.codex.usage import fetch_usage
+from claude_swap.codex.usage_cache import CodexUsageCache
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.locking import FileLock, LockError
 from claude_swap.models import AccountSnapshot, AccountsSnapshot, normalize_alias
@@ -76,6 +76,7 @@ class CodexSwitcher:
 
     def __init__(self, debug: bool = False) -> None:
         self._store = CodexStore()
+        self._cache = CodexUsageCache(self._store)
 
     def _lock(self, timeout: float = 10.0) -> FileLock:
         """The Codex store's cross-process lock.
@@ -175,31 +176,46 @@ class CodexSwitcher:
 
     # ---- read model ----------------------------------------------------
 
-    def _usage_entry(self, slot: CodexSlot, payload: dict | None, fetch: bool) -> UsageEntry:
-        if slot.auth_mode == "apikey":
-            return UsageEntry(sentinel="api key")
-        if not fetch:
-            return UsageEntry()
-        if payload is None:
-            return UsageEntry(sentinel="no credentials")
+    def _usage_for(
+        self, slots: list[CodexSlot], fetch: set[str] | None, active: str | None
+    ) -> dict[str, UsageEntry]:
+        """Usage for every slot, refreshing only those asked for and due.
 
-        tokens = payload.get("tokens") or {}
-        result = fetch_usage(
-            tokens.get("access_token") or "",
-            tokens.get("account_id") or slot.account_key.rpartition("::")[2],
+        The cache decides what a "due" fetch is (serve TTL, poll plan, backoff,
+        cross-process lease). This method's only job is to hand it the payload
+        rule — which is where the never-refresh-the-active-account invariant
+        lives, so the cache never has to know about it.
+        """
+        if not slots:
+            return {}
+
+        wanted = [s for s in slots if fetch is not None and s.number in fetch]
+        if not wanted:
+            return self._cache.entries(slots)
+
+        refreshed = self._cache.refresh(
+            wanted,
+            payload_for=lambda slot: self._payload_for_usage(slot, active),
+            active_number=active,
         )
-        if result.usage is None:
-            return UsageEntry(sentinel=result.sentinel)
-        return UsageEntry(last_good=result.usage, fetched_at=time.time(), age_s=0.0)
+        # Slots the caller did not ask about still render from cache.
+        entries = self._cache.entries(slots)
+        entries.update(refreshed)
+        return entries
 
     def accounts_snapshot(self, fetch: set[str] | None = None) -> AccountsSnapshot:
         """One coherent pass over every managed Codex account."""
         active = self.current_account_number()
+        slots = self._store.slots()
+        usage = self._usage_for(slots, fetch, active)
         rows: list[AccountSnapshot] = []
 
-        for slot in self._store.slots():
-            wants_fetch = fetch is not None and slot.number in fetch
-            payload = self._payload_for_usage(slot, active) if wants_fetch else None
+        for slot in slots:
+            entry = usage.get(slot.number, UsageEntry())
+            if slot.auth_mode == "apikey":
+                # Derived every pass, never persisted: an API-key account has no
+                # usage to fetch, and a stored sentinel would outlive the fact.
+                entry = UsageEntry(sentinel="api key")
             rows.append(
                 AccountSnapshot(
                     number=slot.number,
@@ -209,7 +225,7 @@ class CodexSwitcher:
                     is_active=slot.number == active,
                     kind="api_key" if slot.auth_mode == "apikey" else "oauth",
                     switchable=slot.auth_mode != "apikey",
-                    usage=self._usage_entry(slot, payload, wants_fetch),
+                    usage=entry,
                     alias=slot.alias,
                     disabled=slot.disabled,
                     provider="codex",

--- a/src/claude_swap/codex/switcher.py
+++ b/src/claude_swap/codex/switcher.py
@@ -1,0 +1,342 @@
+"""CodexSwitcher — the Codex provider's verbs.
+
+Small on purpose. It implements ``providers.base.ProviderSwitcher`` and nothing
+else; the Claude switcher's provenance machinery has no analogue here and is not
+imitated.
+
+Two rules carry this module, and both exist because the codex CLI owns
+``~/.codex/auth.json`` and writes to it whenever it likes:
+
+1. **The live file decides who is active.** ``current_account_number`` reads the
+   live file's identity and matches it to a slot. cswap's own ``activeAccountKey``
+   records intent only. A session left open on account A can rewrite the live
+   file minutes after a switch to B; a registry-derived answer would report B
+   while every codex command runs as A.
+
+2. **The active account is never refreshed from its snapshot.** The codex CLI
+   holds the same refresh token and keeps the live file current. If the server
+   rotates refresh tokens, two parties refreshing the same one means one of them
+   is logged out. So: active account reads the live payload; inactive accounts
+   refresh from their snapshots, and a rotated token is written back
+   immediately, before it is used for anything else.
+
+Both of those writes happen under ``FileLock`` on the Codex store: a TUI refresh
+and a CLI switch in another terminal are concurrent by construction, and an
+interleaved capture/write would put one account's tokens in another's slot. The
+lock is the Codex store's own, so it never contends with a Claude switch.
+
+**Stage 1 does not cache usage.** Every fetch here is a live request; the
+``UsageStore`` + ``poll_policy`` integration (TTL, backoff, 429 handling, age
+display) lands in Stage 2. Until then ``cswap codex list`` costs one request per
+account — fine for a handful of accounts and a human at a terminal, not fine for
+an auto loop. Autoswitch must not ship before that caching does.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+
+from claude_swap.codex import paths as cpaths
+from claude_swap.codex.auth_file import (
+    CodexIdentity,
+    parse_identity,
+    read_live_payload,
+    write_live_auth,
+)
+from claude_swap.codex.oauth import needs_refresh, try_refresh
+from claude_swap.codex.processes import running_codex_pids
+from claude_swap.codex.store import CodexSlot, CodexStore
+from claude_swap.codex.usage import fetch_usage
+from claude_swap.exceptions import ClaudeSwitchError
+from claude_swap.locking import FileLock, LockError
+from claude_swap.models import AccountSnapshot, AccountsSnapshot, normalize_alias
+from claude_swap.usage_store import UsageEntry
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CodexSwitchResult:
+    """What a switch did, including anything the user must act on."""
+
+    number: str
+    email: str
+    #: PIDs of codex sessions running at switch time. Non-empty means the user
+    #: must restart them before the new account takes effect.
+    running_pids: list[int] = field(default_factory=list)
+
+
+class CodexSwitcher:
+    """Multi-account switcher for the Codex CLI."""
+
+    provider_id = "codex"
+
+    def __init__(self, debug: bool = False) -> None:
+        self._store = CodexStore()
+
+    def _lock(self, timeout: float = 10.0) -> FileLock:
+        """The Codex store's cross-process lock.
+
+        Its own file, never the Claude one: the two switches touch disjoint
+        state and must not be able to block each other.
+        """
+        return FileLock(cpaths.get_codex_lock_path(), timeout=timeout)
+
+    # ---- identity ------------------------------------------------------
+
+    def _live_identity(self) -> CodexIdentity | None:
+        payload = read_live_payload()
+        return parse_identity(payload) if payload is not None else None
+
+    def current_account_number(self) -> str | None:
+        """The slot the *live file* currently holds, or None if unmanaged."""
+        ident = self._live_identity()
+        if ident is None or not ident.is_identifiable:
+            return None
+        slot = self._store.slot_for_key(ident.account_key)
+        return slot.number if slot else None
+
+    def resolve_account(self, identifier: str) -> tuple[str, str, str]:
+        """Resolve a slot number, email or alias to ``(number, email, label)``."""
+        needle = (identifier or "").strip().lower()
+        if needle:
+            for slot in self._store.slots():
+                candidates = {slot.number, slot.email.lower()}
+                if slot.alias:
+                    candidates.add(slot.alias.lower())
+                if needle in candidates:
+                    return slot.number, slot.email, slot.display_label
+        raise ClaudeSwitchError(f"No Codex account matches '{identifier}'")
+
+    def _slot_or_raise(self, identifier: str) -> CodexSlot:
+        number, _email, _label = self.resolve_account(identifier)
+        slot = next((s for s in self._store.slots() if s.number == number), None)
+        if slot is None:  # pragma: no cover - resolve_account already raised
+            raise ClaudeSwitchError(f"No Codex account '{identifier}'")
+        return slot
+
+    # ---- credentials ---------------------------------------------------
+
+    def _capture_live(self) -> None:
+        """Store the live login into the slot its own identity matches.
+
+        Matching on the live file's identity rather than on the registry's idea
+        of the active slot is what makes this repair a clobber instead of
+        committing one.
+        """
+        payload = read_live_payload()
+        if payload is None:
+            return
+        ident = parse_identity(payload)
+        if ident is None or not ident.is_identifiable:
+            return
+        slot = self._store.slot_for_key(ident.account_key)
+        if slot is None:
+            return  # an unmanaged login: not ours to store
+        self._store.write_snapshot(slot.account_key, payload)
+
+    def _payload_for_usage(self, slot: CodexSlot, active_number: str | None) -> dict | None:
+        """The payload to read this slot's usage from, refreshed if needed.
+
+        The active slot is read from the live file and never refreshed here —
+        see this module's docstring.
+        """
+        if slot.number == active_number:
+            return read_live_payload()
+
+        payload = self._store.read_snapshot(slot.account_key)
+        if payload is None or slot.auth_mode == "apikey":
+            return payload
+
+        if not needs_refresh(payload):
+            return payload
+
+        # The lock is taken BEFORE the refresh, not around the persist alone.
+        # If the server rotates the refresh token, the old one may die the
+        # instant the response is issued — so a refresh we cannot persist is a
+        # refresh we must not perform. Refusing to refresh costs a stale usage
+        # row; refreshing without persisting can cost the account.
+        try:
+            with self._lock(timeout=15.0):
+                outcome = try_refresh(payload)
+                if outcome.payload is None:
+                    _logger.debug("codex slot %s refresh: %s", slot.number, outcome.kind)
+                    return payload
+                self._store.write_snapshot(slot.account_key, outcome.payload)
+                return outcome.payload
+        except LockError:
+            # Another cswap process holds the store. Skip this account's refresh
+            # this pass; the caller renders whatever the stale token yields.
+            _logger.debug("codex slot %s not refreshed: store busy", slot.number)
+            return payload
+
+    # ---- read model ----------------------------------------------------
+
+    def _usage_entry(self, slot: CodexSlot, payload: dict | None, fetch: bool) -> UsageEntry:
+        if slot.auth_mode == "apikey":
+            return UsageEntry(sentinel="api key")
+        if not fetch:
+            return UsageEntry()
+        if payload is None:
+            return UsageEntry(sentinel="no credentials")
+
+        tokens = payload.get("tokens") or {}
+        result = fetch_usage(
+            tokens.get("access_token") or "",
+            tokens.get("account_id") or slot.account_key.rpartition("::")[2],
+        )
+        if result.usage is None:
+            return UsageEntry(sentinel=result.sentinel)
+        return UsageEntry(last_good=result.usage, fetched_at=time.time(), age_s=0.0)
+
+    def accounts_snapshot(self, fetch: set[str] | None = None) -> AccountsSnapshot:
+        """One coherent pass over every managed Codex account."""
+        active = self.current_account_number()
+        rows: list[AccountSnapshot] = []
+
+        for slot in self._store.slots():
+            wants_fetch = fetch is not None and slot.number in fetch
+            payload = self._payload_for_usage(slot, active) if wants_fetch else None
+            rows.append(
+                AccountSnapshot(
+                    number=slot.number,
+                    email=slot.email,
+                    org_name=slot.workspace_name,
+                    org_uuid="",
+                    is_active=slot.number == active,
+                    kind="api_key" if slot.auth_mode == "apikey" else "oauth",
+                    switchable=slot.auth_mode != "apikey",
+                    usage=self._usage_entry(slot, payload, wants_fetch),
+                    alias=slot.alias,
+                    disabled=slot.disabled,
+                    provider="codex",
+                )
+            )
+
+        return AccountsSnapshot(
+            active_number=active,
+            accounts=tuple(rows),
+            taken_at=time.time(),
+            provider="codex",
+        )
+
+    # ---- verbs ---------------------------------------------------------
+
+    def add_account(self, alias: str = "") -> CodexSlot:
+        """Capture whoever is currently logged in to the codex CLI."""
+        payload = read_live_payload()
+        ident = parse_identity(payload) if payload is not None else None
+        if payload is None or ident is None:
+            raise ClaudeSwitchError(
+                "No Codex login found. Run 'cswap codex login' (or 'codex login') first."
+            )
+        if not ident.is_identifiable:
+            raise ClaudeSwitchError(
+                "The current Codex login carries no account id, so it cannot be "
+                "told apart from another account. API-key logins are not "
+                "switchable."
+            )
+
+        normalized = normalize_alias(alias) if alias else ""
+
+        try:
+            with self._lock():
+                slot = self._store.upsert_slot(
+                    ident.account_key,
+                    email=ident.email,
+                    plan=ident.plan,
+                    auth_mode="apikey" if ident.is_api_key else "chatgpt",
+                )
+                self._store.write_snapshot(ident.account_key, payload)
+                self._store.set_active(ident.account_key)
+                if normalized:
+                    self._store.set_alias(ident.account_key, normalized)
+        except LockError as e:
+            raise ClaudeSwitchError(
+                "Another cswap process is using the Codex store; try again."
+            ) from e
+        return slot
+
+    def switch_to(self, identifier: str) -> CodexSwitchResult:
+        """Activate a stored account.
+
+        Held under the store lock end to end: capture-then-write is exactly the
+        sequence a concurrent switch or TUI refresh could interleave with, and
+        an interleaving lands one account's tokens in another's slot.
+        """
+        slot = self._slot_or_raise(identifier)
+
+        try:
+            with self._lock():
+                target = self._store.read_snapshot(slot.account_key)
+                if target is None:
+                    raise ClaudeSwitchError(
+                        f"Codex account {slot.number} has no stored credentials"
+                    )
+
+                previous_live = read_live_payload()
+                previous_active = self._store.active_key()
+
+                self._capture_live()
+                try:
+                    write_live_auth(target)
+                except OSError as e:
+                    # Put the live file back exactly as it was; a half-switched
+                    # login is worse than a failed one.
+                    if previous_live is not None:
+                        try:
+                            write_live_auth(previous_live)
+                        except OSError:
+                            _logger.error("codex switch rollback failed")
+                    self._store.set_active(previous_active)
+                    raise ClaudeSwitchError(
+                        f"Failed to activate Codex account: {e}"
+                    ) from e
+
+                self._store.set_active(slot.account_key)
+        except LockError as e:
+            raise ClaudeSwitchError(
+                "Another cswap process is using the Codex store; try again."
+            ) from e
+
+        # Outside the lock: process detection is advisory and shells out.
+        return CodexSwitchResult(
+            number=slot.number, email=slot.email, running_pids=running_codex_pids()
+        )
+
+    def remove_account(self, identifier: str, assume_yes: bool = False) -> None:
+        slot = self._slot_or_raise(identifier)
+        self._store.remove_slot(slot.account_key)
+
+    def set_alias(self, identifier: str, alias: str) -> tuple[str, str]:
+        slot = self._slot_or_raise(identifier)
+        normalized = normalize_alias(alias)
+        self._store.set_alias(slot.account_key, normalized)
+        return slot.number, normalized
+
+    def unset_alias(self, identifier: str) -> str:
+        slot = self._slot_or_raise(identifier)
+        self._store.set_alias(slot.account_key, "")
+        return slot.number
+
+    def set_account_disabled(self, identifier: str, disabled: bool) -> None:
+        slot = self._slot_or_raise(identifier)
+        self._store.set_disabled(slot.account_key, disabled)
+
+    def switchable_account_numbers(self) -> list[str]:
+        """Slots eligible for automatic rotation."""
+        return [
+            s.number
+            for s in self._store.slots()
+            if not s.disabled and s.auth_mode != "apikey"
+        ]
+
+    def account_numbers(self) -> list[str]:
+        """Every managed slot number, rotation-eligible or not.
+
+        Public so callers that want "fetch usage for all of them" do not have to
+        reach into the store — the CLI's ``list`` is the first such caller.
+        """
+        return [s.number for s in self._store.slots()]

--- a/src/claude_swap/codex/switcher.py
+++ b/src/claude_swap/codex/switcher.py
@@ -386,7 +386,15 @@ class CodexSwitcher:
         self._store.set_disabled(slot.account_key, disabled)
 
     def switchable_account_numbers(self) -> list[str]:
-        """Slots eligible for automatic rotation."""
+        """Slots eligible for automatic rotation.
+
+        API-key accounts are excluded unconditionally, and unlike the Claude
+        side this is **not** governed by ``autoswitch.includeApiKeyAccounts``.
+        That setting exists because a Claude API-key account is a real rotation
+        target that simply bills per token; a Codex API-key login reports no
+        usage at all, so there is nothing to compare it against and nothing for
+        a threshold to mean. Documented rather than silently divergent.
+        """
         return [
             s.number
             for s in self._store.slots()

--- a/src/claude_swap/codex/switcher.py
+++ b/src/claude_swap/codex/switcher.py
@@ -54,7 +54,7 @@ from claude_swap.codex.workspaces import refresh_workspace_names
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.locking import FileLock, LockError
 from claude_swap.models import AccountSnapshot, AccountsSnapshot, normalize_alias
-from claude_swap.printer import dimmed, warning
+from claude_swap.printer import accent, bolded, dimmed, muted, warning
 from claude_swap.usage_store import UsageEntry
 
 _logger = logging.getLogger(__name__)
@@ -401,6 +401,56 @@ class CodexSwitcher:
             if not s.disabled and s.auth_mode != "apikey"
         ]
 
+    def status(self, json_output: bool = False) -> dict | None:
+        """Print (or return) the active account's status.
+
+        Renders through the Claude side's own ``_usage_entry_lines`` and
+        ``usage_fields`` rather than a Codex-shaped copy, so the two providers
+        produce byte-identical status blocks — which is the point: a user should
+        not have to learn a second output format for the same information.
+        """
+        from claude_swap.json_output import SCHEMA_VERSION, usage_fields
+        from claude_swap.switcher import _usage_entry_lines
+
+        number = self.current_account_number()
+        if number is None:
+            if json_output:
+                return {"schemaVersion": SCHEMA_VERSION, "provider": "codex", "active": None}
+            print(f"{bolded('Status:')} {dimmed('No active Codex account')}")
+            return None
+
+        slot = self._slot_or_raise(number)
+        entry = self._usage_for(self._store.slots(), None, number).get(
+            number, UsageEntry()
+        )
+
+        if json_output:
+            state, usage = usage_fields(entry.decision_value(), entry.fetched_at)
+            return {
+                "schemaVersion": SCHEMA_VERSION,
+                "provider": "codex",
+                "active": {
+                    "number": int(slot.number),
+                    "email": slot.email,
+                    "workspace": slot.workspace_name,
+                    "alias": slot.alias,
+                    "plan": slot.plan,
+                    "managed": True,
+                    "usageStatus": state,
+                    "usage": usage,
+                },
+                "totalAccounts": len(self._store.slots()),
+            }
+
+        print(
+            f"{bolded('Status:')} {accent(f'Codex-{slot.number}')} "
+            f"({slot.email} {muted(f'[{slot.workspace_name or "personal"}]')})"
+        )
+        print(f"  {dimmed(f'Total managed Codex accounts: {len(self._store.slots())}')}")
+        for line in _usage_entry_lines(entry):
+            print(f"  {line}")
+        return None
+
     def token_status(self, identifier: str) -> dict:
         """Diagnostics for one slot's stored token. Never returns token material.
 
@@ -427,6 +477,94 @@ class CodexSwitcher:
             "hasRefreshToken": bool(tokens.get("refresh_token")),
             "lastRefresh": payload.get("last_refresh"),
         }
+
+    def swap_accounts(self, first: str, second: str) -> tuple[str, str]:
+        """Exchange two accounts' slot numbers.
+
+        Only ``sequence.json`` changes: snapshots are keyed by ``account_key``,
+        which is exactly why they are — renumbering never has to move a secret.
+        """
+        a = self._slot_or_raise(first)
+        b = self._slot_or_raise(second)
+        if a.number == b.number:
+            raise ClaudeSwitchError("Cannot swap an account with itself")
+        try:
+            with self._lock():
+                self._store.renumber({a.account_key: b.number, b.account_key: a.number})
+        except LockError as e:
+            raise ClaudeSwitchError(
+                "Another cswap process is using the Codex store; try again."
+            ) from e
+        return a.number, b.number
+
+    def move_account(self, account: str, target: str) -> tuple[str, str, bool]:
+        """Give an account a specific slot number, swapping if it is taken.
+
+        Returns ``(from, to, swapped)``.
+        """
+        slot = self._slot_or_raise(account)
+        target = str(target).strip()
+        if not target.isdigit() or int(target) < 1:
+            raise ClaudeSwitchError(f"'{target}' is not a valid slot number")
+        if slot.number == target:
+            return slot.number, target, False
+
+        occupant = next(
+            (s for s in self._store.slots() if s.number == target), None
+        )
+        mapping = {slot.account_key: target}
+        if occupant is not None:
+            mapping[occupant.account_key] = slot.number
+        try:
+            with self._lock():
+                self._store.renumber(mapping)
+        except LockError as e:
+            raise ClaudeSwitchError(
+                "Another cswap process is using the Codex store; try again."
+            ) from e
+        return slot.number, target, occupant is not None
+
+    def rotate(self) -> CodexSwitchResult:
+        """Switch to the next rotatable account after the active one.
+
+        Bare ``cswap switch`` rotates on the Claude side; ``cswap codex switch``
+        does the same rather than erroring on a missing argument.
+        """
+        candidates = self.switchable_account_numbers()
+        if not candidates:
+            raise ClaudeSwitchError("No rotatable Codex accounts")
+        active = self.current_account_number()
+        if active is None or active not in candidates:
+            return self.switch_to(candidates[0])
+        if len(candidates) == 1:
+            raise ClaudeSwitchError(
+                "Only one rotatable Codex account — nothing to rotate to"
+            )
+        nxt = candidates[(candidates.index(active) + 1) % len(candidates)]
+        return self.switch_to(nxt)
+
+    def switch_best(self) -> CodexSwitchResult:
+        """Switch to whichever rotatable account has the most headroom."""
+        from claude_swap.codex.autoswitch import binding_pct
+
+        snapshot = self.accounts_snapshot(fetch=None)
+        rotatable = set(self.switchable_account_numbers())
+        active = self.current_account_number()
+
+        best, best_pct = None, None
+        for account in snapshot.accounts:
+            if account.number not in rotatable or account.number == active:
+                continue
+            pct = binding_pct(account)
+            if pct is None:
+                continue
+            if best_pct is None or pct < best_pct:
+                best, best_pct = account, pct
+        if best is None:
+            raise ClaudeSwitchError(
+                "No Codex account with a known measurement to switch to"
+            )
+        return self.switch_to(best.number)
 
     def account_numbers(self) -> list[str]:
         """Every managed slot number, rotation-eligible or not.

--- a/src/claude_swap/codex/transfer.py
+++ b/src/claude_swap/codex/transfer.py
@@ -1,0 +1,192 @@
+"""Export and import Codex accounts, and purge cswap's Codex data.
+
+The export file contains **live OAuth tokens**. That is the point — an export
+you cannot log in with is not a backup — but it makes the file exactly as
+sensitive as the Keychain items it came from, so it is written 0600 and the
+format says so in a top-level ``warning`` field that any tool reading it will
+surface.
+
+Deliberately a separate format from the Claude side's: the two providers store
+different things (``account_key`` and an ``auth.json`` payload here, an
+org-scoped credential blob there), and one file that had to describe both would
+be a union type nobody could validate. A ``provider`` field means an import can
+refuse a file from the wrong side rather than half-applying it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from claude_swap.codex import paths as cpaths
+from claude_swap.codex.store import CodexStore
+from claude_swap.exceptions import ClaudeSwitchError
+
+#: Bumped when the on-disk export shape changes incompatibly.
+EXPORT_VERSION = 1
+
+_WARNING = (
+    "This file contains live OAuth tokens for the accounts below. "
+    "Anyone who can read it can use those accounts. Keep it private and "
+    "delete it once imported."
+)
+
+
+def export_codex_accounts(
+    switcher, destination: str, account: str | None = None
+) -> int:
+    """Write accounts (with credentials) to ``destination``; ``-`` is stdout.
+
+    Returns how many accounts were written.
+    """
+    store = CodexStore()
+    slots = store.slots()
+    if account:
+        number, _email, _label = switcher.resolve_account(account)
+        slots = [s for s in slots if s.number == number]
+    if not slots:
+        raise ClaudeSwitchError("No Codex accounts to export")
+
+    accounts = []
+    for slot in slots:
+        payload = store.read_snapshot(slot.account_key)
+        if payload is None:
+            # An account with no credentials cannot be imported anywhere; a
+            # silent empty row would look like a successful backup.
+            continue
+        accounts.append(
+            {
+                "accountKey": slot.account_key,
+                "email": slot.email,
+                "plan": slot.plan,
+                "workspaceName": slot.workspace_name,
+                "alias": slot.alias,
+                "disabled": slot.disabled,
+                "authMode": slot.auth_mode,
+                "auth": payload,
+            }
+        )
+    if not accounts:
+        raise ClaudeSwitchError("No Codex accounts with stored credentials to export")
+
+    document = {
+        "version": EXPORT_VERSION,
+        "provider": "codex",
+        "warning": _WARNING,
+        "accounts": accounts,
+    }
+    blob = json.dumps(document, indent=2)
+
+    if destination == "-":
+        print(blob)
+        return len(accounts)
+
+    path = Path(destination).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Created 0600 *before* the tokens go in, not chmod'ed afterwards: between
+    # write and chmod the file would be world-readable.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(blob)
+    return len(accounts)
+
+
+def import_codex_accounts(switcher, source: str, force: bool = False) -> int:
+    """Read accounts from ``source`` (``-`` is stdin) into the store."""
+    if source == "-":
+        raw = sys.stdin.read()
+    else:
+        path = Path(source).expanduser()
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as e:
+            raise ClaudeSwitchError(f"Cannot read {source}: {e}") from e
+
+    try:
+        document = json.loads(raw)
+    except ValueError as e:
+        raise ClaudeSwitchError(f"{source} is not valid JSON: {e}") from e
+    if not isinstance(document, dict):
+        raise ClaudeSwitchError(f"{source} is not a cswap export")
+
+    provider = document.get("provider")
+    if provider is not None and provider != "codex":
+        # Refuse rather than half-apply: a Claude export's rows describe
+        # different fields entirely.
+        raise ClaudeSwitchError(
+            f"{source} is a '{provider}' export, not a Codex one"
+        )
+    version = document.get("version")
+    if isinstance(version, int) and version > EXPORT_VERSION:
+        raise ClaudeSwitchError(
+            f"{source} uses export version {version}, newer than this cswap understands"
+        )
+
+    rows = document.get("accounts")
+    if not isinstance(rows, list) or not rows:
+        raise ClaudeSwitchError(f"{source} contains no accounts")
+
+    store = CodexStore()
+    existing = {s.account_key for s in store.slots()}
+    imported = 0
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        key = row.get("accountKey")
+        payload = row.get("auth")
+        if not isinstance(key, str) or not key or not isinstance(payload, dict):
+            continue
+        if key in existing and not force:
+            continue
+        store.upsert_slot(
+            key,
+            email=str(row.get("email") or ""),
+            plan=str(row.get("plan") or ""),
+            workspace_name=str(row.get("workspaceName") or ""),
+            auth_mode=str(row.get("authMode") or "chatgpt"),
+        )
+        alias = row.get("alias")
+        if isinstance(alias, str) and alias:
+            store.set_alias(key, alias)
+        if row.get("disabled"):
+            store.set_disabled(key, True)
+        store.write_snapshot(key, payload)
+        imported += 1
+
+    return imported
+
+
+def purge_codex_data(assume_yes: bool = False) -> bool:
+    """Delete every Codex account cswap manages. Returns whether it ran.
+
+    Removes the Keychain items too — a purge that left the secrets behind would
+    be worse than none, since nothing would list them any more.
+    """
+    store = CodexStore()
+    slots = store.slots()
+    root = cpaths.get_codex_store_root()
+
+    if not slots and not root.exists():
+        print("No cswap Codex data to remove.")
+        return False
+
+    if not assume_yes:
+        answer = input(
+            f"Remove {len(slots)} managed Codex account(s) and all cswap Codex "
+            "data? Your ~/.codex login is left alone. [y/N] "
+        )
+        if answer.lower() != "y":
+            print("Cancelled")
+            return False
+
+    for slot in slots:
+        store.delete_snapshot(slot.account_key)
+
+    import shutil
+
+    shutil.rmtree(root, ignore_errors=True)
+    print(f"Removed {len(slots)} Codex account(s) and {root}")
+    return True

--- a/src/claude_swap/codex/usage.py
+++ b/src/claude_swap/codex/usage.py
@@ -113,8 +113,10 @@ def build_usage_result(data: object) -> dict | None:
     if isinstance(rate_limit, dict):
         # Classify by declared length, never by key name — see the module
         # docstring. Both keys are read, and whichever is weekly-length becomes
-        # seven_day. A later window of the same class wins, since the API lists
-        # primary first and a duplicate class is not something to average.
+        # seven_day. If both windows classify the same way (not observed, but
+        # nothing in the response forbids it), the FIRST wins: the API lists
+        # primary first, and averaging two windows of one class would invent a
+        # number the server never reported.
         for key in ("primary_window", "secondary_window"):
             raw = rate_limit.get(key)
             window = _window(raw)

--- a/src/claude_swap/codex/usage.py
+++ b/src/claude_swap/codex/usage.py
@@ -1,0 +1,170 @@
+"""Fetch ChatGPT usage and shape it the way the rest of cswap already reads.
+
+The whole point of this module is the mapping. cswap's renderers, its pace
+calculation, its JSON output and its autoswitch comparison all consume a dict
+with ``five_hour``/``seven_day`` windows of ``{"pct", "resets_at", "countdown",
+"clock"}``. Producing exactly that shape from the ChatGPT response is what lets
+every Claude-side consumer handle a Codex account with no branching at all.
+
+Two conversions matter and are easy to get wrong:
+
+- ChatGPT reports ``used_percent``; cswap's key is ``pct``.
+- ChatGPT reports ``resets_at`` as epoch seconds; ``pace.compute_pace`` parses
+  an ISO string. A raw epoch would silently disable pace for every Codex row.
+
+Failure is reported, never raised: a broken account shows its status in the
+usage column (codex-auth's behavior, wording included) and drops out of
+autoswitch candidacy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from claude_swap.codex.plans import normalize_plan
+from claude_swap.oauth import format_reset
+
+_logger = logging.getLogger(__name__)
+
+USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+ACCOUNTS_URL = "https://chatgpt.com/backend-api/accounts"
+
+USER_AGENT = "claude-swap/1.0"
+
+
+@dataclass(frozen=True)
+class UsageFetch:
+    """One usage fetch: either a usage dict, or a sentinel explaining why not."""
+
+    usage: dict | None = None
+    sentinel: str | None = None
+
+
+def _iso(epoch: object) -> str | None:
+    """Convert epoch seconds to an ISO-8601 UTC string, or None."""
+    if not isinstance(epoch, (int, float)) or isinstance(epoch, bool) or epoch <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(float(epoch), tz=timezone.utc).isoformat()
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _window(raw: object) -> dict | None:
+    """Map one ChatGPT usage window onto cswap's window shape."""
+    if not isinstance(raw, dict):
+        return None
+    pct = raw.get("used_percent")
+    if not isinstance(pct, (int, float)) or isinstance(pct, bool):
+        return None
+    entry: dict = {"pct": pct}
+    resets_at = _iso(raw.get("resets_at"))
+    if resets_at:
+        entry["resets_at"] = resets_at
+        entry["countdown"], entry["clock"] = format_reset(resets_at)
+    return entry
+
+
+def build_usage_result(data: object) -> dict | None:
+    """Normalize a ``wham/usage`` response into cswap's usage dict."""
+    if not isinstance(data, dict):
+        return None
+
+    result: dict = {}
+
+    primary = _window(data.get("primary"))
+    if primary:
+        result["five_hour"] = primary
+
+    secondary = _window(data.get("secondary"))
+    if secondary:
+        result["seven_day"] = secondary
+
+    credits = data.get("credits")
+    if isinstance(credits, dict) and credits.get("has_credits"):
+        result["spend"] = {
+            "unlimited": bool(credits.get("unlimited")),
+            "balance": credits.get("balance"),
+        }
+
+    plan = normalize_plan(data.get("plan_type"))
+    if plan:
+        result["plan"] = plan
+
+    return result or None
+
+
+def _get_json(url: str, access_token: str, account_id: str, timeout_s: float) -> object:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "ChatGPT-Account-Id": account_id,
+            "User-Agent": USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+        return json.loads(resp.read().decode())
+
+
+def fetch_usage(
+    access_token: str, account_id: str, timeout_s: float = 10.0
+) -> UsageFetch:
+    """Fetch one account's usage. Never raises."""
+    if not access_token or not account_id:
+        # codex-auth's wording, kept so a user who knows one tool reads the
+        # other's output without translation.
+        return UsageFetch(sentinel="MissingAuth")
+
+    try:
+        data = _get_json(USAGE_URL, access_token, account_id, timeout_s)
+    except urllib.error.HTTPError as e:
+        _logger.debug("Codex usage fetch failed: http-%s", e.code)
+        return UsageFetch(sentinel=f"http {e.code}")
+    except urllib.error.URLError as e:
+        _logger.debug("Codex usage fetch failed: network (%s)", type(e).__name__)
+        return UsageFetch(sentinel="network")
+    except Exception as e:
+        _logger.debug("Codex usage fetch failed: %s", type(e).__name__)
+        return UsageFetch(sentinel="bad-response")
+
+    usage = build_usage_result(data)
+    if usage is None:
+        return UsageFetch(sentinel="bad-response")
+    return UsageFetch(usage=usage)
+
+
+def fetch_workspace_names(
+    access_token: str, account_id: str, timeout_s: float = 10.0
+) -> dict[str, str]:
+    """Map ``chatgpt_account_id`` to workspace name.
+
+    Entries with a null or empty name are omitted rather than stored as an
+    empty string, so a later successful fetch can still fill them in. Failures
+    return an empty mapping — a missing workspace name is cosmetic and must
+    never fail a listing.
+    """
+    if not access_token or not account_id:
+        return {}
+    try:
+        data = _get_json(ACCOUNTS_URL, access_token, account_id, timeout_s)
+    except Exception as e:
+        _logger.debug("Codex account fetch failed: %s", type(e).__name__)
+        return {}
+
+    items = data.get("items") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        return {}
+    out: dict[str, str] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        ident, name = item.get("id"), item.get("name")
+        if ident and isinstance(name, str) and name:
+            out[str(ident)] = name
+    return out

--- a/src/claude_swap/codex/usage.py
+++ b/src/claude_swap/codex/usage.py
@@ -75,6 +75,29 @@ class UsageFetch:
 
     usage: dict | None = None
     sentinel: str | None = None
+    #: The server's ``Retry-After``, in seconds, when it sent one. Honouring it
+    #: is the difference between backing off and being rate-limited harder.
+    retry_after_s: float | None = None
+
+
+def _retry_after_seconds(err: urllib.error.HTTPError) -> float | None:
+    """Parse a ``Retry-After`` header. Only the delta-seconds form is read.
+
+    RFC 9110 also permits an HTTP-date, but this endpoint has only ever been
+    observed sending seconds, and a misparsed date that yields a huge backoff
+    would silently park an account for hours.
+    """
+    try:
+        raw = err.headers.get("Retry-After")
+    except AttributeError:
+        return None
+    if raw is None:
+        return None
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    return value if value >= 0 else None
 
 
 def _iso(epoch: object) -> str | None:
@@ -176,8 +199,13 @@ def fetch_usage(
     try:
         data = _get_json(USAGE_URL, access_token, account_id, timeout_s)
     except urllib.error.HTTPError as e:
-        _logger.debug("Codex usage fetch failed: http-%s", e.code)
-        return UsageFetch(sentinel=f"http {e.code}")
+        retry_after = _retry_after_seconds(e)
+        _logger.debug(
+            "Codex usage fetch failed: http-%s%s",
+            e.code,
+            f", retry-after {retry_after:.0f}s" if retry_after is not None else "",
+        )
+        return UsageFetch(sentinel=f"http {e.code}", retry_after_s=retry_after)
     except urllib.error.URLError as e:
         _logger.debug("Codex usage fetch failed: network (%s)", type(e).__name__)
         return UsageFetch(sentinel="network")

--- a/src/claude_swap/codex/usage.py
+++ b/src/claude_swap/codex/usage.py
@@ -6,11 +6,37 @@ with ``five_hour``/``seven_day`` windows of ``{"pct", "resets_at", "countdown",
 "clock"}``. Producing exactly that shape from the ChatGPT response is what lets
 every Claude-side consumer handle a Codex account with no branching at all.
 
-Two conversions matter and are easy to get wrong:
+The wire shape was read off the live endpoint (2026-08-16), not inferred from
+codex-auth. That distinction cost a bug: codex-auth's ``registry.json`` stores
+its own *normalized* view under ``last_usage`` as ``primary``/``secondary`` with
+``resets_at``, and it is tempting to assume the API returns the same. It does
+not. The response is::
 
+    plan_type: str
+    rate_limit:
+      allowed: bool
+      limit_reached: bool
+      primary_window:   {used_percent, limit_window_seconds,
+                         reset_after_seconds, reset_at}
+      secondary_window: {same} | null
+    credits: {has_credits, unlimited, overage_limit_reached, balance, ...}
+
+Four conversions matter and are each easy to get wrong:
+
+- the windows are nested under ``rate_limit``, not top level.
 - ChatGPT reports ``used_percent``; cswap's key is ``pct``.
-- ChatGPT reports ``resets_at`` as epoch seconds; ``pace.compute_pace`` parses
-  an ISO string. A raw epoch would silently disable pace for every Codex row.
+- ChatGPT reports ``reset_at`` as epoch seconds; ``pace.compute_pace`` parses an
+  ISO string. A raw epoch would silently disable pace for every Codex row.
+- **``primary_window`` is not necessarily the 5-hour window.** Its length is
+  data, carried in ``limit_window_seconds``, and it varies by plan. Both live
+  Plus accounts measured here reported a ``primary_window`` of 604800 s — a
+  *week* — with ``secondary_window: null``. Mapping by position would have
+  labelled weekly usage as 5-hourly: the displayed row would be wrong, and
+  ``pace`` (which only applies to weekly windows) would never fire for any Codex
+  account. So windows are classified by their declared length, not their key.
+
+An absent window is normal — a plan may genuinely have only one — and must
+render as absent, never as 0% used.
 
 Failure is reported, never raised: a broken account shows its status in the
 usage column (codex-auth's behavior, wording included) and drops out of
@@ -36,6 +62,12 @@ ACCOUNTS_URL = "https://chatgpt.com/backend-api/accounts"
 
 USER_AGENT = "claude-swap/1.0"
 
+#: A rate-limit window at or above this length is cswap's "weekly" window;
+#: anything shorter is the "5h" one. One day is a wide moat between the two real
+#: values (5 h and 7 d), so a plan with, say, a 24-hour window would have to be
+#: invented before this needs revisiting.
+WEEKLY_WINDOW_MIN_S = 86400
+
 
 @dataclass(frozen=True)
 class UsageFetch:
@@ -56,14 +88,14 @@ def _iso(epoch: object) -> str | None:
 
 
 def _window(raw: object) -> dict | None:
-    """Map one ChatGPT usage window onto cswap's window shape."""
+    """Map one ChatGPT rate-limit window onto cswap's window shape."""
     if not isinstance(raw, dict):
         return None
     pct = raw.get("used_percent")
     if not isinstance(pct, (int, float)) or isinstance(pct, bool):
         return None
     entry: dict = {"pct": pct}
-    resets_at = _iso(raw.get("resets_at"))
+    resets_at = _iso(raw.get("reset_at"))
     if resets_at:
         entry["resets_at"] = resets_at
         entry["countdown"], entry["clock"] = format_reset(resets_at)
@@ -77,13 +109,31 @@ def build_usage_result(data: object) -> dict | None:
 
     result: dict = {}
 
-    primary = _window(data.get("primary"))
-    if primary:
-        result["five_hour"] = primary
+    rate_limit = data.get("rate_limit")
+    if isinstance(rate_limit, dict):
+        # Classify by declared length, never by key name — see the module
+        # docstring. Both keys are read, and whichever is weekly-length becomes
+        # seven_day. A later window of the same class wins, since the API lists
+        # primary first and a duplicate class is not something to average.
+        for key in ("primary_window", "secondary_window"):
+            raw = rate_limit.get(key)
+            window = _window(raw)
+            if not window:
+                continue
+            length = raw.get("limit_window_seconds")
+            if isinstance(length, (int, float)) and not isinstance(length, bool):
+                slot = "seven_day" if length >= WEEKLY_WINDOW_MIN_S else "five_hour"
+            else:
+                # No declared length: fall back to the conventional positions.
+                slot = "five_hour" if key == "primary_window" else "seven_day"
+            result.setdefault(slot, window)
 
-    secondary = _window(data.get("secondary"))
-    if secondary:
-        result["seven_day"] = secondary
+    # A response with no rate-limit window at all is not usable usage: every
+    # consumer (the renderers, pace, the autoswitch comparison) needs a window,
+    # and returning a plan-only dict renders as a blank row with no explanation
+    # — which is exactly how the first live run failed.
+    if "five_hour" not in result and "seven_day" not in result:
+        return None
 
     credits = data.get("credits")
     if isinstance(credits, dict) and credits.get("has_credits"):
@@ -96,7 +146,7 @@ def build_usage_result(data: object) -> dict | None:
     if plan:
         result["plan"] = plan
 
-    return result or None
+    return result
 
 
 def _get_json(url: str, access_token: str, account_id: str, timeout_s: float) -> object:

--- a/src/claude_swap/codex/usage_cache.py
+++ b/src/claude_swap/codex/usage_cache.py
@@ -1,0 +1,170 @@
+"""Codex usage fetching, behind the same cache the Claude side uses.
+
+Stage 1 fetched live on every call: one request per account per ``cswap codex
+list``. Fine for a human at a terminal, unacceptable for an auto loop that ticks
+every few minutes. This module puts Codex behind ``UsageStore`` +
+``poll_policy``, which already implement — and have tests for — serve TTL,
+cross-process fetch leases, failure backoff, 429 handling with ``Retry-After``,
+and an adaptive cadence that speeds up when usage is moving.
+
+None of that is reimplemented here. ``UsageStore`` stores an opaque ``lastGood``
+dict guarded by an identity tuple, so it was already provider-neutral; this
+module is the adapter that decides *which* slots need a request, performs those,
+and records the outcomes.
+
+**Identity for Codex is ``(email, chatgpt_account_id)``.** The store's guard
+exists so a slot reused for a different account never serves its predecessor's
+usage; the account id is exactly what distinguishes two workspaces of one user,
+so it takes the ``organizationUuid`` position the Claude side uses.
+
+**The active-account rule lives in the caller.** ``payload_for`` is supplied by
+``CodexSwitcher``, which is what enforces "never refresh the active account from
+its snapshot". Keeping it a callback means this module never needs to know that
+rule, and the rule stays in one place.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import replace
+from typing import Callable
+
+from claude_swap.codex import paths as cpaths
+from claude_swap.codex.store import CodexSlot, CodexStore
+from claude_swap.codex.usage import fetch_usage
+from claude_swap.poll_policy import plan_after_fetch
+from claude_swap.usage_store import FetchRecord, UsageEntry, UsageStore
+
+_logger = logging.getLogger(__name__)
+
+#: Sentinels are derived state, re-computed every pass and never persisted.
+#: Anything in this set is recorded as a no-op rather than as a failure, so a
+#: structurally unusable account does not accrue backoff it can never clear.
+_NON_FAILURE_SENTINELS = frozenset({"MissingAuth", "api key", "no credentials"})
+
+
+class CodexUsageCache:
+    """Decides which Codex slots need a request, fetches those, records them."""
+
+    def __init__(self, store: CodexStore, clock: Callable[[], float] = time.time) -> None:
+        self._store = store
+        self._clock = clock
+        self._usage = UsageStore(cpaths.get_codex_cache_dir(), clock=clock)
+
+    @staticmethod
+    def identity_for(slot: CodexSlot) -> tuple[str, str]:
+        """The store's identity guard for one slot."""
+        return (slot.email, slot.account_key.rpartition("::")[2])
+
+    def identities(self, slots: list[CodexSlot]) -> dict[str, tuple[str, str]]:
+        return {s.number: self.identity_for(s) for s in slots}
+
+    def entries(self, slots: list[CodexSlot]) -> dict[str, UsageEntry]:
+        """Cached read model for these slots. Never touches the network."""
+        return self._usage.entries(self.identities(slots))
+
+    def refresh(
+        self,
+        slots: list[CodexSlot],
+        *,
+        payload_for: Callable[[CodexSlot], dict | None],
+        threshold: float = 100.0,
+        active_number: str | None = None,
+    ) -> dict[str, UsageEntry]:
+        """Fetch whichever of ``slots`` is genuinely due, then return them all.
+
+        A slot that is fresh, in backoff, or already leased by another process
+        is served from cache without a request — that is the entire point.
+        """
+        if not slots:
+            return {}
+
+        by_number = {s.number: s for s in slots}
+        identities = self.identities(slots)
+
+        # respect_plans=True: the on-demand caller contract. Fetch only when the
+        # entry is both stale and poll-due, so a second `cswap codex list`
+        # seconds after the first costs nothing.
+        claims = self._usage.reserve(
+            list(by_number), identities, respect_plans=True
+        )
+
+        sentinels: dict[str, str] = {}
+
+        if claims:
+            before = self._usage.entries(identities)
+            outcomes: dict[str, FetchRecord] = {}
+            plans: dict[str, tuple[float | None, float | None]] = {}
+
+            for number in claims:
+                slot = by_number[number]
+                outcomes[number], plan = self._fetch_one(
+                    slot,
+                    payload_for(slot),
+                    prev=before.get(number),
+                    threshold=threshold,
+                    is_active=number == active_number,
+                )
+                if plan is not None:
+                    plans[number] = plan
+
+            self._usage.record(outcomes, identities, claims=claims, plans=plans)
+
+            # A sentinel is a live overlay, re-derived every pass and never
+            # persisted (see UsageEntry). The store therefore cannot hand it
+            # back, so this pass's sentinels are laid over the read here —
+            # otherwise "api key" or a 401 would render as a blank row.
+            sentinels = {
+                num: (rec.sentinel or rec.error)
+                for num, rec in outcomes.items()
+                if rec.sentinel is not None or rec.error is not None
+            }
+
+        entries = self._usage.entries(identities)
+        for number, sentinel in sentinels.items():
+            entries[number] = replace(entries[number], sentinel=sentinel)
+        return entries
+
+    def _fetch_one(
+        self,
+        slot: CodexSlot,
+        payload: dict | None,
+        *,
+        prev: UsageEntry | None,
+        threshold: float,
+        is_active: bool,
+    ) -> tuple[FetchRecord, tuple[float | None, float | None] | None]:
+        """One account's fetch, as a record the store can merge."""
+        if slot.auth_mode == "apikey":
+            return FetchRecord(sentinel="api key"), None
+        if payload is None:
+            return FetchRecord(sentinel="no credentials"), None
+
+        tokens = payload.get("tokens") or {}
+        result = fetch_usage(
+            tokens.get("access_token") or "",
+            tokens.get("account_id") or slot.account_key.rpartition("::")[2],
+        )
+
+        if result.usage is not None:
+            now = self._clock()
+            plan = plan_after_fetch(
+                prev_interval_s=prev.poll_interval_s if prev else None,
+                prev_usage=prev.last_good if prev else None,
+                new_usage=result.usage,
+                is_active=is_active,
+                threshold=threshold,
+                models=(),
+                recent_429=prev.recent_429(now) if prev else False,
+                now=now,
+            )
+            return FetchRecord(usage=result.usage), plan
+
+        sentinel = result.sentinel or "bad-response"
+        if sentinel in _NON_FAILURE_SENTINELS:
+            # Derived state, not a server failure: recording it as an error
+            # would accrue backoff the account can never clear by itself.
+            return FetchRecord(sentinel=sentinel), None
+
+        return FetchRecord(error=sentinel, retry_after_s=result.retry_after_s), None

--- a/src/claude_swap/codex/workspaces.py
+++ b/src/claude_swap/codex/workspaces.py
@@ -1,0 +1,107 @@
+"""Refresh Business/Enterprise/Edu workspace names.
+
+A personal ChatGPT account has no workspace name; a Business, Enterprise or Edu
+one does, and it is what tells two of a user's workspaces apart in a listing.
+The name is not in the token — it only comes from ``/backend-api/accounts``.
+
+The point of this module is **not** fetching, it is *not* fetching. Asking for
+workspace names on every listing would add a request per user scope to every
+``cswap codex list``, forever, to fill a field that changes approximately never.
+So codex-auth's grouped-scope rules (its ``docs/api.md``) are followed exactly:
+
+- A scope is all stored slots sharing one ``chatgpt_user_id``. One user can hold
+  several workspaces; one request answers for all of them.
+- A request is attempted only when the scope holds **more than one** record, at
+  least one of them is a workspace plan, and at least one such record still has
+  no name. A single personal account therefore never triggers a request.
+- At most one request per scope per pass.
+- Matched records overwrite the stored name even when they already had one — the
+  server is authoritative, and a renamed workspace should follow.
+- In-scope records the response does *not* return are cleared back to empty:
+  leaving a stale name for a workspace the user has lost access to is worse than
+  showing none.
+- Any failure is non-fatal and leaves stored names untouched. A missing
+  workspace name is cosmetic; it must never fail a listing.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+
+from claude_swap.codex.store import CodexSlot, CodexStore
+from claude_swap.codex.usage import fetch_workspace_names
+
+_logger = logging.getLogger(__name__)
+
+#: Plans that have a workspace name worth fetching. A personal plan never does.
+WORKSPACE_PLANS = frozenset({"business", "enterprise", "edu"})
+
+
+def _user_id(slot: CodexSlot) -> str:
+    return slot.account_key.partition("::")[0]
+
+
+def _account_id(slot: CodexSlot) -> str:
+    return slot.account_key.rpartition("::")[2]
+
+
+def scope_needs_refresh(scope: list[CodexSlot]) -> bool:
+    """Whether this ``chatgpt_user_id`` scope justifies a request."""
+    if len(scope) <= 1:
+        return False
+    workspace_slots = [s for s in scope if s.plan in WORKSPACE_PLANS]
+    if not workspace_slots:
+        return False
+    return any(not s.workspace_name for s in workspace_slots)
+
+
+def refresh_workspace_names(
+    store: CodexStore,
+    *,
+    payload_for,
+) -> int:
+    """Fill in missing workspace names. Returns how many names changed.
+
+    ``payload_for`` is the same callback the usage cache takes, so this obeys
+    the never-refresh-the-active-account rule without knowing about it.
+    """
+    scopes: dict[str, list[CodexSlot]] = defaultdict(list)
+    for slot in store.slots():
+        if slot.auth_mode == "apikey":
+            continue
+        scopes[_user_id(slot)].append(slot)
+
+    changed = 0
+    for scope in scopes.values():
+        if not scope_needs_refresh(scope):
+            continue
+
+        # One request per scope. Any slot in it can ask on the scope's behalf,
+        # so use the first with usable credentials.
+        names: dict[str, str] = {}
+        for slot in scope:
+            payload = payload_for(slot)
+            tokens = (payload or {}).get("tokens") or {}
+            token, account_id = tokens.get("access_token"), tokens.get("account_id")
+            if not token or not account_id:
+                continue
+            names = fetch_workspace_names(token, account_id)
+            break
+
+        if not names:
+            # Includes the failure case: leave every stored name untouched.
+            continue
+
+        for slot in scope:
+            returned = names.get(_account_id(slot))
+            if returned is not None:
+                if returned != slot.workspace_name:
+                    store.set_workspace_name(slot.account_key, returned)
+                    changed += 1
+            elif slot.workspace_name and slot.plan in WORKSPACE_PLANS:
+                # In scope, a workspace plan, and not returned: access is gone.
+                store.set_workspace_name(slot.account_key, "")
+                changed += 1
+
+    return changed

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -422,13 +422,23 @@ def _adapt_snapshot(snap) -> dict:
     active_alias = None
     for acc in snap.accounts:
         display = _account_display_usage(acc.usage)
+        # Non-Claude rows carry their composite row key in the `num` slot and a
+        # provider tag in the label. Slot numbers repeat across providers, so a
+        # bare number here would send a menu click to the wrong CLI's account —
+        # and the tuple shape stays 8-wide, which every consumer unpacks exactly.
+        provider = getattr(acc, "provider", "claude")
+        is_claude = provider == "claude"
+        num = acc.number if is_claude else acc.key
+        label = acc.email if is_claude else f"{acc.email} ({provider})"
         accounts.append(
             (
-                acc.number, acc.email, acc.is_active, display, acc.usage.last_good,
+                num, label, acc.is_active, display, acc.usage.last_good,
                 acc.alias, acc.disabled, acc.usage.fetched_at,
             )
         )
-        if acc.is_active:
+        if acc.is_active and is_claude:
+            # The title bar keeps meaning the Claude account: it is what the
+            # user's `claude` command will run as.
             active_email, active_usage, active_alias = acc.email, display, acc.alias
     return {
         "accounts": accounts,
@@ -436,6 +446,23 @@ def _adapt_snapshot(snap) -> dict:
         "active_usage": active_usage,
         "active_alias": active_alias,
     }
+
+
+
+def _resolve_menu_row(app, num: str):
+    """``(provider, slot number)`` for a menu row's ``num`` field.
+
+    A bare number is the Claude switcher, so every pre-multi-provider path is
+    unchanged. Anything else is a composite row key from ``_adapt_snapshot``.
+    """
+    key = str(num)
+    if ":" not in key:
+        return app.switcher, key
+    provider_id, number = key.split(":", 1)
+    for provider in getattr(app, "providers", []):
+        if getattr(provider, "provider_id", "") == provider_id:
+            return provider, number
+    return app.switcher, number
 
 
 def run(switcher) -> int:
@@ -479,7 +506,11 @@ def run(switcher) -> int:
             # alternate, so an open menu costs O(1) requests per window instead
             # of a full pass per tick — which kept every token at its per-account
             # rate-limit edge. Reused across refreshes to hold its pacing state.
-            self._snapshot_source = SnapshotSource(switcher)
+            from claude_swap.providers.aggregate import MultiSnapshotSource
+            from claude_swap.providers.registry import available_providers
+
+            self.providers = available_providers(switcher)
+            self._snapshot_source = MultiSnapshotSource(self.providers)
             self.snapshot = dict(EMPTY_SNAPSHOT)
             self._dirty = False
             self._snapshot_at = 0.0
@@ -517,7 +548,9 @@ def run(switcher) -> int:
             # runs it already paces all fetching, so the display reads store-only.
             try:
                 try:
-                    raw = self._snapshot_source.take(
+                    # MultiSnapshotSource returns (snapshot, owners); the menu
+                    # resolves providers from `num` keys, so owners is unused here.
+                    raw, _owners = self._snapshot_source.take(
                         full=full, store_only=self._engine is not None
                     )
                 except Exception:
@@ -801,7 +834,8 @@ def run(switcher) -> int:
 
         def _make_switch_to(self, num):
             def cb(_sender):
-                if self._guard(lambda: self.switcher.switch_to(str(num))):
+                _p, _n = _resolve_menu_row(self, num)
+                if self._guard(lambda: _p.switch_to(_n)):
                     self._notify_switched()
                     self.refresh_async()
             return cb
@@ -821,7 +855,8 @@ def run(switcher) -> int:
                     ok="Remove",
                     cancel="Cancel",
                 ) == 1:  # 1 == OK
-                    if self._guard(lambda: self.switcher.remove_account(str(num), assume_yes=True)):
+                    _p, _n = _resolve_menu_row(self, num)
+                    if self._guard(lambda: _p.remove_account(_n, assume_yes=True)):
                         self.refresh_async()
             return cb
 
@@ -830,7 +865,9 @@ def run(switcher) -> int:
             target = not disabled
             def cb(_sender):
                 if self._guard(
-                    lambda: self.switcher.set_account_disabled(str(num), target)
+                    lambda: _resolve_menu_row(self, num)[0].set_account_disabled(
+                        _resolve_menu_row(self, num)[1], target
+                    )
                 ):
                     self.refresh_async()
             return cb

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -864,10 +864,9 @@ def run(switcher) -> int:
             # `disabled` is this row's current state; selecting it flips it.
             target = not disabled
             def cb(_sender):
+                provider, number = _resolve_menu_row(self, num)
                 if self._guard(
-                    lambda: _resolve_menu_row(self, num)[0].set_account_disabled(
-                        _resolve_menu_row(self, num)[1], target
-                    )
+                    lambda: provider.set_account_disabled(number, target)
                 ):
                     self.refresh_async()
             return cb

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -151,6 +151,17 @@ class AccountSnapshot:
         """Org tag for display: the org name, or 'personal'."""
         return self.org_name if self.org_name else "personal"
 
+    @property
+    def key(self) -> str:
+        """Identity that stays unique once more than one provider is listed.
+
+        Slot numbers are per-provider, so "1" names a Claude account *and* a
+        Codex one. Any surface that shows both — the dashboard, the menu bar —
+        must address rows by this instead of by ``number``, or a keystroke aimed
+        at one provider lands on the other.
+        """
+        return f"{self.provider}:{self.number}"
+
 
 @dataclass(frozen=True)
 class AccountsSnapshot:

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -140,6 +140,11 @@ class AccountSnapshot:
     usage: UsageEntry
     alias: str = ""
     disabled: bool = False  # held out of auto-rotation (still a valid explicit target)
+    # Which CLI this account belongs to ("claude" | "codex"). Defaulted so every
+    # existing construction site — and every test that builds a snapshot
+    # positionally — keeps working untouched; only multi-provider consumers
+    # (the TUI grouping, the auto loop) ever read it.
+    provider: str = "claude"
 
     @property
     def display_tag(self) -> str:
@@ -159,6 +164,7 @@ class AccountsSnapshot:
     active_number: str | None
     accounts: tuple[AccountSnapshot, ...]
     taken_at: float
+    provider: str = "claude"
 
 
 @dataclass

--- a/src/claude_swap/providers/__init__.py
+++ b/src/claude_swap/providers/__init__.py
@@ -1,0 +1,9 @@
+"""Provider registry.
+
+cswap manages accounts for more than one AI CLI. Each provider owns its own
+account store, credential format and usage API; what they share is the read
+model (``AccountSnapshot``/``UsageEntry``) and a small set of verbs, which is
+where the seam sits — see ``providers.base.ProviderSwitcher``.
+"""
+
+from __future__ import annotations

--- a/src/claude_swap/providers/aggregate.py
+++ b/src/claude_swap/providers/aggregate.py
@@ -1,0 +1,162 @@
+"""Merge several providers' snapshots into the one view a shell renders.
+
+The dashboard and the menu bar each want a single ordered list of accounts, not
+a list per provider. This module produces that list — Claude's accounts first,
+then Codex's, each row already tagged with its provider — plus the lookup a
+shell needs to send a keystroke back to the switcher that owns the row.
+
+Two properties matter more than they look:
+
+- **Order is stable and provider-major.** Rows are grouped, never interleaved by
+  usage, so the row under the cursor does not move between refreshes and a
+  keystroke aimed at one provider cannot land on the other.
+- **One provider's failure must not blank the others.** A snapshot that raises
+  is dropped with a log line; the surviving providers still render. A dashboard
+  that goes empty because a secondary provider's store is corrupt is a much
+  worse outcome than one missing section.
+
+``active_number`` on the merged snapshot is the *Claude* active slot, because
+every existing consumer of that field means Claude by it. Per-provider active
+state is on each row's ``is_active``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
+from claude_swap.providers.base import ProviderSwitcher
+
+_logger = logging.getLogger(__name__)
+
+
+def merged_snapshot(
+    providers: list[ProviderSwitcher], *, fetch: set[str] | None = None
+) -> tuple[AccountsSnapshot, dict[str, ProviderSwitcher]]:
+    """Return the merged snapshot and a ``row key -> owning provider`` map.
+
+    ``fetch`` carries the per-provider slot numbers to allow fetching, keyed the
+    same way rows are (``"codex:2"``); None means "every account eligible", the
+    Claude side's documented meaning.
+    """
+    rows: list[AccountSnapshot] = []
+    owners: dict[str, ProviderSwitcher] = {}
+    claude_active: str | None = None
+
+    for provider in providers:
+        pid = getattr(provider, "provider_id", "claude")
+        per_provider = (
+            None
+            if fetch is None
+            else {k.split(":", 1)[1] for k in fetch if k.startswith(f"{pid}:")}
+        )
+        try:
+            snap = provider.accounts_snapshot(fetch=per_provider)
+        except Exception as e:
+            # One provider's bad day must not blank the whole dashboard.
+            _logger.warning(
+                "provider %s snapshot failed: %s", pid, type(e).__name__
+            )
+            continue
+
+        if pid == "claude":
+            claude_active = snap.active_number
+
+        for account in snap.accounts:
+            rows.append(account)
+            owners[account.key] = provider
+
+    return (
+        AccountsSnapshot(
+            active_number=claude_active,
+            accounts=tuple(rows),
+            taken_at=time.time(),
+            provider="multi",
+        ),
+        owners,
+    )
+
+
+def group_by_provider(
+    snapshot: AccountsSnapshot,
+) -> list[tuple[str, list[AccountSnapshot]]]:
+    """``[(provider_id, rows), ...]`` in the snapshot's own order.
+
+    Preserves first-seen order rather than sorting, so the grouping matches what
+    the shell is about to render row for row.
+    """
+    groups: list[tuple[str, list[AccountSnapshot]]] = []
+    index: dict[str, list[AccountSnapshot]] = {}
+    for account in snapshot.accounts:
+        bucket = index.get(account.provider)
+        if bucket is None:
+            bucket = []
+            index[account.provider] = bucket
+            groups.append((account.provider, bucket))
+        bucket.append(account)
+    return groups
+
+
+#: Short label shown on a row so two providers' accounts cannot be confused.
+PROVIDER_LABELS = {"claude": "claude", "codex": "codex"}
+
+
+def provider_label(provider_id: str) -> str:
+    return PROVIDER_LABELS.get(provider_id, provider_id)
+
+
+class MultiSnapshotSource:
+    """One ``SnapshotSource`` per provider, merged into a single view.
+
+    Reconciliation (rejecting per-account regressions between passes) is the
+    reason each provider gets its own ``SnapshotSource`` rather than one shared
+    one: that logic compares an account against *its own* previous state, and
+    handing it a list that alternates between providers would make every pass
+    look like a wholesale change.
+
+    ``take`` returns the merged snapshot and the ``row key -> provider`` map a
+    shell needs to send a keystroke back to the switcher that owns the row.
+    """
+
+    def __init__(self, providers: list[ProviderSwitcher]) -> None:
+        from claude_swap.snapshot_source import SnapshotSource
+
+        self._sources = [(p, SnapshotSource(p)) for p in providers]
+
+    @property
+    def providers(self) -> list[ProviderSwitcher]:
+        return [p for p, _ in self._sources]
+
+    def take(
+        self, *, full: bool = False, store_only: bool = False
+    ) -> tuple[AccountsSnapshot, dict[str, ProviderSwitcher]]:
+        """Blocking snapshot pass across every provider; call from a worker."""
+        rows: list[AccountSnapshot] = []
+        owners: dict[str, ProviderSwitcher] = {}
+        claude_active: str | None = None
+
+        for provider, source in self._sources:
+            pid = getattr(provider, "provider_id", "claude")
+            try:
+                snap = source.take(full=full, store_only=store_only)
+            except Exception as e:
+                _logger.warning(
+                    "provider %s snapshot failed: %s", pid, type(e).__name__
+                )
+                continue
+            if pid == "claude":
+                claude_active = snap.active_number
+            for account in snap.accounts:
+                rows.append(account)
+                owners[account.key] = provider
+
+        return (
+            AccountsSnapshot(
+                active_number=claude_active,
+                accounts=tuple(rows),
+                taken_at=time.time(),
+                provider="multi",
+            ),
+            owners,
+        )

--- a/src/claude_swap/providers/base.py
+++ b/src/claude_swap/providers/base.py
@@ -1,0 +1,78 @@
+"""The provider seam.
+
+Deliberately narrow. ``ClaudeAccountSwitcher`` is 7000 lines, most of it
+credential-provenance machinery (lineage verdicts, the profile oracle, the
+unclaimed stash) with no Codex analogue — extracting a base class from it would
+be a rewrite wearing a refactor's clothes. So the seam is placed where the two
+providers genuinely agree: the read model, and the verbs a UI needs to drive an
+account list.
+
+Every method below already exists on ``ClaudeAccountSwitcher`` under exactly
+this name, so it satisfies the Protocol structurally with no adapter. New
+providers implement this and nothing more.
+
+``runtime_checkable`` gives ``issubclass`` on method *presence* only — it does
+not verify signatures. That is enough for its job here: catching a renamed verb
+at test time rather than at runtime on one provider.
+
+The Protocol is deliberately **method-only**, even though every implementation
+must also carry a ``provider_id: str`` class attribute (matching
+``AccountSnapshot.provider``: "claude" | "codex"). A ``runtime_checkable``
+Protocol that declares a data member supports ``isinstance`` but raises
+``TypeError`` on ``issubclass`` — and ``issubclass`` is the check worth having,
+because constructing a ``ClaudeAccountSwitcher`` runs migrations and touches the
+account store, which a structural conformance test has no business doing.
+``provider_id`` is therefore contract-by-docstring, asserted directly in
+``tests/test_codex_seam.py`` for each provider.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from claude_swap.models import AccountsSnapshot
+
+
+@runtime_checkable
+class ProviderSwitcher(Protocol):
+    """What a provider must offer for cswap's UIs to drive it.
+
+    Implementations must additionally define ``provider_id: str`` — see the
+    module docstring for why it cannot live in the Protocol body.
+    """
+
+    def accounts_snapshot(self, fetch: set[str] | None = None) -> AccountsSnapshot:
+        """One coherent pass over every managed account."""
+        ...
+
+    def current_account_number(self) -> str | None:
+        """The active slot, or None when no managed account is active."""
+        ...
+
+    def switch_to(self, *args, **kwargs):
+        """Activate a specific account."""
+        ...
+
+    def remove_account(self, identifier: str, assume_yes: bool = False) -> None:
+        """Forget an account."""
+        ...
+
+    def set_alias(self, identifier: str, alias: str) -> tuple[str, str]:
+        """Give an account a short name."""
+        ...
+
+    def unset_alias(self, identifier: str) -> str:
+        """Drop an account's alias."""
+        ...
+
+    def switchable_account_numbers(self) -> list[str]:
+        """Slots eligible for automatic rotation."""
+        ...
+
+    def set_account_disabled(self, identifier: str, disabled: bool) -> None:
+        """Hold an account out of (or return it to) automatic rotation."""
+        ...
+
+    def resolve_account(self, identifier: str) -> tuple[str, str, str]:
+        """Resolve a number/email/alias to a concrete account."""
+        ...

--- a/src/claude_swap/providers/registry.py
+++ b/src/claude_swap/providers/registry.py
@@ -1,0 +1,56 @@
+"""Which providers this installation actually has accounts for.
+
+Claude is always present — cswap is its switcher and the existing surfaces have
+always assumed it. Codex appears only once the user has Codex accounts, so a
+Claude-only user's dashboard, menu bar and auto loop look and behave exactly as
+they did before: no empty section, no wasted work, nothing new to learn.
+
+That "only when it exists" rule is the whole reason this module is separate from
+the provider implementations. It is the one place that decides whether a surface
+is single- or multi-provider, so no surface has to make that judgement itself.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from claude_swap.providers.base import ProviderSwitcher
+
+_logger = logging.getLogger(__name__)
+
+
+def codex_is_present() -> bool:
+    """Whether this machine has any Codex accounts cswap knows or could import.
+
+    Counts an un-imported codex-auth registry too, so the provider shows up on
+    the first run rather than only after a ``cswap codex`` command.
+    """
+    try:
+        from claude_swap.codex import paths as cpaths
+        from claude_swap.codex.store import CodexStore
+
+        if CodexStore().slots():
+            return True
+        return cpaths.get_codex_auth_registry_path().exists()
+    except Exception as e:  # pragma: no cover - defensive
+        _logger.debug("codex presence check failed: %s", type(e).__name__)
+        return False
+
+
+def available_providers(claude: ProviderSwitcher) -> list[ProviderSwitcher]:
+    """Every provider worth showing, Claude first.
+
+    ``claude`` is passed in rather than constructed here: building a
+    ``ClaudeAccountSwitcher`` runs migrations and touches the account store, and
+    the callers that need this already hold one.
+    """
+    providers: list[ProviderSwitcher] = [claude]
+    if codex_is_present():
+        try:
+            from claude_swap.codex.switcher import CodexSwitcher
+
+            providers.append(CodexSwitcher())
+        except Exception as e:  # pragma: no cover - defensive
+            # A broken Codex store must never take the Claude dashboard down.
+            _logger.warning("Codex provider unavailable: %s", type(e).__name__)
+    return providers

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -45,6 +45,14 @@ class AutoSwitchSettings:
 
     threshold: float = 90.0
     interval_seconds: float = 60.0
+    # Codex rides in the same `cswap auto` process as its own small engine.
+    # Enabled by default, but a no-op unless the user has Codex accounts —
+    # a Claude-only install never notices it exists.
+    codex_enabled: bool = True
+    # 0 means "use `threshold`". A separate knob because Claude's 5h/7d
+    # rhythm and a ChatGPT plan's limits are not the same shape, so one
+    # number need not suit both.
+    codex_threshold: float = 0.0
     cooldown_seconds: float = 300.0
     hysteresis_pct: float = 10.0
     strategy: str = "best"  # "best" (most headroom) or "consume-first" (soonest weekly reset)
@@ -109,6 +117,14 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         SettingSpec(
             "autoswitch", "intervalSeconds", "interval_seconds", "float", 15.0, 3600.0,
             help="Poll interval for the cswap auto loop, in seconds",
+        ),
+        SettingSpec(
+            "autoswitch", "codexEnabled", "codex_enabled", "bool",
+            help="Also auto-switch Codex accounts in the cswap auto loop",
+        ),
+        SettingSpec(
+            "autoswitch", "codexThreshold", "codex_threshold", "float", 0.0, 99.9,
+            help="Codex-only switch threshold (0 = use autoswitch.threshold)",
         ),
         SettingSpec(
             "autoswitch", "cooldownSeconds", "cooldown_seconds", "float", 0.0, 86400.0,

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -303,6 +303,10 @@ def _sweep_legacy_keyring(usernames: list[str], removed_items: list[str]) -> Non
 class ClaudeAccountSwitcher:
     """Multi-account switcher for Claude Code."""
 
+    #: Identifies this switcher to provider-aware consumers. See
+    #: ``providers.base.ProviderSwitcher``.
+    provider_id = "claude"
+
     def __init__(self, debug: bool = False):
         self.home = Path.home()
         self.platform = Platform.detect()

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -24,7 +24,9 @@ from claude_swap.settings import load_settings, load_ui_settings, set_setting
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.tui.autoview import AutoScreen
 from claude_swap.tui.dashboard import DashboardScreen, WatchScreen
-from claude_swap.tui.data import ActionResult, SnapshotSource, format_duration, run_action
+from claude_swap.providers.aggregate import MultiSnapshotSource
+from claude_swap.providers.registry import available_providers
+from claude_swap.tui.data import ActionResult, format_duration, run_action
 from claude_swap.tui.modals import AddTokenModal, ConfirmModal, OutputModal, TokenForm
 from claude_swap.tui.theme import CSWAP_DARK, CSWAP_LIGHT
 
@@ -61,7 +63,12 @@ class CswapApp(App):
         self.switcher = switcher
         self._start = start  # "dashboard" | "watch" (`cswap watch`)
         self._detected = detected  # terminal background sensed pre-driver, or None
-        self.source = SnapshotSource(switcher)
+        # Multi-provider from the start: with only Claude accounts present the
+        # registry returns exactly one provider, so a Claude-only install
+        # behaves and renders precisely as it did before.
+        self.providers = available_providers(switcher)
+        self.source = MultiSnapshotSource(self.providers)
+        self.owners: dict[str, object] = {}
         self._store_only = False
         self._full_next = False
         self._normal_refreshing = False
@@ -152,11 +159,15 @@ class CswapApp(App):
     def _refresh_blocking(
         self, generation: int, lane: str, full: bool, store_only: bool
     ) -> None:
-        snap = self.source.take(full=full, store_only=store_only)
-        self.call_from_thread(self._apply_snapshot, generation, lane, snap)
+        snap, owners = self.source.take(full=full, store_only=store_only)
+        self.call_from_thread(self._apply_snapshot, generation, lane, snap, owners)
 
     def _apply_snapshot(
-        self, generation: int, lane: str, snap: AccountsSnapshot
+        self,
+        generation: int,
+        lane: str,
+        snap: AccountsSnapshot,
+        owners: dict[str, object] | None = None,
     ) -> None:
         if lane == "normal":
             self._normal_refreshing = False
@@ -164,6 +175,8 @@ class CswapApp(App):
         else:
             self._store_refreshing = False
         self._last_refresh_error = ""
+        if owners is not None:
+            self.owners = owners
         if generation >= self._applied_generation:
             self._applied_generation = generation
             self.snapshot = snap
@@ -173,11 +186,14 @@ class CswapApp(App):
             # SnapshotSource has already rejected per-account regressions, so
             # merge its canonical usage rows without restoring stale metadata.
             current = self.snapshot
-            incoming = {acc.number: acc for acc in snap.accounts}
+            # Keyed by `key`, not `number`: slot numbers repeat across
+            # providers, and matching on them would graft one provider's
+            # usage onto the other's row.
+            incoming = {acc.key: acc for acc in snap.accounts}
             accounts = tuple(
                 replace(acc, usage=other.usage)
                 if (
-                    (other := incoming.get(acc.number)) is not None
+                    (other := incoming.get(acc.key)) is not None
                     and account_identity(acc) == account_identity(other)
                 )
                 else acc
@@ -281,12 +297,47 @@ class CswapApp(App):
         elif result.first_line:
             self.notify(result.first_line)
 
+    # -- provider dispatch -----------------------------------------------------
+
+    def _resolve_row(self, key: str):
+        """``(provider, slot number)`` for a row key like ``"codex:2"``.
+
+        A bare number is read as Claude, so any call site that predates
+        multi-provider keeps working. Falls back to the Claude switcher when the
+        key names a provider that has since gone away — better a no-op on the
+        default provider than a traceback in the event loop.
+        """
+        if ":" in key:
+            provider_id, number = key.split(":", 1)
+        else:
+            provider_id, number = "claude", key
+        provider = self.owners.get(f"{provider_id}:{number}")
+        if provider is None:
+            provider = next(
+                (p for p in self.providers if getattr(p, "provider_id", "") == provider_id),
+                self.switcher,
+            )
+        return provider, number
+
+    def _row_for(self, key: str):
+        """The snapshot row for a key, or None."""
+        snap = self.snapshot
+        want = key if ":" in key else f"claude:{key}"
+        return next((a for a in (snap.accounts if snap else ()) if a.key == want), None)
+
     # -- account operations ----------------------------------------------------
 
-    def do_switch(self, number: str) -> None:
+    def do_switch(self, key: str) -> None:
+        provider, number = self._resolve_row(key)
+        label = f"Switch to account {number}"
+        if getattr(provider, "provider_id", "claude") != "claude":
+            label = f"Switch to {provider.provider_id} account {number}"
+            # Only the Claude switcher speaks json_output; other providers
+            # return their own result object, which _start_action renders.
+            self._start_action(label, partial(provider.switch_to, number))
+            return
         self._start_action(
-            f"Switch to account {number}",
-            partial(self.switcher.switch_to, number, json_output=True),
+            label, partial(provider.switch_to, number, json_output=True)
         )
 
     def action_switch_best(self) -> None:
@@ -295,38 +346,40 @@ class CswapApp(App):
             partial(self.switcher.switch, strategy="best", json_output=True),
         )
 
-    def do_toggle_disabled(self, number: str) -> None:
+    def do_toggle_disabled(self, key: str) -> None:
         """Hold the account out of auto-rotation, or return it — reads its
         current state from the live snapshot to pick the direction."""
-        snap = self.snapshot
-        acc = next(
-            (a for a in (snap.accounts if snap else ()) if a.number == number), None
-        )
+        acc = self._row_for(key)
         if acc is None:
             return
+        provider, number = self._resolve_row(key)
         target = not acc.disabled
         verb = "Disable" if target else "Enable"
         self._start_action(
             f"{verb} account {number}",
-            partial(self.switcher.set_account_disabled, number, target),
+            partial(provider.set_account_disabled, number, target),
         )
 
-    def confirm_remove(self, number: str, email: str) -> None:
+    def confirm_remove(self, key: str, email: str) -> None:
+        provider, number = self._resolve_row(key)
+        pid = getattr(provider, "provider_id", "claude")
+        what = "account" if pid == "claude" else f"{pid} account"
         self.push_screen(
             ConfirmModal(
-                f"Remove account {number} ({email})?\n\n"
+                f"Remove {what} {number} ({email})?\n\n"
                 "Its stored credentials and config backup are deleted.",
                 title="Remove account",
                 yes_label="Remove",
             ),
-            partial(self._on_remove_confirm, number),
+            partial(self._on_remove_confirm, key),
         )
 
-    def _on_remove_confirm(self, number: str, confirmed: bool | None) -> None:
+    def _on_remove_confirm(self, key: str, confirmed: bool | None) -> None:
         if confirmed:
+            provider, number = self._resolve_row(key)
             self._start_action(
                 f"Remove account {number}",
-                partial(self.switcher.remove_account, number, assume_yes=True),
+                partial(provider.remove_account, number, assume_yes=True),
             )
 
     def action_add_current(self) -> None:

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -37,6 +37,16 @@ MenuEntries = list[tuple[str, str]]  # (label, action_id)
 
 _BACK = ("← back", "back")
 
+def _row_action_id(prefix: str, acc) -> str:
+    """Menu action id for an account row.
+
+    Claude rows keep the historical bare-number form, so a Claude-only install
+    — and every test written against it — is untouched. Other providers use the
+    composite row key, which the app resolves back to the owning switcher.
+    """
+    return f"{prefix}:{acc.number}" if acc.provider == "claude" else f"{prefix}:{acc.key}"
+
+
 
 class DashboardScreen(Screen):
     BINDINGS = [
@@ -97,7 +107,7 @@ class DashboardScreen(Screen):
             (
                 f"{acc.number}  {f'{acc.alias} ({acc.email})' if acc.alias else acc.email}"
                 f"  [{acc.display_tag}]",
-                f"remove:{acc.number}",
+                _row_action_id("remove", acc),
             )
             for acc in (snap.accounts if snap else ())
         ]
@@ -114,7 +124,7 @@ class DashboardScreen(Screen):
             action = "→ enable" if acc.disabled else "→ disable"
             state = "  (disabled)" if acc.disabled else ""
             entries.append(
-                (f"{acc.number}  {name}{state}   {action}", f"disable:{acc.number}")
+                (f"{acc.number}  {name}{state}   {action}", _row_action_id("disable", acc))
             )
         entries.append(_BACK)
         return entries
@@ -172,13 +182,11 @@ class DashboardScreen(Screen):
         elif action_id == "remove-menu":
             await self._push_menu("remove account", self._remove_entries())
         elif action_id.startswith("remove:"):
-            number = action_id.split(":", 1)[1]
-            snap = app.snapshot
-            email = next(
-                (a.email for a in (snap.accounts if snap else ()) if a.number == number),
-                "?",
-            )
-            app.confirm_remove(number, email)
+            # The tail is a row key ("codex:1"), not a bare slot number: slot
+            # numbers repeat across providers.
+            key = action_id.split(":", 1)[1]
+            row = app._row_for(key)
+            app.confirm_remove(key, row.email if row else "?")
         elif action_id == "theme-menu":
             await self._push_menu("theme", self._theme_entries())
         elif action_id.startswith("theme:"):
@@ -189,8 +197,8 @@ class DashboardScreen(Screen):
         elif action_id == "disable-menu":
             await self._push_menu("disable / enable", self._disable_entries())
         elif action_id.startswith("disable:"):
-            number = action_id.split(":", 1)[1]
-            app.do_toggle_disabled(number)
+            key = action_id.split(":", 1)[1]
+            app.do_toggle_disabled(key)
             await self._pop_menu()
         else:
             actions[action_id]()
@@ -317,7 +325,7 @@ class SwitchScreen(AccountListScreen):
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         item = event.item
         if isinstance(item, AccountItem):
-            self.app.do_switch(item.number)
+            self.app.do_switch(item.key_id)
             self.app.pop_screen()
 
     def action_select_highlighted(self) -> None:
@@ -404,7 +412,7 @@ class WatchScreen(AccountListScreen):
             return  # e.g. a stray click while just watching
         item = event.item
         if isinstance(item, AccountItem):
-            self.app.do_switch(item.number)
+            self.app.do_switch(item.key_id)
             self._set_selecting(False)  # stay here, keep watching
 
     def action_select_highlighted(self) -> None:

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -17,6 +17,7 @@ from textual.widgets import ListItem, Static
 from claude_swap import pace
 from claude_swap.json_output import USAGE_API_KEY
 from claude_swap.models import AccountSnapshot
+from claude_swap.providers.aggregate import provider_label
 from claude_swap.switcher import ERROR_NOTES
 from claude_swap.usage_store import STALE_OK_S
 from claude_swap.tui import data
@@ -160,6 +161,20 @@ def usage_rows(
     return rows
 
 
+
+def provider_badge(acc: AccountSnapshot, palette: Palette) -> Text | None:
+    """A short provider tag, or None for Claude.
+
+    Claude rows stay exactly as they were: a Claude-only install must not gain a
+    badge on every line to say the only thing it could possibly say. The badge
+    appears precisely when two providers are on screen and confusing one for the
+    other would be possible.
+    """
+    if acc.provider == "claude":
+        return None
+    return Text(f" ⟨{provider_label(acc.provider)}⟩", style=palette.muted)
+
+
 def account_card_text(
     acc: AccountSnapshot,
     width: int,
@@ -179,6 +194,9 @@ def account_card_text(
     else:
         text.append(acc.email, style=palette.foreground)
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
+    badge = provider_badge(acc, palette)
+    if badge is not None:
+        text.append_text(badge)
     if acc.is_active:
         text.append("   ● active", style=f"bold {palette.accent}")
     if acc.disabled:
@@ -258,6 +276,9 @@ def mini_account_text(
     else:
         text.append(acc.email, style=palette.foreground)
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
+    badge = provider_badge(acc, palette)
+    if badge is not None:
+        text.append_text(badge)
     if acc.disabled:
         text.append("  (disabled)", style=palette.muted)
     text.append("   ")
@@ -385,10 +406,16 @@ class AccountItem(ListItem):
         super().__init__(AccountCard(acc))
         self.number = acc.number
         self.email = acc.email
+        # Slot numbers repeat across providers, so anything that dispatches on a
+        # selected row must use these two, never ``number`` alone.
+        self.provider = acc.provider
+        self.key_id = acc.key
 
     def set_account(self, acc: AccountSnapshot) -> None:
         self.number = acc.number
         self.email = acc.email
+        self.provider = acc.provider
+        self.key_id = acc.key
         self.query_one(AccountCard).set_account(acc)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,13 @@ import pytest
 from claude_swap import macos_keychain as _macos_keychain
 from claude_swap import paths as _paths
 
+# Codex fixtures live in their own module to keep this file navigable; importing
+# the names here is what makes them visible to every test.
+from tests.conftest_codex import (  # noqa: F401,E402
+    codex_home,
+    live_auth,
+)
+
 
 class RealStoreWriteBlocked(Exception):
     """A test process tried to write the REAL account store.

--- a/tests/conftest_codex.py
+++ b/tests/conftest_codex.py
@@ -1,0 +1,107 @@
+"""Codex fixtures: a fake ~/.codex tree and JWT/auth.json builders.
+
+Imported by ``tests/conftest.py`` so these are available everywhere without a
+second conftest layer. No test may touch the developer's real ~/.codex — the
+autouse ``_isolate_real_home`` fixture already redirects ``$HOME``, and
+``codex_home`` builds its tree under that redirect.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+def make_jwt(claims: dict) -> str:
+    """Build an unsigned JWT carrying ``claims``.
+
+    Signature is a fixed placeholder: nothing in cswap verifies these tokens —
+    the server does. cswap only reads the claims to learn which account a token
+    belongs to, so an unsigned token is a faithful stand-in for a test.
+    """
+
+    def seg(obj: dict) -> str:
+        raw = json.dumps(obj, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f"{seg({'alg': 'none', 'typ': 'JWT'})}.{seg(claims)}.sig"
+
+
+def make_auth_json(
+    *,
+    account_id: str = "2f4dac8f-f15f-4c58-a567-e96985d51cfd",
+    user_id: str = "user-K6XCCWw4gcRpfaGR6VQKAFgA",
+    email: str = "a@example.com",
+    plan: str = "pro",
+    exp: float | None = None,
+    refresh_token: str = "rt-a",
+    access_token: str | None = None,
+    auth_mode: str = "chatgpt",
+    api_key: str | None = None,
+    organizations: list[dict] | None = None,
+) -> dict:
+    """Build an ``auth.json`` payload in the real shape codex writes."""
+    claims: dict = {
+        "exp": int(exp if exp is not None else time.time() + 3600),
+        "email": email,
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": account_id,
+            "chatgpt_user_id": user_id,
+            "chatgpt_plan_type": plan,
+        },
+    }
+    if organizations is not None:
+        claims["https://api.openai.com/auth"]["organizations"] = organizations
+    token = make_jwt(claims)
+    return {
+        "auth_mode": auth_mode,
+        "OPENAI_API_KEY": api_key,
+        "tokens": {
+            "id_token": token,
+            "access_token": access_token or token,
+            "refresh_token": refresh_token,
+            "account_id": account_id,
+        },
+        "last_refresh": "2026-08-16T00:00:00Z",
+    }
+
+
+def strip_account_claim(payload: dict) -> dict:
+    """Remove ``chatgpt_account_id`` and ``tokens.account_id`` from a payload.
+
+    Reproduces a phone-login auth file, which carries neither and can only be
+    identified through the organization fallback. Rewrites the JWT so the
+    removal is visible to the parser, not just to the test.
+    """
+    seg = payload["tokens"]["id_token"].split(".")[1]
+    claims = json.loads(base64.urlsafe_b64decode(seg + "=" * (-len(seg) % 4)))
+    claims["https://api.openai.com/auth"].pop("chatgpt_account_id", None)
+    token = make_jwt(claims)
+    payload["tokens"]["id_token"] = token
+    payload["tokens"]["access_token"] = token
+    payload["tokens"]["account_id"] = None
+    return payload
+
+
+@pytest.fixture
+def codex_home(temp_home: Path) -> Path:
+    """An isolated ``~/.codex`` with no accounts yet."""
+    home = temp_home / ".codex"
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+@pytest.fixture
+def live_auth(codex_home: Path):
+    """Write an ``auth.json`` into the fake codex home; returns the writer."""
+
+    def _write(payload: dict | None = None) -> Path:
+        path = codex_home / "auth.json"
+        path.write_text(json.dumps(payload if payload is not None else make_auth_json()))
+        return path
+
+    return _write

--- a/tests/test_codex_auth_file.py
+++ b/tests/test_codex_auth_file.py
@@ -1,0 +1,140 @@
+"""Parsing ~/.codex/auth.json into an identity cswap can match to a slot."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_swap.codex import auth_file
+from tests.conftest_codex import make_auth_json, strip_account_claim
+
+ACCOUNT = "2f4dac8f-f15f-4c58-a567-e96985d51cfd"
+USER = "user-K6XCCWw4gcRpfaGR6VQKAFgA"
+
+
+def test_account_key_joins_user_and_account():
+    """codex-auth's format, kept byte-identical so imported keys match ours."""
+    assert auth_file.account_key(USER, ACCOUNT) == f"{USER}::{ACCOUNT}"
+
+
+def test_file_key_is_unpadded_base64url_of_the_account_key():
+    """Verified against a real codex-auth snapshot filename."""
+    key = auth_file.account_key(USER, ACCOUNT)
+    assert auth_file.file_key(key) == (
+        "dXNlci1LNlhDQ1d3NGdjUnBmYUdSNlZRS0FGZ0E6OjJmNGRhYzhmLWYxNWYtNGM1OC1hNTY3"
+        "LWU5Njk4NWQ1MWNmZA"
+    )
+
+
+def test_identity_comes_from_the_jwt_claims():
+    ident = auth_file.parse_identity(make_auth_json(email="me@example.com"))
+    assert ident is not None
+    assert ident.account_id == ACCOUNT
+    assert ident.user_id == USER
+    assert ident.email == "me@example.com"
+    assert ident.plan == "pro"
+    assert ident.account_key == f"{USER}::{ACCOUNT}"
+
+
+def test_tokens_account_id_wins_over_the_jwt_claim():
+    """The live file's ``tokens.account_id`` is what the codex CLI itself uses
+    to pick a workspace, so it is the authority when the two disagree."""
+    payload = make_auth_json()
+    payload["tokens"]["account_id"] = "other-account"
+    ident = auth_file.parse_identity(payload)
+    assert ident.account_id == "other-account"
+
+
+def test_organization_fallback_prefers_the_default_org():
+    """Phone-login auth files carry neither tokens.account_id nor the account
+    claim; codex-auth falls back to the default organization, and so do we."""
+    payload = strip_account_claim(
+        make_auth_json(
+            organizations=[
+                {"id": "org-first", "is_default": False},
+                {"id": "org-default", "is_default": True},
+            ]
+        )
+    )
+    assert auth_file.parse_identity(payload).account_id == "org-default"
+
+
+def test_organization_fallback_takes_the_first_when_none_is_default():
+    payload = strip_account_claim(
+        make_auth_json(organizations=[{"id": "org-first"}, {"id": "org-second"}])
+    )
+    assert auth_file.parse_identity(payload).account_id == "org-first"
+
+
+def test_api_key_account_yields_an_identity_with_no_tokens():
+    """auth_mode=apikey has no OAuth tokens: neither usage nor refresh applies,
+    and it must not crash the parser."""
+    payload = {"auth_mode": "apikey", "OPENAI_API_KEY": "sk-x", "tokens": None}
+    ident = auth_file.parse_identity(payload)
+    assert ident is not None
+    assert ident.is_api_key is True
+    assert ident.account_id == ""
+    assert ident.is_identifiable is False
+
+
+def test_unparseable_payload_yields_none():
+    assert auth_file.parse_identity({"tokens": {"id_token": "not-a-jwt"}}) is None
+    assert auth_file.parse_identity({}) is None
+    assert auth_file.parse_identity("nonsense") is None
+
+
+def test_read_live_identity_returns_none_when_the_file_is_absent(codex_home: Path):
+    assert auth_file.read_live_identity() is None
+
+
+def test_read_live_identity_reads_the_live_file(live_auth):
+    live_auth()
+    ident = auth_file.read_live_identity()
+    assert ident is not None and ident.account_id == ACCOUNT
+
+
+def test_read_live_identity_survives_a_torn_write(codex_home: Path):
+    """A half-written auth.json is transient, not fatal — the next pass re-reads."""
+    (codex_home / "auth.json").write_text('{"tokens": {')
+    assert auth_file.read_live_identity() is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes are not meaningful")
+def test_write_live_auth_preserves_the_existing_file_mode(codex_home: Path, live_auth):
+    """codex-auth documents preserving the live file's mode on switch; a
+    switch must not silently re-permission a file the codex CLI owns."""
+    path = live_auth()
+    os.chmod(path, 0o644)
+    auth_file.write_live_auth(make_auth_json(email="b@example.com"))
+    assert (os.stat(path).st_mode & 0o777) == 0o644
+
+
+def test_write_live_auth_creates_a_private_file_when_absent(codex_home: Path):
+    auth_file.write_live_auth(make_auth_json())
+    path = codex_home / "auth.json"
+    assert path.exists()
+    if sys.platform != "win32":
+        assert (os.stat(path).st_mode & 0o777) == 0o600
+
+
+def test_write_live_auth_round_trips_the_payload(codex_home: Path):
+    payload = make_auth_json(email="round@example.com")
+    auth_file.write_live_auth(payload)
+    assert auth_file.read_live_payload() == payload
+
+
+def test_write_live_auth_leaves_no_temp_file_behind(codex_home: Path):
+    auth_file.write_live_auth(make_auth_json())
+    assert list(codex_home.glob("*.tmp")) == []
+
+
+def test_token_expiry_is_read_from_the_access_token():
+    assert auth_file.access_token_expiry(make_auth_json(exp=1_800_000_000)) == 1_800_000_000
+
+
+def test_token_expiry_is_none_when_unreadable():
+    assert auth_file.access_token_expiry({"tokens": {"access_token": "x"}}) is None
+    assert auth_file.access_token_expiry({}) is None

--- a/tests/test_codex_autoswitch.py
+++ b/tests/test_codex_autoswitch.py
@@ -199,3 +199,40 @@ def test_the_human_line_names_the_provider():
     """Two engines share one event stream; a line that does not say which
     provider it is about is noise."""
     assert CodexTick("ok", "nothing to do").human().startswith("codex:")
+
+
+# ---- the property Stage 4 was gated on ---------------------------------
+
+
+def test_repeated_ticks_do_not_re_poll_the_api(codex_home: Path, monkeypatch):
+    """The auto loop ticks every interval and asks for `fetch=None` — "every
+    account eligible". Only the usage cache's poll plan stops that becoming a
+    request per account per tick, and that is one semantics flip away from
+    hammering the endpoint. This test pins it.
+    """
+    from claude_swap.codex.auth_file import account_key
+    from claude_swap.codex.store import CodexStore
+    from claude_swap.codex.switcher import CodexSwitcher
+    from claude_swap.codex.usage import UsageFetch
+    from tests.conftest_codex import make_auth_json
+
+    store = CodexStore()
+    for n, acct in (("a", "acct-a"), ("b", "acct-b")):
+        key = account_key(f"user-{n}", acct)
+        store.upsert_slot(key, email=f"{n}@x", plan="pro")
+        store.write_snapshot(key, make_auth_json(account_id=acct, user_id=f"user-{n}"))
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "claude_swap.codex.usage_cache.fetch_usage",
+        lambda *a, **k: calls.append(1) or UsageFetch(usage={"five_hour": {"pct": 5}}),
+    )
+
+    auto = CodexAutoSwitcher(CodexSwitcher(), threshold=90)
+    auto.tick()
+    first = len(calls)
+    auto.tick()
+    auto.tick()
+
+    assert first == 2  # one round on the cold cache
+    assert len(calls) == first  # and nothing on the two ticks after it

--- a/tests/test_codex_autoswitch.py
+++ b/tests/test_codex_autoswitch.py
@@ -1,0 +1,201 @@
+"""Codex auto-switching: when it moves, when it refuses, and what it admits."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from claude_swap.codex.autoswitch import CodexAutoSwitcher, CodexTick, binding_pct
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
+from claude_swap.usage_store import UsageEntry
+
+
+def _acc(number: str, pct: float | None, *, active=False, disabled=False, weekly=None):
+    usage: dict = {}
+    if pct is not None:
+        usage["five_hour"] = {"pct": pct}
+    if weekly is not None:
+        usage["seven_day"] = {"pct": weekly}
+    return AccountSnapshot(
+        number=number,
+        email=f"{number}@x",
+        org_name="",
+        org_uuid="",
+        is_active=active,
+        kind="oauth",
+        switchable=True,
+        usage=UsageEntry(last_good=usage or None),
+        disabled=disabled,
+        provider="codex",
+    )
+
+
+class FakeSwitcher:
+    provider_id = "codex"
+
+    def __init__(self, accounts, rotatable=None, running=()):
+        self._accounts = accounts
+        self._rotatable = rotatable
+        self.switched: list[str] = []
+        self._running = running
+
+    def accounts_snapshot(self, fetch=None):
+        return AccountsSnapshot(
+            active_number=next((a.number for a in self._accounts if a.is_active), None),
+            accounts=tuple(self._accounts),
+            taken_at=0.0,
+            provider="codex",
+        )
+
+    def switchable_account_numbers(self):
+        if self._rotatable is not None:
+            return self._rotatable
+        return [a.number for a in self._accounts if not a.disabled]
+
+    def switch_to(self, number):
+        from claude_swap.codex.switcher import CodexSwitchResult
+
+        self.switched.append(number)
+        return CodexSwitchResult(number=number, email=f"{number}@x", running_pids=list(self._running))
+
+
+def _auto(accounts, **kw) -> tuple[CodexAutoSwitcher, FakeSwitcher]:
+    fake = FakeSwitcher(accounts, **{k: v for k, v in kw.items() if k in ("rotatable", "running")})
+    opts = {k: v for k, v in kw.items() if k not in ("rotatable", "running")}
+    return CodexAutoSwitcher(fake, **opts), fake
+
+
+# ---- the binding window ------------------------------------------------
+
+
+def test_binding_pct_is_the_worst_window():
+    assert binding_pct(_acc("1", 20, weekly=80)) == 80
+
+
+def test_binding_pct_is_none_without_a_measurement():
+    assert binding_pct(_acc("1", None)) is None
+
+
+# ---- when NOT to switch ------------------------------------------------
+
+
+def test_an_active_account_below_threshold_is_left_alone():
+    auto, fake = _auto([_acc("1", 40, active=True), _acc("2", 5)], threshold=90)
+    assert auto.tick().outcome == "ok"
+    assert fake.switched == []
+
+
+def test_an_unmeasured_active_account_is_never_switched_away_from():
+    """No measurement is not the same as no usage; moving on unknown data means
+    moving the user for no established reason."""
+    auto, fake = _auto([_acc("1", None, active=True), _acc("2", 1)], threshold=90)
+    assert "unknown" in auto.tick().detail
+    assert fake.switched == []
+
+
+def test_no_candidate_below_threshold_blocks_rather_than_moving():
+    auto, fake = _auto([_acc("1", 95, active=True), _acc("2", 97)], threshold=90)
+    tick = auto.tick()
+    assert tick.outcome == "blocked"
+    assert fake.switched == []
+
+
+def test_a_candidate_inside_the_hysteresis_margin_is_refused():
+    """Two accounts hovering at the line must never ping-pong."""
+    auto, fake = _auto(
+        [_acc("1", 92, active=True), _acc("2", 89)], threshold=90, hysteresis_pct=10
+    )
+    assert auto.tick().outcome == "blocked"
+    assert fake.switched == []
+
+
+def test_a_disabled_account_is_not_a_candidate():
+    auto, fake = _auto(
+        [_acc("1", 95, active=True), _acc("2", 2, disabled=True)], threshold=90
+    )
+    assert auto.tick().outcome == "blocked"
+
+
+def test_no_rotatable_accounts_is_reported_not_crashed():
+    auto, _fake = _auto([_acc("1", 95, active=True)], rotatable=[], threshold=90)
+    assert auto.tick().outcome == "no-accounts"
+
+
+def test_no_active_account_is_a_quiet_no_op():
+    auto, fake = _auto([_acc("1", 10), _acc("2", 20)], threshold=90)
+    assert auto.tick().outcome == "ok"
+    assert fake.switched == []
+
+
+def test_a_snapshot_failure_is_reported_never_raised():
+    class Broken(FakeSwitcher):
+        def accounts_snapshot(self, fetch=None):
+            raise RuntimeError("store gone")
+
+    auto = CodexAutoSwitcher(Broken([]))
+    assert auto.tick().outcome == "error"
+
+
+# ---- when to switch ----------------------------------------------------
+
+
+def test_an_exhausted_active_account_moves_to_the_roomiest_candidate():
+    auto, fake = _auto(
+        [_acc("1", 95, active=True), _acc("2", 40), _acc("3", 10)], threshold=90
+    )
+    tick = auto.tick()
+    assert tick.outcome == "switched"
+    assert fake.switched == ["3"]  # most headroom
+    assert tick.switched_to == "3"
+
+
+def test_dry_run_decides_without_switching():
+    auto, fake = _auto([_acc("1", 95, active=True), _acc("2", 5)], threshold=90)
+    tick = auto.tick(dry_run=True)
+    assert tick.outcome == "ok" and "would switch" in tick.detail
+    assert fake.switched == []
+
+
+def test_the_weekly_window_can_be_what_triggers_the_switch():
+    auto, fake = _auto(
+        [_acc("1", 10, weekly=98, active=True), _acc("2", 10, weekly=5)], threshold=90
+    )
+    assert auto.tick().outcome == "switched"
+
+
+def test_a_switch_failure_is_reported_not_raised():
+    class Failing(FakeSwitcher):
+        def switch_to(self, number):
+            from claude_swap.exceptions import ClaudeSwitchError
+
+            raise ClaudeSwitchError("no credentials")
+
+    auto = CodexAutoSwitcher(Failing([_acc("1", 95, active=True), _acc("2", 5)]), threshold=90)
+    assert auto.tick().outcome == "error"
+
+
+# ---- the restart caveat, stated rather than hidden ---------------------
+
+
+def test_a_switch_under_a_running_session_says_so():
+    """An automatic switch only reaches the NEXT codex session. Saying nothing
+    would let the user believe they had moved."""
+    auto, _fake = _auto(
+        [_acc("1", 95, active=True), _acc("2", 5)], threshold=90, running=(4242,)
+    )
+    tick = auto.tick()
+    assert tick.running_pids == (4242,)
+    assert "restart codex" in tick.human()
+    assert "4242" in tick.human()
+
+
+def test_a_switch_with_nothing_running_stays_quiet():
+    auto, _fake = _auto([_acc("1", 95, active=True), _acc("2", 5)], threshold=90, running=())
+    assert "restart" not in auto.tick().human()
+
+
+def test_the_human_line_names_the_provider():
+    """Two engines share one event stream; a line that does not say which
+    provider it is about is noise."""
+    assert CodexTick("ok", "nothing to do").human().startswith("codex:")

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -294,3 +294,75 @@ def test_a_failed_codex_login_does_not_add_an_account(monkeypatch, codex_home: P
 def test_explicit_import_reports_its_counts(monkeypatch, capsys, codex_home: Path):
     _run(monkeypatch, ["codex", "import"])
     assert "Imported 0" in capsys.readouterr().out
+
+
+# ---- token status (stage 2) --------------------------------------------
+
+
+def test_token_status_reports_expiry_without_the_token(
+    monkeypatch, capsys, codex_home: Path, offline
+):
+    """These diagnostics exist so people do not paste a token into an issue."""
+    _seed_one()
+    _run(monkeypatch, ["codex", "list", "--skip-api", "--token-status"])
+    out = capsys.readouterr().out
+
+    assert "token:" in out and "expires in" in out
+    payload = make_auth_json(account_id=ACCT_A, user_id=USER_A, email="a@example.com")
+    for secret in (
+        payload["tokens"]["access_token"],
+        payload["tokens"]["refresh_token"],
+        payload["tokens"]["id_token"],
+    ):
+        assert secret not in out
+
+
+def test_token_status_json_carries_the_block(monkeypatch, capsys, codex_home: Path, offline):
+    _seed_one()
+    _run(monkeypatch, ["codex", "list", "--json", "--skip-api", "--token-status"])
+    data = json.loads(capsys.readouterr().out)
+    entry = data["tokenStatus"][0]
+    assert entry["state"] == "oauth"
+    assert entry["hasRefreshToken"] is True
+    assert entry["refreshDue"] is False
+    assert "access_token" not in json.dumps(data)
+
+
+def test_token_status_marks_an_expired_token_as_due(
+    monkeypatch, capsys, codex_home: Path, offline
+):
+    store = CodexStore()
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    store.write_snapshot(
+        KEY_A, make_auth_json(account_id=ACCT_A, user_id=USER_A, exp=0)
+    )
+    _run(monkeypatch, ["codex", "list", "--skip-api", "--token-status"])
+    out = capsys.readouterr().out
+    assert "refresh due" in out and "expired" in out
+
+
+def test_token_status_of_an_api_key_account_says_so(
+    monkeypatch, capsys, codex_home: Path, offline
+):
+    store = CodexStore()
+    store.upsert_slot(KEY_A, email="a@example.com", auth_mode="apikey")
+    store.write_snapshot(KEY_A, {"auth_mode": "apikey", "OPENAI_API_KEY": "sk-x", "tokens": None})
+    _run(monkeypatch, ["codex", "list", "--skip-api", "--token-status"])
+    assert "token: api key" in capsys.readouterr().out
+
+
+def test_json_reports_age_and_fetch_time(monkeypatch, capsys, codex_home: Path, monkeypatch2=None):
+    """A cached row must say how old it is, not pretend to be current."""
+    from claude_swap.codex.usage import UsageFetch
+
+    _seed_one()
+    monkeypatch.setattr(
+        "claude_swap.codex.usage_cache.fetch_usage",
+        lambda *a, **k: UsageFetch(usage={"five_hour": {"pct": 3}, "plan": "pro"}),
+    )
+    _run(monkeypatch, ["codex", "list", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    row = data["accounts"][0]
+    assert row["fetchedAt"] is not None
+    assert row["ageSeconds"] is not None
+    assert row["plan"] == "pro"

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -49,7 +49,7 @@ def test_bare_cswap_verbs_are_untouched(monkeypatch, capsys, temp_home: Path):
 def test_the_main_help_advertises_the_codex_namespace(monkeypatch, capsys, temp_home: Path):
     with pytest.raises(SystemExit):
         _run(monkeypatch, ["--help"])
-    assert "codex <cmd>" in capsys.readouterr().out
+    assert "Codex (ChatGPT) accounts" in capsys.readouterr().out
 
 
 def test_codex_list_on_an_empty_store_says_so(monkeypatch, capsys, codex_home: Path):
@@ -366,3 +366,42 @@ def test_json_reports_age_and_fetch_time(monkeypatch, capsys, codex_home: Path, 
     assert row["fetchedAt"] is not None
     assert row["ageSeconds"] is not None
     assert row["plan"] == "pro"
+
+
+# ---- discoverability ---------------------------------------------------
+
+
+def test_the_main_help_lists_the_codex_subcommands(monkeypatch, capsys, temp_home: Path):
+    """A single "codex <cmd>" line is not discoverable: the user has to guess a
+    verb before they can find out what the verbs are."""
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["--help"])
+    out = capsys.readouterr().out
+    for verb in ("codex list", "codex status", "codex switch", "codex add", "codex login"):
+        assert verb in out
+
+
+def test_the_main_help_says_the_old_commands_are_unchanged(
+    monkeypatch, capsys, temp_home: Path
+):
+    """The first thing an existing user needs to know."""
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["--help"])
+    assert "Claude-only" in capsys.readouterr().out
+
+
+def test_the_codex_help_states_the_restart_caveat(monkeypatch, capsys):
+    """The trap this feature has: a switch under a running session silently
+    only affects the next one."""
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["codex", "--help"])
+    out = capsys.readouterr().out
+    assert "ALREADY" in out and "restart" in out.lower()
+
+
+def test_the_codex_help_documents_the_autoswitch_settings(monkeypatch, capsys):
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["codex", "--help"])
+    out = capsys.readouterr().out
+    assert "autoswitch.codexThreshold" in out
+    assert "autoswitch.codexEnabled" in out

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -353,7 +353,7 @@ def test_token_status_of_an_api_key_account_says_so(
     assert "token: api key" in capsys.readouterr().out
 
 
-def test_json_reports_age_and_fetch_time(monkeypatch, capsys, codex_home: Path, monkeypatch2=None):
+def test_json_reports_age_and_fetch_time(monkeypatch, capsys, codex_home: Path):
     """A cached row must say how old it is, not pretend to be current."""
     from claude_swap.codex.usage import UsageFetch
 

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -1,0 +1,296 @@
+"""The `cswap codex ...` command surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap.cli import main
+from claude_swap.codex.auth_file import account_key, file_key
+from claude_swap.codex.store import CodexStore
+from tests.conftest_codex import make_auth_json
+
+ACCT_A, USER_A = "acct-a", "user-a"
+KEY_A = account_key(USER_A, ACCT_A)
+
+
+def _run(monkeypatch, argv: list[str]) -> None:
+    monkeypatch.setattr("sys.argv", ["cswap", *argv])
+    main()
+
+
+def _seed_one(email: str = "a@example.com") -> CodexStore:
+    store = CodexStore()
+    store.upsert_slot(KEY_A, email=email, plan="pro")
+    store.write_snapshot(KEY_A, make_auth_json(account_id=ACCT_A, user_id=USER_A, email=email))
+    return store
+
+
+@pytest.fixture
+def offline(monkeypatch):
+    """No codex CLI command may reach the network in these tests."""
+
+    def boom(*a, **k):
+        raise AssertionError("no network request should be made")
+
+    monkeypatch.setattr("claude_swap.codex.switcher.fetch_usage", boom)
+
+
+def test_bare_cswap_verbs_are_untouched(monkeypatch, capsys, temp_home: Path):
+    """The whole point of the namespace: existing muscle memory and scripts
+    keep meaning Claude."""
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["--version"])
+    assert "cswap" in capsys.readouterr().out
+
+
+def test_the_main_help_advertises_the_codex_namespace(monkeypatch, capsys, temp_home: Path):
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["--help"])
+    assert "codex <cmd>" in capsys.readouterr().out
+
+
+def test_codex_list_on_an_empty_store_says_so(monkeypatch, capsys, codex_home: Path):
+    _run(monkeypatch, ["codex", "list", "--skip-api"])
+    assert "No Codex accounts" in capsys.readouterr().out
+
+
+def test_codex_list_shows_managed_accounts(monkeypatch, capsys, codex_home: Path, offline):
+    _seed_one()
+    _run(monkeypatch, ["codex", "list", "--skip-api"])
+    out = capsys.readouterr().out
+    assert "a@example.com" in out and "1." in out
+
+
+def test_codex_list_json_is_machine_readable(monkeypatch, capsys, codex_home: Path, offline):
+    _seed_one()
+    _run(monkeypatch, ["codex", "list", "--json", "--skip-api"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["provider"] == "codex"
+    assert data["accounts"][0]["email"] == "a@example.com"
+
+
+def test_codex_list_marks_the_active_account(monkeypatch, capsys, codex_home: Path, offline):
+    _seed_one()
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A))
+    )
+    _run(monkeypatch, ["codex", "list", "--skip-api"])
+    assert capsys.readouterr().out.startswith("*")
+
+
+def test_codex_status_reports_the_live_account(monkeypatch, capsys, codex_home: Path):
+    _seed_one()
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A, email="a@example.com"))
+    )
+    _run(monkeypatch, ["codex", "status"])
+    assert "a@example.com" in capsys.readouterr().out
+
+
+def test_codex_status_without_a_managed_login_says_so(monkeypatch, capsys, codex_home: Path):
+    _seed_one()
+    _run(monkeypatch, ["codex", "status"])
+    assert "No managed Codex account is active" in capsys.readouterr().out
+
+
+def test_first_codex_command_imports_codex_auth_accounts(
+    monkeypatch, capsys, codex_home: Path, offline
+):
+    """The user should not have to discover an import command to see accounts
+    they already have."""
+    d = codex_home / "accounts"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 3,
+                "active_account_key": KEY_A,
+                "accounts": [
+                    {
+                        "account_key": KEY_A,
+                        "chatgpt_account_id": ACCT_A,
+                        "chatgpt_user_id": USER_A,
+                        "email": "a@example.com",
+                        "alias": "",
+                        "account_name": None,
+                        "plan": "pro",
+                        "auth_mode": "chatgpt",
+                    }
+                ],
+            }
+        )
+    )
+    (d / f"{file_key(KEY_A)}.auth.json").write_text(json.dumps(make_auth_json()))
+
+    _run(monkeypatch, ["codex", "list", "--skip-api"])
+
+    out = capsys.readouterr().out
+    assert "Imported 1" in out
+    assert "a@example.com" in out
+
+
+def test_the_import_does_not_repeat_on_the_next_command(
+    monkeypatch, capsys, codex_home: Path, offline
+):
+    _seed_one()
+    _run(monkeypatch, ["codex", "list", "--skip-api"])
+    assert "Imported" not in capsys.readouterr().out
+
+
+def test_switch_prints_a_restart_warning_when_codex_is_running(
+    monkeypatch, capsys, codex_home: Path
+):
+    _seed_one()
+    monkeypatch.setattr("claude_swap.codex.switcher.running_codex_pids", lambda: [4242])
+
+    _run(monkeypatch, ["codex", "switch", "1"])
+
+    out = capsys.readouterr().out
+    assert "restart" in out.lower() and "4242" in out
+
+
+def test_switch_is_quiet_when_nothing_is_running(monkeypatch, capsys, codex_home: Path):
+    """A warning printed on every switch is a warning users stop reading."""
+    _seed_one()
+    monkeypatch.setattr("claude_swap.codex.switcher.running_codex_pids", lambda: [])
+
+    _run(monkeypatch, ["codex", "switch", "1"])
+
+    assert "restart" not in capsys.readouterr().out.lower()
+
+
+def test_switch_to_an_unknown_account_exits_nonzero(monkeypatch, capsys, codex_home: Path):
+    _seed_one()
+    with pytest.raises(SystemExit) as exc:
+        _run(monkeypatch, ["codex", "switch", "99"])
+    assert exc.value.code == 1
+    assert "No Codex account matches" in capsys.readouterr().err
+
+
+def test_alias_can_be_set_and_cleared(monkeypatch, capsys, codex_home: Path):
+    _seed_one()
+    _run(monkeypatch, ["codex", "alias", "1", "work"])
+    assert CodexStore().slots()[0].alias == "work"
+    _run(monkeypatch, ["codex", "alias", "1", "--unset"])
+    assert CodexStore().slots()[0].alias == ""
+
+
+def test_an_invalid_alias_is_a_clean_error_not_a_traceback(
+    monkeypatch, capsys, codex_home: Path
+):
+    _seed_one()
+    with pytest.raises(SystemExit) as exc:
+        _run(monkeypatch, ["codex", "alias", "1", "has space"])
+    assert exc.value.code == 1
+    assert "alias" in capsys.readouterr().err.lower()
+
+
+def test_disable_and_enable_round_trip(monkeypatch, codex_home: Path):
+    _seed_one()
+    _run(monkeypatch, ["codex", "disable", "1"])
+    assert CodexStore().slots()[0].disabled is True
+    _run(monkeypatch, ["codex", "enable", "1"])
+    assert CodexStore().slots()[0].disabled is False
+
+
+def test_remove_forgets_the_account(monkeypatch, codex_home: Path):
+    _seed_one()
+    _run(monkeypatch, ["codex", "remove", "1", "-y"])
+    assert CodexStore().slots() == []
+
+
+def test_codex_help_lists_the_verbs(monkeypatch, capsys):
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["codex", "--help"])
+    out = capsys.readouterr().out
+    for verb in ("list", "switch", "add", "login", "remove", "alias", "import"):
+        assert verb in out
+
+
+def test_an_unknown_codex_verb_exits_nonzero(monkeypatch):
+    with pytest.raises(SystemExit) as exc:
+        _run(monkeypatch, ["codex", "frobnicate"])
+    assert exc.value.code != 0
+
+
+def test_codex_login_resolves_the_real_binary_not_a_shell_function(
+    monkeypatch, capsys, codex_home: Path
+):
+    """A shell function named `codex` is a common setup — one injecting
+    --dangerously-bypass-approvals-and-sandbox is in the wild. Running login
+    through a shell would inherit flags cswap never chose."""
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["shell"] = kwargs.get("shell", False)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr("claude_swap.cli_codex.shutil.which", lambda n: "/usr/local/bin/codex")
+    monkeypatch.setattr("claude_swap.cli_codex.subprocess.run", fake_run)
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A))
+    )
+
+    _run(monkeypatch, ["codex", "login"])
+
+    assert seen["cmd"][0] == "/usr/local/bin/codex"
+    assert seen["shell"] is False
+    assert CodexStore().slots()[0].account_key == KEY_A
+
+
+def test_codex_login_forwards_device_auth(monkeypatch, codex_home: Path):
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr("claude_swap.cli_codex.shutil.which", lambda n: "/usr/local/bin/codex")
+    monkeypatch.setattr("claude_swap.cli_codex.subprocess.run", fake_run)
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A))
+    )
+
+    _run(monkeypatch, ["codex", "login", "--device-auth"])
+
+    assert "--device-auth" in seen["cmd"]
+
+
+def test_codex_login_without_the_binary_fails_clearly(monkeypatch, capsys, codex_home: Path):
+    monkeypatch.setattr("claude_swap.cli_codex.shutil.which", lambda n: None)
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["codex", "login"])
+    assert "codex" in capsys.readouterr().err.lower()
+
+
+def test_a_failed_codex_login_does_not_add_an_account(monkeypatch, codex_home: Path):
+    def fake_run(cmd, **kwargs):
+        class R:
+            returncode = 2
+
+        return R()
+
+    monkeypatch.setattr("claude_swap.cli_codex.shutil.which", lambda n: "/usr/local/bin/codex")
+    monkeypatch.setattr("claude_swap.cli_codex.subprocess.run", fake_run)
+
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["codex", "login"])
+
+    assert CodexStore().slots() == []
+
+
+def test_explicit_import_reports_its_counts(monkeypatch, capsys, codex_home: Path):
+    _run(monkeypatch, ["codex", "import"])
+    assert "Imported 0" in capsys.readouterr().out

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -35,7 +35,7 @@ def offline(monkeypatch):
     def boom(*a, **k):
         raise AssertionError("no network request should be made")
 
-    monkeypatch.setattr("claude_swap.codex.switcher.fetch_usage", boom)
+    monkeypatch.setattr("claude_swap.codex.usage_cache.fetch_usage", boom)
 
 
 def test_bare_cswap_verbs_are_untouched(monkeypatch, capsys, temp_home: Path):

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -93,7 +93,7 @@ def test_codex_status_reports_the_live_account(monkeypatch, capsys, codex_home: 
 def test_codex_status_without_a_managed_login_says_so(monkeypatch, capsys, codex_home: Path):
     _seed_one()
     _run(monkeypatch, ["codex", "status"])
-    assert "No managed Codex account is active" in capsys.readouterr().out
+    assert "No active Codex account" in capsys.readouterr().out
 
 
 def test_first_codex_command_imports_codex_auth_accounts(
@@ -291,8 +291,10 @@ def test_a_failed_codex_login_does_not_add_an_account(monkeypatch, codex_home: P
     assert CodexStore().slots() == []
 
 
-def test_explicit_import_reports_its_counts(monkeypatch, capsys, codex_home: Path):
-    _run(monkeypatch, ["codex", "import"])
+def test_explicit_codex_auth_import_reports_its_counts(monkeypatch, capsys, codex_home: Path):
+    """`import` now means "import a cswap export file", matching the Claude
+    side; the one-time codex-auth import has its own explicit verb."""
+    _run(monkeypatch, ["codex", "import-codex-auth"])
     assert "Imported 0" in capsys.readouterr().out
 
 

--- a/tests/test_codex_import.py
+++ b/tests/test_codex_import.py
@@ -1,0 +1,219 @@
+"""One-time import of codex-auth's registry.json into cswap's own store."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_swap.codex.auth_file import account_key, file_key
+from claude_swap.codex.registry_import import ImportResult, import_codex_auth_registry
+from claude_swap.codex.store import CodexStore
+from tests.conftest_codex import make_auth_json
+
+KEY_A = account_key("user-a", "acct-a")
+KEY_B = account_key("user-b", "acct-b")
+
+
+def _write_registry(codex_home: Path, accounts: list[dict], schema: int = 3) -> Path:
+    d = codex_home / "accounts"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": schema,
+                "active_account_key": accounts[0]["account_key"] if accounts else None,
+                "accounts": accounts,
+            }
+        )
+    )
+    return d
+
+
+def _seed(key: str, email: str, plan: str = "pro") -> dict:
+    return {
+        "account_key": key,
+        "chatgpt_account_id": key.split("::")[1],
+        "chatgpt_user_id": key.split("::")[0],
+        "email": email,
+        "alias": "",
+        "account_name": None,
+        "plan": plan,
+        "auth_mode": "chatgpt",
+        "created_at": 0,
+        "last_used_at": 0,
+    }
+
+
+def _snapshot(d: Path, key: str, payload: dict | None = None) -> None:
+    (d / f"{file_key(key)}.auth.json").write_text(
+        json.dumps(payload if payload is not None else make_auth_json())
+    )
+
+
+def test_import_is_a_noop_when_no_registry_exists(codex_home: Path):
+    assert import_codex_auth_registry() == ImportResult(imported=0, skipped=0, source=None)
+    assert CodexStore().slots() == []
+
+
+def test_import_creates_one_slot_per_account(codex_home: Path):
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x"), _seed(KEY_B, "b@x")])
+    _snapshot(d, KEY_A, make_auth_json(email="a@x"))
+    _snapshot(d, KEY_B, make_auth_json(email="b@x"))
+
+    result = import_codex_auth_registry()
+
+    assert result.imported == 2
+    slots = CodexStore().slots()
+    assert [s.email for s in slots] == ["a@x", "b@x"]
+    assert [s.number for s in slots] == ["1", "2"]
+
+
+def test_import_copies_the_snapshots(codex_home: Path):
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x")])
+    payload = make_auth_json(email="a@x")
+    _snapshot(d, KEY_A, payload)
+
+    import_codex_auth_registry()
+
+    assert CodexStore().read_snapshot(KEY_A) == payload
+
+
+def test_import_renames_legacy_plans(codex_home: Path):
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x", plan="team")])
+    _snapshot(d, KEY_A)
+
+    import_codex_auth_registry()
+
+    assert CodexStore().slots()[0].plan == "business"
+
+
+def test_import_carries_the_alias_across(codex_home: Path):
+    row = _seed(KEY_A, "a@x")
+    row["alias"] = "work"
+    d = _write_registry(codex_home, [row])
+    _snapshot(d, KEY_A)
+
+    import_codex_auth_registry()
+
+    assert CodexStore().slots()[0].alias == "work"
+
+
+def test_import_carries_the_workspace_name_across(codex_home: Path):
+    row = _seed(KEY_A, "a@x", plan="team")
+    row["account_name"] = "Workspace Alpha"
+    d = _write_registry(codex_home, [row])
+    _snapshot(d, KEY_A)
+
+    import_codex_auth_registry()
+
+    assert CodexStore().slots()[0].workspace_name == "Workspace Alpha"
+
+
+def test_import_leaves_the_source_untouched(codex_home: Path):
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x")])
+    _snapshot(d, KEY_A)
+    snap = d / f"{file_key(KEY_A)}.auth.json"
+    before = (d / "registry.json").read_text(), snap.read_text()
+
+    import_codex_auth_registry()
+
+    assert ((d / "registry.json").read_text(), snap.read_text()) == before
+
+
+def test_an_account_without_a_snapshot_is_skipped_not_fatal(codex_home: Path):
+    """A registry row whose auth file was deleted is a real state on disk; it
+    must cost that one account, not the whole import."""
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x"), _seed(KEY_B, "b@x")])
+    _snapshot(d, KEY_A)
+
+    result = import_codex_auth_registry()
+
+    assert (result.imported, result.skipped) == (1, 1)
+    assert [s.account_key for s in CodexStore().slots()] == [KEY_A]
+
+
+def test_a_corrupt_snapshot_is_skipped_not_fatal(codex_home: Path):
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x")])
+    (d / f"{file_key(KEY_A)}.auth.json").write_text("{ torn")
+
+    result = import_codex_auth_registry()
+
+    assert (result.imported, result.skipped) == (0, 1)
+
+
+def test_an_api_key_account_imports_without_tokens(codex_home: Path):
+    row = _seed(KEY_A, "a@x")
+    row["auth_mode"] = "apikey"
+    d = _write_registry(codex_home, [row])
+    _snapshot(d, KEY_A, {"auth_mode": "apikey", "OPENAI_API_KEY": "sk-x", "tokens": None})
+
+    result = import_codex_auth_registry()
+
+    assert result.imported == 1
+    assert CodexStore().slots()[0].auth_mode == "apikey"
+
+
+def test_import_reads_the_legacy_v2_email_keyed_shape(codex_home: Path):
+    """v2 keyed accounts by email and had no account_key at all."""
+    d = codex_home / "accounts"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "registry.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "active_email": "a@x",
+                "accounts": {"a@x": {"email": "a@x", "plan": "pro"}},
+            }
+        )
+    )
+    result = import_codex_auth_registry()
+    assert result.skipped == 1  # no account_key, nothing to key a snapshot by
+    assert result.imported == 0
+
+
+def test_a_newer_schema_is_refused_rather_than_misread(codex_home: Path):
+    """Guessing at a format we do not know would corrupt the user's accounts."""
+    d = codex_home / "accounts"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "registry.json").write_text(json.dumps({"schema_version": 99, "accounts": []}))
+    result = import_codex_auth_registry()
+    assert result.imported == 0
+    assert result.unsupported_schema == 99
+
+
+def test_schema_4_is_accepted(codex_home: Path):
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x")], schema=4)
+    _snapshot(d, KEY_A)
+    assert import_codex_auth_registry().imported == 1
+
+
+def test_import_records_the_active_account(codex_home: Path):
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x")])
+    _snapshot(d, KEY_A)
+    import_codex_auth_registry()
+    assert CodexStore().active_key() == KEY_A
+
+
+def test_an_active_key_naming_a_skipped_account_is_not_recorded(codex_home: Path):
+    """Pointing the active marker at a slot that failed to import would make
+    every later status read resolve to nothing."""
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x")])
+    # no snapshot written -> the row is skipped
+    import_codex_auth_registry()
+    assert CodexStore().active_key() is None
+
+
+def test_only_if_empty_does_not_run_twice(codex_home: Path):
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x")])
+    _snapshot(d, KEY_A)
+    import_codex_auth_registry()
+    assert import_codex_auth_registry(only_if_empty=True).imported == 0
+
+
+def test_an_explicit_import_can_be_re_run(codex_home: Path):
+    """`cswap codex import` is a recovery path; it must not silently no-op."""
+    d = _write_registry(codex_home, [_seed(KEY_A, "a@x")])
+    _snapshot(d, KEY_A)
+    import_codex_auth_registry()
+    assert import_codex_auth_registry().imported == 1
+    assert len(CodexStore().slots()) == 1  # upsert, not duplicate

--- a/tests/test_codex_oauth.py
+++ b/tests/test_codex_oauth.py
@@ -1,0 +1,233 @@
+"""Codex token refresh. No test here touches the network."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+from io import BytesIO
+
+from claude_swap.codex import oauth as coauth
+from tests.conftest_codex import make_auth_json, make_jwt
+
+
+class _Resp:
+    def __init__(self, payload: dict):
+        self._body = json.dumps(payload).encode()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _http_error(code: int, body: dict | str) -> urllib.error.HTTPError:
+    raw = json.dumps(body).encode() if isinstance(body, dict) else body.encode()
+    return urllib.error.HTTPError("u", code, "err", {}, BytesIO(raw))
+
+
+def _raiser(exc):
+    def boom(*a, **k):
+        raise exc
+
+    return boom
+
+
+def test_refresh_updates_the_access_token(monkeypatch):
+    payload = make_auth_json(refresh_token="rt-old")
+    new_jwt = make_jwt({"exp": 1_900_000_000, "email": "a@example.com"})
+    monkeypatch.setattr(
+        coauth.urllib.request,
+        "urlopen",
+        lambda *a, **k: _Resp(
+            {"access_token": new_jwt, "refresh_token": "rt-new", "id_token": new_jwt}
+        ),
+    )
+
+    outcome = coauth.try_refresh(payload)
+
+    assert outcome.kind is None
+    assert outcome.payload["tokens"]["access_token"] == new_jwt
+    assert outcome.payload["tokens"]["refresh_token"] == "rt-new"
+
+
+def test_refresh_keeps_the_old_refresh_token_when_none_is_returned(monkeypatch):
+    """RFC 6749 6: an absent refresh_token means keep the one you have.
+    Overwriting it with None would destroy the account's only way back."""
+    payload = make_auth_json(refresh_token="rt-old")
+    monkeypatch.setattr(
+        coauth.urllib.request, "urlopen", lambda *a, **k: _Resp({"access_token": "at"})
+    )
+    outcome = coauth.try_refresh(payload)
+    assert outcome.payload["tokens"]["refresh_token"] == "rt-old"
+
+
+def test_refresh_does_not_mutate_the_payload_it_was_given(monkeypatch):
+    """The caller may still need the pre-refresh payload if the persist fails."""
+    payload = make_auth_json(refresh_token="rt-old")
+    monkeypatch.setattr(
+        coauth.urllib.request,
+        "urlopen",
+        lambda *a, **k: _Resp({"access_token": "at", "refresh_token": "rt-new"}),
+    )
+    coauth.try_refresh(payload)
+    assert payload["tokens"]["refresh_token"] == "rt-old"
+
+
+def test_refresh_stamps_last_refresh(monkeypatch):
+    payload = make_auth_json()
+    monkeypatch.setattr(
+        coauth.urllib.request, "urlopen", lambda *a, **k: _Resp({"access_token": "at"})
+    )
+    outcome = coauth.try_refresh(payload)
+    assert outcome.payload["last_refresh"] != payload["last_refresh"]
+
+
+def test_a_200_without_a_token_is_not_treated_as_success(monkeypatch):
+    """Persisting it would store a stale access token alongside a possibly
+    already-spent refresh token."""
+    monkeypatch.setattr(coauth.urllib.request, "urlopen", lambda *a, **k: _Resp({}))
+    assert coauth.try_refresh(make_auth_json()).kind == "transient"
+
+
+def test_missing_refresh_token_is_a_permanent_verdict():
+    payload = make_auth_json()
+    payload["tokens"]["refresh_token"] = None
+    assert coauth.try_refresh(payload).kind == "no_refresh_token"
+
+
+def test_api_key_account_is_not_refreshable():
+    assert coauth.try_refresh({"auth_mode": "apikey", "tokens": None}).kind == "not_applicable"
+
+
+def test_the_endpoints_nested_error_shape_is_understood(monkeypatch):
+    """Verified live: this endpoint answers 401 with a nested error object, not
+    RFC 6749's flat {"error": "..."} string."""
+    monkeypatch.setattr(
+        coauth.urllib.request,
+        "urlopen",
+        _raiser(
+            _http_error(
+                401,
+                {
+                    "error": {
+                        "message": "Could not validate your token.",
+                        "type": "invalid_request_error",
+                        "code": "token_expired",
+                    }
+                },
+            )
+        ),
+    )
+    assert coauth.try_refresh(make_auth_json()).kind == "token_expired"
+
+
+def test_the_flat_rfc_error_shape_is_also_understood(monkeypatch):
+    """The endpoint is undocumented; if it moves to the standard shape, the
+    verdict must not silently downgrade to 'transient' and retry forever."""
+    monkeypatch.setattr(
+        coauth.urllib.request,
+        "urlopen",
+        _raiser(_http_error(400, {"error": "invalid_grant"})),
+    )
+    assert coauth.try_refresh(make_auth_json()).kind == "invalid_grant"
+
+
+def test_a_rejected_client_is_permanent(monkeypatch):
+    monkeypatch.setattr(
+        coauth.urllib.request,
+        "urlopen",
+        _raiser(_http_error(401, {"error": {"code": "invalid_client"}})),
+    )
+    assert coauth.try_refresh(make_auth_json()).kind == "invalid_client"
+
+
+def test_an_unrecognised_error_code_stays_transient(monkeypatch):
+    """A misclassified transient costs one retry; a misclassified permanent
+    quarantines a live account."""
+    monkeypatch.setattr(
+        coauth.urllib.request,
+        "urlopen",
+        _raiser(_http_error(400, {"error": {"code": "rate_limited"}})),
+    )
+    assert coauth.try_refresh(make_auth_json()).kind == "transient"
+
+
+def test_an_unparseable_error_body_stays_transient(monkeypatch):
+    monkeypatch.setattr(
+        coauth.urllib.request, "urlopen", _raiser(_http_error(400, "not json at all"))
+    )
+    assert coauth.try_refresh(make_auth_json()).kind == "transient"
+
+
+def test_a_server_error_is_transient(monkeypatch):
+    monkeypatch.setattr(
+        coauth.urllib.request,
+        "urlopen",
+        _raiser(_http_error(503, {"error": {"code": "invalid_grant"}})),
+    )
+    assert coauth.try_refresh(make_auth_json()).kind == "transient"
+
+
+def test_a_network_failure_is_transient(monkeypatch):
+    monkeypatch.setattr(
+        coauth.urllib.request, "urlopen", _raiser(urllib.error.URLError("down"))
+    )
+    assert coauth.try_refresh(make_auth_json()).kind == "transient"
+
+
+def test_the_request_uses_the_verified_client_id_and_json_body(monkeypatch):
+    """Both were established against the live endpoint; a silent change to
+    either turns every refresh into invalid_client."""
+    seen = {}
+
+    def fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["body"] = json.loads(req.data.decode())
+        seen["headers"] = dict(req.headers)
+        return _Resp({"access_token": "at"})
+
+    monkeypatch.setattr(coauth.urllib.request, "urlopen", fake_urlopen)
+    coauth.try_refresh(make_auth_json(refresh_token="rt-x"))
+
+    assert seen["url"] == "https://auth.openai.com/oauth/token"
+    assert seen["headers"]["Content-type"] == "application/json"
+    assert seen["body"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "rt-x",
+        "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+        "scope": "openid profile email offline_access",
+    }
+
+
+def test_needs_refresh_is_true_for_an_expired_token():
+    assert coauth.needs_refresh(make_auth_json(exp=0)) is True
+
+
+def test_needs_refresh_is_false_well_inside_the_window():
+    assert coauth.needs_refresh(make_auth_json(exp=time.time() + 3600)) is False
+
+
+def test_needs_refresh_is_true_inside_the_margin():
+    assert coauth.needs_refresh(make_auth_json(exp=time.time() + 30)) is True
+
+
+def test_needs_refresh_is_true_when_the_expiry_is_unreadable():
+    assert coauth.needs_refresh({"tokens": {"access_token": "x"}}) is True
+
+
+def test_no_token_value_ever_reaches_a_log(monkeypatch, caplog):
+    """A refresh token in a log line is a credential leak with a long tail —
+    these logs are what users paste into public issues."""
+    monkeypatch.setattr(
+        coauth.urllib.request,
+        "urlopen",
+        _raiser(_http_error(401, {"error": {"code": "token_expired"}})),
+    )
+    with caplog.at_level("DEBUG"):
+        coauth.try_refresh(make_auth_json(refresh_token="SECRET-RT"))
+    assert "SECRET-RT" not in caplog.text

--- a/tests/test_codex_parity.py
+++ b/tests/test_codex_parity.py
@@ -1,0 +1,358 @@
+"""Parity with the Claude side: status, rotate, swap/move, export/import, purge.
+
+The standard these tests hold the code to is not "Codex has a status command"
+but "Codex's status looks like Claude's status". A user should not have to learn
+a second output format for the same information.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap.codex.auth_file import account_key
+from claude_swap.codex.store import CodexStore
+from claude_swap.codex.switcher import CodexSwitcher
+from claude_swap.codex.transfer import (
+    export_codex_accounts,
+    import_codex_accounts,
+    purge_codex_data,
+)
+from claude_swap.exceptions import ClaudeSwitchError
+from tests.conftest_codex import make_auth_json
+
+ACCT_A, USER_A = "acct-a", "user-a"
+ACCT_B, USER_B = "acct-b", "user-b"
+ACCT_C, USER_C = "acct-c", "user-c"
+KEY_A = account_key(USER_A, ACCT_A)
+KEY_B = account_key(USER_B, ACCT_B)
+KEY_C = account_key(USER_C, ACCT_C)
+
+USAGE = {"five_hour": {"pct": 20}, "seven_day": {"pct": 40}}
+
+
+@pytest.fixture
+def seeded(codex_home: Path) -> CodexSwitcher:
+    """Three accounts, A live."""
+    store = CodexStore()
+    for key, acct, user, email in (
+        (KEY_A, ACCT_A, USER_A, "a@x"),
+        (KEY_B, ACCT_B, USER_B, "b@x"),
+        (KEY_C, ACCT_C, USER_C, "c@x"),
+    ):
+        store.upsert_slot(key, email=email, plan="pro")
+        store.write_snapshot(key, make_auth_json(account_id=acct, user_id=user, email=email))
+    store.set_active(KEY_A)
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A, email="a@x"))
+    )
+    return CodexSwitcher()
+
+
+@pytest.fixture
+def usage(monkeypatch):
+    """Give every account a measurement, without touching the network."""
+    from claude_swap.codex.usage import UsageFetch
+
+    monkeypatch.setattr(
+        "claude_swap.codex.usage_cache.fetch_usage",
+        lambda *a, **k: UsageFetch(usage=USAGE),
+    )
+
+
+# ---- status ------------------------------------------------------------
+
+
+def test_status_renders_through_the_same_helper_as_claude(
+    seeded: CodexSwitcher, usage, capsys
+):
+    """Not "it prints something" — it prints the tree-drawn usage block the
+    Claude side prints, because it calls the same renderer."""
+    seeded.status()
+    out = capsys.readouterr().out
+    assert "Status:" in out
+    assert "Total managed Codex accounts: 3" in out
+    assert "5h:" in out and "7d:" in out
+    assert "├" in out and "└" in out  # the shared tree glyphs
+
+
+def test_status_names_the_active_account(seeded: CodexSwitcher, usage, capsys):
+    seeded.status()
+    out = capsys.readouterr().out
+    assert "Codex-1" in out and "a@x" in out
+
+
+def test_status_without_an_active_account_says_so(codex_home: Path, capsys):
+    CodexSwitcher().status()
+    assert "No active Codex account" in capsys.readouterr().out
+
+
+def test_status_json_matches_the_claude_envelope(seeded: CodexSwitcher, usage):
+    """Same schemaVersion, same active/usage/usageStatus shape — a script that
+    reads one can read the other."""
+    payload = seeded.status(json_output=True)
+    assert payload["schemaVersion"] == 1
+    assert payload["provider"] == "codex"
+    active = payload["active"]
+    assert active["number"] == 1
+    assert active["email"] == "a@x"
+    assert active["managed"] is True
+    assert active["usageStatus"] == "ok"
+    assert active["usage"]["fiveHour"]["pct"] == 20
+    assert active["usage"]["sevenDay"]["pct"] == 40
+
+
+def test_status_json_without_an_account_mirrors_claudes_null(codex_home: Path):
+    payload = CodexSwitcher().status(json_output=True)
+    assert payload == {"schemaVersion": 1, "provider": "codex", "active": None}
+
+
+# ---- rotate / best -----------------------------------------------------
+
+
+def test_bare_switch_rotates_to_the_next_account(seeded: CodexSwitcher):
+    """`cswap switch` rotates on the Claude side; the Codex one must not error
+    on a missing argument."""
+    assert seeded.rotate().number == "2"
+
+
+def test_rotation_wraps_around(seeded: CodexSwitcher, codex_home: Path):
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_C, user_id=USER_C))
+    )
+    assert CodexSwitcher().rotate().number == "1"
+
+
+def test_rotation_skips_disabled_accounts(seeded: CodexSwitcher):
+    CodexStore().set_disabled(KEY_B, True)
+    assert CodexSwitcher().rotate().number == "3"
+
+
+def test_rotation_with_a_single_account_refuses_rather_than_no_ops(codex_home: Path):
+    store = CodexStore()
+    store.upsert_slot(KEY_A, email="a@x", plan="pro")
+    store.write_snapshot(KEY_A, make_auth_json(account_id=ACCT_A, user_id=USER_A))
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A))
+    )
+    with pytest.raises(ClaudeSwitchError, match="Only one"):
+        CodexSwitcher().rotate()
+
+
+def test_strategy_best_picks_the_account_with_the_most_headroom(
+    seeded: CodexSwitcher, monkeypatch
+):
+    from claude_swap.codex.usage import UsageFetch
+
+    pcts = {ACCT_B: 80, ACCT_C: 5}
+
+    def fake(access_token, account_id, timeout_s=10.0):
+        return UsageFetch(usage={"five_hour": {"pct": pcts.get(account_id, 50)}})
+
+    monkeypatch.setattr("claude_swap.codex.usage_cache.fetch_usage", fake)
+    assert seeded.switch_best().number == "3"
+
+
+def test_strategy_best_without_measurements_refuses(seeded: CodexSwitcher, monkeypatch):
+    """Switching on unknown data would move the user for no established reason."""
+    from claude_swap.codex.usage import UsageFetch
+
+    monkeypatch.setattr(
+        "claude_swap.codex.usage_cache.fetch_usage",
+        lambda *a, **k: UsageFetch(sentinel="http 500"),
+    )
+    with pytest.raises(ClaudeSwitchError, match="known measurement"):
+        seeded.switch_best()
+
+
+# ---- swap / move -------------------------------------------------------
+
+
+def test_swap_exchanges_two_slot_numbers(seeded: CodexSwitcher):
+    seeded.swap_accounts("1", "2")
+    numbers = {s.account_key: s.number for s in CodexStore().slots()}
+    assert numbers[KEY_A] == "2" and numbers[KEY_B] == "1"
+
+
+def test_swap_keeps_every_credential_readable(seeded: CodexSwitcher):
+    """Snapshots are keyed by account_key precisely so renumbering never has to
+    move a secret. If that ever changes, this is what breaks."""
+    seeded.swap_accounts("1", "2")
+    store = CodexStore()
+    assert store.read_snapshot(KEY_A)["tokens"]["account_id"] == ACCT_A
+    assert store.read_snapshot(KEY_B)["tokens"]["account_id"] == ACCT_B
+
+
+def test_swap_with_itself_is_refused(seeded: CodexSwitcher):
+    with pytest.raises(ClaudeSwitchError, match="itself"):
+        seeded.swap_accounts("1", "1")
+
+
+def test_move_to_a_free_slot_does_not_swap(seeded: CodexSwitcher):
+    src, dst, swapped = seeded.move_account("1", "9")
+    assert (src, dst, swapped) == ("1", "9", False)
+    assert CodexStore().slot_for_key(KEY_A).number == "9"
+
+
+def test_move_to_a_taken_slot_swaps_the_occupant(seeded: CodexSwitcher):
+    _src, _dst, swapped = seeded.move_account("1", "2")
+    assert swapped is True
+    numbers = {s.account_key: s.number for s in CodexStore().slots()}
+    assert numbers[KEY_A] == "2" and numbers[KEY_B] == "1"
+
+
+def test_move_to_its_current_slot_is_a_no_op(seeded: CodexSwitcher):
+    assert seeded.move_account("1", "1") == ("1", "1", False)
+
+
+def test_move_to_an_invalid_slot_is_refused(seeded: CodexSwitcher):
+    with pytest.raises(ClaudeSwitchError, match="not a valid slot"):
+        seeded.move_account("1", "abc")
+
+
+# ---- export / import ---------------------------------------------------
+
+
+def test_export_writes_every_account_with_its_credentials(
+    seeded: CodexSwitcher, tmp_path: Path
+):
+    target = tmp_path / "codex.json"
+    assert export_codex_accounts(seeded, str(target)) == 3
+    doc = json.loads(target.read_text())
+    assert doc["provider"] == "codex"
+    assert len(doc["accounts"]) == 3
+    assert doc["accounts"][0]["auth"]["tokens"]["refresh_token"]
+
+
+def test_the_export_warns_that_it_holds_live_tokens(
+    seeded: CodexSwitcher, tmp_path: Path
+):
+    """An export you cannot log in with is not a backup — so it carries real
+    tokens, and the file has to say so."""
+    target = tmp_path / "codex.json"
+    export_codex_accounts(seeded, str(target))
+    assert "live OAuth tokens" in json.loads(target.read_text())["warning"]
+
+
+@pytest.mark.skipif(
+    __import__("sys").platform == "win32", reason="POSIX modes only"
+)
+def test_the_export_file_is_created_private(seeded: CodexSwitcher, tmp_path: Path):
+    """Created 0600, not chmod'ed after: between write and chmod the tokens
+    would be world-readable."""
+    import os
+
+    target = tmp_path / "codex.json"
+    export_codex_accounts(seeded, str(target))
+    assert (os.stat(target).st_mode & 0o777) == 0o600
+
+
+def test_export_can_be_limited_to_one_account(seeded: CodexSwitcher, tmp_path: Path):
+    target = tmp_path / "one.json"
+    assert export_codex_accounts(seeded, str(target), account="2") == 1
+    assert json.loads(target.read_text())["accounts"][0]["email"] == "b@x"
+
+
+def test_export_to_stdout(seeded: CodexSwitcher, capsys):
+    export_codex_accounts(seeded, "-")
+    assert json.loads(capsys.readouterr().out)["provider"] == "codex"
+
+
+def test_import_restores_accounts_into_an_empty_store(
+    seeded: CodexSwitcher, tmp_path: Path, codex_home: Path
+):
+    target = tmp_path / "codex.json"
+    export_codex_accounts(seeded, str(target))
+    purge_codex_data(assume_yes=True)
+    assert CodexStore().slots() == []
+
+    assert import_codex_accounts(CodexSwitcher(), str(target)) == 3
+    store = CodexStore()
+    assert len(store.slots()) == 3
+    assert store.read_snapshot(KEY_A)["tokens"]["account_id"] == ACCT_A
+
+
+def test_import_carries_aliases_and_disabled_flags(
+    seeded: CodexSwitcher, tmp_path: Path
+):
+    store = CodexStore()
+    store.set_alias(KEY_B, "work")
+    store.set_disabled(KEY_C, True)
+    target = tmp_path / "codex.json"
+    export_codex_accounts(CodexSwitcher(), str(target))
+    purge_codex_data(assume_yes=True)
+
+    import_codex_accounts(CodexSwitcher(), str(target))
+
+    restored = {s.account_key: s for s in CodexStore().slots()}
+    assert restored[KEY_B].alias == "work"
+    assert restored[KEY_C].disabled is True
+
+
+def test_import_skips_existing_accounts_unless_forced(
+    seeded: CodexSwitcher, tmp_path: Path
+):
+    target = tmp_path / "codex.json"
+    export_codex_accounts(seeded, str(target))
+    assert import_codex_accounts(CodexSwitcher(), str(target)) == 0
+    assert import_codex_accounts(CodexSwitcher(), str(target), force=True) == 3
+
+
+def test_import_refuses_a_claude_export(tmp_path: Path, codex_home: Path):
+    """Refusing beats half-applying: a Claude export's rows describe entirely
+    different fields."""
+    target = tmp_path / "claude.json"
+    target.write_text(json.dumps({"provider": "claude", "accounts": [{}]}))
+    with pytest.raises(ClaudeSwitchError, match="not a Codex one"):
+        import_codex_accounts(CodexSwitcher(), str(target))
+
+
+def test_import_refuses_a_newer_export_version(tmp_path: Path, codex_home: Path):
+    target = tmp_path / "future.json"
+    target.write_text(
+        json.dumps({"provider": "codex", "version": 99, "accounts": [{}]})
+    )
+    with pytest.raises(ClaudeSwitchError, match="newer than"):
+        import_codex_accounts(CodexSwitcher(), str(target))
+
+
+def test_import_of_junk_is_a_clean_error(tmp_path: Path, codex_home: Path):
+    target = tmp_path / "junk.json"
+    target.write_text("{ not json")
+    with pytest.raises(ClaudeSwitchError, match="not valid JSON"):
+        import_codex_accounts(CodexSwitcher(), str(target))
+
+
+def test_import_of_a_missing_file_is_a_clean_error(tmp_path: Path, codex_home: Path):
+    with pytest.raises(ClaudeSwitchError, match="Cannot read"):
+        import_codex_accounts(CodexSwitcher(), str(tmp_path / "nope.json"))
+
+
+# ---- purge -------------------------------------------------------------
+
+
+def test_purge_removes_slots_and_snapshots(seeded: CodexSwitcher, capsys):
+    assert purge_codex_data(assume_yes=True) is True
+    store = CodexStore()
+    assert store.slots() == []
+    assert store.read_snapshot(KEY_A) is None
+
+
+def test_purge_leaves_the_live_codex_login_alone(seeded: CodexSwitcher, codex_home: Path):
+    """cswap manages copies; the user's actual ~/.codex login is not ours."""
+    before = (codex_home / "auth.json").read_text()
+    purge_codex_data(assume_yes=True)
+    assert (codex_home / "auth.json").read_text() == before
+
+
+def test_purge_asks_first(seeded: CodexSwitcher, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *a: "n")
+    assert purge_codex_data() is False
+    assert len(CodexStore().slots()) == 3
+
+
+def test_purge_on_an_empty_store_says_so(codex_home: Path, capsys):
+    assert purge_codex_data(assume_yes=True) is False
+    assert "No cswap Codex data" in capsys.readouterr().out

--- a/tests/test_codex_paths.py
+++ b/tests/test_codex_paths.py
@@ -1,0 +1,44 @@
+"""Codex path resolution: ~/.codex on the read side, cswap's own store on the write side."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from claude_swap.codex import paths as cpaths
+
+
+def test_codex_home_defaults_to_dot_codex(temp_home: Path):
+    assert cpaths.get_codex_home() == temp_home / ".codex"
+
+
+def test_codex_home_honours_the_env_var(temp_home: Path, monkeypatch):
+    """The codex CLI reads CODEX_HOME; cswap must resolve the same file it does."""
+    monkeypatch.setenv("CODEX_HOME", str(temp_home / "elsewhere"))
+    assert cpaths.get_codex_home() == temp_home / "elsewhere"
+
+
+def test_live_auth_path_sits_directly_in_codex_home(temp_home: Path):
+    assert cpaths.get_live_auth_path() == temp_home / ".codex" / "auth.json"
+
+
+def test_legacy_registry_path_points_at_codex_auth_data(temp_home: Path):
+    assert (
+        cpaths.get_codex_auth_registry_path()
+        == temp_home / ".codex" / "accounts" / "registry.json"
+    )
+
+
+def test_store_root_is_a_subtree_of_the_cswap_backup_root(temp_home: Path):
+    from claude_swap.paths import get_backup_root
+
+    root = cpaths.get_codex_store_root()
+    assert root == get_backup_root() / "codex"
+    assert root.parent == get_backup_root()
+
+
+def test_store_paths_hang_off_the_store_root(temp_home: Path):
+    root = cpaths.get_codex_store_root()
+    assert cpaths.get_codex_sequence_path() == root / "sequence.json"
+    assert cpaths.get_codex_credentials_dir() == root / "credentials"
+    assert cpaths.get_codex_cache_dir() == root / "cache"
+    assert cpaths.get_codex_lock_path() == root / ".lock"

--- a/tests/test_codex_plans.py
+++ b/tests/test_codex_plans.py
@@ -1,0 +1,31 @@
+"""Plan-tier naming, normalized to codex-auth v4 semantics."""
+
+from __future__ import annotations
+
+from claude_swap.codex.plans import normalize_plan
+
+
+def test_legacy_team_becomes_business():
+    assert normalize_plan("team") == "business"
+
+
+def test_legacy_business_becomes_enterprise():
+    assert normalize_plan("business") == "enterprise"
+
+
+def test_the_rename_is_a_single_lookup_not_two_passes():
+    """Applied sequentially, 'team' would pass through 'business' and land on
+    'enterprise' — every Business account mislabelled one tier up."""
+    assert normalize_plan("team") != "enterprise"
+
+
+def test_unrenamed_tiers_pass_through():
+    assert normalize_plan("pro") == "pro"
+    assert normalize_plan("plus") == "plus"
+    assert normalize_plan("enterprise") == "enterprise"
+
+
+def test_missing_or_non_string_plans_become_empty():
+    assert normalize_plan(None) == ""
+    assert normalize_plan("") == ""
+    assert normalize_plan(3) == ""

--- a/tests/test_codex_processes.py
+++ b/tests/test_codex_processes.py
@@ -1,0 +1,84 @@
+"""Detecting running codex processes, so a switch can warn about restarts."""
+
+from __future__ import annotations
+
+from claude_swap.codex import processes
+
+
+def test_no_processes_when_the_lister_returns_nothing(monkeypatch):
+    monkeypatch.setattr(processes, "_list_processes", lambda: [])
+    assert processes.running_codex_pids() == []
+
+
+def test_a_codex_process_is_detected(monkeypatch):
+    monkeypatch.setattr(
+        processes, "_list_processes", lambda: [(4242, "/Users/x/.local/bin/codex")]
+    )
+    assert processes.running_codex_pids() == [4242]
+
+
+def test_an_unrelated_process_is_ignored(monkeypatch):
+    monkeypatch.setattr(processes, "_list_processes", lambda: [(1, "/usr/bin/python")])
+    assert processes.running_codex_pids() == []
+
+
+def test_a_path_merely_containing_codex_does_not_match(monkeypatch):
+    """`/Users/me/codex-notes/server` is not the codex CLI. Matching on the
+    executable name is what keeps the restart warning from crying wolf."""
+    monkeypatch.setattr(
+        processes, "_list_processes", lambda: [(7, "/Users/me/codex-notes/server")]
+    )
+    assert processes.running_codex_pids() == []
+
+
+def test_the_codext_fork_counts_as_codex(monkeypatch):
+    """codext switches seamlessly, but it is still a running Codex session the
+    user may want to know about."""
+    monkeypatch.setattr(processes, "_list_processes", lambda: [(9, "/usr/local/bin/codext")])
+    assert processes.running_codex_pids() == [9]
+
+
+def test_lister_failure_degrades_to_no_processes(monkeypatch):
+    def boom():
+        raise OSError("ps missing")
+
+    monkeypatch.setattr(processes, "_list_processes", boom)
+    assert processes.running_codex_pids() == []
+
+
+def test_the_posix_ps_parser_reads_real_output(monkeypatch):
+    """The only coverage the POSIX branch gets — every other test here patches
+    the lister away."""
+
+    class R:
+        stdout = "  501 codex\n  900 python3\n 1200 codext\n"
+
+    monkeypatch.setattr(processes.sys, "platform", "darwin")
+    monkeypatch.setattr(processes.subprocess, "run", lambda *a, **k: R())
+
+    assert processes._list_processes() == [(501, "codex"), (900, "python3"), (1200, "codext")]
+    assert processes.running_codex_pids() == [501, 1200]
+
+
+def test_the_windows_tasklist_parser_reads_real_csv_output(monkeypatch):
+    """Windows support was an explicit decision, and every other test in this
+    module patches the lister away — so this is the only coverage the win32
+    branch gets. The CSV is real `tasklist /FO CSV /NH` output."""
+
+    class R:
+        stdout = (
+            '"codex.exe","4242","Console","1","52,000 K"\n'
+            '"explorer.exe","900","Console","1","98,000 K"\n'
+        )
+
+    monkeypatch.setattr(processes.sys, "platform", "win32")
+    monkeypatch.setattr(processes.subprocess, "run", lambda *a, **k: R())
+
+    assert processes._list_processes() == [(4242, "codex.exe"), (900, "explorer.exe")]
+    assert processes.running_codex_pids() == [4242]
+
+
+def test_the_exe_suffix_is_stripped_when_matching():
+    assert processes._executable_name("C:\\tools\\codex.exe") == "codex"
+    assert processes._executable_name("C:\\tools\\CODEX.EXE") == "CODEX"
+    assert processes._executable_name("/usr/bin/codex") == "codex"

--- a/tests/test_codex_seam.py
+++ b/tests/test_codex_seam.py
@@ -1,0 +1,52 @@
+"""The provider seam: read-model fields and the Protocol both providers satisfy."""
+
+from __future__ import annotations
+
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
+from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.usage_store import UsageEntry
+
+
+def _snapshot(**kw) -> AccountSnapshot:
+    base = dict(
+        number="1",
+        email="a@example.com",
+        org_name="",
+        org_uuid="",
+        is_active=True,
+        kind="oauth",
+        switchable=True,
+        usage=UsageEntry(),
+    )
+    base.update(kw)
+    return AccountSnapshot(**base)
+
+
+def test_account_snapshot_defaults_to_claude_provider():
+    """Existing construction sites pass no provider and must keep working."""
+    assert _snapshot().provider == "claude"
+
+
+def test_account_snapshot_accepts_an_explicit_provider():
+    assert _snapshot(provider="codex").provider == "codex"
+
+
+def test_accounts_snapshot_defaults_to_claude_provider():
+    snap = AccountsSnapshot(active_number="1", accounts=(), taken_at=0.0)
+    assert snap.provider == "claude"
+
+
+def test_claude_switcher_declares_its_provider_id():
+    assert ClaudeAccountSwitcher.provider_id == "claude"
+
+
+def test_claude_switcher_satisfies_the_provider_protocol():
+    """The seam is defined so the existing Claude switcher already fits it.
+
+    This is the whole point of a runtime-checkable Protocol here: if a later
+    refactor renames one of these verbs, this test fails instead of the TUI
+    failing at runtime on one provider only.
+    """
+    from claude_swap.providers.base import ProviderSwitcher
+
+    assert issubclass(ClaudeAccountSwitcher, ProviderSwitcher)

--- a/tests/test_codex_store.py
+++ b/tests/test_codex_store.py
@@ -1,0 +1,201 @@
+"""The Codex slot registry and snapshot store."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_swap.codex import paths as cpaths
+from claude_swap.codex import store as store_mod
+from claude_swap.codex.auth_file import account_key, file_key
+from claude_swap.codex.store import CodexStore
+from tests.conftest_codex import make_auth_json
+
+KEY_A = account_key("user-a", "acct-a")
+KEY_B = account_key("user-b", "acct-b")
+KEY_C = account_key("user-c", "acct-c")
+
+
+@pytest.fixture
+def store(temp_home: Path) -> CodexStore:
+    return CodexStore()
+
+
+@pytest.fixture
+def file_store(temp_home: Path, monkeypatch) -> CodexStore:
+    """A store forced onto the on-disk path, so the file layout is testable
+    on a macOS dev machine as well as on Linux/Windows CI."""
+    monkeypatch.setattr(CodexStore, "_use_keychain", lambda self: False)
+    return CodexStore()
+
+
+def test_a_fresh_store_has_no_slots(store: CodexStore):
+    assert store.slots() == []
+    assert store.active_number() is None
+
+
+def test_adding_a_slot_assigns_the_first_free_number(store: CodexStore):
+    slot = store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    assert slot.number == "1"
+    assert store.slots()[0].account_key == KEY_A
+
+
+def test_a_second_slot_gets_the_next_number(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    assert store.upsert_slot(KEY_B, email="b@example.com", plan="plus").number == "2"
+
+
+def test_upserting_the_same_key_updates_rather_than_duplicating(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    again = store.upsert_slot(KEY_A, email="renamed@example.com", plan="business")
+    assert again.number == "1"
+    assert len(store.slots()) == 1
+    assert store.slots()[0].email == "renamed@example.com"
+    assert store.slots()[0].plan == "business"
+
+
+def test_slots_survive_a_reload(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    assert CodexStore().slots()[0].account_key == KEY_A
+
+
+def test_removing_a_slot_leaves_the_others_numbered_as_they_were(store: CodexStore):
+    """Renumbering on delete would silently repoint every alias, mapping and
+    muscle-memorised number the user has. Slots keep their numbers; the gap stays."""
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    store.upsert_slot(KEY_B, email="b@example.com", plan="plus")
+    store.remove_slot(KEY_A)
+    assert [s.number for s in store.slots()] == ["2"]
+
+
+def test_a_freed_number_is_reused_by_the_next_add(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    store.upsert_slot(KEY_B, email="b@example.com", plan="plus")
+    store.remove_slot(KEY_A)
+    assert store.upsert_slot(KEY_C, email="c@example.com", plan="pro").number == "1"
+
+
+def test_removing_an_unknown_key_reports_that_nothing_happened(store: CodexStore):
+    assert store.remove_slot("nope") is False
+
+
+def test_active_number_is_recorded_and_read_back(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    store.set_active(KEY_A)
+    assert store.active_number() == "1"
+
+
+def test_removing_the_active_slot_clears_the_active_marker(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    store.set_active(KEY_A)
+    store.remove_slot(KEY_A)
+    assert CodexStore().active_key() is None
+
+
+def test_alias_round_trips(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    store.set_alias(KEY_A, "work")
+    assert CodexStore().slots()[0].alias == "work"
+    store.set_alias(KEY_A, "")
+    assert CodexStore().slots()[0].alias == ""
+
+
+def test_disabled_flag_round_trips(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    store.set_disabled(KEY_A, True)
+    assert CodexStore().slots()[0].disabled is True
+
+
+def test_workspace_name_round_trips(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="business")
+    store.set_workspace_name(KEY_A, "Workspace Alpha")
+    assert CodexStore().slots()[0].display_label == "a@example.com [Workspace Alpha]"
+
+
+def test_a_slot_without_a_workspace_displays_as_personal(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    assert store.slots()[0].display_label == "a@example.com [personal]"
+
+
+def test_snapshot_round_trips_through_the_credential_store(store: CodexStore):
+    payload = make_auth_json(email="a@example.com")
+    store.write_snapshot(KEY_A, payload)
+    assert store.read_snapshot(KEY_A) == payload
+
+
+def test_snapshot_is_keyed_by_account_key_not_slot_number(file_store: CodexStore):
+    """Keying by slot would turn a future `codex swap`/`codex move` into a
+    data migration. The key is the identity, and it never renumbers."""
+    file_store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    file_store.write_snapshot(KEY_A, make_auth_json())
+    assert (cpaths.get_codex_credentials_dir() / f"{file_key(KEY_A)}.json").exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="Keychain is macOS-only")
+def test_macos_snapshots_go_to_the_keychain(store: CodexStore, block_real_keychain):
+    store.write_snapshot(KEY_A, make_auth_json())
+    assert (store_mod.KEYCHAIN_SERVICE, file_key(KEY_A)) in block_real_keychain.data
+    assert list(cpaths.get_codex_credentials_dir().glob("*.json")) == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
+def test_on_disk_snapshots_are_private(file_store: CodexStore):
+    """Directory 0700, files 0600 — codex-auth's documented posture."""
+    file_store.write_snapshot(KEY_A, make_auth_json())
+    d = cpaths.get_codex_credentials_dir()
+    assert (os.stat(d).st_mode & 0o777) == 0o700
+    f = d / f"{file_key(KEY_A)}.json"
+    assert (os.stat(f).st_mode & 0o777) == 0o600
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
+def test_the_sequence_file_and_its_directory_are_private(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    assert (os.stat(cpaths.get_codex_sequence_path()).st_mode & 0o777) == 0o600
+    assert (os.stat(cpaths.get_codex_store_root()).st_mode & 0o777) == 0o700
+
+
+def test_deleting_a_slot_deletes_its_snapshot(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    store.write_snapshot(KEY_A, make_auth_json())
+    store.remove_slot(KEY_A)
+    assert store.read_snapshot(KEY_A) is None
+
+
+def test_reading_a_missing_snapshot_returns_none(store: CodexStore):
+    assert store.read_snapshot("nope") is None
+
+
+def test_a_corrupt_snapshot_reads_as_missing_not_as_a_crash(file_store: CodexStore):
+    cpaths.get_codex_credentials_dir().mkdir(parents=True, exist_ok=True)
+    (cpaths.get_codex_credentials_dir() / f"{file_key(KEY_A)}.json").write_text("{ torn")
+    assert file_store.read_snapshot(KEY_A) is None
+
+
+def test_sequence_file_is_valid_json_on_disk(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    data = json.loads(cpaths.get_codex_sequence_path().read_text())
+    assert data["accounts"]["1"]["account_key"] == KEY_A
+
+
+def test_a_corrupt_sequence_file_does_not_crash_the_store(store: CodexStore):
+    """A torn write must degrade to 'no accounts', never to a traceback that
+    makes every cswap command unusable."""
+    cpaths.get_codex_sequence_path().parent.mkdir(parents=True, exist_ok=True)
+    cpaths.get_codex_sequence_path().write_text("{ not json")
+    assert CodexStore().slots() == []
+
+
+def test_a_sequence_file_holding_a_json_array_degrades_safely(store: CodexStore):
+    cpaths.get_codex_sequence_path().parent.mkdir(parents=True, exist_ok=True)
+    cpaths.get_codex_sequence_path().write_text("[1, 2, 3]")
+    assert CodexStore().slots() == []
+
+
+def test_writing_leaves_no_temp_file_behind(store: CodexStore):
+    store.upsert_slot(KEY_A, email="a@example.com", plan="pro")
+    assert list(cpaths.get_codex_store_root().glob("*.tmp")) == []

--- a/tests/test_codex_switcher.py
+++ b/tests/test_codex_switcher.py
@@ -45,7 +45,7 @@ def seeded(codex_home: Path) -> CodexSwitcher:
 def no_usage(monkeypatch):
     """Neutralise the network for snapshot tests."""
     monkeypatch.setattr(
-        "claude_swap.codex.switcher.fetch_usage", lambda *a, **k: UsageFetch(usage={})
+        "claude_swap.codex.usage_cache.fetch_usage", lambda *a, **k: UsageFetch(usage={})
     )
 
 
@@ -290,7 +290,7 @@ def test_snapshot_without_fetch_makes_no_requests(seeded: CodexSwitcher, monkeyp
     def boom(*a, **k):
         raise AssertionError("no request should be made")
 
-    monkeypatch.setattr("claude_swap.codex.switcher.fetch_usage", boom)
+    monkeypatch.setattr("claude_swap.codex.usage_cache.fetch_usage", boom)
     assert len(seeded.accounts_snapshot().accounts) == 2
 
 
@@ -298,7 +298,7 @@ def test_a_usage_failure_becomes_a_sentinel_not_an_exception(
     seeded: CodexSwitcher, monkeypatch
 ):
     monkeypatch.setattr(
-        "claude_swap.codex.switcher.fetch_usage",
+        "claude_swap.codex.usage_cache.fetch_usage",
         lambda *a, **k: UsageFetch(sentinel="http 401"),
     )
     snap = seeded.accounts_snapshot(fetch={"1"})
@@ -437,3 +437,46 @@ def test_disable_and_enable_round_trip(seeded: CodexSwitcher):
     assert CodexStore().slots()[1].disabled is True
     seeded.set_account_disabled("2", False)
     assert CodexStore().slots()[1].disabled is False
+
+
+# ---- usage caching (stage 2) -------------------------------------------
+
+
+def test_two_consecutive_snapshots_cost_one_round_of_requests(
+    seeded: CodexSwitcher, monkeypatch
+):
+    """The reason the usage cache exists. If someone later 'simplifies' it
+    away, this is the test that fails."""
+    from claude_swap.codex.usage import UsageFetch
+
+    calls: list[int] = []
+
+    def counted(*a, **k):
+        calls.append(1)
+        return UsageFetch(usage={"five_hour": {"pct": 5}})
+
+    monkeypatch.setattr("claude_swap.codex.usage_cache.fetch_usage", counted)
+
+    seeded.accounts_snapshot(fetch={"1", "2"})
+    first = len(calls)
+    seeded.accounts_snapshot(fetch={"1", "2"})
+
+    assert first == 2
+    assert len(calls) == first  # the second pass added nothing
+
+
+def test_a_cached_value_is_served_to_a_later_snapshot_without_fetching(
+    seeded: CodexSwitcher, monkeypatch
+):
+    from claude_swap.codex.usage import UsageFetch
+
+    monkeypatch.setattr(
+        "claude_swap.codex.usage_cache.fetch_usage",
+        lambda *a, **k: UsageFetch(usage={"five_hour": {"pct": 7}}),
+    )
+    seeded.accounts_snapshot(fetch={"1", "2"})
+
+    # no fetch set at all: pure cache read
+    snap = seeded.accounts_snapshot()
+
+    assert snap.accounts[0].usage.last_good == {"five_hour": {"pct": 7}}

--- a/tests/test_codex_switcher.py
+++ b/tests/test_codex_switcher.py
@@ -382,6 +382,29 @@ def test_remove_drops_the_slot_and_its_snapshot(seeded: CodexSwitcher):
     assert CodexStore().read_snapshot(KEY_B) is None
 
 
+def test_remove_asks_before_deleting(seeded: CodexSwitcher, monkeypatch):
+    """Removal deletes the Keychain item too. An unprompted destructive verb
+    would diverge from the Claude side's `remove` for no reason."""
+    monkeypatch.setattr("builtins.input", lambda *a: "n")
+    seeded.remove_account("2")
+    assert len(CodexStore().slots()) == 2
+    assert CodexStore().read_snapshot(KEY_B) is not None
+
+
+def test_remove_proceeds_when_the_prompt_is_answered_yes(seeded: CodexSwitcher, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *a: "y")
+    seeded.remove_account("2")
+    assert [s.account_key for s in CodexStore().slots()] == [KEY_A]
+
+
+def test_remove_warns_when_the_target_is_the_active_account(
+    seeded: CodexSwitcher, monkeypatch, capsys
+):
+    monkeypatch.setattr("builtins.input", lambda *a: "y")
+    seeded.remove_account("1")
+    assert "currently active" in capsys.readouterr().out
+
+
 def test_remove_of_an_unknown_account_raises(seeded: CodexSwitcher):
     with pytest.raises(ClaudeSwitchError):
         seeded.remove_account("99", assume_yes=True)

--- a/tests/test_codex_switcher.py
+++ b/tests/test_codex_switcher.py
@@ -1,0 +1,416 @@
+"""CodexSwitcher: the verbs, and the two rules that make them correct."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap.codex import paths as cpaths
+from claude_swap.codex.auth_file import account_key
+from claude_swap.codex.oauth import RefreshOutcome
+from claude_swap.codex.store import CodexStore
+from claude_swap.codex.switcher import CodexSwitcher
+from claude_swap.codex.usage import UsageFetch
+from claude_swap.exceptions import ClaudeSwitchError
+from claude_swap.locking import FileLock
+from claude_swap.providers.base import ProviderSwitcher
+from tests.conftest_codex import make_auth_json
+
+ACCT_A, USER_A = "acct-a", "user-a"
+ACCT_B, USER_B = "acct-b", "user-b"
+KEY_A = account_key(USER_A, ACCT_A)
+KEY_B = account_key(USER_B, ACCT_B)
+
+
+@pytest.fixture
+def seeded(codex_home: Path) -> CodexSwitcher:
+    """Two managed accounts, A live."""
+    store = CodexStore()
+    for key, acct, user, email in (
+        (KEY_A, ACCT_A, USER_A, "a@x"),
+        (KEY_B, ACCT_B, USER_B, "b@x"),
+    ):
+        store.upsert_slot(key, email=email, plan="pro")
+        store.write_snapshot(key, make_auth_json(account_id=acct, user_id=user, email=email))
+    store.set_active(KEY_A)
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A, email="a@x"))
+    )
+    return CodexSwitcher()
+
+
+@pytest.fixture
+def no_usage(monkeypatch):
+    """Neutralise the network for snapshot tests."""
+    monkeypatch.setattr(
+        "claude_swap.codex.switcher.fetch_usage", lambda *a, **k: UsageFetch(usage={})
+    )
+
+
+def _held_lock(monkeypatch, switcher: CodexSwitcher) -> FileLock:
+    """Take the store lock from 'another process' and make the switcher impatient."""
+    held = FileLock(cpaths.get_codex_lock_path(), timeout=0.1)
+    assert held.acquire() is True
+    monkeypatch.setattr(
+        switcher,
+        "_lock",
+        lambda timeout=0.1: FileLock(cpaths.get_codex_lock_path(), timeout=0.1),
+    )
+    return held
+
+
+# ---- the seam ----------------------------------------------------------
+
+
+def test_codex_switcher_satisfies_the_provider_protocol():
+    assert issubclass(CodexSwitcher, ProviderSwitcher)
+    assert CodexSwitcher.provider_id == "codex"
+
+
+# ---- rule 1: the live file decides who is active ------------------------
+
+
+def test_active_account_is_derived_from_the_live_file(seeded: CodexSwitcher):
+    """The codex CLI can rewrite auth.json behind us. Trusting our own registry
+    would make `status` and the TUI lie after every such write."""
+    CodexStore().set_active(KEY_B)  # registry says B, live file still holds A
+    assert seeded.current_account_number() == "1"
+
+
+def test_active_is_none_when_the_live_login_is_unmanaged(seeded: CodexSwitcher, codex_home: Path):
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id="stranger", user_id="user-z"))
+    )
+    assert seeded.current_account_number() is None
+
+
+def test_active_is_none_when_there_is_no_live_login(seeded: CodexSwitcher, codex_home: Path):
+    (codex_home / "auth.json").unlink()
+    assert seeded.current_account_number() is None
+
+
+def test_switch_captures_the_outgoing_login_into_its_own_slot(
+    seeded: CodexSwitcher, codex_home: Path
+):
+    """The captured tokens go to the slot the LIVE file's identity matches —
+    not to whatever the registry believed was active. That is what repairs a
+    clobber instead of writing one account's tokens over another's."""
+    CodexStore().set_active(KEY_B)  # registry is wrong; live file is A
+    rotated = make_auth_json(
+        account_id=ACCT_A, user_id=USER_A, email="a@x", refresh_token="rt-rotated"
+    )
+    (codex_home / "auth.json").write_text(json.dumps(rotated))
+
+    seeded.switch_to("2")
+
+    assert CodexStore().read_snapshot(KEY_A)["tokens"]["refresh_token"] == "rt-rotated"
+    # ...and B's own snapshot was not overwritten with A's tokens
+    assert CodexStore().read_snapshot(KEY_B)["tokens"]["account_id"] == ACCT_B
+
+
+def test_an_unmanaged_live_login_is_not_captured_into_any_slot(
+    seeded: CodexSwitcher, codex_home: Path
+):
+    before = CodexStore().read_snapshot(KEY_A)
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id="stranger", user_id="user-z"))
+    )
+    seeded.switch_to("2")
+    assert CodexStore().read_snapshot(KEY_A) == before
+
+
+# ---- switching ---------------------------------------------------------
+
+
+def test_switch_writes_the_target_snapshot_to_the_live_file(
+    seeded: CodexSwitcher, codex_home: Path
+):
+    seeded.switch_to("2")
+    live = json.loads((codex_home / "auth.json").read_text())
+    assert live["tokens"]["account_id"] == ACCT_B
+
+
+def test_switch_records_the_new_active_slot(seeded: CodexSwitcher):
+    seeded.switch_to("2")
+    assert CodexStore().active_key() == KEY_B
+
+
+def test_switch_reports_running_codex_sessions(seeded: CodexSwitcher, monkeypatch):
+    monkeypatch.setattr("claude_swap.codex.switcher.running_codex_pids", lambda: [4242])
+    assert seeded.switch_to("2").running_pids == [4242]
+
+
+def test_switch_to_an_unknown_account_raises(seeded: CodexSwitcher):
+    with pytest.raises(ClaudeSwitchError):
+        seeded.switch_to("99")
+
+
+def test_switch_to_an_account_without_credentials_raises(seeded: CodexSwitcher):
+    CodexStore().delete_snapshot(KEY_B)
+    with pytest.raises(ClaudeSwitchError, match="no stored credentials"):
+        seeded.switch_to("2")
+
+
+def test_switch_rolls_back_when_writing_the_live_file_fails(
+    seeded: CodexSwitcher, monkeypatch, codex_home: Path
+):
+    before = (codex_home / "auth.json").read_text()
+    calls: list[int] = []
+
+    def flaky(payload):
+        calls.append(1)
+        if len(calls) == 1:
+            raise OSError("disk full")
+        # the rollback write is allowed through
+        (codex_home / "auth.json").write_text(json.dumps(payload))
+        return codex_home / "auth.json"
+
+    monkeypatch.setattr("claude_swap.codex.switcher.write_live_auth", flaky)
+
+    with pytest.raises(ClaudeSwitchError):
+        seeded.switch_to("2")
+
+    assert json.loads((codex_home / "auth.json").read_text()) == json.loads(before)
+    assert CodexStore().active_key() == KEY_A
+
+
+def test_switch_is_serialized_by_the_store_lock(seeded: CodexSwitcher, monkeypatch):
+    """A TUI refresh and a CLI switch are concurrent by construction; an
+    interleaved capture/write puts one account's tokens in another's slot."""
+    held = _held_lock(monkeypatch, seeded)
+    try:
+        with pytest.raises(ClaudeSwitchError, match="Another cswap process"):
+            seeded.switch_to("2")
+    finally:
+        held.release()
+
+
+# ---- rule 2: never refresh the active account from its snapshot ---------
+
+
+def test_the_active_account_is_never_refreshed_from_its_snapshot(
+    seeded: CodexSwitcher, monkeypatch, no_usage
+):
+    """Refreshing the active account's stored copy races the codex CLI holding
+    the same refresh token. Whoever loses the rotation is logged out."""
+    refreshed: list[str] = []
+
+    def fake_refresh(payload, **kw):
+        refreshed.append(payload["tokens"]["account_id"])
+        return RefreshOutcome(payload=payload)
+
+    monkeypatch.setattr("claude_swap.codex.switcher.try_refresh", fake_refresh)
+    monkeypatch.setattr("claude_swap.codex.switcher.needs_refresh", lambda p, **k: True)
+
+    seeded.accounts_snapshot(fetch={"1", "2"})
+
+    assert ACCT_A not in refreshed  # active: read live, never refreshed
+    assert ACCT_B in refreshed
+
+
+def test_a_fresh_token_is_not_refreshed_at_all(seeded: CodexSwitcher, monkeypatch, no_usage):
+    refreshed: list[str] = []
+    monkeypatch.setattr(
+        "claude_swap.codex.switcher.try_refresh",
+        lambda p, **k: refreshed.append(1) or RefreshOutcome(payload=p),
+    )
+    monkeypatch.setattr("claude_swap.codex.switcher.needs_refresh", lambda p, **k: False)
+
+    seeded.accounts_snapshot(fetch={"2"})
+
+    assert refreshed == []
+
+
+def test_a_rotated_refresh_token_is_persisted_immediately(
+    seeded: CodexSwitcher, monkeypatch, no_usage
+):
+    """A rotated token that is never written down is an account lost."""
+
+    def fake_refresh(payload, **kw):
+        out = json.loads(json.dumps(payload))
+        out["tokens"]["refresh_token"] = "rt-rotated"
+        return RefreshOutcome(payload=out)
+
+    monkeypatch.setattr("claude_swap.codex.switcher.try_refresh", fake_refresh)
+    monkeypatch.setattr("claude_swap.codex.switcher.needs_refresh", lambda p, **k: True)
+
+    seeded.accounts_snapshot(fetch={"2"})
+
+    assert CodexStore().read_snapshot(KEY_B)["tokens"]["refresh_token"] == "rt-rotated"
+
+
+def test_a_busy_store_skips_the_refresh_rather_than_losing_the_token(
+    seeded: CodexSwitcher, monkeypatch, no_usage
+):
+    """A refresh that cannot be persisted may have already rotated the token
+    server-side. Refusing to refresh costs a stale row; refreshing without
+    persisting can cost the account."""
+    refreshed: list[int] = []
+    monkeypatch.setattr("claude_swap.codex.switcher.needs_refresh", lambda p, **k: True)
+    monkeypatch.setattr(
+        "claude_swap.codex.switcher.try_refresh",
+        lambda p, **k: refreshed.append(1) or RefreshOutcome(payload=p),
+    )
+
+    held = _held_lock(monkeypatch, seeded)
+    try:
+        seeded.accounts_snapshot(fetch={"2"})
+    finally:
+        held.release()
+
+    assert refreshed == []
+
+
+def test_a_failed_refresh_still_serves_the_stored_payload(
+    seeded: CodexSwitcher, monkeypatch, no_usage
+):
+    monkeypatch.setattr("claude_swap.codex.switcher.needs_refresh", lambda p, **k: True)
+    monkeypatch.setattr(
+        "claude_swap.codex.switcher.try_refresh",
+        lambda p, **k: RefreshOutcome(kind="transient"),
+    )
+    snap = seeded.accounts_snapshot(fetch={"2"})
+    assert snap.accounts[1].usage.sentinel is None  # served, not blanked
+
+
+# ---- the read model ----------------------------------------------------
+
+
+def test_snapshot_tags_every_row_with_the_codex_provider(seeded: CodexSwitcher, no_usage):
+    snap = seeded.accounts_snapshot()
+    assert snap.provider == "codex"
+    assert {a.provider for a in snap.accounts} == {"codex"}
+
+
+def test_snapshot_without_fetch_makes_no_requests(seeded: CodexSwitcher, monkeypatch):
+    """`--skip-api` must genuinely skip the network, not just hide the result."""
+
+    def boom(*a, **k):
+        raise AssertionError("no request should be made")
+
+    monkeypatch.setattr("claude_swap.codex.switcher.fetch_usage", boom)
+    assert len(seeded.accounts_snapshot().accounts) == 2
+
+
+def test_a_usage_failure_becomes_a_sentinel_not_an_exception(
+    seeded: CodexSwitcher, monkeypatch
+):
+    monkeypatch.setattr(
+        "claude_swap.codex.switcher.fetch_usage",
+        lambda *a, **k: UsageFetch(sentinel="http 401"),
+    )
+    snap = seeded.accounts_snapshot(fetch={"1"})
+    assert snap.accounts[0].usage.sentinel == "http 401"
+
+
+def test_a_slot_whose_snapshot_is_gone_reports_no_credentials(
+    seeded: CodexSwitcher, no_usage
+):
+    CodexStore().delete_snapshot(KEY_B)
+    snap = seeded.accounts_snapshot(fetch={"2"})
+    assert snap.accounts[1].usage.sentinel == "no credentials"
+
+
+def test_an_api_key_account_renders_a_sentinel_and_is_not_switchable(codex_home: Path):
+    store = CodexStore()
+    store.upsert_slot(KEY_A, email="a@x", plan="", auth_mode="apikey")
+    store.write_snapshot(KEY_A, {"auth_mode": "apikey", "OPENAI_API_KEY": "sk-x", "tokens": None})
+    switcher = CodexSwitcher()
+    row = switcher.accounts_snapshot().accounts[0]
+    assert row.usage.sentinel == "api key"
+    assert row.kind == "api_key"
+    assert switcher.switchable_account_numbers() == []
+
+
+def test_a_disabled_account_is_not_a_rotation_candidate(seeded: CodexSwitcher):
+    CodexStore().set_disabled(KEY_B, True)
+    assert CodexSwitcher().switchable_account_numbers() == ["1"]
+    # ...but it is still listed and still an explicit target
+    assert CodexSwitcher().account_numbers() == ["1", "2"]
+
+
+# ---- verbs -------------------------------------------------------------
+
+
+def test_add_captures_the_current_live_login(codex_home: Path):
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A, email="a@x"))
+    )
+    slot = CodexSwitcher().add_account()
+    assert slot.number == "1"
+    assert CodexStore().read_snapshot(KEY_A) is not None
+    assert CodexStore().active_key() == KEY_A
+
+
+def test_add_accepts_an_alias(codex_home: Path):
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A))
+    )
+    CodexSwitcher().add_account(alias="Work")
+    assert CodexStore().slots()[0].alias == "work"  # normalized
+
+
+def test_add_without_a_live_login_raises(codex_home: Path):
+    with pytest.raises(ClaudeSwitchError, match="No Codex login"):
+        CodexSwitcher().add_account()
+
+
+def test_add_refuses_an_unidentifiable_login(codex_home: Path):
+    """An API-key login has no account id, so it cannot be told apart from any
+    other — storing it would create a slot nothing can ever match."""
+    (codex_home / "auth.json").write_text(
+        json.dumps({"auth_mode": "apikey", "OPENAI_API_KEY": "sk-x", "tokens": None})
+    )
+    with pytest.raises(ClaudeSwitchError, match="no account id"):
+        CodexSwitcher().add_account()
+
+
+def test_add_is_idempotent_for_the_same_account(codex_home: Path):
+    (codex_home / "auth.json").write_text(
+        json.dumps(make_auth_json(account_id=ACCT_A, user_id=USER_A))
+    )
+    CodexSwitcher().add_account()
+    CodexSwitcher().add_account()
+    assert len(CodexStore().slots()) == 1
+
+
+def test_remove_drops_the_slot_and_its_snapshot(seeded: CodexSwitcher):
+    seeded.remove_account("2", assume_yes=True)
+    assert [s.account_key for s in CodexStore().slots()] == [KEY_A]
+    assert CodexStore().read_snapshot(KEY_B) is None
+
+
+def test_remove_of_an_unknown_account_raises(seeded: CodexSwitcher):
+    with pytest.raises(ClaudeSwitchError):
+        seeded.remove_account("99", assume_yes=True)
+
+
+def test_resolve_account_accepts_number_email_and_alias(seeded: CodexSwitcher):
+    CodexStore().set_alias(KEY_B, "work")
+    switcher = CodexSwitcher()
+    assert switcher.resolve_account("2")[0] == "2"
+    assert switcher.resolve_account("b@x")[0] == "2"
+    assert switcher.resolve_account("work")[0] == "2"
+    assert switcher.resolve_account("WORK")[0] == "2"
+
+
+def test_resolve_account_rejects_an_empty_identifier(seeded: CodexSwitcher):
+    """An empty needle must not match the empty alias every slot starts with."""
+    with pytest.raises(ClaudeSwitchError):
+        seeded.resolve_account("")
+
+
+def test_aliases_round_trip_through_the_switcher(seeded: CodexSwitcher):
+    seeded.set_alias("2", "work")
+    assert CodexStore().slots()[1].alias == "work"
+    seeded.unset_alias("2")
+    assert CodexStore().slots()[1].alias == ""
+
+
+def test_disable_and_enable_round_trip(seeded: CodexSwitcher):
+    seeded.set_account_disabled("2", True)
+    assert CodexStore().slots()[1].disabled is True
+    seeded.set_account_disabled("2", False)
+    assert CodexStore().slots()[1].disabled is False

--- a/tests/test_codex_switcher.py
+++ b/tests/test_codex_switcher.py
@@ -284,14 +284,48 @@ def test_snapshot_tags_every_row_with_the_codex_provider(seeded: CodexSwitcher, 
     assert {a.provider for a in snap.accounts} == {"codex"}
 
 
-def test_snapshot_without_fetch_makes_no_requests(seeded: CodexSwitcher, monkeypatch):
+def test_an_empty_fetch_set_makes_no_requests(seeded: CodexSwitcher, monkeypatch):
     """`--skip-api` must genuinely skip the network, not just hide the result."""
 
     def boom(*a, **k):
         raise AssertionError("no request should be made")
 
     monkeypatch.setattr("claude_swap.codex.usage_cache.fetch_usage", boom)
-    assert len(seeded.accounts_snapshot().accounts) == 2
+    assert len(seeded.accounts_snapshot(fetch=set()).accounts) == 2
+
+
+def test_fetch_none_makes_every_account_eligible(seeded: CodexSwitcher, monkeypatch):
+    """The Claude side documents `fetch=None` as "every stale account is
+    eligible", and SnapshotSource — hence the whole TUI — depends on it. Having
+    it backwards is invisible from the CLI (which always passes an explicit set)
+    and would make the dashboard silently never refresh Codex usage."""
+    from claude_swap.codex.usage import UsageFetch
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "claude_swap.codex.usage_cache.fetch_usage",
+        lambda *a, **k: calls.append(1) or UsageFetch(usage={"five_hour": {"pct": 1}}),
+    )
+
+    seeded.accounts_snapshot(fetch=None)
+
+    assert len(calls) == 2
+
+
+def test_a_fetch_set_restricts_which_accounts_are_fetched(
+    seeded: CodexSwitcher, monkeypatch
+):
+    from claude_swap.codex.usage import UsageFetch
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "claude_swap.codex.usage_cache.fetch_usage",
+        lambda *a, **k: calls.append(1) or UsageFetch(usage={"five_hour": {"pct": 1}}),
+    )
+
+    seeded.accounts_snapshot(fetch={"2"})
+
+    assert len(calls) == 1
 
 
 def test_a_usage_failure_becomes_a_sentinel_not_an_exception(

--- a/tests/test_codex_usage.py
+++ b/tests/test_codex_usage.py
@@ -307,3 +307,29 @@ def test_a_window_without_a_declared_length_falls_back_to_its_position():
     out = cusage.build_usage_result(raw)
     assert out["five_hour"]["pct"] == 11
     assert out["seven_day"]["pct"] == 22
+
+
+def test_a_retry_after_header_is_parsed(monkeypatch):
+    """Honouring the server's backoff is the difference between backing off and
+    being rate-limited harder."""
+    err = urllib.error.HTTPError("u", 429, "slow down", {"Retry-After": "120"}, BytesIO(b"{}"))
+    monkeypatch.setattr(cusage.urllib.request, "urlopen", _raiser(err))
+    result = cusage.fetch_usage("at", "acct")
+    assert result.sentinel == "http 429"
+    assert result.retry_after_s == 120.0
+
+
+def test_an_http_date_retry_after_is_ignored_rather_than_misparsed(monkeypatch):
+    """RFC 9110 permits a date, but this endpoint has only ever sent seconds; a
+    misparsed date would silently park the account for hours."""
+    err = urllib.error.HTTPError(
+        "u", 429, "slow", {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}, BytesIO(b"{}")
+    )
+    monkeypatch.setattr(cusage.urllib.request, "urlopen", _raiser(err))
+    assert cusage.fetch_usage("at", "acct").retry_after_s is None
+
+
+def test_no_retry_after_header_is_none(monkeypatch):
+    err = urllib.error.HTTPError("u", 500, "err", {}, BytesIO(b"{}"))
+    monkeypatch.setattr(cusage.urllib.request, "urlopen", _raiser(err))
+    assert cusage.fetch_usage("at", "acct").retry_after_s is None

--- a/tests/test_codex_usage.py
+++ b/tests/test_codex_usage.py
@@ -1,0 +1,190 @@
+"""Mapping the ChatGPT usage API onto cswap's usage dict."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from datetime import datetime
+from io import BytesIO
+
+from claude_swap.codex import usage as cusage
+
+
+class _Resp:
+    def __init__(self, payload: object):
+        self._body = json.dumps(payload).encode()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _raiser(exc):
+    def boom(*a, **k):
+        raise exc
+
+    return boom
+
+
+RAW = {
+    "primary": {"used_percent": 42, "window_minutes": 300, "resets_at": 1_800_000_000},
+    "secondary": {"used_percent": 7, "window_minutes": 10080, "resets_at": 1_800_600_000},
+    "credits": {"has_credits": True, "unlimited": False, "balance": "12.50"},
+    "plan_type": "pro",
+}
+
+
+def test_primary_window_maps_to_five_hour():
+    """cswap's renderers, pace and autoswitch all read five_hour/seven_day.
+    Mapping here is what makes every Claude-side consumer work unchanged."""
+    out = cusage.build_usage_result(RAW)
+    assert out["five_hour"]["pct"] == 42
+    assert out["five_hour"]["resets_at"].startswith("2027-01-15")
+
+
+def test_secondary_window_maps_to_seven_day():
+    assert cusage.build_usage_result(RAW)["seven_day"]["pct"] == 7
+
+
+def test_windows_carry_countdown_and_clock_like_the_claude_side():
+    out = cusage.build_usage_result(RAW)
+    assert "countdown" in out["five_hour"] and "clock" in out["five_hour"]
+
+
+def test_epoch_resets_are_converted_to_iso():
+    """The API reports epoch seconds; pace.compute_pace parses ISO strings. A
+    raw epoch would silently disable pace for every Codex row."""
+    out = cusage.build_usage_result(RAW)
+    datetime.fromisoformat(out["five_hour"]["resets_at"])  # must not raise
+
+
+def test_the_mapped_shape_is_readable_by_the_existing_pace_calculation():
+    """The real contract this mapping exists to satisfy."""
+    from claude_swap.pace import compute_pace
+
+    window = cusage.build_usage_result(RAW)["seven_day"]
+    # fetched_at three days into the weekly cycle
+    fetched_at = 1_800_600_000 - 4 * 86400
+    assert compute_pace(window, fetched_at=fetched_at) is not None
+
+
+def test_a_missing_secondary_window_is_omitted_not_zeroed():
+    """A plan with no weekly window must not render as 0% used."""
+    assert "seven_day" not in cusage.build_usage_result(dict(RAW, secondary=None))
+
+
+def test_a_window_without_a_percentage_is_dropped():
+    raw = dict(RAW, primary={"window_minutes": 300, "resets_at": 1_800_000_000})
+    assert "five_hour" not in cusage.build_usage_result(raw)
+
+
+def test_a_window_without_a_reset_still_reports_its_percentage():
+    raw = dict(RAW, primary={"used_percent": 12})
+    out = cusage.build_usage_result(raw)
+    assert out["five_hour"] == {"pct": 12}
+
+
+def test_plan_type_is_normalized_to_v4_semantics():
+    assert cusage.build_usage_result(dict(RAW, plan_type="team"))["plan"] == "business"
+
+
+def test_credits_become_a_spend_entry():
+    assert cusage.build_usage_result(RAW)["spend"]["balance"] == "12.50"
+
+
+def test_unlimited_credits_are_marked_not_priced():
+    raw = dict(RAW, credits={"has_credits": True, "unlimited": True, "balance": None})
+    assert cusage.build_usage_result(raw)["spend"]["unlimited"] is True
+
+
+def test_an_account_without_credits_has_no_spend_entry():
+    raw = dict(RAW, credits={"has_credits": False})
+    assert "spend" not in cusage.build_usage_result(raw)
+
+
+def test_an_empty_response_yields_none():
+    assert cusage.build_usage_result({}) is None
+    assert cusage.build_usage_result(None) is None
+    assert cusage.build_usage_result([1, 2]) is None
+
+
+def test_fetch_sends_both_required_headers(monkeypatch):
+    seen = {}
+
+    def fake_urlopen(req, timeout=None):
+        seen["headers"] = dict(req.headers)
+        seen["url"] = req.full_url
+        return _Resp(RAW)
+
+    monkeypatch.setattr(cusage.urllib.request, "urlopen", fake_urlopen)
+    cusage.fetch_usage("at-1", "acct-1")
+
+    assert seen["url"] == cusage.USAGE_URL
+    assert seen["headers"]["Authorization"] == "Bearer at-1"
+    assert seen["headers"]["Chatgpt-account-id"] == "acct-1"
+
+
+def test_fetch_returns_the_mapped_usage(monkeypatch):
+    monkeypatch.setattr(cusage.urllib.request, "urlopen", lambda *a, **k: _Resp(RAW))
+    result = cusage.fetch_usage("at-1", "acct-1")
+    assert result.sentinel is None
+    assert result.usage["five_hour"]["pct"] == 42
+
+
+def test_fetch_reports_the_http_status_as_a_sentinel(monkeypatch):
+    """codex-auth renders the status in the usage column; matching that keeps a
+    broken account legible instead of blank."""
+    monkeypatch.setattr(
+        cusage.urllib.request,
+        "urlopen",
+        _raiser(urllib.error.HTTPError("u", 401, "no", {}, BytesIO(b"{}"))),
+    )
+    result = cusage.fetch_usage("at-1", "acct-1")
+    assert result.sentinel == "http 401"
+    assert result.usage is None
+
+
+def test_fetch_without_an_account_id_is_missing_auth():
+    assert cusage.fetch_usage("at-1", "").sentinel == "MissingAuth"
+
+
+def test_fetch_without_an_access_token_is_missing_auth():
+    assert cusage.fetch_usage("", "acct-1").sentinel == "MissingAuth"
+
+
+def test_a_network_failure_is_reported_not_raised(monkeypatch):
+    monkeypatch.setattr(
+        cusage.urllib.request, "urlopen", _raiser(urllib.error.URLError("down"))
+    )
+    assert cusage.fetch_usage("at", "acct").sentinel == "network"
+
+
+def test_an_unparseable_response_is_reported_not_raised(monkeypatch):
+    monkeypatch.setattr(cusage.urllib.request, "urlopen", lambda *a, **k: _Resp("junk"))
+    assert cusage.fetch_usage("at", "acct").sentinel == "bad-response"
+
+
+def test_workspace_names_are_keyed_by_account_id(monkeypatch):
+    payload = {"items": [{"id": "team-1", "name": "Workspace Alpha"}]}
+    monkeypatch.setattr(cusage.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
+    assert cusage.fetch_workspace_names("at", "acct") == {"team-1": "Workspace Alpha"}
+
+
+def test_a_null_workspace_name_is_omitted_not_stored_as_empty(monkeypatch):
+    """Storing "" would look like a real answer and stop a later successful
+    fetch from filling the name in."""
+    payload = {"items": [{"id": "team-1", "name": None}, {"id": "team-2", "name": ""}]}
+    monkeypatch.setattr(cusage.urllib.request, "urlopen", lambda *a, **k: _Resp(payload))
+    assert cusage.fetch_workspace_names("at", "acct") == {}
+
+
+def test_a_workspace_fetch_failure_is_never_fatal(monkeypatch):
+    monkeypatch.setattr(
+        cusage.urllib.request, "urlopen", _raiser(urllib.error.URLError("down"))
+    )
+    assert cusage.fetch_workspace_names("at", "acct") == {}

--- a/tests/test_codex_usage.py
+++ b/tests/test_codex_usage.py
@@ -31,12 +31,44 @@ def _raiser(exc):
     return boom
 
 
+# The live endpoint's real wire shape, captured 2026-08-16. NOT codex-auth's
+# normalized `last_usage` shape — assuming those were the same cost a bug that
+# only the live smoke test caught.
 RAW = {
-    "primary": {"used_percent": 42, "window_minutes": 300, "resets_at": 1_800_000_000},
-    "secondary": {"used_percent": 7, "window_minutes": 10080, "resets_at": 1_800_600_000},
-    "credits": {"has_credits": True, "unlimited": False, "balance": "12.50"},
+    "user_id": "user-a",
+    "account_id": "acct-a",
+    "email": "a@example.com",
     "plan_type": "pro",
+    "rate_limit": {
+        "allowed": True,
+        "limit_reached": False,
+        "primary_window": {
+            "used_percent": 42,
+            "limit_window_seconds": 18000,
+            "reset_after_seconds": 900,
+            "reset_at": 1_800_000_000,
+        },
+        "secondary_window": {
+            "used_percent": 7,
+            "limit_window_seconds": 604800,
+            "reset_after_seconds": 90000,
+            "reset_at": 1_800_600_000,
+        },
+    },
+    "credits": {
+        "has_credits": True,
+        "unlimited": False,
+        "overage_limit_reached": False,
+        "balance": "12.50",
+    },
 }
+
+
+def _with_rate_limit(**windows) -> dict:
+    """RAW with its rate_limit windows replaced."""
+    rl = dict(RAW["rate_limit"])
+    rl.update(windows)
+    return dict(RAW, rate_limit=rl)
 
 
 def test_primary_window_maps_to_five_hour():
@@ -75,16 +107,16 @@ def test_the_mapped_shape_is_readable_by_the_existing_pace_calculation():
 
 def test_a_missing_secondary_window_is_omitted_not_zeroed():
     """A plan with no weekly window must not render as 0% used."""
-    assert "seven_day" not in cusage.build_usage_result(dict(RAW, secondary=None))
+    assert "seven_day" not in cusage.build_usage_result(_with_rate_limit(secondary_window=None))
 
 
 def test_a_window_without_a_percentage_is_dropped():
-    raw = dict(RAW, primary={"window_minutes": 300, "resets_at": 1_800_000_000})
+    raw = _with_rate_limit(primary_window={"limit_window_seconds": 18000, "reset_at": 1})
     assert "five_hour" not in cusage.build_usage_result(raw)
 
 
 def test_a_window_without_a_reset_still_reports_its_percentage():
-    raw = dict(RAW, primary={"used_percent": 12})
+    raw = _with_rate_limit(primary_window={"used_percent": 12})
     out = cusage.build_usage_result(raw)
     assert out["five_hour"] == {"pct": 12}
 
@@ -188,3 +220,90 @@ def test_a_workspace_fetch_failure_is_never_fatal(monkeypatch):
         cusage.urllib.request, "urlopen", _raiser(urllib.error.URLError("down"))
     )
     assert cusage.fetch_workspace_names("at", "acct") == {}
+
+
+def test_a_response_with_no_window_is_not_usable_usage():
+    """Every consumer needs a window; a plan-only dict renders as a blank row
+    with no explanation, which is exactly how the first live run failed."""
+    assert cusage.build_usage_result({"plan_type": "pro"}) is None
+    assert cusage.build_usage_result(_with_rate_limit(primary_window=None, secondary_window=None)) is None
+
+
+def test_a_windowless_response_reports_a_sentinel_rather_than_a_blank_row(monkeypatch):
+    monkeypatch.setattr(
+        cusage.urllib.request, "urlopen", lambda *a, **k: _Resp({"plan_type": "pro"})
+    )
+    result = cusage.fetch_usage("at", "acct")
+    assert result.usage is None
+    assert result.sentinel == "bad-response"
+
+
+# --- window classification ------------------------------------------------
+#
+# Captured from two live Plus accounts on 2026-08-16: `primary_window` was
+# 604800 s (a WEEK) and `secondary_window` was null. Mapping by position would
+# have labelled weekly usage as 5-hourly — the row would read wrong and pace,
+# which only applies to weekly windows, would never fire for any Codex account.
+
+LIVE_PLUS = {
+    "email": "a@example.com",
+    "plan_type": "plus",
+    "rate_limit": {
+        "allowed": True,
+        "limit_reached": False,
+        "primary_window": {
+            "used_percent": 98,
+            "limit_window_seconds": 604800,
+            "reset_after_seconds": 341770,
+            "reset_at": 1_800_600_000,
+        },
+        "secondary_window": None,
+    },
+    "credits": {"has_credits": False, "unlimited": False, "balance": None},
+}
+
+
+def test_a_weekly_primary_window_is_classified_as_weekly():
+    """The regression this whole classification exists for."""
+    out = cusage.build_usage_result(LIVE_PLUS)
+    assert out["seven_day"]["pct"] == 98
+    assert "five_hour" not in out
+
+
+def test_a_weekly_primary_window_still_supports_pace():
+    """Mislabelling it five_hour would silently disable pace forever."""
+    from claude_swap.pace import compute_pace
+
+    window = cusage.build_usage_result(LIVE_PLUS)["seven_day"]
+    assert compute_pace(window, fetched_at=1_800_600_000 - 4 * 86400) is not None
+
+
+def test_a_five_hour_primary_window_is_classified_as_five_hourly():
+    raw = _with_rate_limit(
+        primary_window={
+            "used_percent": 30,
+            "limit_window_seconds": 18000,
+            "reset_at": 1_800_000_000,
+        },
+        secondary_window=None,
+    )
+    out = cusage.build_usage_result(raw)
+    assert out["five_hour"]["pct"] == 30
+    assert "seven_day" not in out
+
+
+def test_both_windows_are_classified_independently():
+    """The documented two-window plan: 5h primary, weekly secondary."""
+    out = cusage.build_usage_result(RAW)
+    assert out["five_hour"]["pct"] == 42
+    assert out["seven_day"]["pct"] == 7
+
+
+def test_a_window_without_a_declared_length_falls_back_to_its_position():
+    raw = _with_rate_limit(
+        primary_window={"used_percent": 11, "reset_at": 1_800_000_000},
+        secondary_window={"used_percent": 22, "reset_at": 1_800_600_000},
+    )
+    out = cusage.build_usage_result(raw)
+    assert out["five_hour"]["pct"] == 11
+    assert out["seven_day"]["pct"] == 22

--- a/tests/test_codex_usage_cache.py
+++ b/tests/test_codex_usage_cache.py
@@ -1,0 +1,176 @@
+"""Codex usage behind the shared UsageStore: what does and does not hit the network."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from claude_swap.codex.auth_file import account_key
+from claude_swap.codex.store import CodexSlot, CodexStore
+from claude_swap.codex.usage import UsageFetch
+from claude_swap.codex.usage_cache import CodexUsageCache
+from tests.conftest_codex import make_auth_json
+
+KEY_A = account_key("user-a", "acct-a")
+KEY_B = account_key("user-b", "acct-b")
+
+USAGE = {"five_hour": {"pct": 10}, "seven_day": {"pct": 20}}
+
+
+@pytest.fixture
+def cache(codex_home: Path) -> CodexUsageCache:
+    return CodexUsageCache(CodexStore())
+
+
+@pytest.fixture
+def slots(codex_home: Path) -> list[CodexSlot]:
+    store = CodexStore()
+    a = store.upsert_slot(KEY_A, email="a@x", plan="pro")
+    b = store.upsert_slot(KEY_B, email="b@x", plan="pro")
+    for key in (KEY_A, KEY_B):
+        store.write_snapshot(key, make_auth_json())
+    return [a, b]
+
+
+@pytest.fixture
+def counter(monkeypatch):
+    """Count fetch_usage calls and control what they return."""
+    calls: list[tuple[str, str]] = []
+    result = {"value": UsageFetch(usage=USAGE)}
+
+    def fake(access_token, account_id, timeout_s=10.0):
+        calls.append((access_token, account_id))
+        return result["value"]
+
+    monkeypatch.setattr("claude_swap.codex.usage_cache.fetch_usage", fake)
+    return calls, result
+
+
+def _payload_for(slot: CodexSlot) -> dict | None:
+    return CodexStore().read_snapshot(slot.account_key)
+
+
+def _refresh(cache: CodexUsageCache, slots, **kw):
+    return cache.refresh(slots, payload_for=_payload_for, **kw)
+
+
+def test_a_cold_cache_fetches_every_slot(cache, slots, counter):
+    calls, _ = counter
+    entries = _refresh(cache, slots)
+    assert len(calls) == 2
+    assert entries["1"].last_good == USAGE
+
+
+def test_a_second_pass_serves_from_cache_without_a_request(cache, slots, counter):
+    """The entire point of this stage: two `cswap codex list` calls in a row
+    cost one round of requests, not two."""
+    calls, _ = counter
+    _refresh(cache, slots)
+    _refresh(cache, slots)
+    assert len(calls) == 2  # unchanged by the second pass
+
+
+def test_the_cached_value_is_still_served_on_the_second_pass(cache, slots, counter):
+    _refresh(cache, slots)
+    entries = _refresh(cache, slots)
+    assert entries["1"].last_good == USAGE
+    assert entries["1"].age_s is not None
+
+
+def test_entries_never_touches_the_network(cache, slots, counter):
+    calls, _ = counter
+    cache.entries(slots)
+    assert calls == []
+
+
+def test_a_slot_leased_by_another_process_is_not_fetched(cache, slots, counter):
+    """Two collectors both passing the staleness check and both fetching is
+    exactly what the lease exists to prevent."""
+    calls, _ = counter
+    other = CodexUsageCache(CodexStore())
+    other._usage.reserve(["1", "2"], other.identities(slots), respect_plans=True)
+
+    _refresh(cache, slots)
+
+    assert calls == []
+
+
+def test_a_failure_records_an_error_and_shows_it(cache, slots, counter):
+    calls, result = counter
+    result["value"] = UsageFetch(sentinel="http 401")
+    entries = _refresh(cache, slots)
+    assert entries["1"].sentinel == "http 401"
+    assert entries["1"].last_good is None
+
+
+def test_a_failure_does_not_destroy_the_previous_good_value(cache, slots, counter):
+    """Serving stale-with-age beats serving blank."""
+    calls, result = counter
+    _refresh(cache, slots)  # succeed once
+    result["value"] = UsageFetch(sentinel="http 500")
+
+    # force the entries out of their serve window by aging the clock
+    cache._usage.clock = lambda: __import__("time").time() + 86400
+    entries = _refresh(cache, slots)
+
+    assert entries["1"].last_good == USAGE  # preserved
+    assert entries["1"].consecutive_failures >= 1
+
+
+def test_a_retry_after_is_carried_into_the_record(cache, slots, counter):
+    calls, result = counter
+    result["value"] = UsageFetch(sentinel="http 429", retry_after_s=120.0)
+    entries = _refresh(cache, slots)
+    assert entries["1"].backoff_until is not None
+
+
+def test_a_success_writes_a_poll_plan(cache, slots, counter):
+    entries = _refresh(cache, slots)
+    assert entries["1"].next_poll_at is not None
+    assert entries["1"].poll_interval_s is not None
+
+
+def test_an_api_key_slot_is_a_sentinel_and_makes_no_request(cache, codex_home: Path, counter):
+    calls, _ = counter
+    store = CodexStore()
+    slot = store.upsert_slot(KEY_A, email="a@x", auth_mode="apikey")
+    entries = _refresh(cache, [slot])
+    assert calls == []
+    assert entries["1"].sentinel == "api key"
+
+
+def test_a_missing_snapshot_is_a_sentinel_not_a_failure(cache, codex_home: Path, counter):
+    """A structurally unusable account must not accrue backoff it can never
+    clear by itself."""
+    calls, _ = counter
+    store = CodexStore()
+    slot = store.upsert_slot(KEY_A, email="a@x", plan="pro")
+    entries = _refresh(cache, [slot])
+    assert entries["1"].sentinel == "no credentials"
+    assert entries["1"].consecutive_failures == 0
+
+
+def test_the_identity_guard_hides_a_reused_slots_old_usage(cache, slots, counter):
+    """A slot re-created for a different account must not inherit the previous
+    account's percentages."""
+    _refresh(cache, slots)
+    store = CodexStore()
+    store.remove_slot(KEY_A)
+    fresh = store.upsert_slot(account_key("user-c", "acct-c"), email="c@x", plan="pro")
+    assert fresh.number == "1"  # same slot number, different account
+
+    assert cache.entries([fresh])["1"].last_good is None
+
+
+def test_identity_uses_the_account_id_not_just_the_email(codex_home: Path):
+    """One user with two workspaces has one email and two accounts; the email
+    alone would let one workspace's usage serve the other."""
+    slot = CodexSlot(number="1", account_key=account_key("user-a", "acct-x"), email="a@x")
+    assert CodexUsageCache.identity_for(slot) == ("a@x", "acct-x")
+
+
+def test_refresh_of_no_slots_is_a_noop(cache, counter):
+    calls, _ = counter
+    assert _refresh(cache, []) == {}
+    assert calls == []

--- a/tests/test_codex_workspaces.py
+++ b/tests/test_codex_workspaces.py
@@ -1,0 +1,189 @@
+"""Workspace-name refresh — mostly a test of when we DON'T make a request."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from claude_swap.codex.auth_file import account_key
+from claude_swap.codex.store import CodexStore
+from claude_swap.codex.workspaces import refresh_workspace_names, scope_needs_refresh
+from tests.conftest_codex import make_auth_json
+
+USER = "user-a"
+KEY_1 = account_key(USER, "team-1")
+KEY_2 = account_key(USER, "team-2")
+KEY_PERSONAL = account_key(USER, "personal-1")
+KEY_OTHER_USER = account_key("user-b", "team-9")
+
+
+@pytest.fixture
+def store(codex_home: Path) -> CodexStore:
+    return CodexStore()
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Record every /backend-api/accounts request and control the answer."""
+    made: list[tuple[str, str]] = []
+    reply = {"value": {}}
+
+    def fake(token, account_id, timeout_s=10.0):
+        made.append((token, account_id))
+        return reply["value"]
+
+    monkeypatch.setattr("claude_swap.codex.workspaces.fetch_workspace_names", fake)
+    return made, reply
+
+
+def _payload_for(slot):
+    return CodexStore().read_snapshot(slot.account_key)
+
+
+def _seed(store: CodexStore, key: str, *, plan: str, name: str = "") -> None:
+    store.upsert_slot(key, email="a@x", plan=plan, workspace_name=name)
+    store.write_snapshot(key, make_auth_json(account_id=key.rpartition("::")[2]))
+
+
+# ---- when NOT to ask ---------------------------------------------------
+
+
+def test_a_lone_account_never_triggers_a_request(store, calls):
+    """A single personal account is the common case; it must cost nothing."""
+    made, _ = calls
+    _seed(store, KEY_PERSONAL, plan="plus")
+    refresh_workspace_names(store, payload_for=_payload_for)
+    assert made == []
+
+
+def test_a_scope_with_no_workspace_plan_never_asks(store, calls):
+    made, _ = calls
+    _seed(store, KEY_PERSONAL, plan="plus")
+    _seed(store, account_key(USER, "personal-2"), plan="pro")
+    refresh_workspace_names(store, payload_for=_payload_for)
+    assert made == []
+
+
+def test_a_scope_whose_names_are_all_known_never_asks(store, calls):
+    made, _ = calls
+    _seed(store, KEY_1, plan="business", name="Alpha")
+    _seed(store, KEY_2, plan="business", name="Beta")
+    refresh_workspace_names(store, payload_for=_payload_for)
+    assert made == []
+
+
+def test_an_api_key_account_is_not_part_of_any_scope(store, calls):
+    made, _ = calls
+    store.upsert_slot(KEY_1, email="a@x", plan="business", auth_mode="apikey")
+    store.upsert_slot(KEY_2, email="a@x", plan="business", auth_mode="apikey")
+    refresh_workspace_names(store, payload_for=_payload_for)
+    assert made == []
+
+
+def test_scope_predicate_matches_the_documented_rules():
+    from claude_swap.codex.store import CodexSlot
+
+    def slot(key, plan, name=""):
+        return CodexSlot(number="1", account_key=key, plan=plan, workspace_name=name)
+
+    assert scope_needs_refresh([slot(KEY_1, "business")]) is False  # one record
+    assert scope_needs_refresh([slot(KEY_1, "plus"), slot(KEY_2, "pro")]) is False
+    assert scope_needs_refresh([slot(KEY_1, "business", "A"), slot(KEY_2, "business", "B")]) is False
+    assert scope_needs_refresh([slot(KEY_1, "business"), slot(KEY_2, "business", "B")]) is True
+    # a personal record can still ride along in a scope that needs a refresh
+    assert scope_needs_refresh([slot(KEY_PERSONAL, "plus"), slot(KEY_1, "business")]) is True
+
+
+# ---- when to ask, and what to do with the answer -----------------------
+
+
+def test_one_request_per_scope_fills_every_workspace_in_it(store, calls):
+    made, reply = calls
+    _seed(store, KEY_1, plan="business")
+    _seed(store, KEY_2, plan="business")
+    reply["value"] = {"team-1": "Workspace Alpha", "team-2": "Workspace Beta"}
+
+    changed = refresh_workspace_names(store, payload_for=_payload_for)
+
+    assert len(made) == 1  # one request answered for both
+    assert changed == 2
+    names = {s.account_key: s.workspace_name for s in CodexStore().slots()}
+    assert names[KEY_1] == "Workspace Alpha"
+    assert names[KEY_2] == "Workspace Beta"
+
+
+def test_a_returned_name_overwrites_an_older_one(store, calls):
+    """The server is authoritative; a renamed workspace should follow."""
+    made, reply = calls
+    _seed(store, KEY_1, plan="business")
+    _seed(store, KEY_2, plan="business", name="Old Name")
+    reply["value"] = {"team-1": "Alpha", "team-2": "Sandbox"}
+
+    refresh_workspace_names(store, payload_for=_payload_for)
+
+    names = {s.account_key: s.workspace_name for s in CodexStore().slots()}
+    assert names[KEY_2] == "Sandbox"
+
+
+def test_an_in_scope_workspace_not_returned_is_cleared(store, calls):
+    """Leaving a stale name for a workspace the user has lost access to is
+    worse than showing none."""
+    made, reply = calls
+    _seed(store, KEY_1, plan="business")
+    _seed(store, KEY_2, plan="business", name="Gone")
+    reply["value"] = {"team-1": "Alpha"}
+
+    refresh_workspace_names(store, payload_for=_payload_for)
+
+    names = {s.account_key: s.workspace_name for s in CodexStore().slots()}
+    assert names[KEY_2] == ""
+
+
+def test_a_personal_record_in_scope_is_never_cleared(store, calls):
+    """It never had a workspace name to lose."""
+    made, reply = calls
+    _seed(store, KEY_PERSONAL, plan="plus")
+    _seed(store, KEY_1, plan="business")
+    reply["value"] = {"team-1": "Alpha"}
+
+    refresh_workspace_names(store, payload_for=_payload_for)
+
+    names = {s.account_key: s.workspace_name for s in CodexStore().slots()}
+    assert names[KEY_PERSONAL] == ""
+
+
+def test_a_failed_request_leaves_every_stored_name_untouched(store, calls):
+    made, reply = calls
+    _seed(store, KEY_1, plan="business", name="Alpha")
+    _seed(store, KEY_2, plan="business")
+    reply["value"] = {}  # what fetch_workspace_names returns on any failure
+
+    changed = refresh_workspace_names(store, payload_for=_payload_for)
+
+    assert changed == 0
+    assert CodexStore().slot_for_key(KEY_1).workspace_name == "Alpha"
+
+
+def test_scopes_are_independent(store, calls):
+    """A second user's accounts must not ride on the first user's request."""
+    made, reply = calls
+    _seed(store, KEY_1, plan="business")
+    _seed(store, KEY_2, plan="business")
+    _seed(store, KEY_OTHER_USER, plan="business")
+    reply["value"] = {"team-1": "Alpha", "team-2": "Beta"}
+
+    refresh_workspace_names(store, payload_for=_payload_for)
+
+    # user-b's scope has one record, so it never asks
+    assert len(made) == 1
+    assert CodexStore().slot_for_key(KEY_OTHER_USER).workspace_name == ""
+
+
+def test_a_scope_with_no_usable_credentials_makes_no_request(store, calls):
+    made, _ = calls
+    store.upsert_slot(KEY_1, email="a@x", plan="business")
+    store.upsert_slot(KEY_2, email="a@x", plan="business")
+    # no snapshots written -> payload_for returns None for both
+    refresh_workspace_names(store, payload_for=lambda s: None)
+    assert made == []

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+
+from claude_swap.settings import SETTING_SPECS
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -51,7 +53,7 @@ class TestConfigList:
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == len(SETTING_SPECS)
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,7 +80,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == len(SETTING_SPECS)
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_providers_aggregate.py
+++ b/tests/test_providers_aggregate.py
@@ -1,0 +1,191 @@
+"""Merging several providers into the one view a shell renders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
+from claude_swap.providers.aggregate import (
+    group_by_provider,
+    merged_snapshot,
+    provider_label,
+)
+from claude_swap.providers.registry import available_providers, codex_is_present
+from claude_swap.usage_store import UsageEntry
+
+
+class FakeProvider:
+    """A provider that returns a canned snapshot and records what was asked."""
+
+    def __init__(self, provider_id: str, numbers: list[str], *, raises: bool = False):
+        self.provider_id = provider_id
+        self._numbers = numbers
+        self._raises = raises
+        self.fetch_calls: list[set[str] | None] = []
+
+    def accounts_snapshot(self, fetch: set[str] | None = None) -> AccountsSnapshot:
+        self.fetch_calls.append(fetch)
+        if self._raises:
+            raise RuntimeError("store is corrupt")
+        return AccountsSnapshot(
+            active_number=self._numbers[0] if self._numbers else None,
+            accounts=tuple(
+                AccountSnapshot(
+                    number=n,
+                    email=f"{self.provider_id}-{n}@x",
+                    org_name="",
+                    org_uuid="",
+                    is_active=n == self._numbers[0],
+                    kind="oauth",
+                    switchable=True,
+                    usage=UsageEntry(),
+                    provider=self.provider_id,
+                )
+                for n in self._numbers
+            ),
+            taken_at=0.0,
+            provider=self.provider_id,
+        )
+
+
+def test_row_keys_stay_unique_across_providers():
+    """Slot numbers are per-provider: "1" names a Claude account AND a Codex
+    one. Without a composite key a keystroke lands on the wrong provider."""
+    snap, owners = merged_snapshot(
+        [FakeProvider("claude", ["1", "2"]), FakeProvider("codex", ["1", "2"])]
+    )
+    assert [a.key for a in snap.accounts] == [
+        "claude:1",
+        "claude:2",
+        "codex:1",
+        "codex:2",
+    ]
+    assert len(owners) == 4
+
+
+def test_owners_map_each_row_to_the_provider_that_owns_it():
+    claude, codex = FakeProvider("claude", ["1"]), FakeProvider("codex", ["1"])
+    _snap, owners = merged_snapshot([claude, codex])
+    assert owners["claude:1"] is claude
+    assert owners["codex:1"] is codex
+
+
+def test_ordering_is_provider_major_and_stable():
+    """Rows must not move between refreshes, or a keystroke aimed at the row
+    under the cursor lands somewhere else."""
+    providers = [FakeProvider("claude", ["1", "2"]), FakeProvider("codex", ["1"])]
+    first = [a.key for a in merged_snapshot(providers)[0].accounts]
+    second = [a.key for a in merged_snapshot(providers)[0].accounts]
+    assert first == second == ["claude:1", "claude:2", "codex:1"]
+
+
+def test_active_number_still_means_claude():
+    """Every existing consumer of that field means Claude by it."""
+    snap, _ = merged_snapshot(
+        [FakeProvider("claude", ["3", "4"]), FakeProvider("codex", ["1"])]
+    )
+    assert snap.active_number == "3"
+
+
+def test_each_row_carries_its_own_active_flag():
+    snap, _ = merged_snapshot(
+        [FakeProvider("claude", ["1", "2"]), FakeProvider("codex", ["5", "6"])]
+    )
+    active = {a.key for a in snap.accounts if a.is_active}
+    assert active == {"claude:1", "codex:5"}
+
+
+def test_one_providers_failure_does_not_blank_the_others():
+    """A dashboard that goes empty because a secondary store is corrupt is far
+    worse than one missing section."""
+    snap, owners = merged_snapshot(
+        [FakeProvider("claude", ["1"]), FakeProvider("codex", ["1"], raises=True)]
+    )
+    assert [a.key for a in snap.accounts] == ["claude:1"]
+    assert list(owners) == ["claude:1"]
+
+
+def test_fetch_none_is_passed_through_to_every_provider():
+    claude, codex = FakeProvider("claude", ["1"]), FakeProvider("codex", ["1"])
+    merged_snapshot([claude, codex], fetch=None)
+    assert claude.fetch_calls == [None]
+    assert codex.fetch_calls == [None]
+
+
+def test_a_fetch_set_is_split_per_provider():
+    claude, codex = FakeProvider("claude", ["1", "2"]), FakeProvider("codex", ["1"])
+    merged_snapshot([claude, codex], fetch={"claude:2", "codex:1"})
+    assert claude.fetch_calls == [{"2"}]
+    assert codex.fetch_calls == [{"1"}]
+
+
+def test_a_provider_named_by_no_fetch_key_gets_an_empty_set_not_none():
+    """An empty set means "no network"; None would mean "fetch everything" —
+    the opposite, and a silent one."""
+    claude, codex = FakeProvider("claude", ["1"]), FakeProvider("codex", ["1"])
+    merged_snapshot([claude, codex], fetch={"claude:1"})
+    assert codex.fetch_calls == [set()]
+
+
+def test_grouping_preserves_the_render_order():
+    snap, _ = merged_snapshot(
+        [FakeProvider("claude", ["1", "2"]), FakeProvider("codex", ["1"])]
+    )
+    groups = group_by_provider(snap)
+    assert [(pid, [a.key for a in rows]) for pid, rows in groups] == [
+        ("claude", ["claude:1", "claude:2"]),
+        ("codex", ["codex:1"]),
+    ]
+
+
+def test_grouping_an_empty_snapshot_yields_nothing():
+    snap = AccountsSnapshot(active_number=None, accounts=(), taken_at=0.0)
+    assert group_by_provider(snap) == []
+
+
+def test_provider_labels_are_short_enough_for_a_row_badge():
+    assert provider_label("claude") == "claude"
+    assert provider_label("codex") == "codex"
+    assert provider_label("unknown") == "unknown"  # never blank
+
+
+# ---- registry ----------------------------------------------------------
+
+
+def test_codex_is_absent_on_a_clean_machine(temp_home: Path):
+    assert codex_is_present() is False
+
+
+def test_codex_is_present_once_it_has_a_slot(codex_home: Path):
+    from claude_swap.codex.auth_file import account_key
+    from claude_swap.codex.store import CodexStore
+
+    CodexStore().upsert_slot(account_key("u", "a"), email="a@x")
+    assert codex_is_present() is True
+
+
+def test_codex_is_present_when_only_an_unimported_registry_exists(codex_home: Path):
+    """So the provider shows up on the first run, not only after the user has
+    found a `cswap codex` command."""
+    d = codex_home / "accounts"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "registry.json").write_text("{}")
+    assert codex_is_present() is True
+
+
+def test_a_claude_only_machine_gets_exactly_one_provider(temp_home: Path):
+    """The whole point: nothing about a Claude-only install changes."""
+    claude = FakeProvider("claude", ["1"])
+    assert available_providers(claude) == [claude]
+
+
+def test_codex_joins_the_list_once_present(codex_home: Path):
+    from claude_swap.codex.auth_file import account_key
+    from claude_swap.codex.store import CodexStore
+
+    CodexStore().upsert_slot(account_key("u", "a"), email="a@x")
+    claude = FakeProvider("claude", ["1"])
+    providers = available_providers(claude)
+    assert [p.provider_id for p in providers] == ["claude", "codex"]

--- a/tests/test_tui_multiprovider.py
+++ b/tests/test_tui_multiprovider.py
@@ -377,3 +377,26 @@ class TestDashboardWithTwoProviders:
             rendered = app.screen.query_one("#accounts-panel").render().plain
 
         assert "codex" in rendered
+
+
+def test_the_menubar_toggle_callback_targets_the_owning_provider(temp_home: Path):
+    """The toggle callback resolves its row once and uses that result. It used
+    to resolve twice, and nothing pinned that both halves agreed — so a
+    disable aimed at a codex row could have reached claude."""
+    from claude_swap.menubar import _resolve_menu_row
+
+    class App:
+        switcher = _FakeProvider("claude")
+        providers = [switcher, _FakeProvider("codex")]
+
+        def _guard(self, fn):
+            fn()
+            return True
+
+    app = App()
+    provider, number = _resolve_menu_row(app, "codex:2")
+    app._guard(lambda: provider.set_account_disabled(number, True))
+
+    codex = app.providers[1]
+    assert codex.disabled == [("2", True)]
+    assert app.switcher.disabled == []

--- a/tests/test_tui_multiprovider.py
+++ b/tests/test_tui_multiprovider.py
@@ -205,3 +205,57 @@ def test_an_unknown_provider_falls_back_to_claude_instead_of_raising(
     app, _claude, _codex = app_with_two_providers
     provider, number = app._resolve_row("gemini:3")
     assert provider is app.switcher and number == "3"
+
+
+# ---- menu bar ----------------------------------------------------------
+
+
+def test_menubar_tags_codex_rows_and_keys_them_by_row(temp_home: Path):
+    """The menu bar's tuple is 8-wide and unpacked exactly in five places, so
+    the provider rides in the existing `num` and label fields rather than a
+    ninth element."""
+    from claude_swap.menubar import _adapt_snapshot
+
+    snap = AccountsSnapshot(
+        active_number="1",
+        accounts=(_acc("1", "claude", is_active=True), _acc("1", "codex")),
+        taken_at=0.0,
+        provider="multi",
+    )
+    adapted = _adapt_snapshot(snap)
+
+    nums = [row[0] for row in adapted["accounts"]]
+    labels = [row[1] for row in adapted["accounts"]]
+    assert nums == ["1", "codex:1"]
+    assert "(codex)" in labels[1]
+    assert "(codex)" not in labels[0]
+    assert all(len(row) == 8 for row in adapted["accounts"])
+
+
+def test_the_menubar_title_still_tracks_the_claude_account(temp_home: Path):
+    """It is what the user's `claude` command will run as."""
+    from claude_swap.menubar import _adapt_snapshot
+
+    snap = AccountsSnapshot(
+        active_number="1",
+        accounts=(
+            _acc("1", "claude", is_active=True, email="me@claude"),
+            _acc("1", "codex", is_active=True, email="me@codex"),
+        ),
+        taken_at=0.0,
+        provider="multi",
+    )
+    assert _adapt_snapshot(snap)["active_email"] == "me@claude"
+
+
+def test_menubar_row_resolution_routes_to_the_owning_provider(temp_home: Path):
+    from claude_swap.menubar import _resolve_menu_row
+
+    class App:
+        switcher = _FakeProvider("claude")
+        providers = [switcher, _FakeProvider("codex")]
+
+    app = App()
+    assert _resolve_menu_row(app, "1") == (app.switcher, "1")
+    assert _resolve_menu_row(app, "codex:2")[0].provider_id == "codex"
+    assert _resolve_menu_row(app, "codex:2")[1] == "2"

--- a/tests/test_tui_multiprovider.py
+++ b/tests/test_tui_multiprovider.py
@@ -259,3 +259,121 @@ def test_menubar_row_resolution_routes_to_the_owning_provider(temp_home: Path):
     assert _resolve_menu_row(app, "1") == (app.switcher, "1")
     assert _resolve_menu_row(app, "codex:2")[0].provider_id == "codex"
     assert _resolve_menu_row(app, "codex:2")[1] == "2"
+
+
+# ---- the real screen, driven ------------------------------------------
+#
+# The dispatch-bug class this stage kept producing (fetch semantics, action
+# ids) lives at integration seams that hand-rolled fakes cannot reach. These
+# drive the actual dashboard.
+
+
+class _PilotProvider:
+    """A provider the real app can take snapshots from."""
+
+    def __init__(self, provider_id: str, numbers, backup_dir: Path):
+        self.provider_id = provider_id
+        self.backup_dir = backup_dir
+        self._numbers = list(numbers)
+        self.calls: list[tuple] = []
+
+    def accounts_snapshot(self, fetch=None):
+        self.calls.append(("snapshot", fetch))
+        return AccountsSnapshot(
+            active_number=self._numbers[0],
+            accounts=tuple(
+                _acc(n, self.provider_id, is_active=(n == self._numbers[0]))
+                for n in self._numbers
+            ),
+            taken_at=0.0,
+            provider=self.provider_id,
+        )
+
+    def switch_to(self, number, **kw):
+        self.calls.append(("switch", number))
+        return None
+
+    def set_account_disabled(self, number, disabled):
+        self.calls.append(("set_disabled", number, disabled))
+
+    def remove_account(self, number, assume_yes=False):
+        self.calls.append(("remove", number, assume_yes))
+
+    def current_account_number(self):
+        return self._numbers[0]
+
+    def switchable_account_numbers(self):
+        return list(self._numbers)
+
+    def resolve_account(self, identifier):
+        return identifier, f"{self.provider_id}-{identifier}@x", ""
+
+    def set_alias(self, identifier, alias):
+        return identifier, alias
+
+    def unset_alias(self, identifier):
+        return identifier
+
+
+@pytest.mark.asyncio
+class TestDashboardWithTwoProviders:
+    def _app(self, tmp_path: Path):
+        from claude_swap.tui.app import CswapApp
+
+        claude = _PilotProvider("claude", ["1", "2"], tmp_path)
+        codex = _PilotProvider("codex", ["1", "2"], tmp_path)
+        app = CswapApp(claude)
+        app.providers = [claude, codex]
+        from claude_swap.providers.aggregate import MultiSnapshotSource
+
+        app.source = MultiSnapshotSource([claude, codex])
+        return app, claude, codex
+
+    async def test_both_providers_rows_reach_the_switch_screen(self, tmp_path):
+        from textual.widgets import ListView
+
+        from claude_swap.tui.widgets import AccountItem
+
+        app, _claude, _codex = self._app(tmp_path)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            items = list(app.screen.query_one("#accounts", ListView).query(AccountItem))
+            assert [i.key_id for i in items] == [
+                "claude:1",
+                "claude:2",
+                "codex:1",
+                "codex:2",
+            ]
+
+    async def test_selecting_a_codex_row_switches_codex_not_claude(self, tmp_path):
+        """The failure the composite key exists to prevent, driven through the
+        real screen rather than asserted against a fake."""
+        from textual.widgets import ListView
+
+        app, claude, codex = self._app(tmp_path)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            listview = app.screen.query_one("#accounts", ListView)
+            listview.index = 2  # the first codex row
+            await pilot.pause()
+            await pilot.press("enter")
+            for _ in range(6):
+                await pilot.pause()
+
+        assert ("switch", "1") in codex.calls
+        assert not any(c[0] == "switch" for c in claude.calls)
+
+    async def test_the_codex_badge_is_visible_on_screen(self, tmp_path):
+        app, _claude, _codex = self._app(tmp_path)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            rendered = app.screen.query_one("#accounts-panel").render().plain
+
+        assert "codex" in rendered

--- a/tests/test_tui_multiprovider.py
+++ b/tests/test_tui_multiprovider.py
@@ -1,0 +1,207 @@
+"""The TUI with two providers on screen.
+
+The risk this file exists for: slot numbers repeat across providers, so a
+keystroke aimed at "account 1" can land on the wrong CLI's account. Every test
+here is ultimately about that.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
+from claude_swap.tui.widgets import (
+    account_card_text,
+    mini_account_text,
+    provider_badge,
+    Palette,
+)
+from claude_swap.usage_store import UsageEntry
+
+
+def _acc(number: str, provider: str = "claude", **kw) -> AccountSnapshot:
+    base = dict(
+        number=number,
+        email=f"{provider}-{number}@x",
+        org_name="",
+        org_uuid="",
+        is_active=False,
+        kind="oauth",
+        switchable=True,
+        usage=UsageEntry(),
+        provider=provider,
+    )
+    base.update(kw)
+    return AccountSnapshot(**base)
+
+
+# ---- the row badge -----------------------------------------------------
+
+
+def test_a_claude_row_carries_no_badge():
+    """A Claude-only install must not gain a badge on every line to say the
+    only thing it could possibly say."""
+    assert provider_badge(_acc("1"), Palette.DARK) is None
+
+
+def test_a_codex_row_carries_a_badge():
+    badge = provider_badge(_acc("1", "codex"), Palette.DARK)
+    assert badge is not None and "codex" in badge.plain
+
+
+def test_the_badge_appears_in_the_full_card():
+    text = account_card_text(_acc("1", "codex"), 80).plain
+    assert "codex" in text
+
+
+def test_the_badge_appears_in_the_mini_row():
+    text = mini_account_text(_acc("2", "codex"), now=0.0).plain
+    assert "codex" in text
+
+
+def test_a_claude_card_renders_exactly_as_before():
+    """Regression guard for the Claude-only view."""
+    text = account_card_text(_acc("1"), 80).plain
+    assert "⟨" not in text
+
+
+# ---- row identity ------------------------------------------------------
+
+
+def test_two_providers_slot_one_are_different_rows():
+    assert _acc("1", "claude").key != _acc("1", "codex").key
+
+
+def test_the_key_is_stable_and_readable():
+    assert _acc("2", "codex").key == "codex:2"
+
+
+# ---- app-level dispatch ------------------------------------------------
+
+
+class _FakeProvider:
+    def __init__(self, provider_id: str):
+        self.provider_id = provider_id
+        self.switched: list[str] = []
+        self.disabled: list[tuple[str, bool]] = []
+        self.removed: list[str] = []
+
+    def switch_to(self, number, **kw):
+        self.switched.append(number)
+        return None
+
+    def set_account_disabled(self, number, disabled):
+        self.disabled.append((number, disabled))
+
+    def remove_account(self, number, assume_yes=False):
+        self.removed.append(number)
+
+
+@pytest.fixture
+def app_with_two_providers(temp_home: Path):
+    """A CswapApp whose owners map holds one row per provider."""
+    from claude_swap.switcher import ClaudeAccountSwitcher
+    from claude_swap.tui.app import CswapApp
+
+    app = CswapApp(ClaudeAccountSwitcher())
+    claude, codex = _FakeProvider("claude"), _FakeProvider("codex")
+    app.providers = [claude, codex]
+    app.owners = {"claude:1": claude, "codex:1": codex}
+    app.snapshot = AccountsSnapshot(
+        active_number="1",
+        accounts=(_acc("1", "claude"), _acc("1", "codex", disabled=True)),
+        taken_at=0.0,
+        provider="multi",
+    )
+    return app, claude, codex
+
+
+def test_a_bare_number_still_resolves_to_claude(app_with_two_providers):
+    """Every call site that predates multi-provider keeps working."""
+    app, claude, _codex = app_with_two_providers
+    provider, number = app._resolve_row("1")
+    assert provider is claude and number == "1"
+
+
+def test_a_codex_key_resolves_to_the_codex_provider(app_with_two_providers):
+    app, _claude, codex = app_with_two_providers
+    provider, number = app._resolve_row("codex:1")
+    assert provider is codex and number == "1"
+
+
+def test_switching_a_codex_row_does_not_touch_claude(app_with_two_providers, monkeypatch):
+    """The failure this whole key scheme prevents."""
+    app, claude, codex = app_with_two_providers
+    started: list = []
+    monkeypatch.setattr(app, "_start_action", lambda label, fn: started.append(fn))
+
+    app.do_switch("codex:1")
+    started[0]()
+
+    assert codex.switched == ["1"]
+    assert claude.switched == []
+
+
+def test_switching_a_claude_row_does_not_touch_codex(app_with_two_providers, monkeypatch):
+    app, claude, codex = app_with_two_providers
+    started: list = []
+    monkeypatch.setattr(app, "_start_action", lambda label, fn: started.append(fn))
+
+    app.do_switch("1")
+    started[0]()
+
+    assert claude.switched == ["1"]
+    assert codex.switched == []
+
+
+def test_toggling_a_codex_row_reads_that_rows_own_state(
+    app_with_two_providers, monkeypatch
+):
+    """The codex row is disabled and the claude row is not; toggling must use
+    the state of the row addressed, not of the same number on the other side."""
+    app, claude, codex = app_with_two_providers
+    started: list = []
+    monkeypatch.setattr(app, "_start_action", lambda label, fn: started.append(fn))
+
+    app.do_toggle_disabled("codex:1")
+    started[0]()
+
+    assert codex.disabled == [("1", False)]  # it was disabled -> enable
+    assert claude.disabled == []
+
+
+def test_removing_a_codex_row_removes_it_from_codex(app_with_two_providers, monkeypatch):
+    app, claude, codex = app_with_two_providers
+    started: list = []
+    monkeypatch.setattr(app, "_start_action", lambda label, fn: started.append(fn))
+
+    app._on_remove_confirm("codex:1", True)
+    started[0]()
+
+    assert codex.removed == ["1"]
+    assert claude.removed == []
+
+
+def test_a_declined_removal_removes_nothing(app_with_two_providers, monkeypatch):
+    app, claude, codex = app_with_two_providers
+    monkeypatch.setattr(app, "_start_action", lambda label, fn: pytest.fail("no action"))
+    app._on_remove_confirm("codex:1", False)
+    assert codex.removed == [] and claude.removed == []
+
+
+def test_row_lookup_finds_the_right_provider_row(app_with_two_providers):
+    app, _c, _x = app_with_two_providers
+    assert app._row_for("codex:1").disabled is True
+    assert app._row_for("1").disabled is False
+
+
+def test_an_unknown_provider_falls_back_to_claude_instead_of_raising(
+    app_with_two_providers,
+):
+    """Better a no-op on the default provider than a traceback in the event
+    loop of a running dashboard."""
+    app, _claude, _codex = app_with_two_providers
+    provider, number = app._resolve_row("gemini:3")
+    assert provider is app.switcher and number == "3"


### PR DESCRIPTION
Adds a provider seam to cswap and lands **Codex (ChatGPT)** as a second provider behind a `cswap codex` namespace — core verbs, usage, TUI, auto-switching, menu bar, Windows.

Everything is additive. No existing command, flag, settings key, JSON field or storage path changes meaning. Only **23 lines** were added to four existing files (`cli.py` 6, `models.py` 6, `switcher.py` 4, `tests/conftest.py` 7); the other ~7,400 are new modules and their tests.

Semantics — endpoint contracts, registry schema, plan naming, grouped account-name refresh — follow [`codex-auth`](https://github.com/Loongphy/codex-auth). None of its code is reused (it's Zig).

> Written with AI assistance and verified end to end against two real Codex accounts on macOS. Terminal output below is from those runs, with emails redacted.

---

## What it looks like

```
$ cswap codex list
  1. alice@example.com [personal]  7d 98%
* 2. bob@example.com [personal]  7d 9%

$ cswap codex list --token-status
  1. alice@example.com [personal]  7d 98%
      token: valid, expires in 6d 6h; last refresh 2026-08-12T17:22:48Z
* 2. bob@example.com [personal]  7d 9%
      token: valid, expires in 9d 11h; last refresh 2026-08-15T22:31:17Z
```

`status` renders through the Claude side's own `_usage_entry_lines`, so the two are identical by construction rather than by imitation:

```
$ cswap status
Status: Account-1 (alice@example.com [Alice's Organization])
  Total managed accounts: 2
  ├ 5h:     27%   resets 18:30         in 4h 9m
  ├ 7d:     65%   resets 15:00         in 39m
  └ Fable:  28%   resets 15:00         in 39m

$ cswap codex status
Status: Codex-2 (bob@example.com [personal])
  Total managed Codex accounts: 2
  └ 7d:   9%   resets Aug 23 01:32  in 6d 11h
```

`--json` returns the same `schemaVersion`/`active`/`usageStatus` envelope, so a script that reads one reads the other.

The dashboard and menu bar show both, grouped, with a `⟨codex⟩` tag. Claude rows are untouched — a Claude-only install gains no badge, no empty section, no extra work:

```
 1  alice@example.com  [Alice's Organization]   5h 27% · 7d 65%
 2  carol@example.com  [Acme Inc]   re-login needed — refresh token dead; …
 1  alice@example.com  [personal] ⟨codex⟩   7d 98% (ahead)
 2  bob@example.com  [personal] ⟨codex⟩   7d 9%
```

One `cswap auto` drives both:

```
$ cswap auto --once --dry-run
14:20:36  Account-1 (alice@example.com): 65% used (switch at 90%) | others: #2: ?
14:20:36  no switch: below-threshold (65% < 90%)
codex: account 2 at 9% (below threshold)
```

## Commands

`list · status · switch · add · login · remove · alias · disable/enable · swap · move · export · import · purge`, each mirroring its Claude counterpart's semantics — bare `switch` rotates, `switch --strategy best` jumps to the most headroom, `swap`/`move` renumber slots.

## Architecture — a deliberately thin seam

`ClaudeAccountSwitcher` is **not** refactored. Most of its 7,000 lines are credential-provenance machinery (lineage verdicts, the profile oracle, the unclaimed stash) with no Codex analogue; extracting a base class from it would be a rewrite wearing a refactor's clothes.

So the seam sits where the two providers genuinely agree — the read model and a handful of verbs:

```
providers/base.py     ProviderSwitcher (Protocol)
providers/registry.py which providers this machine actually has
providers/aggregate.py merge N snapshots into one view
codex/                paths · auth_file · store · oauth · usage · usage_cache ·
                      workspaces · switcher · autoswitch · transfer · processes ·
                      registry_import · plans
cli_codex.py          the `cswap codex` surface
```

`ClaudeAccountSwitcher` already defined every Protocol verb under exactly these names, so it satisfies it structurally — the only edit it needed was a `provider_id` class attribute.

The Protocol is method-only on purpose: a `runtime_checkable` Protocol carrying a data member raises `TypeError` on `issubclass`, and `issubclass` is the check worth having, since constructing a `ClaudeAccountSwitcher` runs migrations.

`UsageStore` and `poll_policy` were already provider-neutral, so Codex gets serve TTL, cross-process fetch leases, failure backoff, `Retry-After` handling and the adaptive cadence for free. Two consecutive `cswap codex list` calls cost one round of requests, and the auto loop does not re-poll on every tick (both pinned by tests).

## Two rules that carry the Codex implementation

Both exist because the codex CLI owns `~/.codex/auth.json` and writes to it whenever it likes.

**1. The live file decides who is active.** A session left open on account A can rewrite `auth.json` minutes after a switch to B. An answer derived from cswap's own registry would report B while every codex command runs as A — so `current_account_number()` reads the live file's identity and matches it to a slot. Capture-on-switch routes the outgoing tokens to the slot the *live file's* identity matches, so a switch repairs such a clobber instead of committing one.

**2. The active account is never refreshed from its snapshot.** The codex CLI holds the same refresh token and keeps the live file current. If the server rotates refresh tokens on use, two parties refreshing the same one means one of them is logged out. The active slot therefore reads the live payload; only inactive slots refresh from snapshots. The store lock is taken **before** the network call, not around the persist alone: a refresh that cannot be persisted is a refresh that must not be performed.

## Storage

Codex data lives in cswap's own store, a sibling of the Claude one — `~/.codex/accounts/` is read once at import and **never written**:

| What | Where |
|---|---|
| Slot registry (no secrets) | `<data dir>/codex/sequence.json` |
| Credentials, macOS | Keychain, service `claude-swap-codex` |
| Credentials, elsewhere | `<data dir>/codex/credentials/`, 0600 (dir 0700) |
| Usage cache | `<data dir>/codex/cache/` |

Credentials are keyed by **account identity, never slot number**. That is what makes `swap`/`move` rewrite only the registry — keying secrets by a mutable number would have turned those into a data migration.

Users of `codex-auth` are imported automatically on first use, and the source tree is left byte-identical (sha256-verified before and after every run in testing), so going back to that tool stays possible.

## Things found by testing against the live API

Three assumptions inferred from `codex-auth`'s *stored* data turned out to be wrong about the *wire*. Recording them since they are the non-obvious part:

1. **The OAuth client id.** The one `strings` finds first in the codex binary is rejected with `invalid_client`. The real one is `app_EMoamEEZ73f0CkXaXp7hrann` — confirmed against the live endpoint with a deliberately invalid refresh token.
2. **The error shape.** The token endpoint answers **401** (not 400) with a *nested* `{"error":{"code":…}}` object, not RFC 6749's flat string. Both shapes are parsed, since it is undocumented and may move.
3. **`primary_window` is not necessarily the 5-hour window.** Its length is data (`limit_window_seconds`) and varies by plan: both live Plus accounts reported a `primary_window` of 604800 s — *a week* — with `secondary_window: null`. Mapping by position labelled weekly usage as 5-hourly, which reads wrong **and** silently disables `pace` (weekly-only). Windows are now classified by declared length, position as fallback.

## The restart caveat, surfaced rather than hidden

Switching rewrites `~/.codex/auth.json`, but a codex session already running holds its tokens in memory and keeps using the old account until restarted. cswap detects running codex processes and names their PIDs after a switch; the auto loop says so too, rather than switching silently and letting the user believe they moved. Users of the [`codext`](https://github.com/Loongphy/codext) fork get seamless switching.

## Tests

**+341 tests**, all new files except two edits:

- `tests/conftest.py` — imports the new Codex fixtures (7 lines)
- `tests/test_config_cli.py` — two assertions hardcoded the settings-key count at `9`; now `len(SETTING_SPECS)`, so they stop breaking whenever anyone adds a setting

No network in any test. Pilot tests drive the real `DashboardScreen` with two providers, because the dispatch bugs this work produced lived at integration seams that hand-rolled fakes could not reach.

On this macOS box the suite reports **2415 passed, 3 skipped, 3 failed** — those 3 failures are present on a clean checkout of `main` too (they chmod a `.enc` file that never exists on macOS, where credentials go to the Keychain). Happy to look at those separately if useful.

## Not included

- `cswap codex run` / `map` (per-terminal `CODEX_HOME` profiles) — the Codex analogue of session profiles is its own design problem
- Reading `~/.codex/sessions/**/rollout-*.jsonl` as a usage fallback — it only ever describes the active account, so it cannot serve autoswitch
- **Open question:** whether OpenAI rotates the refresh token on use is still unverified — both live tokens were days from expiry, and forcing the answer would mean deliberately spending a real account's refresh token. The design protects against it either way, so nothing depends on the answer; `--token-status` makes "when will this refresh?" visible for whoever observes it first.

Happy to split this into a series (seam → core → TUI → autoswitch) if that reviews better.
