### PR TITLE
feat(autoswitch): spend a named drain account first, and return to it once it resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ cswap auto --threshold 80      # switch earlier
 cswap auto --model Fable       # also switch when the Fable weekly limit is hit
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
+cswap auto --drain-account work       # spend this one first, come back when it resets
 cswap auto --strategy consume-first   # burn the soonest-resetting account first
 ```
 
@@ -99,6 +100,7 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - Runs safely alongside Claude Code: switches take the same credential locks Claude Code uses, so a swap never collides with a token refresh.
 - A cooldown (default 5 min) and a hysteresis margin stop it flip-flopping near the threshold: a proactive switch only lands on an account that's below the threshold *and* better than the current one by the margin — a candidate that clears the margin is always taken, but two accounts hovering at the line never ping-pong. When every account is exhausted it keeps checking on a bounded slow cadence, waking sooner for an imminent reset.
 - **Strategies** (`--strategy`, or `cswap config set autoswitch.strategy`): `best` (default) stays put until the active account nears its limit, then moves to the account with the most quota left. `consume-first` proactively keeps you on the account whose **weekly window resets soonest** — use-it-or-lose-it — switching to a sooner-resetting account (with room to spare) even below the threshold, so perishable weekly quota isn't wasted.
+- **A drain account** (`--drain-account`, or `cswap config set autoswitch.drainAccount`): name the account whose quota you want **spent first** — by alias, slot number, or email. Everything else becomes overflow: you run on it until it hits the threshold, fall back while it is spent, and are moved back the moment its window resets. Note the direction — naming an account makes it burn **sooner**, not later; there is no setting for "save this one for last". While you are on a healthy drain account, `consume-first` is held back: both rules decide which account burns first, and a spend order can only have one anchor, so the name you gave wins over the one inferred from reset times. Departures at or above the threshold are unaffected. A drain account that is disabled, quarantined, metered (API-key, unless `--include-api-key-accounts`), or whose usage cannot be read is simply not returned to.
 - Usage polling is adaptive — a couple of accounts per check, busy alternates watched more closely, and exhausted ones checked about every ten minutes (or slower after 429s) — so API traffic stays flat no matter how many accounts you manage.
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you either log in with it and re-run `cswap add --slot N`, or replace its stored credentials from a known-good export — a plain `cswap import backup.cswap` replaces dead-token slots on its own (`--force` is still required to replace other existing accounts; note a stale export can carry an already-superseded token). API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
@@ -259,6 +261,7 @@ cswap config                              # list effective settings ("(default)"
 cswap config get autoswitch.threshold
 cswap config set autoswitch.threshold 80  # validated: rejects out-of-range values loudly
 cswap config set autoswitch.model Fable   # per-model switching (see "auto"); Fable,Opus for several
+cswap config set autoswitch.drainAccount work  # spend it first; return once it resets
 cswap config unset autoswitch.threshold   # back to the default
 cswap config path                         # where settings.json lives
 ```

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1221,21 +1221,19 @@ class AutoSwitchEngine:
             return ranked
 
         decided_now = self.clock()
-        # Whether the drain account was hard-selected, rather than ranked.
         # Everything downstream keys on THIS, not on the trigger string: the
         # freshness contract belongs to "we bypassed ranking for a named
         # account", and `failover` reaching the same bypass under its own name
         # slipped past a trigger-string check once already.
         drain_forced = drain_num is not None and trigger in ("drain-return", "failover")
         if drain_forced:
-            # A NAMED target, not a ranked one — skip `_rank` entirely so
-            # neither the hysteresis margin nor the no-return bar can veto it.
-            # Both of those answer "is this a BETTER account?"; drain-return
-            # asks "is the drain account usable yet?", which the gate answered
-            # against this same headroom snapshot. Ranking here would strand
-            # the user on an away account that merely has more headroom — the
-            # normal case right after a reset, and the whole point of naming
-            # an account in the first place.
+            # Skipping `_rank` is what stops the hysteresis margin and the
+            # no-return bar from vetoing this. Both of those answer "is this
+            # a BETTER account?"; drain-return asks "is the drain account
+            # usable yet?", which the gate answered against this same
+            # headroom snapshot. Ranking here would strand the user on an
+            # away account that merely has more headroom — the normal case
+            # right after a reset, and the whole point of naming an account.
             #
             # PROVISIONAL. The two-phase block below re-asks the same question
             # against a refetch and can overturn this pick — reading only this
@@ -1247,9 +1245,7 @@ class AutoSwitchEngine:
             # `leftTrigger` in the state, and `_no_return_account` reads that
             # to choose the more permissive release legs a failover departure
             # is owed -- an ordinary-departure classification there would sit
-            # on a `leftHeadroom` of None that was never measured. The
-            # debounce is untouched for the same reason it exists: one
-            # unreadable tick must not move anyone.
+            # on a `leftHeadroom` of None that was never measured.
             ordered, any_known, active_reset_ts = [drain_num], True, None
         else:
             ordered, any_known, active_reset_ts = _rank(
@@ -1583,9 +1579,8 @@ class AutoSwitchEngine:
         not. Departures at/above the threshold are untouched — those are not
         a spend-order question, they are the engine's whole point.
 
-        A DISABLED drain account does not win: `cswap disable` is the user's
-        own "hold this out of rotation", which is newer and more specific than
-        a drain account set earlier.
+        A DISABLED drain account does not win either — see
+        :meth:`_drain_account_target` for why disabling outranks it.
         """
         num = self._resolved_drain_account(settings)
         return (
@@ -1603,19 +1598,17 @@ class AutoSwitchEngine:
     ) -> str | None:
         """The drain account, when it is both configured and usable again.
 
-        Returns None unless every condition holds, so a caller that gets None
-        falls through to today's below-threshold behaviour untouched:
+        Returns None unless every check below passes, so a caller that gets
+        None falls through to today's below-threshold behaviour untouched.
+        The checks read plainly; two of them carry a decision that does not:
 
-        - ``autoswitch.drainAccount`` resolves to a switchable, non-quarantined
-          account. A DISABLED one stays out on purpose:
-          ``switchable_account_numbers`` already honours ``cswap disable``,
-          and disabling is the user's own "leave this one alone" — it must
-          outrank a drain account set earlier and forgotten.
-        - it is not where we already are.
-        - its binding window is READABLE and under the threshold. Unknown
-          headroom is not "probably fine": landing on an account we cannot
-          measure would re-trigger blind on the next tick, which is the same
-          harm the landing gate in ``_rank_candidates`` exists to prevent.
+        - ``switchable_account_numbers`` is what folds in ``cswap disable``,
+          and a disabled drain account staying out is the point — disabling
+          is the user's own "leave this one alone", newer and more specific
+          than a drain account set earlier and forgotten.
+        - unreadable headroom is refused, not assumed fine. Landing on an
+          account we cannot measure would re-trigger blind on the next tick,
+          the same harm the landing gate in ``_rank_candidates`` prevents.
 
         WHY RETURNING HERE DOES NOT FLAP, despite bypassing the anti-flap
         gates — and what that argument depends on. Returning fires only

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -973,25 +973,23 @@ class AutoSwitchEngine:
             return TickOutcome.NO_ACTION
 
         active_headroom = headroom.get(current)
-        # Resolved in the gate below, read again at ranking time. Hoisted so
-        # the ranking bypass sees it on every path through the gate.
-        # Asked BEFORE the active account is classified, and deliberately so.
-        # A spend order is a statement about where quota should be consumed,
-        # not a reaction to how the stand-in happens to be doing. Consulted
-        # only in the below-threshold branch, it was ignored on the one tick
-        # that matters most -- the drain account resetting while the overflow
-        # account crosses the threshold -- and ordinary ranking sent the user
-        # to whichever peer had the most headroom instead. That detour also
-        # stamps a fresh cooldown, so the return they actually asked for was
-        # pushed out by another `cooldownSeconds` on top of the wasted hop.
+        # Resolved here, BEFORE the active account is classified, and read
+        # again at ranking time -- hoisted so the ranking bypass sees it on
+        # every path through the gate. A spend order states where quota
+        # should be consumed; it is not a reaction to how the stand-in is
+        # doing. Move this back inside the below-threshold branch and the
+        # setting goes dead on the one tick it matters most: the drain
+        # account resetting while the overflow account crosses the threshold,
+        # where ranking sends the user to the roomiest peer instead and
+        # stamps a cooldown that delays the real return further still.
         drain_num = self._drain_account_target(
             settings, headroom, quarantined, current
         )
         # `at-limit` skips the cooldown by design: sitting still on a spent
         # account is never the right answer. A drain-return fired from that
         # same state is the same move under a different name, so it must keep
-        # the bypass -- otherwise the fix above trades an extra hop for being
-        # stranded on a 100% account until the cooldown lapses. Tracked
+        # the bypass, or the user is stranded on a 100% account until the
+        # cooldown lapses. Tracked
         # separately from the trigger because the trigger now says where we
         # are going, while this says whether staying was ever an option.
         # (`failover` needs no entry here: it keeps its own trigger name and
@@ -1002,15 +1000,9 @@ class AutoSwitchEngine:
             self._idle_hold_since = None
             utilization = 100.0 - active_headroom
             if drain_num is not None:
-                # The drain account's window is back under the threshold,
-                # so resume spending it. `drainAccount` is a spend-order
-                # rule: it names the account to burn first and makes every
-                # other one overflow. That is the same question
-                # `consume-first` answers, with a different anchor (a name
-                # the user chose, rather than the soonest weekly reset) --
-                # which is exactly why the two cannot both be live. A spend
-                # order has ONE anchor; the user's wins, and
-                # `_at_drain_account` enforces it.
+                # The drain account's window is back under the threshold, so
+                # resume spending it. `_at_drain_account` carries why this
+                # rule and `consume-first` cannot both be live.
                 trigger = "drain-return"
             elif utilization >= settings.threshold:
                 trigger = "at-limit" if must_move else "proactive"

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -973,31 +973,82 @@ class AutoSwitchEngine:
             return TickOutcome.NO_ACTION
 
         active_headroom = headroom.get(current)
+        # Resolved in the gate below, read again at ranking time. Hoisted so
+        # the ranking bypass sees it on every path through the gate.
+        # Asked BEFORE the active account is classified, and deliberately so.
+        # A spend order is a statement about where quota should be consumed,
+        # not a reaction to how the stand-in happens to be doing. Consulted
+        # only in the below-threshold branch, it was ignored on the one tick
+        # that matters most -- the drain account resetting while the overflow
+        # account crosses the threshold -- and ordinary ranking sent the user
+        # to whichever peer had the most headroom instead. That detour also
+        # stamps a fresh cooldown, so the return they actually asked for was
+        # pushed out by another `cooldownSeconds` on top of the wasted hop.
+        drain_num = self._drain_account_target(
+            settings, headroom, quarantined, current
+        )
+        # `at-limit` skips the cooldown by design: sitting still on a spent
+        # account is never the right answer. A drain-return fired from that
+        # same state is the same move under a different name, so it must keep
+        # the bypass -- otherwise the fix above trades an extra hop for being
+        # stranded on a 100% account until the cooldown lapses. Tracked
+        # separately from the trigger because the trigger now says where we
+        # are going, while this says whether staying was ever an option.
+        # (`failover` needs no entry here: it keeps its own trigger name and
+        # was never in the cooldown tuple.)
+        must_move = active_headroom is not None and active_headroom <= 0
         if active_headroom is not None:
             self._unhealthy_ticks = 0
             self._idle_hold_since = None
             utilization = 100.0 - active_headroom
-            if utilization < settings.threshold:
-                if settings.strategy != "consume-first":
-                    self._emit(
-                        NoSwitchEvent(
-                            reason="below-threshold",
-                            # Both sides through pct_label: .0f utilization could
-                            # display an impossible "100% < 99.9%".
-                            detail=(
-                                f"{pct_label(utilization)}% < "
-                                f"{pct_label(settings.threshold)}%"
-                            ),
-                        )
+            if drain_num is not None:
+                # The drain account's window is back under the threshold,
+                # so resume spending it. `drainAccount` is a spend-order
+                # rule: it names the account to burn first and makes every
+                # other one overflow. That is the same question
+                # `consume-first` answers, with a different anchor (a name
+                # the user chose, rather than the soonest weekly reset) --
+                # which is exactly why the two cannot both be live. A spend
+                # order has ONE anchor; the user's wins, and
+                # `_at_drain_account` enforces it.
+                trigger = "drain-return"
+            elif utilization >= settings.threshold:
+                trigger = "at-limit" if must_move else "proactive"
+            elif settings.strategy != "consume-first":
+                self._emit(
+                    NoSwitchEvent(
+                        reason="below-threshold",
+                        # Both sides through pct_label: .0f utilization could
+                        # display an impossible "100% < 99.9%".
+                        detail=(
+                            f"{pct_label(utilization)}% < "
+                            f"{pct_label(settings.threshold)}%"
+                        ),
                     )
-                    return TickOutcome.NO_ACTION
-                # consume-first: below the threshold we still proactively move to
-                # whichever account's weekly window resets soonest, to burn the
-                # most-perishable quota first. Candidate selection decides whether
-                # a sooner-resetting account with room actually exists.
-                trigger = "consume-first"
+                )
+                return TickOutcome.NO_ACTION
+            elif self._at_drain_account(settings, current):
+                # Placed HERE, after the strategy check, so every other
+                # strategy keeps emitting today's below-threshold event
+                # verbatim: consume-first is the only one that can reach a
+                # move from this state, so it is the only one that needs
+                # intercepting (see `_at_drain_account` for the cycle).
+                self._emit(
+                    NoSwitchEvent(
+                        reason="drain-preferred",
+                        detail=(
+                            "staying on the configured drain account "
+                            "while it is under the threshold"
+                        ),
+                    )
+                )
+                return TickOutcome.NO_ACTION
             else:
-                trigger = "at-limit" if active_headroom <= 0 else "proactive"
+                # consume-first: below the threshold we still proactively move
+                # to whichever account's weekly window resets soonest, to burn
+                # the most-perishable quota first. Candidate selection decides
+                # whether a sooner-resetting account with room actually exists.
+                trigger = "consume-first"
         else:
             if usage.get(current) == USAGE_TOKEN_EXPIRED:
                 # Expired and the refresh could not complete this pass (lock
@@ -1046,7 +1097,11 @@ class AutoSwitchEngine:
                 return TickOutcome.NO_ACTION
             trigger = "failover"
 
-        if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+        if (
+            (trigger in ("proactive", "consume-first")
+             or (trigger == "drain-return" and not must_move))
+            and self._in_cooldown(state)
+        ):
             self._emit(NoSwitchEvent(reason="cooldown"))
             return TickOutcome.NO_ACTION
 
@@ -1174,19 +1229,50 @@ class AutoSwitchEngine:
             return ranked
 
         decided_now = self.clock()
-        ordered, any_known, active_reset_ts = _rank(
-            trigger=trigger,
-            consume_first=consume_first,
-            oauth_candidates=oauth_candidates,
-            usage=usage,
-            headroom=headroom,
-            current=current,
-            active_headroom=active_headroom,
-            settings=settings,
-            now=decided_now,
-        )
+        # Whether the drain account was hard-selected, rather than ranked.
+        # Everything downstream keys on THIS, not on the trigger string: the
+        # freshness contract belongs to "we bypassed ranking for a named
+        # account", and `failover` reaching the same bypass under its own name
+        # slipped past a trigger-string check once already.
+        drain_forced = drain_num is not None and trigger in ("drain-return", "failover")
+        if drain_forced:
+            # A NAMED target, not a ranked one — skip `_rank` entirely so
+            # neither the hysteresis margin nor the no-return bar can veto it.
+            # Both of those answer "is this a BETTER account?"; drain-return
+            # asks "is the drain account usable yet?", which the gate answered
+            # against this same headroom snapshot. Ranking here would strand
+            # the user on an away account that merely has more headroom — the
+            # normal case right after a reset, and the whole point of naming
+            # an account in the first place.
+            #
+            # PROVISIONAL. The two-phase block below re-asks the same question
+            # against a refetch and can overturn this pick — reading only this
+            # far would leave you thinking the target is settled here.
+            #
+            # `failover` rides this too, but keeps its own trigger name: the
+            # trigger records WHY we moved (the active account went
+            # unreadable), not where we landed. Relabelling it would rewrite
+            # `leftTrigger` in the state, and `_no_return_account` reads that
+            # to choose the more permissive release legs a failover departure
+            # is owed -- an ordinary-departure classification there would sit
+            # on a `leftHeadroom` of None that was never measured. The
+            # debounce is untouched for the same reason it exists: one
+            # unreadable tick must not move anyone.
+            ordered, any_known, active_reset_ts = [drain_num], True, None
+        else:
+            ordered, any_known, active_reset_ts = _rank(
+                trigger=trigger,
+                consume_first=consume_first,
+                oauth_candidates=oauth_candidates,
+                usage=usage,
+                headroom=headroom,
+                current=current,
+                active_headroom=active_headroom,
+                settings=settings,
+                now=decided_now,
+            )
 
-        if trigger == "consume-first" and ordered:
+        if (trigger == "consume-first" or drain_forced) and ordered:
             # Two-phase commit: the provisional pick may have ridden a
             # snapshot up to CANDIDATE_MAX_INTERVAL_S stale — consume-first
             # decides below the threshold, where the collector only escalates
@@ -1205,17 +1291,98 @@ class AutoSwitchEngine:
             headroom = _headroom_by_account(usage, self._models)
             active_headroom = headroom.get(current)
             decided_now = self.clock()
-            ordered, any_known, active_reset_ts = _rank(
-                trigger=trigger,
-                consume_first=consume_first,
-                oauth_candidates=oauth_candidates,
-                usage=usage,
-                headroom=headroom,
-                current=current,
-                active_headroom=active_headroom,
-                settings=settings,
-                now=decided_now,
-            )
+            if drain_forced:
+                # Re-ask the same question of the fresh data. The drain
+                # account is a CANDIDATE, so its stored snapshot can be up to
+                # CANDIDATE_MAX_INTERVAL_S old, and a stale-LOW reading is
+                # exactly the case `_drain_account_target`'s no-flap argument
+                # cannot cover: that argument is about its TRUE utilization,
+                # which only falls on a window reset, while a stale value can
+                # read low because the account was burned from another machine
+                # or a `cswap run` terminal since. Returning on it would land
+                # on a spent account and leave again next tick.
+                drain_num = self._drain_account_target(
+                    settings, headroom, quarantined, current
+                )
+                # Two separate ways to fail, and the predicate above only
+                # covers one. It re-answers "does this account still qualify?"
+                # — but it answers it from whatever row the store holds, which
+                # the best-effort refetch may have failed to refresh (failure
+                # backoff, or a concurrent poller holding the claim). A row
+                # that qualifies on stale numbers is not evidence, so the age
+                # is checked separately from the verdict.
+                entry = entries.get(drain_num) if drain_num else None
+                stale = entry is None or not entry.fresh(self.clock())
+                if drain_num is not None and not stale:
+                    ordered = [drain_num]
+                # ORDER MATTERS. This arm sits ahead of the `drain_num is
+                # None` one on purpose: both conditions hold for a failover
+                # whose drain account stopped qualifying on the fresh data,
+                # and the other arm HOLDS — the one thing failover must never
+                # do. Pinned by
+                # `test_a_failover_moves_on_when_the_drain_account_stops_qualifying`,
+                # which fails if the two are swapped.
+                elif trigger == "failover":
+                    # Holding is what `drain-return` does here, and it is right
+                    # for it: staying put is a correct outcome when the active
+                    # account is fine. `failover` fires precisely because it is
+                    # NOT fine — we cannot even read it — so the must-move
+                    # contract outranks the drain order. Drop the hard target
+                    # and let ordinary ranking pick from the fresh data.
+                    #
+                    # The unverified account is dropped from that ranking too,
+                    # and it has to be: ranking scores on headroom, so a
+                    # stale-LOW drain row simply looks like the roomiest
+                    # candidate and gets re-picked, making the verification
+                    # above decorative. Measured with a 240s 20% drain row
+                    # against a fresh 50% peer. Excluded only for THIS tick —
+                    # the next one refetches and it competes normally.
+                    drain_forced = False
+                    unverified = self._resolved_drain_account(settings)
+                    ordered, any_known, active_reset_ts = _rank(
+                        trigger=trigger,
+                        consume_first=consume_first,
+                        oauth_candidates=[
+                            n for n in oauth_candidates if n != unverified
+                        ],
+                        usage=usage,
+                        headroom=headroom,
+                        current=current,
+                        active_headroom=active_headroom,
+                        settings=settings,
+                        now=decided_now,
+                    )
+                elif drain_num is None:
+                    self._emit(
+                        NoSwitchEvent(
+                            reason="drain-unavailable",
+                            detail=(
+                                "the drain account is no longer under the "
+                                "threshold on fresh usage; staying put"
+                            ),
+                        )
+                    )
+                    return TickOutcome.NO_ACTION
+                else:
+                    # Still qualifies, but the refetch could not refresh it
+                    # (failure backoff, or a concurrent poller holding the
+                    # claim). That is a different fact from "no longer under
+                    # the threshold" and must not borrow its message — leave
+                    # it to the commit loop's `stale-usage` gate, which says
+                    # so and retries next tick.
+                    ordered = [drain_num]
+            else:
+                ordered, any_known, active_reset_ts = _rank(
+                    trigger=trigger,
+                    consume_first=consume_first,
+                    oauth_candidates=oauth_candidates,
+                    usage=usage,
+                    headroom=headroom,
+                    current=current,
+                    active_headroom=active_headroom,
+                    settings=settings,
+                    now=decided_now,
+                )
 
         if not ordered and api_key_candidates and trigger != "consume-first":
             # Last resort when we must move: metered API-key accounts
@@ -1313,7 +1480,7 @@ class AutoSwitchEngine:
         systemic = ""
         for num in ordered:
             email = self.switcher.account_email(num)
-            if trigger == "consume-first":
+            if trigger == "consume-first" or drain_forced:
                 # The phase-2 refetch is best-effort: the collector refuses
                 # accounts in failure backoff or claimed by a concurrent
                 # poller, which then serve their stored entries. Consume-first
@@ -1335,7 +1502,7 @@ class AutoSwitchEngine:
             if self.dry_run:
                 # Dry-run stops at the decision: no token refresh, no
                 # quarantine writes — freshening is a mutation.
-                return self._perform(num, email, trigger, left_snapshot)
+                return self._perform(num, email, trigger, left_snapshot, must_move)
             status = self._freshen_target(num, email)
             if status == "identity-conflict":
                 # The slot's credential is alive but belongs to a different
@@ -1366,7 +1533,7 @@ class AutoSwitchEngine:
                 continue
             if status == "skip-live-session":
                 continue
-            return self._perform(num, email, trigger, left_snapshot)
+            return self._perform(num, email, trigger, left_snapshot, must_move)
 
         if systemic or transient_failure:
             self._emit(
@@ -1380,6 +1547,130 @@ class AutoSwitchEngine:
             return TickOutcome.ERROR
         self._emit(NoSwitchEvent(reason="no-viable-target"))
         return TickOutcome.BLOCKED
+
+    def _resolved_drain_account(self, settings: AutoSwitchSettings) -> str | None:
+        """``autoswitch.drainAccount`` as an account number, or None if not usable.
+
+        One definition shared by both questions the setting raises — "is it a
+        target?" (:meth:`_drain_account_target`) and "are we ON it?"
+        (:meth:`_at_drain_account`) — so the two can never disagree about
+        which slot the setting names.
+        """
+        if not settings.drain_account:
+            return None
+        try:
+            return self.switcher._resolve_account_identifier(settings.drain_account)
+        except ClaudeSwitchError:
+            # Unresolvable or ambiguous (e.g. two slots sharing an email).
+            # Never guess which slot the user meant — hold and let the
+            # below-threshold path answer as it does today.
+            return None
+
+    def _at_drain_account(
+        self, settings: AutoSwitchSettings, current: str
+    ) -> bool:
+        """Are we sitting on the drain account, and is it still in rotation?
+
+        Used to suppress a proactive consume-first DEPARTURE, because a
+        spend order can only have ONE anchor.
+
+        `drainAccount` and `consume-first` are not opposites, they are the
+        same kind of rule: both decide whose quota burns first, and
+        they differ only in who picks the anchor — a name the user gave, or
+        the soonest weekly reset found in the data. Two anchors cannot both
+        be live, and left alone they do not merely disagree once, they cycle
+        forever on data that never changes: measured 1 -> 2 -> 1 -> 3 -> 1 ->
+        2 across fixed snapshots a cooldown apart, because
+        `_no_return_account` bars only the account we most recently left and
+        a third account keeps feeding the loop a fresh target.
+
+        The user's anchor wins. It is an explicit standing instruction, while
+        consume-first is an inference from reset times; and the cost of
+        honouring it is bounded (perishable weekly quota that would have been
+        burned first is burned later, or lost) where the cost of the cycle is
+        not. Departures at/above the threshold are untouched — those are not
+        a spend-order question, they are the engine's whole point.
+
+        A DISABLED drain account does not win: `cswap disable` is the user's
+        own "hold this out of rotation", which is newer and more specific than
+        a drain account set earlier.
+        """
+        num = self._resolved_drain_account(settings)
+        return (
+            num is not None
+            and num == current
+            and num in self.switcher.switchable_account_numbers()
+        )
+
+    def _drain_account_target(
+        self,
+        settings: AutoSwitchSettings,
+        headroom: dict[str, float | None],
+        quarantined: set[str],
+        current: str,
+    ) -> str | None:
+        """The drain account, when it is both configured and usable again.
+
+        Returns None unless every condition holds, so a caller that gets None
+        falls through to today's below-threshold behaviour untouched:
+
+        - ``autoswitch.drainAccount`` resolves to a switchable, non-quarantined
+          account. A DISABLED one stays out on purpose:
+          ``switchable_account_numbers`` already honours ``cswap disable``,
+          and disabling is the user's own "leave this one alone" — it must
+          outrank a drain account set earlier and forgotten.
+        - it is not where we already are.
+        - its binding window is READABLE and under the threshold. Unknown
+          headroom is not "probably fine": landing on an account we cannot
+          measure would re-trigger blind on the next tick, which is the same
+          harm the landing gate in ``_rank_candidates`` exists to prevent.
+
+        WHY RETURNING HERE DOES NOT FLAP, despite bypassing the anti-flap
+        gates — and what that argument depends on. Returning fires only
+        strictly below the threshold, and its utilization rises
+        monotonically while it is active and cannot fall while it is not, so
+        the only thing that moves it back down is a window reset: the event
+        this feature exists to catch. That is a different shape from the
+        pair-relative gates ``_no_return_account`` guards, where burn
+        re-opens a move repeatedly and ``[1, 2, 1, 2]`` is reachable.
+
+        The argument holds only while two things stay true elsewhere, and
+        BOTH were violated by the first version of this feature:
+
+        - Departure from it must happen only at/above the threshold. It is
+          not intrinsic — ``consume-first`` departs BELOW it, on the
+          unrelated axis of which weekly window resets soonest, and the pair
+          cycled forever on unchanging data until
+          :meth:`_at_drain_account` suppressed that departure. Any future
+          strategy that can leave a healthy account needs the same
+          treatment or this predicate starts flapping again.
+        - The reading must be its TRUE utilization. The drain account is a
+          candidate, so what the caller holds may be minutes old, and a
+          stale-LOW value (burned from another machine or a ``cswap run``
+          since the snapshot) reads like a reset that never happened. The
+          caller therefore re-runs this predicate against the phase-2
+          refetch before committing.
+
+        On its own this predicate is necessary, not sufficient.
+        """
+        num = self._resolved_drain_account(settings)
+        if num is None or num == current or num in quarantined:
+            return None
+        if num not in self.switcher.switchable_account_numbers():
+            return None
+        if (
+            self.switcher.account_kind_for(num) == "api_key"
+            and not settings.include_api_key_accounts
+        ):
+            # The ranking path keeps metered accounts as a last resort; this
+            # path skips `_rank`, so it carries that rule itself rather than
+            # leaning on API-key accounts happening to report unreadable
+            # headroom somewhere else in the codebase.
+            return None
+        h = headroom.get(num)
+        if h is None or (100.0 - h) >= settings.threshold:
+            return None
+        return num
 
     def _no_return_account(
         self,
@@ -2102,6 +2393,7 @@ class AutoSwitchEngine:
         email: str,
         trigger: str,
         left: tuple[float | None, float],
+        must_move: bool = False,
     ) -> TickOutcome:
         if self.dry_run:
             current = self.switcher.current_account_number()
@@ -2124,7 +2416,11 @@ class AutoSwitchEngine:
         # state lock.
         with self._state_lock():
             state = self._read_state()
-            if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+            if (
+                (trigger in ("proactive", "consume-first")
+                 or (trigger == "drain-return" and not must_move))
+                and self._in_cooldown(state)
+            ):
                 self._emit(NoSwitchEvent(reason="cooldown"))
                 return TickOutcome.NO_ACTION
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -642,6 +642,16 @@ Defaults live in settings.json in the backup root; flags override them.
         ),
     )
     parser.add_argument(
+        "--drain-account",
+        metavar="ACCOUNT",
+        help=(
+            "Spend this account first (alias, slot number, or email). The others "
+            "become overflow: you stay on it until it hits the threshold and are "
+            "moved back as soon as its window resets. Naming an account makes it "
+            "burn sooner, not later"
+        ),
+    )
+    parser.add_argument(
         "--include-api-key-accounts",
         action=argparse.BooleanOptionalAction,
         default=None,

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -57,6 +57,23 @@ class AutoSwitchSettings:
     # 5h/7d windows still have headroom. None = account-wide 5h/7d only
     # (default).
     model: str | None = None
+    # Account identifier (alias, slot number, or email) whose quota is spent
+    # FIRST; every other account becomes overflow. The engine returns to it as
+    # soon as its binding window is back under ``threshold``. No strategy does
+    # that today -- the tick gate answers below-threshold NO_ACTION for
+    # everything but consume-first, so one departure strands the user off the
+    # account they chose until an unrelated threshold crossing moves them.
+    #
+    # Named for the direction it actually pushes. An earlier draft called this
+    # "home", which reads as a resting place: someone wanting to CONSERVE an
+    # account could set it and silently get the opposite policy.
+    #
+    # This is the same question ``strategy: consume-first`` answers -- which
+    # account's quota burns first -- with a different anchor (a name the user
+    # gave, rather than the soonest weekly reset). A spend order has one
+    # anchor, so the two cannot both be live; see ``_at_drain_account``.
+    # None = no drain account (default).
+    drain_account: str | None = None
 
 
 @dataclass(frozen=True)
@@ -134,6 +151,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         SettingSpec(
             "autoswitch", "model", "model", "string",
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
+        ),
+        SettingSpec(
+            "autoswitch", "drainAccount", "drain_account", "string",
+            help="Spend this account first; others are overflow while it is at its limit",
         ),
         SettingSpec(
             "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
@@ -431,6 +452,7 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
         ("include_api_key_accounts", "include_api_key_accounts"),
         ("model", "model"),
         ("strategy", "strategy"),
+        ("drain_account", "drain_account"),
     ):
         value = getattr(args, attr, None)
         if value is not None:

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -58,21 +58,13 @@ class AutoSwitchSettings:
     # (default).
     model: str | None = None
     # Account identifier (alias, slot number, or email) whose quota is spent
-    # FIRST; every other account becomes overflow. The engine returns to it as
-    # soon as its binding window is back under ``threshold``. No strategy does
-    # that today -- the tick gate answers below-threshold NO_ACTION for
-    # everything but consume-first, so one departure strands the user off the
-    # account they chose until an unrelated threshold crossing moves them.
-    #
-    # Named for the direction it actually pushes. An earlier draft called this
-    # "home", which reads as a resting place: someone wanting to CONSERVE an
-    # account could set it and silently get the opposite policy.
-    #
-    # This is the same question ``strategy: consume-first`` answers -- which
-    # account's quota burns first -- with a different anchor (a name the user
-    # gave, rather than the soonest weekly reset). A spend order has one
-    # anchor, so the two cannot both be live; see ``_at_drain_account``.
-    # None = no drain account (default).
+    # FIRST; every other account is overflow, and the engine returns here as
+    # soon as this account's binding window is back under ``threshold``.
+    # Reads as a spend order, not a resting place: naming an account makes it
+    # burn SOONER. Cannot be live at the same time as
+    # ``strategy: consume-first``, which answers the same question from a
+    # different anchor -- see ``AutoSwitchEngine._at_drain_account``, which
+    # owns that rule. None = no drain account (default).
     drain_account: str | None = None
 
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -2782,6 +2782,44 @@ def _usage7(pct5: float, pct7: float, reset7: str | None = None) -> dict:
     return {"five_hour": {"pct": pct5}, "seven_day": seven}
 
 
+def _two_phase_tick(
+    h: EngineHarness, stored: dict, fresh: dict
+) -> tuple[TickOutcome, list[set]]:
+    """Drive one tick where stored-snapshot collections serve ``stored``
+    and the all-candidates escalation serves ``fresh``.
+
+    Usable only on ticks where the collector does not reach for every
+    candidate on its own, because such a call is indistinguishable from the
+    phase-2 refetch — both ask for ``{current, *candidates}``, and the fetch
+    set is all this has to tell the phases apart. ``escalate`` in
+    `_collect_scheduled_usage` reaches for everyone in TWO cases, not one: when the
+    active account's utilization is within ``ESCALATION_MARGIN_PCT`` of the
+    threshold, and when its headroom cannot be read at all. Either way the
+    GATE is served ``fresh``, so nothing is ever provisionally decided on
+    ``stored`` and the phase-2 branch under test is not reached at all.
+
+    The unreadable case is measured, not reasoned: it is why
+    ``test_a_failover_moves_on_when_the_drain_account_stops_qualifying``
+    discriminates by call ORDER instead of using this helper.
+
+    Shared by both refetching paths (consume-first and a forced drain
+    target) so that fetch set cannot drift in one copy: a set that stops
+    matching does not fail, it serves ``stored`` to phase 2 and the test
+    passes without exercising the verification it is named after.
+    """
+    fetch_sets: list[set] = []
+
+    def collect(fetch=None, **_kwargs):
+        requested = set(fetch or ())
+        fetch_sets.append(requested)
+        view = fresh if requested == {"1", "2", "3"} else stored
+        return {num: _entry_for(value, h.clock.now) for num, value in view.items()}
+
+    with patch.object(h.switcher, "usage_entries_by_account", side_effect=collect):
+        outcome = h.engine.tick()
+    return outcome, fetch_sets
+
+
 class TestConsumeFirstStrategy:
     def _harness(self, temp_home: Path) -> EngineHarness:
         h = EngineHarness(temp_home, strategy="consume-first")
@@ -3067,35 +3105,6 @@ class TestConsumeFirstStrategy:
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
         assert reasons == ["reset-unknown"]
 
-    def _two_phase_tick(
-        self, h: EngineHarness, stored: dict, fresh: dict
-    ) -> tuple[TickOutcome, list[set]]:
-        """Drive one tick where stored-snapshot collections serve ``stored``
-        and the all-candidates escalation serves ``fresh``.
-
-        These ticks run outside the escalation band (utilization far below
-        threshold - ESCALATION_MARGIN_PCT), so the collector never escalates
-        on its own and the only all-candidates call a tick can make is the
-        consume-first phase-2 refetch — the returned fetch sets prove whether
-        it happened.
-        """
-        fetch_sets: list[set] = []
-
-        def collect(fetch=None, **_kwargs):
-            requested = set(fetch or ())
-            fetch_sets.append(requested)
-            view = fresh if requested == {"1", "2", "3"} else stored
-            return {
-                num: _entry_for(value, h.clock.now)
-                for num, value in view.items()
-            }
-
-        with patch.object(
-            h.switcher, "usage_entries_by_account", side_effect=collect
-        ):
-            outcome = h.engine.tick()
-        return outcome, fetch_sets
-
     def test_two_phase_refetch_disqualifies_stale_pick(self, temp_home):
         # The stored snapshot ranks #2; the phase-2 refetch shows it
         # exhausted. The tick must re-decide on the fresh data and hold.
@@ -3110,7 +3119,7 @@ class TestConsumeFirstStrategy:
             "2": _usage7(100, 100, _R_SOON),   # burned out since the snapshot
             "3": _usage7(10, 10, _R_LATEST),
         }
-        outcome, fetch_sets = self._two_phase_tick(h, stored, fresh)
+        outcome, fetch_sets = _two_phase_tick(h, stored, fresh)
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
@@ -3126,7 +3135,7 @@ class TestConsumeFirstStrategy:
             "2": _usage7(10, 10, _R_SOON),
             "3": _usage7(10, 10, _R_LATEST),
         }
-        outcome, fetch_sets = self._two_phase_tick(h, view, view)
+        outcome, fetch_sets = _two_phase_tick(h, view, view)
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
         assert {"1", "2", "3"} in fetch_sets
@@ -3146,7 +3155,7 @@ class TestConsumeFirstStrategy:
             "2": _usage7(10, 10, _R_LATER),    # still sooner than active
             "3": _usage7(10, 10, _R_SOON),     # but #3 is now soonest
         }
-        outcome, _ = self._two_phase_tick(h, stored, fresh)
+        outcome, _ = _two_phase_tick(h, stored, fresh)
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 3
 
@@ -3168,7 +3177,7 @@ class TestConsumeFirstStrategy:
             "2": _usage7(10, 10, _R_LATEST),   # no longer strictly sooner
             "3": _usage7(10, 10, _R_LATEST),
         }
-        outcome, fetch_sets = self._two_phase_tick(h, stored, fresh)
+        outcome, fetch_sets = _two_phase_tick(h, stored, fresh)
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         assert not any(isinstance(e, SwitchEvent) for e in h.events)
@@ -6894,3 +6903,746 @@ class TestFreshenRoutesThroughGate:
         assert gate_calls["args"][0] == "2"
         assert "called" not in direct, "freshen must not POST outside the gate"
 
+
+
+class TestDrainAccount:
+    """`autoswitch.drainAccount` — a user-named account the engine returns to.
+
+    The engine already leaves an account that hits the threshold. What it has
+    never done is come BACK: the tick gate returns NO_ACTION for every
+    strategy but consume-first once the active account sits below the
+    threshold, so an account the user prefers is left behind permanently
+    after one departure, even when its window has since reset.
+
+    `consume-first` does not cover this: its anchor is "whichever weekly
+    window resets soonest", chosen from the data. A drain account is named by the
+    user and does not move.
+    """
+
+    def _harness(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, threshold=90.0, **kw)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def _leave_the_drain_account(self, h: EngineHarness) -> None:
+        """Burn the drain account past the threshold so the ENGINE leaves it.
+
+        Going through a real departure is the point: it arms `lastSwitchTo`
+        and with it the `_no_return_account` bar (PR #202, "NEVER UNDO THE
+        PREVIOUS MOVE"). A test that merely starts the engine on the away
+        account would pass without ever touching the gate that actually
+        blocks this feature.
+        """
+        assert h.tick_with_usage({
+            "1": _usage7(95, 20),
+            "2": _usage7(10, 10),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(400)  # clear the proactive cooldown (default 300s)
+        h.events.clear()
+
+    def test_returns_once_the_drain_account_is_back_under_the_threshold(self, temp_home):
+        """The whole feature: the drain account's window reset, so go back."""
+        h = self._harness(temp_home, drain_account="1")
+        self._leave_the_drain_account(h)
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(10, 10),   # drain account recovered
+            "2": _usage7(20, 20),   # away is fine too -- irrelevant
+        })
+
+        assert outcome is TickOutcome.SWITCHED, (
+            "the drain account recovered but the engine is parked away; "
+            "today the tick gate answers below-threshold NO_ACTION and the "
+            "user never gets back to the account they chose"
+        )
+        assert h.active_number() == 1
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "drain-return"
+
+    def test_stays_away_while_the_drain_account_is_still_over_the_threshold(self, temp_home):
+        """Not a magnet: the drain account must be usable before we go back."""
+        h = self._harness(temp_home, drain_account="1")
+        self._leave_the_drain_account(h)
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(95, 20),   # drain account still spent
+            "2": _usage7(20, 20),
+        })
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 2
+
+    def test_drain_return_ignores_hysteresis(self, temp_home):
+        """`hysteresis_pct` must not gate the return.
+
+        Hysteresis exists to stop two accounts trading places while both
+        hover near the line -- it asks "is the target BETTER?". Drain-return
+        does not ask that question: the target is named, not ranked. Gating
+        it here would strand the user on an away account that merely happens
+        to have more headroom, which is the normal case after a return.
+        """
+        h = self._harness(temp_home, drain_account="1", hysteresis_pct=10.0)
+        self._leave_the_drain_account(h)
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(80, 20),   # drain usable, but WORSE than away
+            "2": _usage7(5, 5),
+        })
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 1
+
+    def test_unset_drain_account_leaves_todays_behaviour_untouched(self, temp_home):
+        """Regression guard: the default must change nothing."""
+        h = self._harness(temp_home)  # home unset
+        self._leave_the_drain_account(h)
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(10, 10),
+            "2": _usage7(20, 20),
+        })
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 2
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
+
+
+class TestDrainAccountWithMoreThanTwoAccounts:
+    """The drain account is one among many — the other axes must keep working.
+
+    With two accounts "leave the drain account" and "go to the other one" are the
+    same decision, so a two-account suite cannot tell whether drain-return
+    distorts target selection or merely adds a return leg.
+    """
+
+    def _harness(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, threshold=90.0, **kw)
+        h.seed(1, "a@example.com")   # drain account
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_departure_from_the_drain_account_still_obeys_the_strategy(self, temp_home):
+        """Naming a drain account must not bias which account we LEAVE to.
+
+        it answers "where do I return", not "where do I go next" — the
+        strategy still owns departure, so the most-headroom peer wins.
+        """
+        h = self._harness(temp_home, drain_account="1")
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(95, 20),   # drain account, spent -> must leave
+            "2": _usage7(50, 50),
+            "3": _usage7(10, 10),   # most headroom -> `best` picks this
+        })
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+
+    def test_returns_to_the_drain_account_not_the_roomiest_peer(self, temp_home):
+        """The return target is the drain account, not whoever ranks best."""
+        h = self._harness(temp_home, drain_account="1")
+        assert h.tick_with_usage({
+            "1": _usage7(95, 20),
+            "2": _usage7(50, 50),
+            "3": _usage7(10, 10),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+        h.clock.advance(400)
+        h.events.clear()
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(40, 20),   # drain recovered, but NOT the roomiest
+            "2": _usage7(1, 1),     # roomiest by far -- must lose to drain
+            "3": _usage7(30, 30),
+        })
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 1
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "drain-return"
+
+    def test_no_shuffling_between_peers_while_the_drain_account_is_spent(self, temp_home):
+        """Below the threshold with the drain account unusable, NO_ACTION stands.
+
+        A drain account that cannot be returned to must not turn the gate into a
+        general-purpose "move to the roomiest account" rule.
+        """
+        h = self._harness(temp_home, drain_account="1")
+        assert h.tick_with_usage({
+            "1": _usage7(95, 20),
+            "2": _usage7(50, 50),
+            "3": _usage7(10, 10),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+        h.clock.advance(400)
+        h.events.clear()
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(95, 20),   # drain account still spent
+            "2": _usage7(1, 1),     # far roomier than where we are
+            "3": _usage7(30, 30),
+        })
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 3
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
+
+
+class TestDrainReturnFreshnessAndKind:
+    """The two ways a naive drain-return lands somewhere it should not."""
+
+    def _harness(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, threshold=90.0, **kw)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_a_stale_drain_account_snapshot_does_not_trigger_a_doomed_return(self, temp_home):
+        """The drain account is a CANDIDATE, so its snapshot can be minutes old.
+
+        `_drain_account_target` argues drain-return cannot flap because its
+        utilization only falls on a window reset. That holds for the TRUE
+        value; it does not hold for a stale one. It can be burned from
+        another machine or a `cswap run` terminal while we are away, and a
+        stale-low reading would send us back to a spent account and straight out
+        again on the next tick — the one way the no-flap argument is
+        defeated. consume-first already re-decides on fresh data before
+        committing a below-threshold move; drain-return has the same exposure.
+        """
+        h = self._harness(temp_home, drain_account="2")
+        stored = {
+            "1": _usage7(20, 20),
+            "2": _usage7(10, 10),    # drain looks recovered...
+            "3": _usage7(20, 20),
+        }
+        fresh = {
+            "1": _usage7(20, 20),
+            "2": _usage7(99, 99),    # ...but it was burned elsewhere since
+            "3": _usage7(20, 20),
+        }
+
+        outcome, fetch_sets = _two_phase_tick(h, stored, fresh)
+
+        assert outcome is TickOutcome.NO_ACTION, (
+            "returned on a stale snapshot; the fresh read shows the drain "
+            "spent, so this lands on an exhausted account and leaves again "
+            "next tick"
+        )
+        assert h.active_number() == 1
+        assert {"1", "2", "3"} in fetch_sets, "phase-2 refetch never happened"
+
+    def test_a_fresh_confirmation_still_returns(self, temp_home):
+        """The refetch is a check, not a veto: agreeing data still switches."""
+        h = self._harness(temp_home, drain_account="2")
+        view = {
+            "1": _usage7(20, 20),
+            "2": _usage7(10, 10),
+            "3": _usage7(20, 20),
+        }
+
+        outcome, fetch_sets = _two_phase_tick(h, view, view)
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert {"1", "2", "3"} in fetch_sets
+
+    def test_an_api_key_drain_account_is_never_returned_to(self, temp_home):
+        """`include_api_key_accounts` must gate this like every other target.
+
+        The ranking path splits OAuth from API-key candidates and keeps the
+        metered ones as a last resort; drain-return skips `_rank` entirely, so
+        it has to carry that rule itself. Relying on API-key accounts merely
+        happening to report unreadable headroom leaves the invariant to an
+        accident somewhere else in the codebase.
+        """
+        h = self._harness(temp_home, drain_account="2")
+        data = h.switcher._get_sequence_data()
+        data["accounts"]["2"]["kind"] = "api_key"
+        h.switcher._write_json(h.switcher.sequence_file, data)
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20),
+            "2": _usage7(0, 0),      # a readable, wide-open API-key drain
+            "3": _usage7(20, 20),
+        })
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+
+
+class TestDrainAccountWithConsumeFirst:
+    """`drainAccount` + `consume-first`: two below-threshold triggers.
+
+    drain-return was written as orthogonal to `strategy`, but consume-first is
+    the one strategy that also moves BELOW the threshold. Its departure rule
+    (go to the soonest weekly reset) and drain-return's return rule (go to
+    the drain account) are not disjoint, so the pair cycles on data that never
+    changes.
+    """
+
+    def test_consume_first_does_not_drag_us_off_a_healthy_drain_account(self, temp_home):
+        """Fixed snapshot, one cooldown apart: the active account must settle.
+
+        drain #1 resets LAST, so consume-first always wants to leave it;
+        drain-return always wants to come back. `_no_return_account` cannot break
+        the tie because it only bars the account we most recently left, and a
+        third account keeps the cycle supplied with a fresh target.
+        """
+        h = EngineHarness(
+            temp_home, threshold=90.0, drain_account="1", strategy="consume-first"
+        )
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+
+        snapshot = {
+            "1": _usage7(20, 20, _R_LATEST),  # drain account, resets last
+            "2": _usage7(20, 20, _R_SOON),
+            "3": _usage7(20, 20, _R_LATER),
+        }
+
+        seen = []
+        for _ in range(6):
+            h.tick_with_usage(snapshot)
+            seen.append(h.active_number())
+            h.clock.advance(301)  # clear the cooldown between ticks
+
+        assert seen == [1, 1, 1, 1, 1, 1], (
+            f"nothing about the usage changed, yet the engine kept moving: "
+            f"{seen}. Naming a drain account means preferring it; "
+            f"consume-first must not drag us off one still under the threshold"
+        )
+
+    def test_other_strategies_keep_the_below_threshold_event_verbatim(
+        self, temp_home
+    ):
+        """The cycle fix must not spread beyond consume-first.
+
+        Only consume-first can reach a move from a healthy drain account, so
+        only it needs intercepting. Sitting on it under `best` must still report
+        `below-threshold`, not a new reason -- an event rename is a behaviour
+        change for anyone parsing `cswap auto --json`.
+        """
+        h = EngineHarness(temp_home, threshold=90.0, drain_account="1", strategy="best")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = h.tick_with_usage({"1": _usage7(20, 20), "2": _usage7(10, 10)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
+
+
+class TestDrainReturnRefusesWhatItCannotTrust:
+    """Every way `autoswitch.drainAccount` can name something unusable.
+
+    Each one must fall through to today's below-threshold behaviour rather
+    than switch — the setting is a preference, not an override of the checks
+    that keep the engine off accounts it cannot use.
+    """
+
+    def _harness(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, threshold=90.0, **kw)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def _healthy(self) -> dict:
+        return {"1": _usage7(20, 20), "2": _usage7(10, 10)}
+
+    def test_a_quarantined_drain_account_is_not_returned_to(self, temp_home):
+        """A dead refresh token makes it unusable however preferred it is."""
+        h = self._harness(temp_home, drain_account="2")
+        h.engine._quarantine("2", "b@example.com", "identity-conflict")
+
+        outcome = h.tick_with_usage(self._healthy())
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+
+    def test_a_disabled_drain_account_is_not_returned_to(self, temp_home):
+        """`cswap disable` is newer and more specific than a drain set earlier."""
+        h = self._harness(temp_home, drain_account="2")
+        data = h.switcher._get_sequence_data()
+        data["accounts"]["2"]["disabled"] = True
+        h.switcher._write_json(h.switcher.sequence_file, data)
+
+        outcome = h.tick_with_usage(self._healthy())
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+
+    def test_an_ambiguous_drain_account_email_never_guesses_a_slot(self, temp_home):
+        """Two slots, one email — resolution raises, and we must not pick one.
+
+        This is the real shape for anyone with a personal and an org account
+        under the same address: `cswap switch <email>` already refuses it, so
+        silently choosing a slot here would be worse than doing nothing.
+        """
+        h = EngineHarness(temp_home, threshold=90.0, drain_account="dup@example.com")
+        h.seed(1, "a@example.com")
+        h.seed(2, "dup@example.com")
+        h.seed(3, "dup@example.com")
+        h.make_live("a@example.com", 1)
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20), "2": _usage7(10, 10), "3": _usage7(10, 10),
+        })
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+
+    def test_an_unknown_drain_account_name_is_inert(self, temp_home):
+        """A typo'd or removed account must not break the tick."""
+        h = self._harness(temp_home, drain_account="nope@example.com")
+
+        outcome = h.tick_with_usage(self._healthy())
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+
+    def test_an_unreadable_drain_account_holds_rather_than_guesses(self, temp_home):
+        """Unknown headroom is not 'probably fine'.
+
+        Landing on an account whose usage we cannot read would re-trigger
+        blind on the next tick — the same harm the landing gate in
+        `_rank_candidates` exists to prevent.
+        """
+        h = self._harness(temp_home, drain_account="2")
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20),
+            "2": USAGE_TOKEN_EXPIRED,   # sentinel: no readable window
+        })
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+
+
+class TestDrainReturnHonoursTheModelWindow:
+    """`autoswitch.model` must gate the return, not just the departure.
+
+    Drain-return reads headroom from the same `_headroom_by_account` the rest of
+    the engine uses, so folding a per-model weekly window in should apply for
+    free. "For free" is exactly the kind of inherited property that breaks
+    silently later, and it is the live configuration here: an account whose
+    5h and 7d have room while its Fable weekly window is spent is a normal
+    state, not a corner case.
+    """
+
+    def _harness(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, threshold=90.0, drain_account="2", **kw)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_a_drain_account_whose_model_window_is_spent_is_not_returned_to(self, temp_home):
+        h = self._harness(temp_home, model="Fable")
+
+        outcome = h.tick_with_usage({
+            "1": _model_usage(20, 20),
+            "2": _model_usage(5, 95),   # 5h/7d wide open, Fable spent
+        })
+
+        assert outcome is TickOutcome.NO_ACTION, (
+            "returned to a drain account whose Fable weekly window is at 95%: the "
+            "5h/7d headroom says it is fine, but the model the user actually "
+            "works in is blocked there"
+        )
+        assert h.active_number() == 1
+
+    def test_the_same_account_is_returned_to_when_the_model_is_not_watched(
+        self, temp_home
+    ):
+        """The differential: identical usage, `model` unset -> the return fires.
+
+        Without this pair the test above would also pass if drain-return were
+        broken in some unrelated way, and it would not show that `model` is
+        what made the difference.
+        """
+        h = self._harness(temp_home)  # model unset
+
+        outcome = h.tick_with_usage({
+            "1": _model_usage(20, 20),
+            "2": _model_usage(5, 95),
+        })
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+
+class TestDrainReturnOutranksTheOverflowAccountsState:
+    """The return must not depend on how the account we are ON is doing.
+
+    `_drain_account_target` was consulted only inside the below-threshold
+    branch, so a tick where the drain account recovers AND the overflow
+    account crosses the threshold fell through to ordinary ranking. That is
+    the one tick where the setting matters most, and it is exactly when it
+    was ignored.
+    """
+
+    def _harness(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, threshold=90.0, drain_account="1", **kw)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_a_recovered_drain_account_beats_a_roomier_third_account(self, temp_home):
+        """Overflow hits the threshold the same tick the drain account resets.
+
+        Ranking would send us to the roomiest peer, adding a hop the user did
+        not ask for — and that hop records a cooldown, so the return they DID
+        ask for is delayed by another `cooldownSeconds` on top.
+        """
+        h = self._harness(temp_home)
+        assert h.tick_with_usage({
+            "1": _usage7(95, 20),   # drain account spent -> leave
+            "2": _usage7(10, 10),   # roomiest -> lands here
+            "3": _usage7(50, 50),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(400)
+        h.events.clear()
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20),   # drain account recovered
+            "2": _usage7(95, 20),   # where we are, now over the threshold
+            "3": _usage7(0, 0),     # roomier than the drain account
+        })
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 1, (
+            "went to the roomiest peer instead of the account the user named; "
+            "the drain order should not be contingent on how the overflow "
+            "account happens to be doing"
+        )
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "drain-return"
+
+    def test_an_exhausted_overflow_still_escapes_during_the_cooldown(self, temp_home):
+        """Making the return outrank `at-limit` must not re-gate the escape.
+
+        `at-limit` bypasses the cooldown by design — sitting still on a spent
+        account is never right. Routing that tick through drain-return must
+        keep the bypass, or the fix trades an extra hop for being stranded.
+        """
+        h = self._harness(temp_home)
+        assert h.tick_with_usage({
+            "1": _usage7(95, 20),
+            "2": _usage7(10, 10),
+            "3": _usage7(50, 50),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(5)  # still well inside the default 300s cooldown
+        h.events.clear()
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20),    # drain account recovered
+            "2": _usage7(100, 100),  # where we are, fully exhausted
+            "3": _usage7(0, 0),
+        })
+
+        assert outcome is TickOutcome.SWITCHED, (
+            "held on a 100% account because the cooldown was applied to a "
+            "move that had to happen"
+        )
+        assert h.active_number() == 1
+
+
+    def test_a_failover_move_also_lands_on_the_drain_account(self, temp_home):
+        """Failover picks a target too, and that target is a spend-order call.
+
+        The debounce is untouched — a single unreadable tick must not move
+        anyone. But once failover has decided to move, ranking used to send us
+        to whichever peer was roomiest: measured, drain #1 recovered at 20%
+        and the engine went to #3 at 0% instead, leaving the user off the
+        account they named until some later tick happened to bring them back.
+        """
+        h = EngineHarness(
+            temp_home, threshold=90.0, drain_account="1", unhealthy_ticks=1
+        )
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        assert h.tick_with_usage({
+            "1": _usage7(95, 20),
+            "2": _usage7(10, 10),
+            "3": _usage7(50, 50),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(400)
+        h.events.clear()
+
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20),   # drain account recovered
+            "2": None,              # where we are — unreadable, so failover
+            "3": _usage7(0, 0),     # roomier than the drain account
+        })
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 1
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "failover", (
+            "the trigger records WHY we moved, not where we landed; "
+            "relabelling it would rewrite `leftTrigger` and mislead the "
+            "anti-flap release legs that a failover departure is owed"
+        )
+
+    def test_a_failover_landing_on_a_stale_drain_row_is_verified_first(
+        self, temp_home
+    ):
+        """The hard target must not skip the freshness check failover rides past.
+
+        The two-phase refetch is keyed on the trigger string, so routing
+        `failover` through the same hard target quietly reintroduced exactly
+        the staleness hole this PR closed for `drain-return`: a drain row read
+        minutes ago can say 20% while the account has since been burned to 99%
+        from another machine, and we land on a spent account and leave again
+        next tick.
+
+        Holding is not the answer here the way it is for `drain-return` --
+        failover fires precisely because staying put is not an option. It has
+        to fall back to a fresh ordinary candidate instead.
+        """
+        h = EngineHarness(
+            temp_home, threshold=90.0, drain_account="1", unhealthy_ticks=1
+        )
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        assert h.tick_with_usage({
+            "1": _usage7(95, 20),
+            "2": _usage7(10, 10),
+            "3": _usage7(50, 50),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(400)
+        h.events.clear()
+
+        now = h.clock.now
+        stale = UsageEntry(
+            last_good=_usage7(20, 20), fetched_at=now - 240.0, age_s=240.0
+        )
+        outcome = h.tick_with_entries({
+            "1": stale,                                   # drain, but not fresh
+            "2": _entry_for(None, now),                   # unreadable -> failover
+            # Fresh, and DELIBERATELY worse than the stale drain row. With the
+            # peer roomier the drain loses on merit and the test passes without
+            # the exclusion ever running — it has to be the one that looks
+            # better on stale data for this to isolate the mechanism.
+            "3": _entry_for(_usage7(50, 50), now),
+        })
+
+        assert outcome is TickOutcome.SWITCHED, (
+            "failover must still move — holding on an unreadable account is "
+            "the one thing this trigger exists to prevent"
+        )
+        assert h.active_number() == 3, (
+            "landed on the drain account from a 240s-old row without "
+            "re-verifying it. A stale-low reading is indistinguishable from a "
+            "reset that never happened, and dropping the hard target is not "
+            "enough on its own: ordinary ranking will re-pick the same "
+            "unverified account whenever it looks the roomiest"
+        )
+
+    def test_a_failover_moves_on_when_the_drain_account_stops_qualifying(
+        self, temp_home
+    ):
+        """The hold that is right for `drain-return` is wrong for `failover`.
+
+        Phase 2 can find the drain account not merely stale but no longer
+        under the threshold at all — burned elsewhere between the snapshot
+        the gate read and the refetch. For `drain-return` the answer is to
+        hold and say `drain-unavailable`: the active account is healthy, so
+        staying put is a correct outcome. `failover` fires because the active
+        account cannot even be READ, so holding is the one thing it must
+        never do.
+
+        Only the ORDER of two branches separates those cases — a failover
+        whose drain account stopped qualifying satisfies both — and nothing
+        else pins it: with this test absent, swapping the two arms leaves the
+        whole suite green while every failover in this state stalls.
+        """
+        h = EngineHarness(
+            temp_home, threshold=90.0, drain_account="1", unhealthy_ticks=1
+        )
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        assert h.tick_with_usage({
+            "1": _usage7(95, 20),
+            "2": _usage7(10, 10),
+            "3": _usage7(50, 50),
+        }) is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        h.clock.advance(400)
+        h.events.clear()
+
+        stored = {
+            "1": _usage7(20, 20),   # drain looks recovered -> forced target
+            "2": None,              # where we are: unreadable -> failover
+            "3": _usage7(50, 50),
+        }
+        # The drain account was burned elsewhere since, so the refetch
+        # disqualifies it outright rather than merely finding it stale.
+        fresh = {**stored, "1": _usage7(99, 99)}
+        served: list[set] = []
+
+        def collect(fetch=None, **_kwargs):
+            # `_two_phase_tick` cannot express this tick. It tells the two
+            # phases apart by the all-candidates fetch set, and the collector
+            # asks for exactly that set on its own whenever the active
+            # account's headroom is unreadable — which is this tick's whole
+            # premise, since that is what makes it a failover. The gate would
+            # then already see `fresh`, the drain would never be forced, and
+            # phase 2 would never run (measured: the branch under test was
+            # not reached even once).
+            #
+            # Order tells them apart instead: the pre-gate escalation comes
+            # first, the phase-2 refetch second.
+            requested = set(fetch or ())
+            served.append(requested)
+            everyone = requested == {"1", "2", "3"}
+            phase2 = everyone and served.count({"1", "2", "3"}) > 1
+            view = fresh if phase2 else stored
+            return {
+                num: _entry_for(value, h.clock.now) for num, value in view.items()
+            }
+
+        with patch.object(
+            h.switcher, "usage_entries_by_account", side_effect=collect
+        ):
+            outcome = h.engine.tick()
+
+        assert served.count({"1", "2", "3"}) > 1, (
+            "the phase-2 refetch never happened, so nothing re-asked whether "
+            "the drain account still qualifies"
+        )
+        assert outcome is TickOutcome.SWITCHED, (
+            "stalled on an account it cannot read because the drain account "
+            "stopped qualifying; that answer belongs to drain-return, which "
+            "has a healthy account to stay on"
+        )
+        assert h.active_number() == 3
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "failover"

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,10 +48,11 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "autoswitch.drainAccount",
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,7 +79,9 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
+        assert by_key["autoswitch.drainAccount"]["value"] is None
+        assert by_key["autoswitch.drainAccount"]["isSet"] is False
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -273,6 +273,12 @@ class TestMergedWithCli:
         )
         assert merged.include_api_key_accounts is True
 
+    def test_drain_account_override(self):
+        merged = merged_with_cli(
+            AutoSwitchSettings(drain_account="work"), _args(drain_account="personal")
+        )
+        assert merged.drain_account == "personal"
+
     def test_model_override(self):
         merged = merged_with_cli(AutoSwitchSettings(), _args(model="Fable"))
         assert merged.model == "Fable"


### PR DESCRIPTION
## The gap

The engine leaves an account that hits the threshold, but it has never come back. `_tick_inner`'s gate answers `NoSwitchEvent(reason="below-threshold")` → `NO_ACTION` for every strategy but `consume-first` once the active account is under the threshold, so a single departure strands the user off the account they picked until some unrelated threshold crossing happens to move them again.

People already work around this from outside. #255 is a different request, but the workaround it describes has exactly this shape: a cron that runs `cswap disable`, waits for the window to reset, then runs `cswap enable`.

## What this adds

`autoswitch.drainAccount` / `--drain-account <account>` (alias, slot number, or email). **This account's quota is spent first and every other account becomes overflow.** You run on it until it hits the threshold, fall back while it is spent, and are moved back the moment its window resets.

## A spend order has one anchor

`drainAccount` and `strategy: consume-first` are not orthogonal — they answer the same question, *whose quota burns first*, and differ only in who picks the anchor: a name the user gave, or the soonest weekly reset inferred from the data.

The first draft of this treated them as independent, and that assumption was the bug. Two live anchors do not disagree once, they cycle forever on data that never changes — measured `1 → 2 → 1 → 3 → 1 → 2` across fixed snapshots a cooldown apart. `_no_return_account` cannot stop it because it only ever bars the account most recently left, so a third account keeps feeding the loop a fresh target.

So a healthy drain account suppresses the proactive `consume-first` departure (`drain-preferred`). The user's anchor wins because it is an explicit standing instruction where `consume-first` is an inference, and because honouring it costs a bounded amount (perishable weekly quota burned later, or lost) where the cycle's cost is unbounded. **Departures at or above the threshold are untouched** — those are not a spend-order question, they are the engine's whole purpose.

## Why this name

`home`, `primary`, `pin` and friends all read as *a place to stay*. The real meaning is a spend order, so someone who wants to **conserve** an account would set it and silently get the opposite policy. Docs cannot fix that: the person who falls into it is exactly the person configuring from `cswap config` and `--help`. `drainAccount` puts the direction in the word, and #149 already called this concept a "reset-aware drain strategy". The `Account` suffix removes the verb/noun ambiguity that a bare `autoswitch.drain = work` would carry.

## Scoping

- **`_rank_candidates` is bypassed entirely**, so neither the hysteresis margin nor the no-return bar (#202) can veto the return. Both answer *"is this a better account?"*; the return asks *"is the drain account usable yet?"*, which the gate just answered. Ranked, the user stays parked on an away account that merely has more headroom — which is the normal state right after a reset, and the whole point of naming an account.
- **The return is decided before the active account is classified.** A spend order is not a reaction to how the stand-in is doing. Consulted only inside the below-threshold branch, it was ignored on the one tick that matters most — the drain account resetting while the overflow account crosses the threshold — and ordinary ranking sent the user to the roomiest peer instead, stamping a fresh cooldown that pushed the real return out by another `cooldownSeconds` on top of the wasted hop.
- **The no-flap argument depends on two things, and both were broken in the first draft.** ① Departure must happen only at or above the threshold — `consume-first` broke it, hence the suppression above. ② The value read must be the account's TRUE utilization — the drain account is a *candidate*, so its snapshot can be `CANDIDATE_MAX_INTERVAL_S` old, and a stale-LOW row (burned from another machine or a `cswap run` terminal) is indistinguishable from a reset that never happened. It rides `consume-first`'s two-phase commit and is re-verified against the refetch, on the predicate **and** on the row's age — those fail in different ways, and a row that qualifies on stale numbers is not evidence.
- **`failover` rides the same hard target but keeps its own trigger name.** The trigger records *why* we moved, not where we landed, and `_perform` writes it to `state["leftTrigger"]` where `_no_return_account` reads it to choose the more permissive release legs a failover departure is owed. Relabelling would classify it as an ordinary departure sitting on a `leftHeadroom` of `None` that was never measured. When verification fails, failover must **not** hold — it fires precisely because the active account cannot be read — so it drops the target and re-ranks, with the unverified account excluded for that tick. Excluding it is not optional: ranking scores on headroom, so a stale-LOW row simply looks like the roomiest candidate and gets re-picked, which would make the verification decorative.
- **The cooldown is checked in both places** — the fast path and again inside the state lock — except when the active account is already spent. `at-limit` bypasses the cooldown by design, and routing that tick through the return must not re-gate the escape.
- **API-key and `cswap disable`d accounts are refused here**, carried explicitly rather than inherited from the ranking path that was skipped. A test proved the API-key hole was real, not theoretical.
- **Unreadable means hold.** Landing on an account we cannot measure would re-trigger blind on the next tick.
- `autoswitch.model` is honoured for free by sharing `_headroom_by_account`, and there is a test pinning that rather than leaving it to an inherited property.

## Tests (25)

- The return itself, driven through a **real departure** so `lastSwitchTo` is set and the no-return bar is genuinely armed. A test that starts the engine on the away account passes without ever touching the gate that blocks this feature.
- **Three accounts throughout.** With two, "leave the drain account" and "go to the other one" are the same decision, so a two-account suite cannot tell whether the return distorts target selection or merely adds a leg.
- The `consume-first` cycle regression, on fixed snapshots, asserting the active account settles.
- An event-string guard: every other strategy keeps emitting today's `below-threshold` verbatim. Renaming an event is a behaviour change for anyone parsing `cswap auto --json`.
- Freshness, account kind, and the `model` window — each as a differential pair, so the test also shows the option makes a difference.
- Five refusals: quarantined · disabled · ambiguous email · unknown name · unreadable.
- **Branch-order pinning.** A failover whose drain account stops qualifying on fresh data satisfies *both* arms of the verification block, and only their order keeps the must-move contract. Verified by mutation: swap the two arms and this test fails. Writing it also turned up that the collector escalates to all candidates on its own when the active account is unreadable, which is why that test discriminates by call order rather than by fetch set.

## Suite

```
3 failed, 2110 passed, 3 skipped
```

The 3 failures reproduce on a clean fork of this branch's base and are unrelated to this change (macOS 26.4 / Python 3.14, `FileNotFoundError`): `test_move_accounts` · `test_real_store_guard` · `test_swap_accounts`. Baseline right after forking was `3 failed, 2085 passed`.

Changed files under `src/` are ruff clean. The three ruff findings in `tests/test_autoswitch.py` (E702 ×2, F841) are pre-existing on `main`.

## Verified against real accounts

Installed editable and run under launchd as `cswap auto` with two real accounts. Measured on the drain account's 5h reset:

```
03:09:06  Account-1: 86% used | others: #2: 5h 100%
03:10:05  Account-1: 86% used | others: #2: 5h   0%
03:10:05  Switched Account-1 -> Account-2 (drain-return)
03:11:02  Account-2: 26% used → no switch: below-threshold
```

It returned on the first poll after the reset and stayed put for the following 21 polls. Toggling `autoswitch.model` was also confirmed to change the verdict in practice.

## Out of scope

While configuring this I found that an **unrecognised key in `settings.json` is dropped silently** — filed as #259. It is not caused by this change and fixing it means touching the settings-loading path, which would widen the review surface here.
