### PR TITLE
feat(menubar): run the menu bar as a launchd LaunchAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,16 @@ cswap menubar
 
 Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
 
+**Keep it running without a terminal.** `cswap menubar` runs in the foreground, so the status item dies with the terminal that started it and does not come back after a reboot. `--install-service` hands it to launchd instead — starts at login, restarts on crash, no `.app` bundle:
+
+```bash
+cswap menubar --install-service     # start now, and at every login
+cswap menubar --service-status      # installed? loaded? pid?
+cswap menubar --uninstall-service   # stop it and remove the plist
+```
+
+The agent lives at `~/Library/LaunchAgents/com.cswap.menubar.plist` and logs to `~/Library/Logs/com.cswap.menubar.{log,err}`. It pins the `cswap` console script, whose path survives an upgrade — but the running process keeps the old build until it restarts, so after `cswap upgrade` either re-run `--install-service` or `launchctl kickstart -k gui/$(id -u)/com.cswap.menubar`.
+
 </details>
 
 ## Advanced

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -903,6 +903,51 @@ def _use_native_tls() -> None:
         pass
 
 
+def _menubar_service(args) -> int:
+    """Handle ``menubar --install-service|--uninstall-service|--service-status``.
+
+    Split out of the dispatch chain because these three share one import and
+    one output shape, and because the menu bar branch below them is a
+    non-returning call — folding the service paths inline would leave the
+    reader tracing which branches fall through to launching the app.
+    """
+    from claude_swap import launch_agent
+
+    if args.install_service:
+        result = launch_agent.install()
+        print(f"Menu bar service installed ({result['label']}).")
+        print(f"  plist: {result['plist']}")
+        print(f"  logs:  {result['stderr_log']}")
+        print(
+            dimmed(
+                "It starts at login from now on. Re-run this after a cswap "
+                "upgrade to point launchd at the new build."
+            )
+        )
+        return 0
+
+    if args.uninstall_service:
+        result = launch_agent.uninstall()
+        if result["was_loaded"] or result["removed_plist"]:
+            print("Menu bar service removed.")
+        else:
+            print("Menu bar service was not installed.")
+        return 0
+
+    result = launch_agent.status()
+    if not result["installed"] and not result["loaded"]:
+        print("Menu bar service is not installed.")
+        print(dimmed("Install it with: cswap menubar --install-service"))
+        return 0
+    state = result["state"] or ("loaded" if result["loaded"] else "stopped")
+    pid = f" (pid {result['pid']})" if result["pid"] else ""
+    print(f"Menu bar service: {state}{pid}")
+    print(f"  plist: {result['plist']}")
+    if not result["installed"]:
+        print(dimmed("launchd still has it loaded, but the plist is gone."))
+    return 0
+
+
 def main() -> None:
     """Main entry point for the CLI."""
     force_utf8_output()
@@ -993,6 +1038,7 @@ Commands:
   %(prog)s tui                        interactive dashboard (also: bare %(prog)s)
   %(prog)s watch                      dashboard, opened on the live watch page
   %(prog)s menubar                    macOS menu bar app
+  %(prog)s menubar --install-service  keep the menu bar running via launchd
   %(prog)s upgrade                    self-upgrade to latest
   %(prog)s purge                      remove all claude-swap data
 
@@ -1096,6 +1142,27 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         "--full",
         action="store_true",
         help="Include full ~/.claude.json in export (default: oauthAccount only)",
+    )
+    parser.add_argument(
+        "--install-service",
+        action="store_true",
+        help=(
+            "With 'menubar': install a launchd LaunchAgent so the menu bar "
+            "starts at login and restarts on crash (macOS)"
+        ),
+    )
+    parser.add_argument(
+        "--uninstall-service",
+        action="store_true",
+        help="With 'menubar': stop the LaunchAgent and remove its plist (macOS)",
+    )
+    parser.add_argument(
+        "--service-status",
+        action="store_true",
+        help=(
+            "With 'menubar': report whether the LaunchAgent is installed "
+            "and running"
+        ),
     )
 
     # Legacy `--flag` interface. Still fully supported (bare subcommands rewrite
@@ -1351,6 +1418,8 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             if sys.platform != "darwin":
                 error("The menu bar is only available on macOS.")
                 sys.exit(1)
+            if args.install_service or args.uninstall_service or args.service_status:
+                sys.exit(_menubar_service(args))
             # menubar is import-safe without the extra; a missing rumps
             # surfaces from run() as a ClaudeSwitchError with the install hint.
             from claude_swap.menubar import run as menubar_run

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -1322,6 +1322,14 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.full and not args.export:
         parser.error("--full can only be used with 'export'")
 
+    if (
+        args.install_service or args.uninstall_service or args.service_status
+    ) and not args.menubar:
+        parser.error(
+            "--install-service, --uninstall-service and --service-status "
+            "can only be used with 'menubar'"
+        )
+
     # Self-upgrade runs before switcher init so we don't touch config/keychain
     # just to upgrade the tool itself.
     if args.upgrade:

--- a/src/claude_swap/launch_agent.py
+++ b/src/claude_swap/launch_agent.py
@@ -31,6 +31,7 @@ import plistlib
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from claude_swap.exceptions import ClaudeSwitchError
@@ -42,6 +43,13 @@ LABEL = "com.cswap.menubar"
 # menu bar shells out to detect running sessions, so seed a PATH that finds it.
 _EXTRA_PATH_DIRS = ("~/.local/bin", "/opt/homebrew/bin", "/usr/local/bin")
 _BASE_PATH_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin")
+
+# `launchctl bootout` can return before launchd has finished tearing the
+# job down, and a `bootstrap` inside that window fails with "Operation
+# already in progress". Poll until the job is really gone instead of
+# assuming bootout was synchronous (Homebrew's services code does the same).
+_UNLOAD_TIMEOUT_SECONDS = 5.0
+_UNLOAD_POLL_SECONDS = 0.1
 
 
 def _require_macos() -> None:
@@ -155,6 +163,20 @@ def _launchctl(*args: str) -> subprocess.CompletedProcess:
         raise ClaudeSwitchError("launchctl not found; is this macOS?") from e
 
 
+def _wait_until_unloaded(
+    label: str = LABEL,
+    uid: int | None = None,
+    timeout: float = _UNLOAD_TIMEOUT_SECONDS,
+) -> bool:
+    """Block until launchd has dropped the job. True if it went away in time."""
+    deadline = time.monotonic() + timeout
+    while is_loaded(label, uid):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_UNLOAD_POLL_SECONDS)
+    return True
+
+
 def is_loaded(label: str = LABEL, uid: int | None = None) -> bool:
     """Whether launchd currently knows about the service."""
     return _launchctl("print", service_target(label, uid)).returncode == 0
@@ -213,12 +235,16 @@ def install(
     out_log.parent.mkdir(parents=True, exist_ok=True)
     target_plist.write_bytes(build_plist(program, label, home))
 
+    settled = True
     if is_loaded(label, uid):
         _launchctl("bootout", service_target(label, uid))
+        settled = _wait_until_unloaded(label, uid)
 
     booted = _launchctl("bootstrap", domain_target(uid), str(target_plist))
     if booted.returncode != 0:
         detail = (booted.stderr or booted.stdout or "").strip()
+        if not settled:
+            detail = f"{detail}; the previous instance was still shutting down".lstrip("; ")
         raise ClaudeSwitchError(
             f"launchctl bootstrap failed (exit {booted.returncode})"
             + (f": {detail}" if detail else "")

--- a/src/claude_swap/launch_agent.py
+++ b/src/claude_swap/launch_agent.py
@@ -40,7 +40,7 @@ LABEL = "com.cswap.menubar"
 # launchd's default PATH is /usr/bin:/bin:/usr/sbin:/sbin, which covers
 # `security` (Keychain reads) but not a Homebrew or ~/.local/bin `claude`. The
 # menu bar shells out to detect running sessions, so seed a PATH that finds it.
-_EXTRA_PATH_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
+_EXTRA_PATH_DIRS = ("~/.local/bin", "/opt/homebrew/bin", "/usr/local/bin")
 _BASE_PATH_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin")
 
 
@@ -78,19 +78,22 @@ def resolve_program() -> list[str]:
     Prefers the installed console script (stable across upgrades, see the
     module docstring) and falls back to running the package through the
     interpreter that is executing right now.
+
+    The path is made absolute but deliberately NOT resolved: a `uv tool
+    install` puts a symlink at ``~/.local/bin/cswap`` pointing into the tool's
+    virtualenv, and resolving it would write that virtualenv-internal path
+    into the plist — the very path this module avoids pinning, since a
+    reinstall recreates the virtualenv while the symlink keeps its name.
     """
-    candidate = Path(sys.argv[0]) if sys.argv and sys.argv[0] else None
+    candidate = sys.argv[0] if sys.argv and sys.argv[0] else None
     if candidate is not None:
-        try:
-            resolved = candidate.resolve()
-        except OSError:
-            resolved = None
-        if resolved is not None and resolved.is_file() and resolved.name == "cswap":
-            return [str(resolved)]
+        absolute = Path(os.path.abspath(candidate))
+        if absolute.name == "cswap" and absolute.is_file():
+            return [str(absolute)]
 
     which = shutil.which("cswap")
     if which:
-        return [str(Path(which).resolve())]
+        return [str(Path(os.path.abspath(which)))]
 
     return [sys.executable, "-m", "claude_swap"]
 
@@ -102,8 +105,9 @@ def _path_env(program: list[str]) -> str:
     if str(first) not in ("", "."):
         dirs.append(str(first))
     for extra in (*_EXTRA_PATH_DIRS, *_BASE_PATH_DIRS):
-        if extra not in dirs:
-            dirs.append(extra)
+        expanded = os.path.expanduser(extra)
+        if expanded not in dirs:
+            dirs.append(expanded)
     return ":".join(dirs)
 
 
@@ -124,7 +128,11 @@ def build_plist(
             "Label": label,
             "ProgramArguments": [*program, "menubar"],
             "RunAtLoad": True,
-            "KeepAlive": True,
+            # Restart a crash, but respect a deliberate Quit. The menu bar's
+            # quit handler calls rumps.quit_application(), a clean exit(0);
+            # under a bare `KeepAlive: True` launchd would relaunch it at once
+            # and the Quit item would do nothing the user can see.
+            "KeepAlive": {"SuccessfulExit": False},
             # A menu bar owner is a UI process; Background would have launchd
             # apply throttled I/O and CPU bands to it.
             "ProcessType": "Interactive",

--- a/src/claude_swap/launch_agent.py
+++ b/src/claude_swap/launch_agent.py
@@ -1,0 +1,255 @@
+"""Run ``cswap menubar`` as a launchd LaunchAgent instead of a foreground process.
+
+``cswap menubar`` blocks the terminal that started it, so the status item dies
+with that terminal — and never comes back after a logout or reboot. launchd is
+the native macOS answer: a per-user LaunchAgent starts the menu bar at login,
+restarts it if it crashes, and needs no ``.app`` bundle.
+
+Two decisions here are worth stating, because both differ from the obvious
+approach:
+
+*The plist pins the console script, not ``sys.executable``.* A LaunchAgent
+outlives upgrades, and the two paths age differently: ``uv tool upgrade`` (and
+``cswap upgrade``) rebuilds the tool's virtualenv — ``sys.executable`` points
+inside that virtualenv and can be replaced — while the console script keeps its
+path across upgrades. Pinning the script means an upgraded cswap needs a
+``launchctl kickstart``, not a reinstalled service. ``sys.executable -m
+claude_swap`` stays as the fallback for installs that expose no console script.
+
+*Logs go to ``~/Library/Logs``, not ``/tmp``.* ``/tmp`` is world-writable and
+periodically purged, so a crash log can vanish before anyone reads it, and a
+predictable world-writable path is a poor place to point a long-lived writer.
+
+Everything here is macOS-only; callers guard on ``sys.platform`` and the public
+functions refuse rather than half-work elsewhere.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from claude_swap.exceptions import ClaudeSwitchError
+
+LABEL = "com.cswap.menubar"
+
+# launchd's default PATH is /usr/bin:/bin:/usr/sbin:/sbin, which covers
+# `security` (Keychain reads) but not a Homebrew or ~/.local/bin `claude`. The
+# menu bar shells out to detect running sessions, so seed a PATH that finds it.
+_EXTRA_PATH_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
+_BASE_PATH_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin")
+
+
+def _require_macos() -> None:
+    if sys.platform != "darwin":
+        raise ClaudeSwitchError(
+            "The menu bar service is only available on macOS."
+        )
+
+
+def plist_path(label: str = LABEL, home: Path | None = None) -> Path:
+    """Absolute path of the LaunchAgent plist for ``label``."""
+    return (home or Path.home()) / "Library" / "LaunchAgents" / f"{label}.plist"
+
+
+def log_paths(label: str = LABEL, home: Path | None = None) -> tuple[Path, Path]:
+    """``(stdout, stderr)`` log destinations for ``label``."""
+    logs = (home or Path.home()) / "Library" / "Logs"
+    return logs / f"{label}.log", logs / f"{label}.err"
+
+
+def service_target(label: str = LABEL, uid: int | None = None) -> str:
+    """launchd service target, e.g. ``gui/501/com.cswap.menubar``."""
+    return f"gui/{os.getuid() if uid is None else uid}/{label}"
+
+
+def domain_target(uid: int | None = None) -> str:
+    """launchd domain target, e.g. ``gui/501``."""
+    return f"gui/{os.getuid() if uid is None else uid}"
+
+
+def resolve_program() -> list[str]:
+    """Argv prefix that launchd should run, minus the subcommand.
+
+    Prefers the installed console script (stable across upgrades, see the
+    module docstring) and falls back to running the package through the
+    interpreter that is executing right now.
+    """
+    candidate = Path(sys.argv[0]) if sys.argv and sys.argv[0] else None
+    if candidate is not None:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = None
+        if resolved is not None and resolved.is_file() and resolved.name == "cswap":
+            return [str(resolved)]
+
+    which = shutil.which("cswap")
+    if which:
+        return [str(Path(which).resolve())]
+
+    return [sys.executable, "-m", "claude_swap"]
+
+
+def _path_env(program: list[str]) -> str:
+    """PATH for the agent, with the program's own directory first."""
+    dirs: list[str] = []
+    first = Path(program[0]).parent
+    if str(first) not in ("", "."):
+        dirs.append(str(first))
+    for extra in (*_EXTRA_PATH_DIRS, *_BASE_PATH_DIRS):
+        if extra not in dirs:
+            dirs.append(extra)
+    return ":".join(dirs)
+
+
+def build_plist(
+    program: list[str] | None = None,
+    label: str = LABEL,
+    home: Path | None = None,
+) -> bytes:
+    """Serialize the LaunchAgent plist.
+
+    Built with :mod:`plistlib` rather than a formatted XML string so paths
+    containing ``&`` or ``<`` cannot produce a plist launchd refuses to parse.
+    """
+    program = program or resolve_program()
+    out_log, err_log = log_paths(label, home)
+    return plistlib.dumps(
+        {
+            "Label": label,
+            "ProgramArguments": [*program, "menubar"],
+            "RunAtLoad": True,
+            "KeepAlive": True,
+            # A menu bar owner is a UI process; Background would have launchd
+            # apply throttled I/O and CPU bands to it.
+            "ProcessType": "Interactive",
+            "EnvironmentVariables": {"PATH": _path_env(program)},
+            "StandardOutPath": str(out_log),
+            "StandardErrorPath": str(err_log),
+        }
+    )
+
+
+def _launchctl(*args: str) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            ["launchctl", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as e:  # pragma: no cover - launchctl is in the base OS
+        raise ClaudeSwitchError("launchctl not found; is this macOS?") from e
+
+
+def is_loaded(label: str = LABEL, uid: int | None = None) -> bool:
+    """Whether launchd currently knows about the service."""
+    return _launchctl("print", service_target(label, uid)).returncode == 0
+
+
+def status(label: str = LABEL, uid: int | None = None, home: Path | None = None) -> dict:
+    """Installed / loaded / running state, plus the pid when there is one."""
+    _require_macos()
+    printed = _launchctl("print", service_target(label, uid))
+    loaded = printed.returncode == 0
+    state: str | None = None
+    pid: int | None = None
+    if loaded:
+        for line in printed.stdout.splitlines():
+            # `launchctl print` nests sub-dictionaries — pid-local endpoints,
+            # inherited environment — and those repeat keys the job itself
+            # uses, `state` among them. The job's own fields are the ones at a
+            # single tab, so anything deeper is a different object's field.
+            if not line.startswith("\t") or line.startswith("\t\t"):
+                continue
+            stripped = line.strip()
+            if state is None and stripped.startswith("state = "):
+                state = stripped.removeprefix("state = ").strip()
+            elif pid is None and stripped.startswith("pid = "):
+                raw = stripped.removeprefix("pid = ").strip()
+                if raw.isdigit():
+                    pid = int(raw)
+    return {
+        "label": label,
+        "installed": plist_path(label, home).exists(),
+        "loaded": loaded,
+        "state": state,
+        "pid": pid,
+        "plist": str(plist_path(label, home)),
+    }
+
+
+def install(
+    label: str = LABEL,
+    home: Path | None = None,
+    program: list[str] | None = None,
+    uid: int | None = None,
+) -> dict:
+    """Write the plist and hand the service to launchd.
+
+    Idempotent: an already-loaded service is booted out first, so running this
+    after an upgrade re-reads the plist instead of failing with launchd's
+    "service already loaded" (EEXIST, code 5).
+    """
+    _require_macos()
+    program = program or resolve_program()
+    target_plist = plist_path(label, home)
+    out_log, err_log = log_paths(label, home)
+
+    target_plist.parent.mkdir(parents=True, exist_ok=True)
+    out_log.parent.mkdir(parents=True, exist_ok=True)
+    target_plist.write_bytes(build_plist(program, label, home))
+
+    if is_loaded(label, uid):
+        _launchctl("bootout", service_target(label, uid))
+
+    booted = _launchctl("bootstrap", domain_target(uid), str(target_plist))
+    if booted.returncode != 0:
+        detail = (booted.stderr or booted.stdout or "").strip()
+        raise ClaudeSwitchError(
+            f"launchctl bootstrap failed (exit {booted.returncode})"
+            + (f": {detail}" if detail else "")
+        )
+
+    return {
+        "label": label,
+        "plist": str(target_plist),
+        "program": [*program, "menubar"],
+        "stdout_log": str(out_log),
+        "stderr_log": str(err_log),
+    }
+
+
+def uninstall(
+    label: str = LABEL,
+    home: Path | None = None,
+    uid: int | None = None,
+) -> dict:
+    """Stop the service and delete its plist.
+
+    Tolerates every partial state — loaded without a plist, a plist that was
+    never bootstrapped, neither — because the point of an uninstall is to
+    arrive at "gone", not to insist on the path taken to get there.
+    """
+    _require_macos()
+    target_plist = plist_path(label, home)
+    was_loaded = is_loaded(label, uid)
+    if was_loaded:
+        booted_out = _launchctl("bootout", service_target(label, uid))
+        if booted_out.returncode != 0 and is_loaded(label, uid):
+            detail = (booted_out.stderr or booted_out.stdout or "").strip()
+            raise ClaudeSwitchError(
+                f"launchctl bootout failed (exit {booted_out.returncode})"
+                + (f": {detail}" if detail else "")
+            )
+
+    existed = target_plist.exists()
+    if existed:
+        target_plist.unlink()
+
+    return {"label": label, "was_loaded": was_loaded, "removed_plist": existed}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -469,6 +469,119 @@ class TestCLI:
         assert exc.value.code == 0
         assert called.get("ran") is True
 
+    def _service_harness(self, monkeypatch, argv):
+        """Drive `cswap menubar <service flag>` with launch_agent stubbed out."""
+        seen = {"menubar_ran": False}
+
+        class _FakeSwitcher:
+            def __init__(self, *a, **k):
+                pass
+
+            def _is_running_in_container(self):
+                return False
+
+        def _fake_menubar(switcher):
+            seen["menubar_ran"] = True
+            return 0
+
+        def _record(name, payload):
+            def _call(*a, **k):
+                seen["called"] = name
+                return payload
+
+            return _call
+
+        monkeypatch.setattr(cli, "ClaudeAccountSwitcher", _FakeSwitcher)
+        monkeypatch.setattr(sys, "argv", argv)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr("claude_swap.menubar.run", _fake_menubar, raising=False)
+        monkeypatch.setattr(cli.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(
+            "claude_swap.launch_agent.install",
+            _record(
+                "install",
+                {
+                    "label": "com.cswap.menubar",
+                    "plist": "/tmp/p.plist",
+                    "program": ["/tmp/cswap", "menubar"],
+                    "stdout_log": "/tmp/o.log",
+                    "stderr_log": "/tmp/e.log",
+                },
+            ),
+        )
+        monkeypatch.setattr(
+            "claude_swap.launch_agent.uninstall",
+            _record("uninstall", {"label": "com.cswap.menubar", "was_loaded": True, "removed_plist": True}),
+        )
+        monkeypatch.setattr(
+            "claude_swap.launch_agent.status",
+            _record(
+                "status",
+                {
+                    "label": "com.cswap.menubar",
+                    "installed": True,
+                    "loaded": True,
+                    "state": "running",
+                    "pid": 4242,
+                    "plist": "/tmp/p.plist",
+                },
+            ),
+        )
+        return seen
+
+    def test_menubar_install_service_routes_to_launch_agent(self, monkeypatch, capsys):
+        seen = self._service_harness(monkeypatch, ["cswap", "menubar", "--install-service"])
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 0
+        assert seen["called"] == "install"
+        # The service flags must not also start a foreground menu bar.
+        assert seen["menubar_ran"] is False
+        assert "installed" in capsys.readouterr().out
+
+    def test_menubar_uninstall_service_routes_to_launch_agent(self, monkeypatch, capsys):
+        seen = self._service_harness(monkeypatch, ["cswap", "menubar", "--uninstall-service"])
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 0
+        assert seen["called"] == "uninstall"
+        assert seen["menubar_ran"] is False
+        assert "removed" in capsys.readouterr().out
+
+    def test_menubar_service_status_reports_state_and_pid(self, monkeypatch, capsys):
+        seen = self._service_harness(monkeypatch, ["cswap", "menubar", "--service-status"])
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 0
+        assert seen["called"] == "status"
+        out = capsys.readouterr().out
+        assert "running" in out and "4242" in out
+
+    def test_menubar_service_flags_still_refuse_off_macos(self, monkeypatch):
+        self._service_harness(monkeypatch, ["cswap", "menubar", "--install-service"])
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 1
+
+    def test_plain_menubar_does_not_touch_the_service(self, monkeypatch):
+        seen = self._service_harness(monkeypatch, ["cswap", "menubar"])
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 0
+        assert seen["menubar_ran"] is True
+        assert "called" not in seen
+
 
 class TestCLICommands:
     """Test individual CLI commands."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -572,6 +572,17 @@ class TestCLI:
 
         assert exc.value.code == 1
 
+    def test_service_flags_are_rejected_outside_menubar(self, monkeypatch, capsys):
+        # `--full` already guards this way; without a matching check
+        # `cswap list --install-service` would be accepted and silently ignored.
+        monkeypatch.setattr(sys, "argv", ["cswap", "list", "--install-service"])
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 2
+        assert "can only be used with 'menubar'" in capsys.readouterr().err
+
     def test_plain_menubar_does_not_touch_the_service(self, monkeypatch):
         seen = self._service_harness(monkeypatch, ["cswap", "menubar"])
 

--- a/tests/test_launch_agent.py
+++ b/tests/test_launch_agent.py
@@ -9,6 +9,7 @@ or writes outside the temp directory.
 
 from __future__ import annotations
 
+import os
 import plistlib
 import subprocess
 import sys
@@ -54,7 +55,17 @@ def test_build_plist_is_parseable_and_runs_the_menubar_subcommand(tmp_path):
     assert parsed["Label"] == launch_agent.LABEL
     assert parsed["ProgramArguments"] == [*PROGRAM, "menubar"]
     assert parsed["RunAtLoad"] is True
-    assert parsed["KeepAlive"] is True
+
+
+def test_build_plist_keepalive_restarts_a_crash_but_respects_a_quit(tmp_path):
+    """A bare `KeepAlive: True` would make the menu bar's Quit item a no-op.
+
+    menubar.py's quit handler calls rumps.quit_application() — a clean exit(0)
+    — so unconditional KeepAlive relaunches it immediately and the user has no
+    way to stop the menu bar short of `launchctl bootout`.
+    """
+    parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=tmp_path))
+    assert parsed["KeepAlive"] == {"SuccessfulExit": False}
 
 
 def test_build_plist_marks_the_agent_interactive_not_background(tmp_path):
@@ -74,6 +85,14 @@ def test_build_plist_path_env_leads_with_the_programs_own_directory(tmp_path):
     assert parsed["EnvironmentVariables"]["PATH"].split(":")[0] == "/Users/x/.local/bin"
 
 
+def test_build_plist_path_env_includes_the_user_bin_dir(tmp_path):
+    # A uv tool install puts cswap's siblings in ~/.local/bin; launchd's own
+    # default PATH does not include it.
+    parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=tmp_path))
+    entries = parsed["EnvironmentVariables"]["PATH"].split(":")
+    assert os.path.expanduser("~/.local/bin") in entries
+
+
 def test_build_plist_path_env_keeps_the_launchd_defaults(tmp_path):
     parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=tmp_path))
     entries = parsed["EnvironmentVariables"]["PATH"].split(":")
@@ -87,7 +106,36 @@ def test_resolve_program_prefers_the_console_script(tmp_path):
     script = tmp_path / "cswap"
     script.write_text("#!/bin/sh\n")
     with patch.object(launch_agent.sys, "argv", [str(script)]):
-        assert launch_agent.resolve_program() == [str(script.resolve())]
+        assert launch_agent.resolve_program() == [str(script)]
+
+
+def test_resolve_program_keeps_the_symlink_and_does_not_follow_it(tmp_path):
+    """`uv tool install` links ~/.local/bin/cswap into the tool's virtualenv.
+
+    Resolving that symlink would pin the virtualenv-internal path, which a
+    reinstall recreates — exactly the path this module exists to avoid.
+    """
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    real = venv_bin / "cswap"
+    real.write_text("#!/bin/sh\n")
+    link_dir = tmp_path / "local" / "bin"
+    link_dir.mkdir(parents=True)
+    link = link_dir / "cswap"
+    link.symlink_to(real)
+
+    with patch.object(launch_agent.sys, "argv", [str(link)]):
+        assert launch_agent.resolve_program() == [str(link)]
+
+
+def test_resolve_program_makes_a_relative_argv0_absolute(tmp_path, monkeypatch):
+    script = tmp_path / "cswap"
+    script.write_text("#!/bin/sh\n")
+    monkeypatch.chdir(tmp_path)
+    with patch.object(launch_agent.sys, "argv", ["./cswap"]):
+        result = launch_agent.resolve_program()
+    assert result == [str(script)]
+    assert Path(result[0]).is_absolute()
 
 
 def test_resolve_program_falls_back_to_the_interpreter_without_a_script(tmp_path):
@@ -105,7 +153,7 @@ def test_resolve_program_ignores_an_argv0_that_is_not_cswap(tmp_path):
     found.write_text("#!/bin/sh\n")
     with patch.object(launch_agent.sys, "argv", [str(other)]):
         with patch.object(launch_agent.shutil, "which", return_value=str(found)):
-            assert launch_agent.resolve_program() == [str(found.resolve())]
+            assert launch_agent.resolve_program() == [str(found)]
 
 
 # --- install ---------------------------------------------------------------

--- a/tests/test_launch_agent.py
+++ b/tests/test_launch_agent.py
@@ -80,11 +80,19 @@ def test_build_plist_survives_paths_that_would_break_hand_written_xml(tmp_path):
     assert parsed["StandardErrorPath"] == str(odd / "Library/Logs" / f"{launch_agent.LABEL}.err")
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="asserts POSIX path shapes; the agent only ever runs on macOS",
+)
 def test_build_plist_path_env_leads_with_the_programs_own_directory(tmp_path):
     parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=tmp_path))
     assert parsed["EnvironmentVariables"]["PATH"].split(":")[0] == "/Users/x/.local/bin"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="asserts POSIX path shapes; the agent only ever runs on macOS",
+)
 def test_build_plist_path_env_includes_the_user_bin_dir(tmp_path):
     # A uv tool install puts cswap's siblings in ~/.local/bin; launchd's own
     # default PATH does not include it.

--- a/tests/test_launch_agent.py
+++ b/tests/test_launch_agent.py
@@ -1,0 +1,298 @@
+"""Tests for the launchd LaunchAgent that keeps ``cswap menubar`` alive.
+
+``subprocess.run`` is patched throughout so the real ``launchctl`` is never
+driven: these assert the argv this module *shapes* and how it reads launchctl's
+replies, not launchd's behaviour. Every test pins ``home`` to a tmp path and
+passes an explicit ``uid``, so nothing here depends on the machine it runs on
+or writes outside the temp directory.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import launch_agent
+from claude_swap.exceptions import ClaudeSwitchError
+
+PROGRAM = ["/Users/x/.local/bin/cswap"]
+UID = 501
+
+
+@pytest.fixture(autouse=True)
+def _on_macos():
+    """The module refuses off-darwin; these tests exercise the darwin path."""
+    with patch.object(launch_agent.sys, "platform", "darwin"):
+        yield
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=["launchctl"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _router(responses: dict[str, subprocess.CompletedProcess]):
+    """Answer per launchctl subcommand, defaulting to success."""
+
+    def run(argv, **kwargs):
+        return responses.get(argv[1], _completed(0))
+
+    return run
+
+
+# --- plist shape -----------------------------------------------------------
+
+
+def test_build_plist_is_parseable_and_runs_the_menubar_subcommand(tmp_path):
+    parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=tmp_path))
+    assert parsed["Label"] == launch_agent.LABEL
+    assert parsed["ProgramArguments"] == [*PROGRAM, "menubar"]
+    assert parsed["RunAtLoad"] is True
+    assert parsed["KeepAlive"] is True
+
+
+def test_build_plist_marks_the_agent_interactive_not_background(tmp_path):
+    # Background would have launchd throttle a process that owns UI.
+    parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=tmp_path))
+    assert parsed["ProcessType"] == "Interactive"
+
+
+def test_build_plist_survives_paths_that_would_break_hand_written_xml(tmp_path):
+    odd = tmp_path / "home & <co>"
+    parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=odd))
+    assert parsed["StandardErrorPath"] == str(odd / "Library/Logs" / f"{launch_agent.LABEL}.err")
+
+
+def test_build_plist_path_env_leads_with_the_programs_own_directory(tmp_path):
+    parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=tmp_path))
+    assert parsed["EnvironmentVariables"]["PATH"].split(":")[0] == "/Users/x/.local/bin"
+
+
+def test_build_plist_path_env_keeps_the_launchd_defaults(tmp_path):
+    parsed = plistlib.loads(launch_agent.build_plist(PROGRAM, home=tmp_path))
+    entries = parsed["EnvironmentVariables"]["PATH"].split(":")
+    assert {"/usr/bin", "/bin", "/usr/sbin", "/sbin"} <= set(entries)
+
+
+# --- program resolution ----------------------------------------------------
+
+
+def test_resolve_program_prefers_the_console_script(tmp_path):
+    script = tmp_path / "cswap"
+    script.write_text("#!/bin/sh\n")
+    with patch.object(launch_agent.sys, "argv", [str(script)]):
+        assert launch_agent.resolve_program() == [str(script.resolve())]
+
+
+def test_resolve_program_falls_back_to_the_interpreter_without_a_script(tmp_path):
+    with patch.object(launch_agent.sys, "argv", [str(tmp_path / "gone")]):
+        with patch.object(launch_agent.shutil, "which", return_value=None):
+            assert launch_agent.resolve_program() == [sys.executable, "-m", "claude_swap"]
+
+
+def test_resolve_program_ignores_an_argv0_that_is_not_cswap(tmp_path):
+    # Running through pytest, argv[0] is the test runner — not a thing launchd
+    # should be pointed at.
+    other = tmp_path / "pytest"
+    other.write_text("#!/bin/sh\n")
+    found = tmp_path / "cswap"
+    found.write_text("#!/bin/sh\n")
+    with patch.object(launch_agent.sys, "argv", [str(other)]):
+        with patch.object(launch_agent.shutil, "which", return_value=str(found)):
+            assert launch_agent.resolve_program() == [str(found.resolve())]
+
+
+# --- install ---------------------------------------------------------------
+
+
+def test_install_writes_the_plist_and_bootstraps_it(tmp_path):
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(1)})
+        result = launch_agent.install(home=tmp_path, program=PROGRAM, uid=UID)
+
+    written = Path(result["plist"])
+    assert written.exists()
+    calls = [c.args[0] for c in run.call_args_list]
+    assert ["launchctl", "bootstrap", f"gui/{UID}", str(written)] in calls
+
+
+def test_install_creates_the_log_directory(tmp_path):
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(1)})
+        result = launch_agent.install(home=tmp_path, program=PROGRAM, uid=UID)
+    assert Path(result["stderr_log"]).parent.is_dir()
+
+
+def test_install_boots_out_first_when_already_loaded(tmp_path):
+    # Without this, launchd refuses a reinstall with "service already loaded".
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(0)})
+        launch_agent.install(home=tmp_path, program=PROGRAM, uid=UID)
+
+    subcommands = [c.args[0][1] for c in run.call_args_list]
+    assert subcommands.index("bootout") < subcommands.index("bootstrap")
+
+
+def test_install_does_not_boot_out_when_nothing_is_loaded(tmp_path):
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(1)})
+        launch_agent.install(home=tmp_path, program=PROGRAM, uid=UID)
+
+    assert "bootout" not in [c.args[0][1] for c in run.call_args_list]
+
+
+def test_install_raises_with_launchctl_detail_when_bootstrap_fails(tmp_path):
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router(
+            {"print": _completed(1), "bootstrap": _completed(5, stderr="Input/output error")}
+        )
+        with pytest.raises(ClaudeSwitchError, match="Input/output error"):
+            launch_agent.install(home=tmp_path, program=PROGRAM, uid=UID)
+
+
+def test_install_refuses_off_macos(tmp_path):
+    with patch.object(launch_agent.sys, "platform", "linux"):
+        with pytest.raises(ClaudeSwitchError, match="only available on macOS"):
+            launch_agent.install(home=tmp_path, program=PROGRAM, uid=UID)
+
+
+# --- uninstall -------------------------------------------------------------
+
+
+def test_uninstall_boots_out_and_removes_the_plist(tmp_path):
+    target = launch_agent.plist_path(home=tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"x")
+
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(0)})
+        result = launch_agent.uninstall(home=tmp_path, uid=UID)
+
+    assert result == {"label": launch_agent.LABEL, "was_loaded": True, "removed_plist": True}
+    assert not target.exists()
+    assert ["launchctl", "bootout", f"gui/{UID}/{launch_agent.LABEL}"] in [
+        c.args[0] for c in run.call_args_list
+    ]
+
+
+def test_uninstall_is_quiet_when_nothing_is_installed(tmp_path):
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(1)})
+        result = launch_agent.uninstall(home=tmp_path, uid=UID)
+    assert result["was_loaded"] is False and result["removed_plist"] is False
+
+
+def test_uninstall_removes_a_plist_that_was_never_bootstrapped(tmp_path):
+    target = launch_agent.plist_path(home=tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"x")
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(1)})
+        result = launch_agent.uninstall(home=tmp_path, uid=UID)
+    assert result["removed_plist"] is True and not target.exists()
+
+
+def test_uninstall_raises_when_bootout_fails_and_the_service_stays_loaded(tmp_path):
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(0), "bootout": _completed(3, stderr="in use")})
+        with pytest.raises(ClaudeSwitchError, match="in use"):
+            launch_agent.uninstall(home=tmp_path, uid=UID)
+
+
+def test_uninstall_tolerates_a_bootout_race_that_already_unloaded_it(tmp_path):
+    # bootout returns non-zero because the job went away underneath it; the
+    # follow-up print shows it gone, which is the outcome uninstall wants.
+    calls = {"print": 0}
+
+    def run(argv, **kwargs):
+        if argv[1] == "print":
+            calls["print"] += 1
+            return _completed(0) if calls["print"] == 1 else _completed(1)
+        if argv[1] == "bootout":
+            return _completed(3, stderr="No such process")
+        return _completed(0)
+
+    with patch.object(launch_agent.subprocess, "run", side_effect=run):
+        result = launch_agent.uninstall(home=tmp_path, uid=UID)
+    assert result["was_loaded"] is True
+
+
+# --- status ----------------------------------------------------------------
+
+
+def test_status_reads_state_and_pid_from_launchctl_print(tmp_path):
+    printed = "\tstate = running\n\tpid = 25026\n\tlast exit code = (never exited)\n"
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(0, stdout=printed)})
+        result = launch_agent.status(home=tmp_path, uid=UID)
+
+    assert result["loaded"] is True
+    assert result["state"] == "running"
+    assert result["pid"] == 25026
+
+
+def test_status_reports_not_loaded_without_inventing_a_pid(tmp_path):
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(1)})
+        result = launch_agent.status(home=tmp_path, uid=UID)
+    assert result["loaded"] is False
+    assert result["pid"] is None and result["state"] is None
+
+
+def test_status_separates_installed_from_loaded(tmp_path):
+    # A plist on disk that launchd has not been given is a real state, and the
+    # difference is what tells a user to run --install-service again.
+    target = launch_agent.plist_path(home=tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"x")
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(1)})
+        result = launch_agent.status(home=tmp_path, uid=UID)
+    assert result["installed"] is True and result["loaded"] is False
+
+
+def test_status_reads_the_jobs_own_state_not_a_nested_blocks(tmp_path):
+    """Regression: real `launchctl print` repeats `state` inside sub-dicts.
+
+    Observed on macOS 25.5.0 — the job prints `state = running`, then a
+    `pid-local endpoints` block prints `state = active`. Taking the last match
+    reported the endpoint's state as the service's.
+    """
+    printed = (
+        "gui/501/com.cswap.menubar = {\n"
+        "\tactive count = 1\n"
+        "\tstate = running\n"
+        "\tpid = 25026\n"
+        "\tpid-local endpoints = {\n"
+        "\t\tstate = active\n"
+        "\t\tpid = 999\n"
+        "\t}\n"
+        "}\n"
+    )
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(0, stdout=printed)})
+        result = launch_agent.status(home=tmp_path, uid=UID)
+
+    assert result["state"] == "running"
+    assert result["pid"] == 25026
+
+
+def test_status_keeps_multi_word_launchd_states(tmp_path):
+    # Before the process spawns, launchd reports "spawn scheduled".
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(0, stdout="\tstate = spawn scheduled\n")})
+        result = launch_agent.status(home=tmp_path, uid=UID)
+    assert result["state"] == "spawn scheduled"
+
+
+def test_status_ignores_a_non_numeric_pid_line(tmp_path):
+    with patch.object(launch_agent.subprocess, "run") as run:
+        run.side_effect = _router({"print": _completed(0, stdout="\tpid = (none)\n")})
+        result = launch_agent.status(home=tmp_path, uid=UID)
+    assert result["pid"] is None

--- a/tests/test_launch_agent.py
+++ b/tests/test_launch_agent.py
@@ -203,6 +203,48 @@ def test_install_does_not_boot_out_when_nothing_is_loaded(tmp_path):
     assert "bootout" not in [c.args[0][1] for c in run.call_args_list]
 
 
+def test_install_waits_for_the_old_job_to_go_away_before_bootstrapping(tmp_path):
+    """`bootout` can return before launchd has finished the teardown.
+
+    A `bootstrap` inside that window fails with "Operation already in
+    progress", so install polls until the job is actually gone.
+    """
+    prints = {"n": 0}
+
+    def run(argv, **kwargs):
+        if argv[1] == "print":
+            prints["n"] += 1
+            return _completed(0 if prints["n"] <= 3 else 1)
+        return _completed(0)
+
+    with patch.object(launch_agent.time, "sleep") as slept:
+        with patch.object(launch_agent.subprocess, "run", side_effect=run) as ran:
+            launch_agent.install(home=tmp_path, program=PROGRAM, uid=UID)
+
+    assert slept.called, "did not wait for the old job at all"
+    subcommands = [c.args[0][1] for c in ran.call_args_list]
+    # every liveness check sits between the bootout and the bootstrap
+    assert subcommands.index("bootout") < subcommands.index("bootstrap")
+    assert subcommands.count("print") > 2
+
+
+def test_wait_until_unloaded_gives_up_after_the_timeout(tmp_path):
+    with patch.object(launch_agent.time, "sleep"):
+        with patch.object(launch_agent.subprocess, "run") as run:
+            run.side_effect = _router({"print": _completed(0)})
+            assert launch_agent._wait_until_unloaded(uid=UID, timeout=0.0) is False
+
+
+def test_install_names_the_lingering_predecessor_when_bootstrap_fails(tmp_path):
+    with patch.object(launch_agent, "_wait_until_unloaded", return_value=False):
+        with patch.object(launch_agent.subprocess, "run") as run:
+            run.side_effect = _router(
+                {"print": _completed(0), "bootstrap": _completed(5, stderr="Operation already in progress")}
+            )
+            with pytest.raises(ClaudeSwitchError, match="still shutting down"):
+                launch_agent.install(home=tmp_path, program=PROGRAM, uid=UID)
+
+
 def test_install_raises_with_launchctl_detail_when_bootstrap_fails(tmp_path):
     with patch.object(launch_agent.subprocess, "run") as run:
         run.side_effect = _router(


### PR DESCRIPTION
## Why

Closes #141.

`cswap menubar` runs in the foreground, so the status item is tied to the terminal that started it — close that window, log out, or reboot and the menu bar is gone. `cswap auto` already has cron/systemd guidance; the menu bar had no equivalent, and the README stopped at `cswap menubar`.

## What this adds

Three flags on the existing `menubar` subcommand (macOS only):

```bash
cswap menubar --install-service     # write the plist, hand it to launchd, start now
cswap menubar --service-status      # installed? loaded? which pid?
cswap menubar --uninstall-service   # bootout and remove the plist
```

Plus a README subsection under *Menu bar (macOS)* documenting the same, including the `launchctl kickstart` line for restarting after an upgrade.

`--install-service` is idempotent: an already-loaded service is booted out before bootstrap, so re-running after an upgrade re-reads the plist rather than failing with launchd's "service already loaded". `--uninstall-service` tolerates every partial state — loaded without a plist, a plist that was never bootstrapped, neither — because the goal is to arrive at "gone".

## How it works

New `launch_agent.py`; the CLI branch stays thin. Two decisions differ from the plist in the issue, both deliberate:

**The plist pins the `cswap` console script, not `sys.executable`.** A LaunchAgent outlives upgrades and the two paths age differently: `uv tool upgrade` rebuilds the tool's virtualenv, so `sys.executable` can be replaced underneath the agent, while the console script keeps its path. `sys.executable -m claude_swap` remains the fallback where no console script exists.

That decision turned out to matter more than expected. While testing I pointed an agent at a checkout under `~/Documents` and launchd could not start it at all:

```
PermissionError: [Errno 1] Operation not permitted: '.../.venv/pyvenv.cfg'
```

A launchd-spawned process does not inherit the user's TCC grants, so a LaunchAgent pointing into `~/Documents`, `~/Desktop` or `~/Downloads` needs Full Disk Access before it will run. `~/.local/bin` is outside that, which is where the console script lives.

**Logs go to `~/Library/Logs/com.cswap.menubar.{log,err}`, not `/tmp`.** `/tmp` is world-writable and periodically purged, so a crash log can vanish before it is read.

The plist is built with `plistlib` rather than a formatted XML string, so a path containing `&` or `<` cannot produce a plist launchd refuses to parse.

## Validation

- `uv run pytest` — 2113 passed, 3 failed, 3 skipped. The 3 failures (`test_move_accounts`, `test_real_store_guard`, `test_swap_accounts`, all unreadable-source guards) reproduce unchanged on a clean `origin/main` worktree; I ran them there to confirm rather than assuming.
- 31 new tests: 25 in `tests/test_launch_agent.py` (plist shape, program resolution, install/uninstall/status, macOS refusal), 6 in `tests/test_cli.py` (flag routing, and that the service flags never also start a foreground menu bar).
- Negative controls: the bootout-before-bootstrap step, `ProcessType: Interactive`, the pid parse, and the nested-block state parse were each broken at the source, the matching test was observed failing for the right reason, then restored.
- One bug came out of live testing rather than the unit tests. `launchctl print` nests sub-dictionaries — `pid-local endpoints` prints its own `state = active` — so reading the last match reported the endpoint's state as the service's. The parser now only reads the job's own fields (single-tab depth) and takes the first match; `test_status_reads_the_jobs_own_state_not_a_nested_blocks` pins it with the real observed output.
- Exercised live on macOS (Darwin 25.5.0): installed, `--service-status` reported `running (pid 42418)`, the status item appeared and survived closing the terminal; `--uninstall-service` removed both the job and the plist.

## Scope

macOS only — other platforms hit the existing "menu bar is only available on macOS" guard rather than a partial implementation. `--json` is deliberately **not** extended to these flags: the guard in `cli.py` restricts it to `list` / `status` / `switch`, and widening the documented v1 JSON surface felt like a separate decision from adding a launchd service. Happy to add it if you want it.
