### PR TITLE
fix(usage): a refused certificate is not an unreachable host

### DIFF
--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sys
 
@@ -878,6 +879,9 @@ Examples:
         sys.exit(130)
 
 
+_logger = logging.getLogger("claude-swap")
+
+
 def _use_native_tls() -> None:
     """Route TLS trust decisions through the OS-native verifier.
 
@@ -893,14 +897,28 @@ def _use_native_tls() -> None:
     with its own bundled roots) is unaffected. ``truststore`` delegates to them.
 
     Best-effort: on any failure fall back to stdlib ``ssl`` rather than block
-    the CLI over a TLS-trust nicety.
+    the CLI over a TLS-trust nicety — but SAY SO, because the fallback is not
+    trust-neutral. Measured on macOS 2026-08-17: the OS keychains carry 173
+    unique roots and stdlib loads 128, of which 67 are trusted by the OS and
+    not by stdlib. Four of those sit in /Library/Keychains/System.keychain,
+    where an administrator installs a corporate MITM CA. So a swallowed
+    failure here can withdraw the exact root the machine was configured with,
+    and the user is then told by ``ERROR_NOTES["tls-cert"]`` to trust the CA in
+    a store nothing is reading. One WARNING costs nothing on the healthy path,
+    which never reaches it.
     """
     try:
         import truststore
 
         truststore.inject_into_ssl()
-    except Exception:
-        pass
+    except Exception as e:
+        _logger.warning(
+            "native TLS trust unavailable (%s: %s) — falling back to stdlib "
+            "ssl, which does not read the OS certificate store; a CA trusted "
+            "only there will not verify",
+            type(e).__name__,
+            e,
+        )
 
 
 def main() -> None:

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import ssl
 import urllib.error
 import urllib.request
 from collections.abc import Callable, Sequence
@@ -378,8 +379,8 @@ def _classify_usage_error(e: Exception) -> tuple[str, float | None]:
     """Map a usage-fetch exception to ``(kind, retry_after_s)``.
 
     ``kind`` is a short stable token for logs and backoff decisions
-    (``"http-429"``, ``"timeout"``, ``"network"``, ``"bad-response"``, or the
-    exception type name as a fallback). ``retry_after_s`` is the parsed
+    (``"http-429"``, ``"timeout"``, ``"tls-cert"``, ``"network"``,
+    ``"bad-response"``, or the exception type name as a fallback). ``retry_after_s`` is the parsed
     ``Retry-After`` header when the server sent one (seconds form only — the
     HTTP-date form is rare enough to ignore).
     """
@@ -397,6 +398,19 @@ def _classify_usage_error(e: Exception) -> tuple[str, float | None]:
     if isinstance(e, urllib.error.URLError):
         if isinstance(e.reason, TimeoutError):
             return "timeout", None
+        # A TLS handshake that the SERVER answered and we refused is not a
+        # transport failure, and calling it one hides the only fix that works.
+        # Measured 2026-08-17: a TLS-terminating proxy (corporate MITM, or a
+        # local one) presents a CA that urllib does not trust, every poll
+        # raises URLError(SSLCertVerificationError), and all of it was recorded
+        # as "network". An account sat unpolled for ten days with that one word
+        # as the whole record. `network` says "the host is unreachable" and
+        # sends you to look at DNS and connectivity; the actual repair is a CA
+        # bundle. urllib reads SSL_CERT_FILE and neither REQUESTS_CA_BUNDLE nor
+        # NODE_EXTRA_CA_CERTS, which is exactly how a host can look configured
+        # and still fail here.
+        if isinstance(e.reason, ssl.SSLCertVerificationError):
+            return "tls-cert", None
         return "network", None
     if isinstance(e, json.JSONDecodeError):
         return "bad-response", None

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -382,8 +382,7 @@ def _classify_usage_error(e: Exception) -> tuple[str, float | None]:
     (``"http-429"``, ``"timeout"``, ``"tls-cert"``, ``"network"``,
     ``"bad-response"``, or the exception type name as a fallback).
     ``retry_after_s`` is the parsed ``Retry-After`` header when the server sent
-    one (seconds form only — the
-    HTTP-date form is rare enough to ignore).
+    one (seconds form only — the HTTP-date form is rare enough to ignore).
     """
     if isinstance(e, urllib.error.HTTPError):
         retry_after = None
@@ -399,22 +398,14 @@ def _classify_usage_error(e: Exception) -> tuple[str, float | None]:
     if isinstance(e, urllib.error.URLError):
         if isinstance(e.reason, TimeoutError):
             return "timeout", None
-        # A TLS handshake that the SERVER answered and we refused is not a
-        # transport failure, and calling it one hides the only fix that works.
-        # Measured 2026-08-17: a TLS-terminating proxy (corporate MITM, or a
-        # local one) presents a CA that urllib does not trust, every poll
-        # raises URLError(SSLCertVerificationError), and all of it was recorded
-        # as "network". An account sat unpolled for ten days with that one word
-        # as the whole record. `network` says "the host is unreachable" and
-        # sends you to look at DNS and connectivity; the actual repair is a CA
-        # bundle -- and WHICH bundle depends on the platform, because
-        # `cli.py` injects `truststore`, whose backends do not agree:
-        # truststore's OpenSSL backend calls set_default_verify_paths(), so on
-        # Linux SSL_CERT_FILE is read; its macOS and Windows backends verify
-        # through Security.framework and SChannel and read it not at all, so
-        # there the CA has to be trusted in the OS store. Nothing in this path
-        # reads REQUESTS_CA_BUNDLE or NODE_EXTRA_CA_CERTS on any platform,
-        # which is how a host can look configured and still fail here.
+        # A TLS handshake the SERVER answered and we refused is not a
+        # transport failure, and calling it one sends you to DNS while the
+        # repair is a CA bundle. Measured 2026-08-17: a TLS-terminating proxy
+        # presented a CA urllib does not trust, every poll raised
+        # URLError(SSLCertVerificationError), all of it stored as "network",
+        # and one account sat unpolled for ten days with that one word as the
+        # whole record. The remedy is platform-dependent and lives in
+        # ERROR_NOTES["tls-cert"], where the operator actually reads it.
         if isinstance(e.reason, ssl.SSLCertVerificationError):
             return "tls-cert", None
         return "network", None

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -380,8 +380,9 @@ def _classify_usage_error(e: Exception) -> tuple[str, float | None]:
 
     ``kind`` is a short stable token for logs and backoff decisions
     (``"http-429"``, ``"timeout"``, ``"tls-cert"``, ``"network"``,
-    ``"bad-response"``, or the exception type name as a fallback). ``retry_after_s`` is the parsed
-    ``Retry-After`` header when the server sent one (seconds form only — the
+    ``"bad-response"``, or the exception type name as a fallback).
+    ``retry_after_s`` is the parsed ``Retry-After`` header when the server sent
+    one (seconds form only — the
     HTTP-date form is rare enough to ignore).
     """
     if isinstance(e, urllib.error.HTTPError):
@@ -406,9 +407,14 @@ def _classify_usage_error(e: Exception) -> tuple[str, float | None]:
         # as "network". An account sat unpolled for ten days with that one word
         # as the whole record. `network` says "the host is unreachable" and
         # sends you to look at DNS and connectivity; the actual repair is a CA
-        # bundle. urllib reads SSL_CERT_FILE and neither REQUESTS_CA_BUNDLE nor
-        # NODE_EXTRA_CA_CERTS, which is exactly how a host can look configured
-        # and still fail here.
+        # bundle -- and WHICH bundle depends on the platform, because
+        # `cli.py` injects `truststore`, whose backends do not agree:
+        # truststore's OpenSSL backend calls set_default_verify_paths(), so on
+        # Linux SSL_CERT_FILE is read; its macOS and Windows backends verify
+        # through Security.framework and SChannel and read it not at all, so
+        # there the CA has to be trusted in the OS store. Nothing in this path
+        # reads REQUESTS_CA_BUNDLE or NODE_EXTRA_CA_CERTS on any platform,
+        # which is how a host can look configured and still fail here.
         if isinstance(e.reason, ssl.SSLCertVerificationError):
             return "tls-cert", None
         return "network", None

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -180,9 +180,11 @@ _DEMOTING_STASH_REASONS = (
 
 ERROR_NOTES = {
     "tls-cert": (
-        "the server's certificate was refused — a TLS-terminating proxy "
-        "(corporate or local) whose CA is not trusted here; trust that CA in "
-        "the OS store on macOS/Windows, or set SSL_CERT_FILE on Linux"
+        "the certificate chain was not trusted — most often a TLS-terminating "
+        "proxy whose CA is missing here, sometimes an expired duplicate root "
+        "shadowing a valid one; fix it in the OS store on macOS/Windows, or "
+        "via SSL_CERT_FILE on Linux (REQUESTS_CA_BUNDLE and "
+        "NODE_EXTRA_CA_CERTS are not read on this path)"
     ),
     "store-unmirrored": (
         "CLAUDE_SECURESTORAGE_CONFIG_DIR set — unset it or run from a "

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -179,6 +179,11 @@ _DEMOTING_STASH_REASONS = (
 )
 
 ERROR_NOTES = {
+    "tls-cert": (
+        "the server's certificate was refused — a TLS-terminating proxy "
+        "(corporate or local) whose CA is not trusted here; trust that CA in "
+        "the OS store on macOS/Windows, or set SSL_CERT_FILE on Linux"
+    ),
     "store-unmirrored": (
         "CLAUDE_SECURESTORAGE_CONFIG_DIR set — unset it or run from a "
         "normal shell"

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -871,6 +871,62 @@ class TestFetchUsageForAccount:
         assert "cswap --add-account" in output
 
 
+class TestNativeTlsFallbackIsAudible:
+    """A silent fallback to stdlib ssl is a silent NARROWING OF TRUST.
+
+    ``_use_native_tls`` swallows every exception so the CLI is never blocked
+    over a trust nicety. That part is right. What is wrong is that it leaves no
+    trace, and the two paths do not trust the same roots.
+
+    Measured on macOS 2026-08-17, comparing the OS keychains against what
+    stdlib actually loads:
+
+        OS-store unique roots           173   (system 154, admin 4, login 15)
+        stdlib-loaded roots             128
+        trusted by OS, NOT by stdlib     67   <-- lost, with no message
+
+    Four of those live in /Library/Keychains/System.keychain, which is where an
+    administrator puts a corporate MITM CA. So the fallback can take away the
+    exact root the machine was configured with, and the user is then told to
+    "trust the CA in the OS store" by a remedy note pointing at a store that is
+    no longer being read.
+    """
+
+    def test_a_failed_injection_says_so(self, caplog):
+        import logging
+        import builtins
+        from claude_swap import cli
+
+        real_import = builtins.__import__
+
+        def refuse(name, *a, **k):
+            if name == "truststore":
+                raise ImportError("simulated: truststore unavailable")
+            return real_import(name, *a, **k)
+
+        builtins.__import__ = refuse
+        try:
+            with caplog.at_level(logging.WARNING):
+                cli._use_native_tls()
+        finally:
+            builtins.__import__ = real_import
+
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "truststore" in joined.lower() or "native" in joined.lower(), (
+            f"the fallback left no trace; records={[r.getMessage() for r in caplog.records]}"
+        )
+
+    def test_a_successful_injection_stays_quiet(self, caplog):
+        """The control: the normal path must not warn, or the warning is noise
+        every run and stops being read."""
+        import logging
+        from claude_swap import cli
+
+        with caplog.at_level(logging.WARNING):
+            cli._use_native_tls()
+        assert not [r for r in caplog.records if "truststore" in r.getMessage().lower()]
+
+
 class TestClassifyUsageError:
     """Test _classify_usage_error kinds and Retry-After parsing."""
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -927,6 +927,41 @@ class TestClassifyUsageError:
             urllib.error.URLError(ConnectionRefusedError())
         )[0] == "network"
 
+    def test_tls_cert_failure_is_not_flattened_to_network(self):
+        """A MITM proxy with an untrusted CA must not read as a transport error.
+
+        Measured 2026-08-17 on lambda-docker: every usage poll went through a
+        TLS-terminating proxy whose CA urllib does not trust, so each one raised
+
+            URLError(SSLCertVerificationError(1, "[SSL: CERTIFICATE_VERIFY_FAILED]
+            certificate verify failed: unable to get local issuer certificate"))
+
+        and was recorded as ``network``. One account sat dead for ten days and
+        "network" is the only word anyone could see; the real cause reaches
+        DEBUG alone, which nothing enables. "Cannot reach the host" and "reached
+        the host and refused its certificate" need opposite fixes, so they may
+        not share a token.
+        """
+        import ssl
+        e = urllib.error.URLError(
+            ssl.SSLCertVerificationError(
+                1,
+                "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: "
+                "unable to get local issuer certificate (_ssl.c:1000)",
+            )
+        )
+        assert oauth._classify_usage_error(e)[0] == "tls-cert"
+
+    def test_plain_transport_failure_still_reads_as_network(self):
+        """Control for the case above: narrowing must not swallow the ordinary
+        transport error, which is what ``network`` exists for."""
+        assert oauth._classify_usage_error(
+            urllib.error.URLError(ConnectionRefusedError())
+        )[0] == "network"
+        assert oauth._classify_usage_error(
+            urllib.error.URLError(OSError("unreachable"))
+        )[0] == "network"
+
     def test_bad_response(self):
         try:
             json.loads("not json")

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -943,7 +943,6 @@ class TestClassifyUsageError:
         the host and refused its certificate" need opposite fixes, so they may
         not share a token.
         """
-        import ssl
         e = urllib.error.URLError(
             ssl.SSLCertVerificationError(
                 1,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import ssl
 import urllib.error
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
@@ -952,15 +953,39 @@ class TestClassifyUsageError:
         )
         assert oauth._classify_usage_error(e)[0] == "tls-cert"
 
-    def test_plain_transport_failure_still_reads_as_network(self):
-        """Control for the case above: narrowing must not swallow the ordinary
-        transport error, which is what ``network`` exists for."""
+    def test_a_non_cert_ssl_failure_is_not_a_cert_failure(self):
+        """Pins the PREDICATE, not just the outcome.
+
+        ``ssl.SSLCertVerificationError`` is the narrow choice on purpose, and
+        the obvious loosening -- ``ssl.SSLError`` -- passes every other test in
+        this file. A non-cert TLS failure is a different condition with a
+        different repair: speaking https to a plaintext port raises
+        ``SSLError("record layer failure")``, and calling that ``tls-cert``
+        sends the operator to fix a CA bundle for a wrong-port problem.
+        """
         assert oauth._classify_usage_error(
-            urllib.error.URLError(ConnectionRefusedError())
+            urllib.error.URLError(ssl.SSLEOFError("handshake failed"))
         )[0] == "network"
         assert oauth._classify_usage_error(
-            urllib.error.URLError(OSError("unreachable"))
+            urllib.error.URLError(ssl.SSLError("record layer failure"))
         )[0] == "network"
+
+    def test_tls_cert_carries_a_remedy_note(self):
+        """A kind with no ERROR_NOTES entry renders as the bare identifier.
+
+        The whole point of splitting this out of ``network`` is that the two
+        need different repairs, and that only reaches the operator through the
+        note. Without one the display trades one uninformative word for
+        another. ``test_every_deterministic_kind_has_a_note`` states the same
+        principle but iterates ``_DETERMINISTIC_REFRESH_ERRORS``, which is a
+        refresh-error list -- a usage-fetch kind is outside its loop, so it
+        cannot cover this.
+        """
+        from claude_swap.switcher import ERROR_NOTES
+
+        assert "tls-cert" in ERROR_NOTES
+        note = ERROR_NOTES["tls-cert"]
+        assert "SSL_CERT_FILE" in note
 
     def test_bad_response(self):
         try:


### PR DESCRIPTION
## The defect

`_classify_usage_error` maps every `urllib.error.URLError` that is not a timeout
to `network`. A TLS certificate the client *refused* therefore gets recorded
with the same word as a host it could not *reach*.

Those two need opposite fixes. `network` points at DNS and connectivity; the
repair for a refused certificate is a CA bundle. Anyone reading the stored
failure sees only the first.

## Measured

On a machine whose `HTTPS_PROXY` is a TLS-terminating proxy, every usage poll
raised:

```
URLError(SSLCertVerificationError(1, "[SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: unable to get local issuer certificate (_ssl.c:1000)"))
```

and each was stored as `network`. One account reached **1155 consecutive
failures over ten days** with that one word as the entire record — the exception
repr only reaches `DEBUG`, which nothing enables in normal operation.

The same request with `SSL_CERT_FILE` pointing at the proxy's CA returns
`HTTP 200`. The account, the token and the endpoint were healthy the whole time.

| `SSL_CERT_FILE` | result |
| --- | --- |
| unset | `URLError` → recorded `network` |
| proxy CA bundle | `HTTP 200`, usage parsed |
| system CA bundle | `URLError` (system store does not trust the proxy) |
| unset, no proxy | `HTTP 200` (control) |

## Not specific to one setup

`urllib` reads `SSL_CERT_FILE` and reads neither `REQUESTS_CA_BUNDLE` nor
`NODE_EXTRA_CA_CERTS`. A user behind a corporate MITM proxy (Zscaler, Netskope,
and similar) who has configured either of those still fails here, and still sees
only `network`.

## Scope

Deliberately narrow. No renames, no control-flow changes. The guard fires on
`SSLCertVerificationError` alone, so an ordinary transport error keeps reporting
`network`.

This PR only stops the cause from being erased. It does **not** make cswap read
anyone's CA bundle — that is a separate decision and is not proposed here.

## Tests

- `test_tls_cert_failure_is_not_flattened_to_network` — written first, failed
  with `assert 'network' == 'tls-cert'`, passes after the fix.
- `test_plain_transport_failure_still_reads_as_network` — the control, so the
  narrowing cannot swallow the case `network` exists for.

Mutation-checked: removing the guard makes the first test fail and leaves the
control passing. Full suite `2090 passed, 3 skipped`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
