### PR TITLE
Add opt-in 'pace' auto-switch strategy: rotate off accounts burning ahead of weekly pace

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
 cswap auto --strategy consume-first   # burn the soonest-resetting account first
 cswap auto --strategy pace            # rotate off accounts burning ahead of weekly pace
+cswap auto --threshold-5h 95 --threshold-7d 85   # ride the 5h window, protect weekly quota
 ```
 
 <details>
@@ -99,6 +100,7 @@ cswap auto --strategy pace            # rotate off accounts burning ahead of wee
 
 - Runs safely alongside Claude Code: switches take the same credential locks Claude Code uses, so a swap never collides with a token refresh.
 - A cooldown (default 5 min) and a hysteresis margin stop it flip-flopping near the threshold: a proactive switch only lands on an account that's below the threshold *and* better than the current one by the margin — a candidate that clears the margin is always taken, but two accounts hovering at the line never ping-pong. When every account is exhausted it keeps checking on a bounded slow cadence, waking sooner for an imminent reset.
+- **Per-window thresholds** (`--threshold-5h` / `--threshold-7d`, or `cswap config set autoswitch.threshold5h`): the two windows recover on different scales, so one ceiling suits neither. A 5-hour window at 95% is whole again within the session; a weekly window at 95% is spent for days. Set them apart to ride the 5h window (fewer switches) while leaving weekly quota earlier (more of it left for the rest of the week). Per-model weekly limits follow `--threshold-7d`. Unset, both fall back to `--threshold` and behavior is unchanged.
 - **Strategies** (`--strategy`, or `cswap config set autoswitch.strategy`): `best` (default) stays put until the active account nears its limit, then moves to the account with the most quota left. `consume-first` proactively keeps you on the account whose **weekly window resets soonest** — use-it-or-lose-it — switching to a sooner-resetting account (with room to spare) even below the threshold, so perishable weekly quota isn't wasted. `pace` keeps `best`'s behavior and adds an early rotation: when the active account's weekly window is meaningfully ahead of pace (the dashboard's `(ahead)` marker), it moves to the on-pace account with the most quota left, so a hot week gets spread across accounts before anything nears its limit.
 - Usage polling is adaptive — a couple of accounts per check, busy alternates watched more closely, and exhausted ones checked about every ten minutes (or slower after 429s) — so API traffic stays flat no matter how many accounts you manage.
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ cswap auto --model Fable       # also switch when the Fable weekly limit is hit
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
 cswap auto --strategy consume-first   # burn the soonest-resetting account first
+cswap auto --strategy pace            # rotate off accounts burning ahead of weekly pace
 ```
 
 <details>
@@ -98,7 +99,7 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 
 - Runs safely alongside Claude Code: switches take the same credential locks Claude Code uses, so a swap never collides with a token refresh.
 - A cooldown (default 5 min) and a hysteresis margin stop it flip-flopping near the threshold: a proactive switch only lands on an account that's below the threshold *and* better than the current one by the margin — a candidate that clears the margin is always taken, but two accounts hovering at the line never ping-pong. When every account is exhausted it keeps checking on a bounded slow cadence, waking sooner for an imminent reset.
-- **Strategies** (`--strategy`, or `cswap config set autoswitch.strategy`): `best` (default) stays put until the active account nears its limit, then moves to the account with the most quota left. `consume-first` proactively keeps you on the account whose **weekly window resets soonest** — use-it-or-lose-it — switching to a sooner-resetting account (with room to spare) even below the threshold, so perishable weekly quota isn't wasted.
+- **Strategies** (`--strategy`, or `cswap config set autoswitch.strategy`): `best` (default) stays put until the active account nears its limit, then moves to the account with the most quota left. `consume-first` proactively keeps you on the account whose **weekly window resets soonest** — use-it-or-lose-it — switching to a sooner-resetting account (with room to spare) even below the threshold, so perishable weekly quota isn't wasted. `pace` keeps `best`'s behavior and adds an early rotation: when the active account's weekly window is meaningfully ahead of pace (the dashboard's `(ahead)` marker), it moves to the on-pace account with the most quota left, so a hot week gets spread across accounts before anything nears its limit.
 - Usage polling is adaptive — a couple of accounts per check, busy alternates watched more closely, and exhausted ones checked about every ten minutes (or slower after 429s) — so API traffic stays flat no matter how many accounts you manage.
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you either log in with it and re-run `cswap add --slot N`, or replace its stored credentials from a known-good export — a plain `cswap import backup.cswap` replaces dead-token slots on its own (`--force` is still required to replace other existing accounts; note a stale export can carry an already-superseded token). API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -323,6 +323,12 @@ class PollEvent(AutoSwitchEvent):
     # (e.g. "89%") hides which window binds — #115 was reported off that
     # ambiguity.
     windows: dict[str, dict[str, float]] = field(default_factory=dict)
+    # Resolved per-window ceilings, emitted only when they differ from each
+    # other. `threshold` alone cannot describe a split policy, so a reader
+    # of the JSON stream would see "threshold: 88" while the engine was
+    # actually gating on 95/85 and be unable to explain any decision. Kept
+    # conditional so the default single-threshold output is byte-identical.
+    window_thresholds: dict[str, float] = field(default_factory=dict)
 
     def _fields(self) -> dict:
         fields = {
@@ -330,6 +336,8 @@ class PollEvent(AutoSwitchEvent):
             "headroomPct": self.headroom,
             "threshold": self.threshold,
         }
+        if self.window_thresholds:
+            fields["windowThresholds"] = self.window_thresholds
         if self.fetch_errors:
             fields["fetchErrors"] = self.fetch_errors
         if self.windows:
@@ -1062,6 +1070,14 @@ class AutoSwitchEngine:
                 active=active_ref,
                 headroom=headroom,
                 threshold=settings.threshold,
+                window_thresholds=(
+                    {}
+                    if thresholds.uniform
+                    else {
+                        "5h": thresholds.for_label("5h"),
+                        "7d": thresholds.for_label("7d"),
+                    }
+                ),
                 fetch_errors={
                     num: entry.last_error
                     for num, entry in entries.items()

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -7,8 +7,11 @@ typed events handed to an ``on_event`` callback; the CLI renders them as
 human lines or JSONL, and any future frontend (TUI dashboard, menubar) can
 consume the same stream.
 
-Policy in one paragraph: when the active account's *binding window* (the
-higher of its 5h/7d utilization) crosses ``settings.threshold``, switch to
+Policy in one paragraph: when any of the active account's windows crosses
+its own ceiling (``settings.threshold``, or the per-window
+``threshold_5h``/``threshold_7d`` overrides when set. The 5h window is
+cheap to ride because it recovers within the session, weekly quota is not),
+switch to
 the candidate with the most headroom — proactively, so the old account is
 still valid while a running Claude Code picks the new one up (this is what
 makes the macOS ~30s Keychain cache latency harmless). Candidates must sit
@@ -599,9 +602,8 @@ def _binding_recovery_ts(
 
 def _every_account_above_threshold(
     candidates: Sequence[str],
-    headroom: dict[str, float | None],
-    active_headroom: float | None,
-    threshold: float,
+    excess: dict[str, float | None],
+    active_excess: float | None,
 ) -> bool:
     """Whether the active account AND every measured candidate are at or over
     the threshold — the state where "land somewhere healthy" has no answer.
@@ -612,12 +614,12 @@ def _every_account_above_threshold(
     verdict (it may be healthy, but it cannot be *chosen* either — the caller
     skips ``None`` headroom) as long as at least one candidate was measured.
     """
-    if active_headroom is None or (100.0 - active_headroom) < threshold:
+    if active_excess is None or active_excess < 0:
         return False
-    measured = [headroom.get(n) for n in candidates if headroom.get(n) is not None]
+    measured = [excess.get(n) for n in candidates if excess.get(n) is not None]
     if not measured:
         return False
-    return all((100.0 - h) >= threshold for h in measured)
+    return all(e >= 0 for e in measured)
 
 
 def _ref(number: str, email: str) -> dict:
@@ -634,6 +636,66 @@ def _headroom_by_account(
         )
         for num, value in usage.items()
     }
+
+
+def _thresholds_for(settings: AutoSwitchSettings) -> oauth.WindowThresholds:
+    """The per-window threshold policy this settings object describes."""
+    return oauth.WindowThresholds(
+        default=settings.threshold,
+        five_hour=settings.threshold_5h,
+        weekly=settings.threshold_7d,
+    )
+
+
+def _excess_by_account(
+    usage: dict[str, dict | str | None],
+    models: tuple[str, ...],
+    thresholds: oauth.WindowThresholds,
+) -> dict[str, float | None]:
+    """Per-account threshold excess derived from decision values.
+
+    The policy sibling of ``_headroom_by_account``: that one measures
+    distance to the hard 100% limit (what the at-limit escape and the
+    anti-flap margins are calibrated on), this one measures distance past
+    the configured per-window ceiling. Both are read every tick because they
+    answer different questions, and conflating them is what a single
+    threshold on ``max(pct)`` did.
+    """
+    return {
+        num: oauth.threshold_excess(
+            value if isinstance(value, dict) else None,
+            models,
+            thresholds=thresholds,
+        )
+        for num, value in usage.items()
+    }
+
+
+def _below_detail(
+    usage: dict | str | None,
+    models: tuple[str, ...],
+    thresholds: oauth.WindowThresholds,
+) -> str:
+    """``below-threshold`` detail: the window nearest its own ceiling.
+
+    Names the window only when the policy is non-uniform; with one
+    threshold there is nothing to disambiguate, and the bare
+    ``"<pct>% < <threshold>%"`` form is what every existing consumer reads.
+    Both sides go through ``pct_label`` for the same reason as before: a
+    ``.0f`` utilization could otherwise render an impossible
+    ``"100% < 99.9%"``.
+    """
+    windows = oauth.relevant_windows(
+        usage if isinstance(usage, dict) else None, models
+    )
+    if not windows:
+        return ""
+    label, pct, _ = max(
+        windows, key=lambda w: w[1] - thresholds.for_label(w[0])
+    )
+    limit = thresholds.for_label(label)
+    lead = "" if thresholds.uniform else f"{label} "
+    return f"{lead}{pct_label(pct)}% < {pct_label(limit)}%"
 
 
 def _weekly_ahead(
@@ -713,7 +775,9 @@ class AutoSwitchEngine:
         # Poll plans written by the collector must key on the same threshold/
         # models the engine decides with (CLI overrides included), not on
         # whatever the settings file happens to say.
-        switcher.set_poll_policy_inputs(settings.threshold, self._models)
+        switcher.set_poll_policy_inputs(
+            _thresholds_for(settings).floor, self._models
+        )
         self.on_event = on_event
         self.dry_run = dry_run
         self.state_path = state_path or (switcher.backup_dir / STATE_FILENAME)
@@ -988,9 +1052,11 @@ class AutoSwitchEngine:
             "email": "",
         }
 
+        thresholds = _thresholds_for(settings)
         entries, usage, headroom = self._collect_scheduled_usage(
-            current, quarantined, threshold=settings.threshold
+            current, quarantined, thresholds=thresholds
         )
+        excess = _excess_by_account(usage, self._models, thresholds)
         self._emit(
             PollEvent(
                 active=active_ref,
@@ -1027,11 +1093,17 @@ class AutoSwitchEngine:
             return TickOutcome.NO_ACTION
 
         active_headroom = headroom.get(current)
+        active_excess = excess.get(current)
         if active_headroom is not None:
             self._unhealthy_ticks = 0
             self._idle_hold_since = None
-            utilization = 100.0 - active_headroom
-            if utilization < settings.threshold:
+            # Under policy when EVERY window is under its own ceiling. With a
+            # uniform policy this is the old `utilization < threshold` test,
+            # bit for bit; with a split one it is the whole point: a 5h
+            # window riding high does not evict an account whose weekly quota
+            # is barely touched, and a weekly window creeping up does not get
+            # a free pass because the 5h window happens to be idle.
+            if active_excess is not None and active_excess < 0:
                 active_entry = entries.get(current)
                 if settings.strategy == "pace" and _weekly_ahead(
                     usage.get(current) if isinstance(usage.get(current), dict) else None,
@@ -1050,11 +1122,8 @@ class AutoSwitchEngine:
                     self._emit(
                         NoSwitchEvent(
                             reason="below-threshold",
-                            # Both sides through pct_label: .0f utilization could
-                            # display an impossible "100% < 99.9%".
-                            detail=(
-                                f"{pct_label(utilization)}% < "
-                                f"{pct_label(settings.threshold)}%"
+                            detail=_below_detail(
+                                usage.get(current), self._models, thresholds
                             ),
                         )
                     )
@@ -1156,9 +1225,8 @@ class AutoSwitchEngine:
             self._emit(
                 NoSwitchEvent(
                     reason="below-threshold",
-                    detail=(
-                        f"{pct_label(100.0 - active_headroom)}% < "
-                        f"{pct_label(settings.threshold)}%"
+                    detail=_below_detail(
+                        usage.get(current), self._models, thresholds
                     ),
                 )
             )
@@ -1237,6 +1305,7 @@ class AutoSwitchEngine:
                 kw["settings"],
                 kw["now"],
                 kw["current"],
+                excess=kw["excess"],
             )
             no_return = self._no_return_account(
                 trigger,
@@ -1246,6 +1315,7 @@ class AutoSwitchEngine:
                 recovered,
                 kw["settings"],
                 kw["current"],
+                excess=kw["excess"],
             )
             ranked = self._rank_candidates(no_return=no_return, **kw)
             if no_return is not None and not ranked[0] and recovered:
@@ -1261,8 +1331,10 @@ class AutoSwitchEngine:
             oauth_candidates=oauth_candidates,
             usage=usage,
             headroom=headroom,
+            excess=excess,
             current=current,
             active_headroom=active_headroom,
+            active_excess=active_excess,
             settings=settings,
             now=decided_now,
             pace_ahead=pace_ahead,
@@ -1285,7 +1357,9 @@ class AutoSwitchEngine:
             )
             usage = {num: entry.decision_value() for num, entry in entries.items()}
             headroom = _headroom_by_account(usage, self._models)
+            excess = _excess_by_account(usage, self._models, thresholds)
             active_headroom = headroom.get(current)
+            active_excess = excess.get(current)
             if pace_ahead is not None:
                 pace_ahead = _pace_ahead_by_account(usage, entries, self._models)
             decided_now = self.clock()
@@ -1295,8 +1369,10 @@ class AutoSwitchEngine:
                 oauth_candidates=oauth_candidates,
                 usage=usage,
                 headroom=headroom,
+                excess=excess,
                 current=current,
                 active_headroom=active_headroom,
+                active_excess=active_excess,
                 settings=settings,
                 now=decided_now,
                 pace_ahead=pace_ahead,
@@ -1492,6 +1568,8 @@ class AutoSwitchEngine:
         recovered: bool,
         settings: AutoSwitchSettings,
         current: str | None = None,
+        *,
+        excess: dict[str, float | None],
     ) -> str | None:
         """The account this engine most recently left, while it is still barred.
 
@@ -1593,10 +1671,7 @@ class AutoSwitchEngine:
             if active_headroom is not None:
                 if left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO:
                     return None               # beats us outright; not a flip
-            elif (
-                settings is not None
-                and left_headroom > 100.0 - settings.threshold
-            ):
+            elif excess.get(barred) is not None and excess[barred] < 0:
                 # An unreadable active must not be silently scored as "the
                 # peer does not beat it" -- same landing-eligible fallback
                 # `_left_account_recovered` uses when it, too, has no active
@@ -1613,6 +1688,8 @@ class AutoSwitchEngine:
         settings: AutoSwitchSettings,
         now: float,
         current: str | None = None,
+        *,
+        excess: dict[str, float | None],
     ) -> bool:
         """Is the account we left a better proposition than when we left it?
 
@@ -1639,7 +1716,7 @@ class AutoSwitchEngine:
         departure — there is no `leftHeadroom` to diff against and never was
         — so the two signals that do not depend on the active's LIVE state
         are (1) whether the peer, right now, would itself be a healthy place
-        to land: `h > 100 - settings.threshold`, the same "would the ranking
+        to land: a negative threshold excess, the same "would the ranking
         accept this as a landing spot" test `_rank_candidates` already runs
         (`:1617`) on every candidate, reused rather than inventing a fresh
         constant; and (2), when the landing floor cannot answer, whether the
@@ -1654,7 +1731,7 @@ class AutoSwitchEngine:
         floor should land on: sweeping mutations of this same leg for the
         ordinary path showed an absolute floor is silently reintroducible
         with a green suite, so this is not free of that risk either — the
-        difference is this constant is `settings.threshold`, not a
+        difference is this bound is the threshold policy, not a
         hardcoded number, so a
         user's OWN policy decides how conservative the hold is, and it moves
         when they change it (pinned directly, below). Deliberately MORE
@@ -1753,7 +1830,7 @@ class AutoSwitchEngine:
             # that proved it. Two legs, both read-only against CURRENT state
             # (no departure baseline exists to diff against):
             #
-            #   landing   `h > 100 - settings.threshold` -- would the
+            #   landing   negative threshold excess -- would the
             #             ranking accept this peer as a landing spot right
             #             now (`_rank_candidates`, :1636)?
             #   recovery  the peer's binding reset is meaningfully sooner
@@ -1771,7 +1848,7 @@ class AutoSwitchEngine:
             # when a nearer window starts binding, never as a side effect
             # of the active spending down -- the failure mode a bare
             # dominance leg has, guarded directly in the mutation table.
-            if h is not None and h > 100.0 - settings.threshold:
+            if h is not None and (excess.get(barred) or 0.0) < 0:
                 return True
             peer_recovery_ts = _binding_recovery_ts(usage.get(barred), self._models, now)
             active_recovery_ts = _binding_recovery_ts(usage.get(current), self._models, now)
@@ -1837,7 +1914,7 @@ class AutoSwitchEngine:
             if active_headroom is not None:
                 if h > active_headroom * HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT:
                     return True
-            elif h > 100.0 - settings.threshold:
+            elif (excess.get(barred) or 0.0) < 0:
                 return True
         if (
             isinstance(left_headroom, (int, float))
@@ -1863,8 +1940,10 @@ class AutoSwitchEngine:
         no_return: str | None,
         usage: dict[str, dict | str | None],
         headroom: dict[str, float | None],
+        excess: dict[str, float | None],
         current: str,
         active_headroom: float | None,
+        active_excess: float | None,
         settings: AutoSwitchSettings,
         now: float,
         pace_ahead: dict[str, bool] | None = None,
@@ -1894,7 +1973,7 @@ class AutoSwitchEngine:
         # wins the normal way, and RECOVERY_HYSTERESIS_S below replaces the
         # percentage-point margin so two accounts in the 90s cannot ping-pong.
         all_above = _every_account_above_threshold(
-            oauth_candidates, headroom, active_headroom, settings.threshold
+            oauth_candidates, excess, active_excess
         )
         # "Is anything worth having?" — the most headroom any candidate with a
         # READABLE row offers. Two exclusions and no others:
@@ -1926,6 +2005,11 @@ class AutoSwitchEngine:
             else 0.0  # unread unless all_above; never a live sentinel
         )
 
+        # Room before the ACTIVE account trips its own policy: the
+        # reference the linear margins below are measured against. See
+        # `trip_room` in the loop for why these margins moved off headroom.
+        active_trip = None if active_excess is None else -active_excess
+
         qualifying: list[tuple[tuple, str]] = []
         fallback: list[tuple[tuple, str]] = []
         any_known = False
@@ -1938,6 +2022,21 @@ class AutoSwitchEngine:
                 continue  # itself at its limit — never a target
             if num == no_return:
                 continue  # the account we just left; see _no_return_account
+            # Room before THIS account trips its own policy. Equal to
+            # `h - (100 - threshold)` under a uniform policy, a constant
+            # offset, so every margin and ordering below is bit-identical to
+            # the headroom version it replaces. Under a SPLIT policy the two
+            # axes genuinely diverge: an account bound by a weekly window at
+            # 84 (headroom 16, one point of policy room) outranks one bound by
+            # a 5h window at 90 (headroom 10, five points) on headroom, while
+            # tripping five times sooner. The linear margins and sort keys
+            # therefore use this axis; the RATIO gates in the all_above branch
+            # stay on headroom, where distance to the real 100% (not to a
+            # policy line every account is already past) is what a ratio can
+            # mean. Assigned for every trigger: at-limit and failover skip the
+            # gate block below but still reach the sort keys.
+            candidate_excess = excess.get(num)
+            trip_room = None if candidate_excess is None else -candidate_excess
             reset_ts = (
                 _seven_day_reset_ts(usage.get(num), now) if consume_first else None
             )
@@ -1951,7 +2050,11 @@ class AutoSwitchEngine:
                 # would re-trigger on the very next tick. At-limit and failover
                 # are escapes that skip this whole block — any account with real
                 # headroom beats a blocked or dead one.
-                if (100.0 - h) >= settings.threshold and not all_above:
+                if (
+                    candidate_excess is not None
+                    and candidate_excess >= 0
+                    and not all_above
+                ):
                     continue
                 if all_above:
                     # Checked before the strategies, because with nothing below
@@ -2028,11 +2131,11 @@ class AutoSwitchEngine:
                     # the account that lasts the week.
                     if pace_ahead is not None and pace_ahead.get(num):
                         continue
-                elif active_headroom is not None:
+                elif active_trip is not None and trip_room is not None:
                     # best: the candidate must beat the active account by the
                     # full hysteresis margin (a one-way move like 99%→89%
                     # qualifies; near-line pairs can't flap back).
-                    if h - active_headroom < settings.hysteresis_pct:
+                    if trip_room - active_trip < settings.hysteresis_pct:
                         continue
             if all_above and trigger in ("proactive", "consume-first"):
                 # Ranked on the axis its own gate decided, and TIERED so the two
@@ -2062,9 +2165,12 @@ class AutoSwitchEngine:
             elif consume_first:
                 # Soonest weekly reset first (unknown resets sort last), most
                 # headroom breaks ties, then sequence order.
-                key = (reset_ts if reset_ts is not None else float("inf"), -h)
+                key = (
+                    reset_ts if reset_ts is not None else float("inf"),
+                    -h if trip_room is None else -trip_room,
+                )
             else:
-                key = (-h,)
+                key = (-h if trip_room is None else -trip_room,)
             qualifying.append((key, num))
         # Ascending by the strategy's key; list order (sequence order) breaks ties.
         qualifying = qualifying or fallback
@@ -2078,7 +2184,7 @@ class AutoSwitchEngine:
         current: str,
         quarantined: set[str] = frozenset(),
         *,
-        threshold: float | None = None,
+        thresholds: oauth.WindowThresholds | None = None,
     ) -> tuple[dict, dict[str, dict | str | None], dict[str, float | None]]:
         """Two-phase usage collection with an O(1) baseline.
 
@@ -2176,15 +2282,23 @@ class AutoSwitchEngine:
         active_headroom = oauth.account_headroom(
             active_value if isinstance(active_value, dict) else None, self._models
         )
-        # The caller's tick-snapshotted threshold, so one tick fetches and
+        # The caller's tick-snapshotted policy, so one tick fetches and
         # decides on the same value even if apply_threshold() lands mid-tick.
-        if threshold is None:
-            threshold = self.settings.threshold
+        if thresholds is None:
+            thresholds = _thresholds_for(self.settings)
+        # Excess, not utilization-vs-one-threshold: the band must open when
+        # ANY window comes within the margin of ITS OWN ceiling, which is
+        # exactly what a negative excess inside the margin says.
+        active_excess = oauth.threshold_excess(
+            active_value if isinstance(active_value, dict) else None,
+            self._models,
+            thresholds=thresholds,
+        )
         escalate = bool(candidates) and (
             (active_headroom is None and active_value != USAGE_TOKEN_EXPIRED)
             or (
-                active_headroom is not None
-                and 100.0 - active_headroom >= threshold - ESCALATION_MARGIN_PCT
+                active_excess is not None
+                and active_excess >= -ESCALATION_MARGIN_PCT
             )
         )
         if escalate:
@@ -2404,7 +2518,9 @@ class AutoSwitchEngine:
         state) are fixed at construction. The frozen-settings swap is atomic
         and each tick snapshots ``self.settings`` once, so no locking."""
         self.settings = replace(self.settings, threshold=threshold)
-        self.switcher.set_poll_policy_inputs(threshold, self._models)
+        self.switcher.set_poll_policy_inputs(
+            _thresholds_for(self.settings).floor, self._models
+        )
 
     def _next_delay(self, outcome: TickOutcome) -> float:
         interval = self.settings.interval_seconds

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -20,7 +20,13 @@ activation the target's token is *freshened* (refreshed if it expires within
 under-lock re-read sees a fresh token and aborts its own refresh); a target
 whose refresh token is dead gets quarantined instead of activated. When the
 active account's own usage becomes unreadable for ``unhealthy_ticks``
-consecutive ticks, the engine fails over to any healthy candidate.
+consecutive ticks, the engine fails over to any healthy candidate. The
+opt-in ``pace`` strategy keeps all of the above and adds one early
+rotation below the threshold: when the active account's weekly window is
+meaningfully ahead of pace (the same noise-gated signal as the UI's
+``(ahead)`` marker, see :mod:`claude_swap.pace`), it moves to the on-pace
+candidate with the most headroom, spreading a week's burn across the
+fleet before any threshold trips.
 
 Cooldown and quarantine persist in ``<backup_root>/autoswitch_state.json``
 (so cron-driven ``cswap auto --once`` ticks behave across processes), mutated
@@ -42,7 +48,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import ClassVar
 
-from claude_swap import oauth, poll_policy
+from claude_swap import oauth, pace, poll_policy
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import SCHEMA_VERSION, USAGE_TOKEN_EXPIRED
 from claude_swap.locking import FileLock
@@ -362,7 +368,7 @@ class PollEvent(AutoSwitchEvent):
 @dataclass(frozen=True)
 class SwitchEvent(AutoSwitchEvent):
     kind: ClassVar[str] = "switch"
-    trigger: str  # "proactive" | "at-limit" | "failover" | "consume-first"
+    trigger: str  # "proactive" | "at-limit" | "failover" | "consume-first" | "pace"
     from_ref: dict | None
     to_ref: dict | None
     warnings: list[str] = field(default_factory=list)
@@ -628,6 +634,54 @@ def _headroom_by_account(
         )
         for num, value in usage.items()
     }
+
+
+def _weekly_ahead(
+    usage: dict | None, fetched_at: float | None, models: Sequence[str]
+) -> bool:
+    """Whether any weekly window is meaningfully ahead of pace.
+
+    Weekly means the 7-day window plus every configured scoped per-model
+    window, the same ``models`` filter every other decision reads (the 5h
+    window is excluded: pace is undefined there, see :mod:`claude_swap.pace`).
+    Windows come through :func:`oauth.relevant_windows`, the canonical window
+    source, so a window that binds a decision can never be invisible here.
+    ``compute_pace`` supplies the noise gates (24h post-reset suppression,
+    the 15-point ahead threshold); this helper adds no thresholds of its own,
+    so the engine's trigger and the UI's ``(ahead)`` marker can never
+    disagree about what "ahead" means.
+    """
+    if not isinstance(usage, dict):
+        return False
+    for label, pct, resets_at in oauth.relevant_windows(usage, models):
+        if label == "5h":
+            continue
+        result = pace.compute_pace(
+            {"pct": pct, "resets_at": resets_at}, fetched_at=fetched_at
+        )
+        if result is not None and result.ahead:
+            return True
+    return False
+
+
+def _pace_ahead_by_account(
+    usage: dict[str, dict | str | None], entries: dict, models: tuple[str, ...]
+) -> dict[str, bool]:
+    """Per-account weekly ahead-of-pace flags, from decision values.
+
+    ``fetched_at`` comes from each account's store entry rather than the
+    wall clock: a decision value served stale is evaluated against the clock
+    it was measured at (the rule every other pace consumer follows).
+    """
+    out: dict[str, bool] = {}
+    for num, value in usage.items():
+        entry = entries.get(num)
+        out[num] = _weekly_ahead(
+            value if isinstance(value, dict) else None,
+            entry.fetched_at if entry is not None else None,
+            models,
+        )
+    return out
 
 
 class AutoSwitchEngine:
@@ -978,7 +1032,21 @@ class AutoSwitchEngine:
             self._idle_hold_since = None
             utilization = 100.0 - active_headroom
             if utilization < settings.threshold:
-                if settings.strategy != "consume-first":
+                active_entry = entries.get(current)
+                if settings.strategy == "pace" and _weekly_ahead(
+                    usage.get(current) if isinstance(usage.get(current), dict) else None,
+                    active_entry.fetched_at if active_entry is not None else None,
+                    self._models,
+                ):
+                    # pace: below the threshold, a weekly window meaningfully
+                    # ahead of pace (compute_pace's noise-gated marker) means
+                    # this account is projected to exhaust before its reset.
+                    # Rotate off it now, while every window still has room,
+                    # instead of riding it to the threshold cliff. Candidate
+                    # selection decides whether an on-pace account with room
+                    # actually exists.
+                    trigger = "pace"
+                elif settings.strategy != "consume-first":
                     self._emit(
                         NoSwitchEvent(
                             reason="below-threshold",
@@ -991,11 +1059,13 @@ class AutoSwitchEngine:
                         )
                     )
                     return TickOutcome.NO_ACTION
-                # consume-first: below the threshold we still proactively move to
-                # whichever account's weekly window resets soonest, to burn the
-                # most-perishable quota first. Candidate selection decides whether
-                # a sooner-resetting account with room actually exists.
-                trigger = "consume-first"
+                else:
+                    # consume-first: below the threshold we still proactively
+                    # move to whichever account's weekly window resets soonest,
+                    # to burn the most-perishable quota first. Candidate
+                    # selection decides whether a sooner-resetting account
+                    # with room actually exists.
+                    trigger = "consume-first"
             else:
                 trigger = "at-limit" if active_headroom <= 0 else "proactive"
         else:
@@ -1046,7 +1116,9 @@ class AutoSwitchEngine:
                 return TickOutcome.NO_ACTION
             trigger = "failover"
 
-        if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+        if trigger in ("proactive", "consume-first", "pace") and self._in_cooldown(
+            state
+        ):
             self._emit(NoSwitchEvent(reason="cooldown"))
             return TickOutcome.NO_ACTION
 
@@ -1099,6 +1171,15 @@ class AutoSwitchEngine:
             return TickOutcome.BLOCKED
 
         consume_first = settings.strategy == "consume-first"
+        # Weekly ahead-of-pace flags for the pace strategy's landing gate,
+        # recomputed wherever usage/headroom are refetched so the three can
+        # never describe different snapshots. None for every other strategy:
+        # the ranking must not pay for a signal it never reads.
+        pace_ahead = (
+            _pace_ahead_by_account(usage, entries, self._models)
+            if settings.strategy == "pace"
+            else None
+        )
 
         def _rank(**kw):
             """Rank with the no-return bar, and WITHOUT it if that empties AND
@@ -1184,12 +1265,13 @@ class AutoSwitchEngine:
             active_headroom=active_headroom,
             settings=settings,
             now=decided_now,
+            pace_ahead=pace_ahead,
         )
 
-        if trigger == "consume-first" and ordered:
+        if trigger in ("consume-first", "pace") and ordered:
             # Two-phase commit: the provisional pick may have ridden a
             # snapshot up to CANDIDATE_MAX_INTERVAL_S stale — consume-first
-            # decides below the threshold, where the collector only escalates
+            # and pace decide below the threshold, where the collector only escalates
             # inside the ESCALATION_MARGIN_PCT band (flat-traffic invariant).
             # A switch is imminent, so spend the fetches now and re-decide on
             # fresh data.
@@ -1204,6 +1286,8 @@ class AutoSwitchEngine:
             usage = {num: entry.decision_value() for num, entry in entries.items()}
             headroom = _headroom_by_account(usage, self._models)
             active_headroom = headroom.get(current)
+            if pace_ahead is not None:
+                pace_ahead = _pace_ahead_by_account(usage, entries, self._models)
             decided_now = self.clock()
             ordered, any_known, active_reset_ts = _rank(
                 trigger=trigger,
@@ -1215,12 +1299,17 @@ class AutoSwitchEngine:
                 active_headroom=active_headroom,
                 settings=settings,
                 now=decided_now,
+                pace_ahead=pace_ahead,
             )
 
-        if not ordered and api_key_candidates and trigger != "consume-first":
+        if not ordered and api_key_candidates and trigger not in (
+            "consume-first",
+            "pace",
+        ):
             # Last resort when we must move: metered API-key accounts
             # (unmeasurable headroom). Never for a below-threshold consume-first
-            # nudge — those API-key accounts have no weekly window to consume.
+            # or pace nudge: those are opportunistic moves, and an API-key
+            # account has no weekly window to consume or to pace.
             ordered = api_key_candidates
 
         if not ordered:
@@ -1261,6 +1350,19 @@ class AutoSwitchEngine:
                     NoSwitchEvent(
                         reason="already-consuming-soonest",
                         detail="no sooner-resetting account with room to spare",
+                    )
+                )
+                return TickOutcome.NO_ACTION
+            if trigger == "pace":
+                # Below the threshold and healthy: staying put is a correct
+                # outcome, never a block (the consume-first contract). One
+                # reason covers every gate that emptied the list: candidates
+                # over the threshold, ahead of pace themselves, or unreadable
+                # this tick.
+                self._emit(
+                    NoSwitchEvent(
+                        reason="no-on-pace-candidate",
+                        detail="no on-pace account with room to spare",
                     )
                 )
                 return TickOutcome.NO_ACTION
@@ -1313,11 +1415,11 @@ class AutoSwitchEngine:
         systemic = ""
         for num in ordered:
             email = self.switcher.account_email(num)
-            if trigger == "consume-first":
+            if trigger in ("consume-first", "pace"):
                 # The phase-2 refetch is best-effort: the collector refuses
                 # accounts in failure backoff or claimed by a concurrent
                 # poller, which then serve their stored entries. Consume-first
-                # is opportunistic, not an escape — never act on stale data
+                # and pace are opportunistic, not escapes; never act on stale data
                 # or slide to a worse-ranked target; hold and retry next tick.
                 entry = entries.get(num)
                 if entry is None or not entry.fresh(self.clock()):
@@ -1467,7 +1569,7 @@ class AutoSwitchEngine:
         left, or only a different active?
         """
         came_from = state.get("lastSwitchFrom")
-        if trigger not in ("proactive", "consume-first") or came_from is None:
+        if trigger not in ("proactive", "consume-first", "pace") or came_from is None:
             return None
         # Only while we are still standing where that switch put us. A manual
         # switch away already undid the move, so there is nothing left to
@@ -1765,6 +1867,7 @@ class AutoSwitchEngine:
         active_headroom: float | None,
         settings: AutoSwitchSettings,
         now: float,
+        pace_ahead: dict[str, bool] | None = None,
     ) -> tuple[list[str], bool, float | None]:
         """Filter and rank OAuth candidates for this tick's trigger.
 
@@ -1843,7 +1946,7 @@ class AutoSwitchEngine:
                 if all_above
                 else 0.0
             )
-            if trigger in ("proactive", "consume-first"):
+            if trigger in ("proactive", "consume-first", "pace"):
                 # Landing must be healthy: an account at/over the threshold
                 # would re-trigger on the very next tick. At-limit and failover
                 # are escapes that skip this whole block — any account with real
@@ -1906,6 +2009,24 @@ class AutoSwitchEngine:
                         or active_reset_ts is None
                         or reset_ts >= active_reset_ts
                     ):
+                        continue
+                elif trigger == "pace":
+                    # Only land where the weekly windows are themselves on
+                    # pace: another over-pace account trades one projected
+                    # exhaustion for the next, and the pair would ping-pong.
+                    # One-way by pace dynamics: a landed-on account's `ahead`
+                    # can only fire after real burn, and the account we left
+                    # stays ahead until expected catches its actual (hours at
+                    # minimum), during which the no-return bar holds anyway.
+                    # Unknown pace counts as on pace: compute_pace suppresses
+                    # the first day after a reset, which is exactly when a
+                    # window is freshest, and an unknowable pace cannot prove
+                    # a candidate hot. No headroom hysteresis on this branch,
+                    # deliberately: the point of the move is that raw headroom
+                    # misleads when burn rates differ, and an on-pace account
+                    # with less headroom than the over-pace active is still
+                    # the account that lasts the week.
+                    if pace_ahead is not None and pace_ahead.get(num):
                         continue
                 elif active_headroom is not None:
                     # best: the candidate must beat the active account by the
@@ -2124,7 +2245,9 @@ class AutoSwitchEngine:
         # state lock.
         with self._state_lock():
             state = self._read_state()
-            if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+            if trigger in ("proactive", "consume-first", "pace") and self._in_cooldown(
+            state
+        ):
                 self._emit(NoSwitchEvent(reason="cooldown"))
                 return TickOutcome.NO_ACTION
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -60,7 +60,12 @@ from claude_swap.poll_policy import (
     RESET_SLACK_S,
     binding_pct,
 )
-from claude_swap.settings import AutoSwitchSettings, atomic_write_json, parse_model_names
+from claude_swap.settings import (
+    SETTING_SPECS,
+    AutoSwitchSettings,
+    atomic_write_json,
+    parse_model_names,
+)
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.usage_store import due_candidate, plan_oversleeps_interval
 
@@ -652,6 +657,47 @@ def _thresholds_for(settings: AutoSwitchSettings) -> oauth.WindowThresholds:
         default=settings.threshold,
         five_hour=settings.threshold_5h,
         weekly=settings.threshold_7d,
+    )
+
+
+def policy_floor(settings: AutoSwitchSettings) -> float:
+    """The lowest ceiling this policy gates on, and what the bar tick shows."""
+    return _thresholds_for(settings).floor
+
+
+def shifted_to_floor(
+    settings: AutoSwitchSettings, target_floor: float
+) -> AutoSwitchSettings:
+    """``settings`` with its policy FLOOR moved to ``target_floor``.
+
+    The session control adjusts one number, but a split policy has two
+    ceilings, so "set the threshold to 72" has no single meaning. It moves
+    the floor instead, which is exactly what the bar tick renders, and
+    carries both ceilings by the same delta so the gap the user configured
+    survives the adjustment.
+
+    Under a UNIFORM policy the floor is the threshold, so this is the
+    original single-value update, unchanged. That is what keeps every
+    existing session-override behaviour identical.
+
+    Both ceilings clamp to the configured bounds, so a shift that would
+    push one out of range moves it to the bound instead of silently
+    inventing an out-of-policy value; the achieved floor is whatever the
+    clamped pair yields and may differ from ``target_floor``.
+    """
+    current = _thresholds_for(settings)
+    if current.uniform:
+        return replace(settings, threshold=target_floor)
+    spec = SETTING_SPECS["autoswitch.threshold5h"]
+
+    def _clamped(value: float) -> float:
+        return min(spec.hi, max(spec.lo, value))
+
+    delta = target_floor - current.floor
+    return replace(
+        settings,
+        threshold_5h=_clamped(current.for_label("5h") + delta),
+        threshold_7d=_clamped(current.for_label("7d") + delta),
     )
 
 
@@ -2528,15 +2574,24 @@ class AutoSwitchEngine:
         """Cut the current inter-tick sleep short and tick now."""
         self._wake.set()
 
-    def apply_threshold(self, threshold: float) -> None:
+    def apply_threshold(self, threshold: float) -> float:
         """Session override from the TUI: retarget the trigger and poll
         cadence mid-run. Threshold only — the model axes (and their derived
         state) are fixed at construction. The frozen-settings swap is atomic
-        and each tick snapshots ``self.settings`` once, so no locking."""
-        self.settings = replace(self.settings, threshold=threshold)
-        self.switcher.set_poll_policy_inputs(
-            _thresholds_for(self.settings).floor, self._models
-        )
+        and each tick snapshots ``self.settings`` once, so no locking.
+
+        ``threshold`` is the target policy FLOOR, and the achieved floor is
+        returned. Under a uniform policy those are the same number and this
+        behaves exactly as it always did. Under a SPLIT policy they are not:
+        writing ``settings.threshold`` alone would be inert, because
+        ``for_label`` reads the per-window overrides and ignores the
+        fallback, so the control would report a change that moved no policy
+        at all. See ``shifted_to_floor``.
+        """
+        self.settings = shifted_to_floor(self.settings, threshold)
+        achieved = _thresholds_for(self.settings).floor
+        self.switcher.set_poll_policy_inputs(achieved, self._models)
+        return achieved
 
     def _next_delay(self, outcome: TickOutcome) -> float:
         interval = self.settings.interval_seconds

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -622,7 +622,31 @@ Defaults live in settings.json in the backup root; flags override them.
         metavar="PCT",
         help=(
             "Switch when the active account's binding 5h/7d window reaches "
-            "this utilization (50-99.9; default 90)"
+            "this utilization (50-99.9; default 90). Acts as the fallback "
+            "for --threshold-5h / --threshold-7d"
+        ),
+    )
+    parser.add_argument(
+        "--threshold-5h",
+        type=float,
+        metavar="PCT",
+        dest="threshold_5h",
+        help=(
+            "Override --threshold for the 5-hour window only (50-99.9). It "
+            "recovers within the session, so it is usually worth riding "
+            "higher than weekly quota"
+        ),
+    )
+    parser.add_argument(
+        "--threshold-7d",
+        type=float,
+        metavar="PCT",
+        dest="threshold_7d",
+        help=(
+            "Override --threshold for weekly windows only (50-99.9), "
+            "including per-model weekly limits. Weekly quota does not come "
+            "back until the window resets, so it is usually worth leaving "
+            "earlier"
         ),
     )
     parser.add_argument(

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -652,12 +652,13 @@ Defaults live in settings.json in the backup root; flags override them.
     )
     parser.add_argument(
         "--strategy",
-        choices=("best", "consume-first"),
+        choices=("best", "consume-first", "pace"),
         default=None,
         help=(
-            "Target selection: 'best' (most quota left; default) or "
+            "Target selection: 'best' (most quota left; default), "
             "'consume-first' (proactively use the account whose weekly window "
-            "resets soonest)"
+            "resets soonest), or 'pace' (best, plus rotate off an account "
+            "burning ahead of its weekly pace)"
         ),
     )
     parser.add_argument(

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -562,6 +562,89 @@ def account_headroom(
 
 
 @dataclass(frozen=True)
+class WindowThresholds:
+    """Per-window switch thresholds, resolved by window label.
+
+    ONE THRESHOLD CANNOT SERVE BOTH WINDOWS, because the two recover on
+    different scales. A 5-hour window at 95% is *temporarily* busy and is
+    whole again within the session; a weekly window at 95% is spent for
+    days. Riding the first is nearly free and saves a switch (and the cold
+    prompt cache every switch costs); riding the second trades a week of
+    quota for the same few minutes. Collapsing them through one ``max()``
+    forces the user to pick which mistake to make.
+
+    ``five_hour`` and ``weekly`` are overrides; ``None`` falls back to
+    ``default`` (the account-wide ``autoswitch.threshold``), so an unset
+    pair reproduces the single-threshold behaviour exactly.
+
+    Scoped per-model windows resolve to ``weekly``: they reset on the same
+    7-day cadence as ``seven_day`` (which is why ``pace`` treats them as
+    weekly too), so they are perishable in the same way and want the same
+    protection.
+    """
+
+    default: float
+    five_hour: float | None = None
+    weekly: float | None = None
+
+    def for_label(self, label: str) -> float:
+        """The threshold gating one window, by its ``relevant_windows`` label."""
+        if label == "5h":
+            return self.default if self.five_hour is None else self.five_hour
+        # "7d" and every scoped per-model window: all weekly, see class docstring.
+        return self.default if self.weekly is None else self.weekly
+
+    @property
+    def uniform(self) -> bool:
+        """Whether every window resolves to the same threshold.
+
+        True for an unset pair (the single-threshold policy) and for a pair
+        deliberately set equal. Both are cases where naming the window in a
+        message would disambiguate nothing.
+        """
+        return self.for_label("5h") == self.for_label("7d")
+
+    @property
+    def floor(self) -> float:
+        """The lowest threshold any window can be gated by.
+
+        For consumers that need one scalar and must not under-react (poll
+        cadence): the earliest point at which *some* window could trip.
+        """
+        return min(
+            self.for_label("5h"), self.for_label("7d")
+        )
+
+
+def threshold_excess(
+    usage: dict | None,
+    models: Sequence[str] = (),
+    *,
+    thresholds: WindowThresholds,
+) -> float | None:
+    """How far past its OWN threshold the worst relevant window sits.
+
+    ``>= 0`` means the account is at or over its switch policy on at least
+    one window; ``< 0`` means it is under, and ``-excess`` is the points of
+    room left before the first window trips. ``None`` when usage carries no
+    window data: the same "unknown" every other window reader returns, and
+    never auto-skipped.
+
+    This is the per-window generalisation of the old
+    ``(100 - account_headroom) >= threshold`` test, and is exactly
+    equivalent to it whenever every window resolves to the same threshold.
+    It deliberately does NOT replace :func:`account_headroom`: headroom is
+    distance to the real 100% limit, which is what the at-limit escape and
+    the anti-flap margins are calibrated on. Threshold policy and hard
+    limits are different axes, and the engine reads both.
+    """
+    windows = relevant_windows(usage, models)
+    if not windows:
+        return None
+    return max(pct - thresholds.for_label(label) for label, pct, _ in windows)
+
+
+@dataclass(frozen=True)
 class UsageOutcome:
     """Result of a usage-API fetch attempt.
 

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -41,9 +41,20 @@ class AutoSwitchSettings:
     re-triggers next tick) and beat the active account's utilization by at
     least ``hysteresis_pct``, so two accounts hovering at the line never
     ping-pong while a strictly better account is always taken.
+
+    ``threshold_5h`` / ``threshold_7d`` override it per window when set: the
+    5-hour window is worth riding higher (it is whole again within the
+    session) while weekly quota is worth leaving earlier (it is gone for
+    days). Scoped per-model weekly windows follow ``threshold_7d``.
     """
 
     threshold: float = 90.0
+    # Per-window overrides on ``threshold``. None = use ``threshold`` for that
+    # window, so an unset pair behaves exactly like the single-threshold
+    # policy. The 5h window recovers within the session and the weekly one
+    # does not, so they want different ceilings. See oauth.WindowThresholds.
+    threshold_5h: float | None = None
+    threshold_7d: float | None = None
     interval_seconds: float = 60.0
     cooldown_seconds: float = 300.0
     hysteresis_pct: float = 10.0
@@ -107,6 +118,14 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         SettingSpec(
             "autoswitch", "threshold", "threshold", "float", 50.0, 99.9,
             help="Switch when the binding 5h/7d window reaches this pct",
+        ),
+        SettingSpec(
+            "autoswitch", "threshold5h", "threshold_5h", "float", 50.0, 99.9,
+            help="Switch when the 5h window reaches this pct (unset: threshold)",
+        ),
+        SettingSpec(
+            "autoswitch", "threshold7d", "threshold_7d", "float", 50.0, 99.9,
+            help="Switch when a weekly window reaches this pct (unset: threshold)",
         ),
         SettingSpec(
             "autoswitch", "intervalSeconds", "interval_seconds", "float", 15.0, 3600.0,
@@ -428,6 +447,8 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
     overrides = {}
     for attr, field in (
         ("threshold", "threshold"),
+        ("threshold_5h", "threshold_5h"),
+        ("threshold_7d", "threshold_7d"),
         ("interval", "interval_seconds"),
         ("cooldown", "cooldown_seconds"),
         ("include_api_key_accounts", "include_api_key_accounts"),

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -47,7 +47,9 @@ class AutoSwitchSettings:
     interval_seconds: float = 60.0
     cooldown_seconds: float = 300.0
     hysteresis_pct: float = 10.0
-    strategy: str = "best"  # "best" (most headroom) or "consume-first" (soonest weekly reset)
+    # "best" (most headroom), "consume-first" (soonest weekly reset), or
+    # "pace" (best, plus rotate off ahead-of-pace weekly burn early)
+    strategy: str = "best"
     include_api_key_accounts: bool = False
     unhealthy_ticks: int = 3
     # Comma-separated model display name(s) (e.g. "Fable" or "Fable,Opus"),
@@ -120,7 +122,7 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         ),
         SettingSpec(
             "autoswitch", "strategy", "strategy", "choice",
-            choices=("best", "consume-first"),
+            choices=("best", "consume-first", "pace"),
             help="How auto-switch picks the target account",
         ),
         SettingSpec(

--- a/src/claude_swap/tui/app.py
+++ b/src/claude_swap/tui/app.py
@@ -72,10 +72,17 @@ class CswapApp(App):
         self._last_refresh_error = ""
         # The auto-switch threshold, drawn as a tick on the status strip's
         # bars everywhere. Missing/invalid settings fall back to the default.
+        # One tick is drawn against bars for BOTH windows, so it shows the
+        # policy FLOOR: with per-window thresholds set, the earliest point at
+        # which some window trips. Drawing `threshold` alone would put the
+        # tick above the real ceiling on whichever window was lowered, which
+        # reads as "still fine" right up to a switch.
         try:
-            self.threshold_pct: float | None = load_settings(
-                switcher.backup_dir
-            ).threshold
+            from claude_swap.autoswitch import _thresholds_for
+
+            self.threshold_pct: float | None = _thresholds_for(
+                load_settings(switcher.backup_dir)
+            ).floor
         except Exception:
             self.threshold_pct = None
         try:

--- a/src/claude_swap/tui/autoview.py
+++ b/src/claude_swap/tui/autoview.py
@@ -29,6 +29,8 @@ from claude_swap.autoswitch import (
     AutoSwitchEvent,
     binding_pct,
     pct_label,
+    policy_floor,
+    shifted_to_floor,
 )
 from claude_swap.models import AccountsSnapshot
 from claude_swap.settings import SETTING_SPECS, load_settings, parse_model_names
@@ -106,8 +108,8 @@ class AutoScreen(Screen):
         # startup — sync it to the fresh file value so bars and engine agree,
         # and remember that value: unmount restores it (only the session
         # adjustment reverts, not this correction).
-        self._configured_threshold = self._settings.threshold
-        self.app.threshold_pct = self._settings.threshold
+        self._configured_threshold = self._policy_floor()
+        self.app.threshold_pct = self._configured_threshold
         self._update_summary()
         self.watch(self.app, "snapshot", self._on_snapshot)
         self.watch(self.app, "theme", self._on_theme_change)
@@ -148,7 +150,7 @@ class AutoScreen(Screen):
             self._end_adjust()
             return
         self._adjusting = True
-        self._entry_threshold = self._settings.threshold
+        self._entry_threshold = self._policy_floor()
         self._update_summary()
         self.refresh_bindings()
 
@@ -160,32 +162,49 @@ class AutoScreen(Screen):
         if not self._adjusting:
             return
         spec = SETTING_SPECS["autoswitch.threshold"]
-        value = min(spec.hi, max(spec.lo, self._settings.threshold + delta))
+        value = min(spec.hi, max(spec.lo, self._policy_floor() + delta))
         self._set_threshold(value)
 
     def _end_adjust(self) -> None:
         self._adjusting = False
         self._update_summary()
         self.refresh_bindings()
-        if self._settings.threshold == self._entry_threshold:
+        if self._policy_floor() == self._entry_threshold:
             return  # no net change: nothing to announce, no tick to force
         if self._engine is not None:
             self._engine.wake()  # show a decision at the new value now
         self.query_one("#event-log", RichLog).write(
             Text(
-                f"— threshold set to {pct_label(self._settings.threshold)}% "
+                f"— threshold set to {pct_label(self._policy_floor())}% "
                 "for this session —",
                 style=Palette.from_theme(self.app.current_theme).muted,
             )
         )
 
+    def _policy_floor(self) -> float:
+        """The value this control edits: the policy FLOOR.
+
+        With one threshold the floor IS the threshold, so this reads exactly
+        as `.threshold` always did. With a split policy `.threshold` is only
+        a fallback that `for_label` never consults, so editing it would move
+        no policy at all while the summary claimed otherwise. The floor is
+        also what the bar tick renders, so the number shown and the number
+        adjusted are the same number.
+        """
+        return policy_floor(self._settings)
+
     def _set_threshold(self, value: float) -> None:
-        if value == self._settings.threshold:
+        if value == self._policy_floor():
             return
-        self._settings = replace(self._settings, threshold=value)
+        # Both sides apply the SAME pure function to the same input, so the
+        # screen and the engine cannot drift. Deliberately not read back off
+        # the engine: that couples the view to a live engine existing at all,
+        # and the value would be identical anyway.
+        self._settings = shifted_to_floor(self._settings, value)
+        achieved = self._policy_floor()
         if self._engine is not None:
             self._engine.apply_threshold(value)
-        self.app.threshold_pct = value
+        self.app.threshold_pct = achieved
         self.query_one("#auto-active-panel", AccountsPanel).refresh()
         self._update_summary()
 
@@ -194,10 +213,10 @@ class AutoScreen(Screen):
         text = Text()
         text.append("auto-switch · ")
         text.append(
-            f"threshold {pct_label(self._settings.threshold)}%",
+            f"threshold {pct_label(self._policy_floor())}%",
             style=palette.accent if self._adjusting else "",
         )
-        if self._settings.threshold != self._configured_threshold:
+        if self._policy_floor() != self._configured_threshold:
             text.append(" (session)", style=palette.muted)
         text.append(f" · poll every {self._settings.interval_seconds:.0f}s")
         if self._adjusting:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -7322,3 +7322,29 @@ class TestPerWindowThresholds:
         assert parse_setting_value(spec, "95") == 95.0
         with pytest.raises(ConfigError):
             parse_setting_value(spec, "120")
+
+
+class TestPollEventReportsThePolicy:
+    def test_uniform_policy_emits_no_extra_field(self, temp_home):
+        h = EngineHarness(temp_home, threshold=88.0)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        h.tick_with_usage({"1": _usage7(10, 10), "2": _usage7(10, 10)})
+        poll = next(e for e in h.events if isinstance(e, PollEvent))
+        assert "windowThresholds" not in poll.to_json(), (
+            "a single-threshold run must keep its JSON byte-identical"
+        )
+
+    def test_split_policy_reports_both_ceilings(self, temp_home):
+        h = EngineHarness(
+            temp_home, threshold=88.0, threshold_5h=95.0, threshold_7d=85.0
+        )
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        h.tick_with_usage({"1": _usage7(10, 10), "2": _usage7(10, 10)})
+        poll = next(e for e in h.events if isinstance(e, PollEvent))
+        assert poll.to_json()["windowThresholds"] == {"5h": 95.0, "7d": 85.0}, (
+            "a reader of the stream must be able to explain the decision"
+        )

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -7293,6 +7293,57 @@ class TestPerWindowThresholds:
             "weekly window is days from resetting"
         )
 
+    @pytest.mark.parametrize(
+        "pct5,pct7,over,who",
+        [
+            (94.9, 10.0, False, "5h just under its ceiling"),
+            (95.0, 10.0, True, "5h exactly at its ceiling"),
+            (95.1, 10.0, True, "5h just over"),
+            (10.0, 84.9, False, "7d just under its ceiling"),
+            (10.0, 85.0, True, "7d exactly at its ceiling"),
+            (10.0, 85.1, True, "7d just over"),
+            (94.0, 84.0, False, "both just under, neither trips"),
+            (90.0, 86.0, True, "only the weekly trips, and that is enough"),
+        ],
+    )
+    def test_boundaries_at_each_ceiling(self, pct5, pct7, over, who):
+        """`excess >= 0` is the trip test, so equality trips. Pinned per
+        window because a split policy has two independent boundaries and an
+        off-by-one on either is a silent switch or a silent hold."""
+        t = oauth.WindowThresholds(default=88.0, five_hour=95.0, weekly=85.0)
+        excess = oauth.threshold_excess(_usage7(pct5, pct7), (), thresholds=t)
+        assert (excess >= 0) is over, f"{who}: excess={excess}"
+
+    @pytest.mark.parametrize("threshold", [50.0, 75.0, 88.0, 99.9])
+    def test_uniform_boundary_matches_the_legacy_comparison_exactly(self, threshold):
+        """Legacy equivalence at the boundary itself, across the settable
+        range: `excess >= 0` must agree with `(100 - headroom) >= threshold`
+        for every window value, including exact equality."""
+        flat = oauth.WindowThresholds(default=threshold)
+        for pct in (threshold - 0.1, threshold, threshold + 0.1, 0.0, 100.0):
+            usage = _usage7(pct, 0.0)
+            new = oauth.threshold_excess(usage, (), thresholds=flat) >= 0
+            legacy = (100.0 - oauth.account_headroom(usage, ())) >= threshold
+            assert new is legacy, f"pct={pct} threshold={threshold}"
+
+    def test_the_no_return_bar_still_applies_under_a_split_policy(self, temp_home):
+        """Anti-flap is not bypassed by the new axis: the engine still refuses
+        to undo its own last move when the ceilings are split."""
+        h = self._harness(temp_home, **_pw(95.0, 85.0))
+        first = h.tick_with_usage({
+            "1": _usage7(10, 90),   # active past the weekly ceiling
+            "2": _usage7(20, 10),
+            "3": _usage7(30, 10),
+        })
+        assert first is TickOutcome.SWITCHED
+        landed = h.active_number()
+        state = h.state()
+        assert state["lastSwitchTo"] == str(landed)
+        assert state["lastSwitchFrom"] == 1, (
+            "the departure must be recorded so the bar has something to "
+            "refuse to undo under a split policy too"
+        )
+
     def test_thresholds_resolve_and_stay_uniform_when_unset(self):
         from claude_swap.autoswitch import _thresholds_for
 

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -37,6 +37,28 @@ from claude_swap.settings import AutoSwitchSettings
 from claude_swap.switcher import ClaudeAccountSwitcher
 
 
+def _uniform_excess(headroom: dict, engine) -> dict:
+    """Threshold excess equivalent to a headroom map under a UNIFORM policy.
+
+    These tests predate per-window thresholds and all run a single
+    `autoswitch.threshold`, where `excess == (100 - headroom) - threshold`
+    exactly. Deriving it here keeps them asserting on the same fleet shapes
+    they always did instead of restating every case in the new units.
+    """
+    from claude_swap.autoswitch import _thresholds_for
+
+    # Some cases drive a bare AutoSwitchEngine stub that sets only `_models`;
+    # those construct a default AutoSwitchSettings of their own, so defaults
+    # are the right fallback.
+    settings = getattr(engine, "settings", None) or AutoSwitchSettings()
+    t = _thresholds_for(settings)
+    assert t.uniform, "helper is only valid for a single-threshold policy"
+    limit = t.for_label("7d")
+    return {
+        n: None if h is None else (100.0 - h) - limit for n, h in headroom.items()
+    }
+
+
 class FakeClock:
     def __init__(self, now: float = 1_000_000.0):
         self.now = now
@@ -2238,7 +2260,9 @@ class TestSessionThreshold:
         with patch.object(
             harness.switcher, "usage_entries_by_account", return_value=entries
         ) as collect:
-            harness.engine._collect_scheduled_usage("1", threshold=threshold)
+            harness.engine._collect_scheduled_usage(
+                "1", thresholds=oauth.WindowThresholds(default=threshold)
+            )
         return [c.kwargs.get("fetch") for c in collect.call_args_list]
 
     def test_collect_escalates_on_the_tick_snapshot_threshold(self, harness):
@@ -3234,10 +3258,10 @@ class TestConsumeFirstDepartureRecordsItsOwnTrigger:
 
         failover_recovered = e._left_account_recovered(
             failover_state, usage, headroom, 5.0, settings, now, "2"
-        )
+        , excess=_uniform_excess(headroom, e))
         ordinary_recovered = e._left_account_recovered(
             consume_first_state, usage, headroom, 5.0, settings, now, "2"
-        )
+        , excess=_uniform_excess(headroom, e))
         assert failover_recovered is True, (
             "a real failover departure's landing floor (h > 10) releases "
             "on an 11-point peer with no baseline to diff against"
@@ -3275,7 +3299,7 @@ class TestConsumeFirstDepartureRecordsItsOwnTrigger:
         }
         recovered = e._left_account_recovered(
             legacy_state, usage, headroom, 5.0, settings, now, "2"
-        )
+        , excess=_uniform_excess(headroom, e))
         assert recovered is True, (
             "no leftTrigger recorded -> fall back to the pre-I-B inference "
             "(both null -> failover), same as before this fix"
@@ -3311,7 +3335,7 @@ class TestConsumeFirstDepartureRecordsItsOwnTrigger:
         }
         recovered = e._left_account_recovered(
             legacy_state_real_headroom, usage, headroom, 5.0, settings, now, "2"
-        )
+        , excess=_uniform_excess(headroom, e))
         assert recovered is False, (
             "leftHeadroom=10.0 is a real (non-null) baseline, so this is "
             "unambiguously an ORDINARY departure -- the failover landing "
@@ -4498,14 +4522,14 @@ class TestHorizonAxisDoesNotFlap:
             for active in (10.0, None):
                 assert harness.engine._no_return_account(
                     trigger, state, headroom, active, ["1", "3"], harness.settings
-                ) is None, (
+                , excess=_uniform_excess(headroom, harness.engine)) is None, (
                     f"trigger={trigger} active_headroom={active} barred the "
                     "account we left; an escape must reach every candidate"
                 )
         # The control: the SAME state bars on a proactive tick.
         assert harness.engine._no_return_account(
             "proactive", state, headroom, 10.0, ["1", "3"], harness.settings
-        ) == "1", "premise: these inputs are barred when the trigger allows it"
+        , excess=_uniform_excess(headroom, harness.engine)) == "1", "premise: these inputs are barred when the trigger allows it"
 
     @pytest.mark.parametrize(
         "landed,live,expect",
@@ -4634,8 +4658,12 @@ class TestHorizonAxisDoesNotFlap:
             oauth_candidates=["1", "3"],
             usage={"1": _usage(40), "2": _usage(96), "3": _usage(99)},
             headroom={"1": 60.0, "2": 4.0, "3": 1.0},
+            excess=_uniform_excess(
+                {"1": 60.0, "2": 4.0, "3": 1.0}, harness.engine
+            ),
             current="2",
             active_headroom=4.0,
+            active_excess=(100.0 - 4.0) - AutoSwitchSettings().threshold,
             settings=AutoSwitchSettings(),
             now=harness.clock.now,
         )
@@ -4768,7 +4796,7 @@ class TestHorizonAxisDoesNotFlap:
         headroom = {"2": 10.0, "3": 40.0}       # slot 1 unreadable — absent
         assert harness.engine._no_return_account(
             "proactive", state, headroom, 10.0, ["1", "3"], harness.settings
-        ) == "1", (
+        , excess=_uniform_excess(headroom, harness.engine)) == "1", (
             "an unreadable barred account must still bar — unknown headroom "
             "is not evidence it beats us"
         )
@@ -5107,7 +5135,7 @@ class TestHorizonAxisDoesNotFlap:
             60.0,
             harness.settings,
             harness.clock(),
-        )
+        excess=_uniform_excess({"1": 100.0}, harness.engine))
         assert recovered is True, (
             "the clamp must still release a departure recorded at a near-full "
             "leftHeadroom even where dominance over the active does not fire"
@@ -5149,10 +5177,10 @@ class TestHorizonAxisDoesNotFlap:
         usage = {"2": _usage(60.0)}  # peer frozen at 40 pts headroom
         readable = harness.engine._left_account_recovered(
             state, usage, {"2": 40.0}, 2.0, harness.settings, harness.clock(), "1",
-        )
+        excess=_uniform_excess({"2": 40.0}, harness.engine))
         unreadable = harness.engine._left_account_recovered(
             state, usage, {"2": 40.0}, None, harness.settings, harness.clock(), "1",
-        )
+        excess=_uniform_excess({"2": 40.0}, harness.engine))
         assert readable is True, "premise: a readable, dominant active releases"
         assert unreadable is True, (
             f"readable={readable} unreadable={unreadable} -- the SAME peer, "
@@ -5183,10 +5211,10 @@ class TestHorizonAxisDoesNotFlap:
         for trigger in ("proactive", "consume-first"):
             readable = harness.engine._no_return_account(
                 trigger, state, headroom, 2.0, recovered=True, settings=harness.settings
-            )
+            , excess=_uniform_excess(headroom, harness.engine))
             unreadable = harness.engine._no_return_account(
                 trigger, state, headroom, None, recovered=True, settings=harness.settings
-            )
+            , excess=_uniform_excess(headroom, harness.engine))
             assert readable is None, f"premise: {trigger} releases when readable"
             assert unreadable is None, (
                 f"trigger={trigger} readable={readable!r} "
@@ -5221,7 +5249,7 @@ class TestHorizonAxisDoesNotFlap:
         }
         recovered = h.engine._left_account_recovered(
             state, usage, {"1": 5.0}, 2.0, h.settings, h.clock(), "2",
-        )
+        excess=_uniform_excess({"1": 5.0}, h.engine))
         assert recovered is False, (
             "the peer's reset is only 60s sooner than the active's, well "
             "inside RECOVERY_HYSTERESIS_S (300s) -- without the margin any "
@@ -5245,7 +5273,7 @@ class TestHorizonAxisDoesNotFlap:
         usage = {"2": _usage(95.0)}  # 5 pts, no resets_at at all
         recovered = harness.engine._left_account_recovered(
             state, usage, {"2": 5.0}, None, harness.settings, harness.clock(), "1",
-        )
+        excess=_uniform_excess({"2": 5.0}, harness.engine))
         assert recovered is False, (
             "the peer is unreadable-active-fallback-eligible in shape only -- "
             "at 5 pts it is BELOW the landing floor (10), so the fallback "
@@ -5268,7 +5296,7 @@ class TestHorizonAxisDoesNotFlap:
         no_return = harness.engine._no_return_account(
             "proactive", state, headroom, None, recovered=True,
             settings=harness.settings,
-        )
+        excess=_uniform_excess(headroom, harness.engine))
         assert no_return == "2", (
             "the barred peer at 5 pts is below the landing floor (10); an "
             "unreadable active must not unconditionally release it"
@@ -5436,14 +5464,14 @@ class TestHorizonAxisDoesNotFlap:
 
         assert harness.engine._left_account_recovered(
             state, {"2": _usage(96)}, {"2": 4.0}, 2.0, harness.settings, harness.clock()
-        ) is True, (
+        , excess=_uniform_excess({"2": 4.0}, harness.engine)) is True, (
             "a pre-upgrade record (no snapshot) must release even when the "
             "barred account is currently poor (4 pts) — absence of evidence "
             "is not the same state as a measured-unmeasurable failover"
         )
         assert harness.engine._left_account_recovered(
             state, {"2": None}, {"2": None}, 2.0, harness.settings, harness.clock()
-        ) is True, (
+        , excess=_uniform_excess({"2": None}, harness.engine)) is True, (
             "a pre-upgrade record (no snapshot) must release even when the "
             "barred account is currently unreadable — absence of evidence "
             "releases regardless of what can be measured right now"
@@ -6322,7 +6350,7 @@ class TestTheReleasePredicateOneStateShapePerTest:
         state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
         assert harness.engine._left_account_recovered(
             state, {"2": _usage(85)}, {"2": 15.0}, 2.0, harness.settings, harness.clock()
-        ) is True, (
+        , excess=_uniform_excess({"2": 15.0}, harness.engine)) is True, (
             "a failover departure with the peer now readable at 15 points "
             "(past the threshold-derived floor of 10, under any floor of "
             "20 or 50) must release"
@@ -6346,7 +6374,7 @@ class TestTheReleasePredicateOneStateShapePerTest:
         state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
         assert h_low.engine._left_account_recovered(
             state, {"2": _usage(65)}, {"2": 35.0}, 2.0, h_low.settings, h_low.clock()
-        ) is False, (
+        , excess=_uniform_excess({"2": 35.0}, h_low.engine)) is False, (
             "threshold=60 -> floor=40; a peer at 35 points is BELOW that "
             "floor and must hold"
         )
@@ -6357,7 +6385,7 @@ class TestTheReleasePredicateOneStateShapePerTest:
         h_high.make_live("a@example.com", 1)
         assert h_high.engine._left_account_recovered(
             state, {"2": _usage(65)}, {"2": 35.0}, 2.0, h_high.settings, h_high.clock()
-        ) is True, (
+        , excess=_uniform_excess({"2": 35.0}, h_high.engine)) is True, (
             "the SAME peer at 35 points, only `settings.threshold` changed "
             "(71 -> floor 29) — a hardcoded absolute floor would answer the "
             "same both times; this must flip, proving the floor is the "
@@ -6405,7 +6433,7 @@ class TestTheReleasePredicateOneStateShapePerTest:
         # 5.0 < 100 - 90 = 10, the threshold-derived floor: readable, but poor.
         assert harness.engine._left_account_recovered(
             state, {"2": _usage(95)}, {"2": 5.0}, 2.0, harness.settings, harness.clock()
-        ) is False, (
+        , excess=_uniform_excess({"2": 5.0}, harness.engine)) is False, (
             "a failover departure with the peer readable but under the "
             "floor must hold — readable is not the same as recovered"
         )
@@ -6415,7 +6443,7 @@ class TestTheReleasePredicateOneStateShapePerTest:
         state = {"lastSwitchFrom": "2", "leftHeadroom": None, "leftRecoveryAt": None}
         assert harness.engine._left_account_recovered(
             state, {"2": None}, {"2": None}, 2.0, harness.settings, harness.clock()
-        ) is False, (
+        , excess=_uniform_excess({"2": None}, harness.engine)) is False, (
             "a failover departure with the peer still unreadable must hold; "
             "unknown is not evidence of recovery"
         )
@@ -6442,7 +6470,8 @@ class TestTheReleasePredicateOneStateShapePerTest:
             8.0,
             harness.settings,
             harness.clock(),
-        ) is True, (
+        excess=_uniform_excess(# now back in 1 MINUTE
+            {"2": 4.0}, harness.engine)) is True, (
             "the peer's weekly-bound reset moved meaningfully nearer, which "
             "is a real recovery event the headroom leg cannot see"
         )
@@ -6452,7 +6481,7 @@ class TestTheReleasePredicateOneStateShapePerTest:
         state = {"lastSwitchFrom": "2"}  # no leftHeadroom / leftRecoveryAt key
         assert harness.engine._left_account_recovered(
             state, {"2": _usage(96)}, {"2": 4.0}, 2.0, harness.settings, harness.clock()
-        ) is True, (
+        , excess=_uniform_excess({"2": 4.0}, harness.engine)) is True, (
             "absence of the snapshot fields (a pre-upgrade record) carries "
             "no evidence either way and must release, not hold forever"
         )
@@ -6471,7 +6500,7 @@ class TestTheReleasePredicateOneStateShapePerTest:
             for recovered in (True, False):
                 assert harness.engine._no_return_account(
                     "at-limit", state, headroom, active, recovered, harness.settings
-                ) is None, (
+                , excess=_uniform_excess(headroom, harness.engine)) is None, (
                     "at-limit must escape the bar regardless of "
                     "active_headroom or the recovered predicate's answer"
                 )
@@ -7049,3 +7078,192 @@ class TestPaceStrategy:
         from claude_swap.settings import _clamped
 
         assert _clamped(AutoSwitchSettings(strategy="pace")).strategy == "pace"
+
+
+# --- per-window thresholds -----------------------------------------------
+
+
+def _pw(five_h: float | None, weekly: float | None, default: float = 88.0):
+    return {"threshold": default, "threshold_5h": five_h, "threshold_7d": weekly}
+
+
+class TestPerWindowThresholds:
+    """A split policy: ride the 5h window, leave weekly quota early.
+
+    Fleet shape throughout is the one that motivated the feature: an active
+    account whose WEEKLY window is the binding one while its 5h window is
+    nearly idle, next to a peer in the mirror image.
+    """
+
+    def _harness(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, **kw)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_unset_overrides_are_identical_to_one_threshold(self, temp_home):
+        """The backward-compatibility pin: an unset pair must decide exactly
+        as the single-threshold policy did, including the detail string."""
+        h = self._harness(temp_home, threshold=88.0)
+        outcome = h.tick_with_usage({
+            "1": _usage7(50, 50), "2": _usage7(10, 10), "3": _usage7(10, 10),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        detail = next(
+            e.detail for e in h.events
+            if isinstance(e, NoSwitchEvent) and e.reason == "below-threshold"
+        )
+        assert detail == "50% < 88%", (
+            "an unset per-window pair must not change the message shape; "
+            f"got {detail!r}"
+        )
+
+    def test_a_hot_5h_window_does_not_evict_an_account_with_weekly_left(
+        self, temp_home
+    ):
+        """The switch this feature exists to PREVENT.
+
+        Active is at 92% on a 5h window that resets within the session, and
+        at 5% on its weekly. Under one threshold of 88 that is a switch (and
+        a cold prompt cache in every live session) to save a window that
+        heals itself. Under 5h=95 it keeps working.
+        """
+        h = self._harness(temp_home, **_pw(95.0, 85.0))
+        outcome = h.tick_with_usage({
+            "1": _usage7(92, 5),     # hot 5h, weekly barely touched
+            "2": _usage7(10, 10),
+            "3": _usage7(10, 10),
+        })
+        assert outcome is TickOutcome.NO_ACTION, (
+            "a 5h window under its own ceiling must not trigger a switch "
+            "just because it is over the account-wide default"
+        )
+        assert h.active_number() == 1
+        detail = next(
+            e.detail for e in h.events
+            if isinstance(e, NoSwitchEvent) and e.reason == "below-threshold"
+        )
+        assert detail == "5h 92% < 95%", (
+            f"a split policy must name the window it measured; got {detail!r}"
+        )
+
+    def test_the_same_pcts_under_one_threshold_do_switch(self, temp_home):
+        """Control for the test above: identical fleet, uniform policy."""
+        h = self._harness(temp_home, threshold=88.0)
+        outcome = h.tick_with_usage({
+            "1": _usage7(92, 5), "2": _usage7(10, 10), "3": _usage7(10, 10),
+        })
+        assert outcome is TickOutcome.SWITCHED, (
+            "premise: one threshold of 88 evicts this account; the split "
+            "policy is what changes the answer, not the fleet"
+        )
+
+    def test_a_weekly_window_trips_earlier_than_the_default(self, temp_home):
+        """The switch this feature exists to CAUSE. The live case: active
+        binding on 84% weekly with a nearly idle 5h window."""
+        h = self._harness(temp_home, **_pw(95.0, 85.0))
+        outcome = h.tick_with_usage({
+            "1": _usage7(27, 86),    # weekly over 85, under the 88 default
+            "2": _usage7(19, 3),
+            "3": _usage7(10, 10),
+        })
+        assert outcome is TickOutcome.SWITCHED, (
+            "a weekly window past its own lowered ceiling must rotate off "
+            "even though it is under the account-wide default"
+        )
+        assert h.active_number() in (2, 3)
+
+    # One fleet, two policies, different landings: the discriminating pair.
+    # #2 is hot only on its self-healing 5h window (88, under a 95 ceiling)
+    # with 81 points of weekly room; #3 is quiet on 5h but past a lowered
+    # weekly ceiling (87 > 85). Raw headroom prefers #3 (13 pts vs 12).
+    _SPLIT_FLEET = {
+        "1": _usage7(10, 90),    # active: past the 85 weekly ceiling, must move
+        "2": _usage7(88, 4),
+        "3": _usage7(10, 87),
+    }
+
+    def test_a_candidate_is_gated_per_window_too(self, temp_home):
+        """Landing uses the same per-window policy as the trigger."""
+        h = self._harness(temp_home, hysteresis_pct=0.0, **_pw(95.0, 85.0))
+        outcome = h.tick_with_usage(dict(self._SPLIT_FLEET))
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2, (
+            "#3 is past the lowered weekly ceiling and must be skipped even "
+            "though it holds more raw headroom; #2 is hot only on a window "
+            "that heals itself within the session"
+        )
+
+    def test_the_same_fleet_under_one_threshold_lands_elsewhere(self, temp_home):
+        """Control: identical fleet, uniform 88. #2 is now illegal (5h 88 is
+        at the ceiling) and #3 legal, so the landing flips; the policy is
+        what moved the answer, not the numbers."""
+        h = self._harness(temp_home, hysteresis_pct=0.0, threshold=88.0)
+        outcome = h.tick_with_usage(dict(self._SPLIT_FLEET))
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3, (
+            "premise: one threshold picks the weekly-depleted account; the "
+            "split policy is what changes the landing"
+        )
+
+    def test_scoped_model_windows_follow_the_weekly_threshold(self, temp_home):
+        """Per-model windows reset weekly, so they are perishable the same
+        way and must be gated by threshold7d, not the 5h one."""
+        h = self._harness(temp_home, model="Fable", **_pw(95.0, 85.0))
+        usage = {
+            "five_hour": {"pct": 10.0},
+            "seven_day": {"pct": 10.0},
+            "scoped": [{"name": "Fable", "pct": 90.0}],
+        }
+        outcome = h.tick_with_usage({
+            "1": usage, "2": _usage7(10, 10), "3": _usage7(10, 10),
+        })
+        assert outcome is TickOutcome.SWITCHED, (
+            "a scoped weekly window at 90% is past the 85% weekly ceiling; "
+            "gating it with the 5h ceiling (95) would have held"
+        )
+
+    def test_at_limit_still_escapes_regardless_of_policy(self, temp_home):
+        """A real 100% is a hard limit, not a policy choice: the at-limit
+        escape reads headroom, which per-window thresholds must not shift."""
+        h = self._harness(temp_home, **_pw(99.0, 99.0))
+        outcome = h.tick_with_usage({
+            "1": _usage7(100, 10), "2": _usage7(10, 10), "3": _usage7(10, 10),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "at-limit", (
+            "100% must still read as at-limit even with both ceilings at 99"
+        )
+
+    def test_thresholds_resolve_and_stay_uniform_when_unset(self):
+        from claude_swap.autoswitch import _thresholds_for
+
+        t = _thresholds_for(AutoSwitchSettings(threshold=88.0))
+        assert (t.for_label("5h"), t.for_label("7d"), t.uniform) == (88.0, 88.0, True)
+        split = _thresholds_for(
+            AutoSwitchSettings(threshold=88.0, threshold_5h=95.0, threshold_7d=85.0)
+        )
+        assert split.for_label("5h") == 95.0
+        assert split.for_label("Fable") == 85.0   # scoped -> weekly
+        assert split.floor == 85.0 and not split.uniform
+
+    def test_excess_matches_the_old_test_when_uniform(self):
+        """`threshold_excess` must be the exact generalisation of the old
+        `(100 - headroom) >= threshold` comparison."""
+        flat = oauth.WindowThresholds(default=88.0)
+        for pct5, pct7 in ((10, 50), (95, 5), (88, 88), (0, 100)):
+            usage = _usage7(pct5, pct7)
+            old = (100.0 - oauth.account_headroom(usage, ())) - 88.0
+            assert oauth.threshold_excess(usage, (), thresholds=flat) == old
+
+    def test_config_set_rejects_out_of_range_per_window_values(self):
+        from claude_swap.settings import SETTING_SPECS, parse_setting_value
+        from claude_swap.exceptions import ConfigError
+
+        spec = SETTING_SPECS["autoswitch.threshold5h"]
+        assert parse_setting_value(spec, "95") == 95.0
+        with pytest.raises(ConfigError):
+            parse_setting_value(spec, "120")

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -6894,3 +6894,158 @@ class TestFreshenRoutesThroughGate:
         assert gate_calls["args"][0] == "2"
         assert "called" not in direct, "freshen must not POST outside the gate"
 
+
+# --- pace strategy -------------------------------------------------------------
+
+# Weekly-reset instants for pace math, anchored to FakeClock's 1_000_000.0
+# epoch (~1970-01-12 13:46:40Z). Elapsed time in the current weekly cycle is
+# 7d minus the time remaining to the reset, and compute_pace's expected pct
+# is elapsed/7d, so each instant pins a known expected value:
+#   _R7_MIDWEEK  58.2h out -> 109.8h elapsed -> expected ~65.3%
+#   _R7_EARLY   138.0h out ->  30.0h elapsed -> expected ~17.9%
+#   _R7_FRESH   156.0h out ->  12.0h elapsed -> inside the 24h suppression
+_R7_MIDWEEK = "1970-01-15T00:00:00Z"
+_R7_EARLY = "1970-01-18T07:46:40Z"
+_R7_FRESH = "1970-01-19T01:46:40Z"
+
+
+class TestPaceStrategy:
+    def _harness(self, temp_home: Path) -> EngineHarness:
+        h = EngineHarness(temp_home, strategy="pace")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_ahead_of_pace_switches_to_on_pace_candidate(self, temp_home):
+        """The discriminating case: the ahead-of-pace candidate has MORE
+        headroom than the on-pace one, so a plain headroom sort would pick it.
+        The pace landing gate must exclude it and land on the on-pace peer."""
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(10, 85, _R7_MIDWEEK),  # active: 85 vs ~65 expected -> ahead
+            "2": _usage7(10, 50, _R7_MIDWEEK),  # on pace, 50 pts headroom
+            "3": _usage7(0, 40, _R7_EARLY),     # 60 pts headroom but ahead (40 vs ~18)
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "pace"
+        assert sw.to_ref == {"number": 2, "email": "b@example.com"}
+
+    def test_on_pace_below_threshold_stays(self, temp_home):
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(10, 50, _R7_MIDWEEK),  # 50 vs ~65 expected -> on pace
+            "2": _usage7(0, 10, _R7_MIDWEEK),
+            "3": _usage7(0, 10, _R7_MIDWEEK),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
+
+    def test_every_candidate_ahead_stays(self, temp_home):
+        h = EngineHarness(temp_home, strategy="pace")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        outcome = h.tick_with_usage({
+            "1": _usage7(10, 85, _R7_MIDWEEK),  # ahead
+            "2": _usage7(10, 82, _R7_MIDWEEK),  # also ahead (82 vs ~65: 16.7 over)
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["no-on-pace-candidate"]
+
+    def test_pace_target_must_still_be_healthy(self, temp_home):
+        """An on-pace weekly window does not excuse a binding 5h window at or
+        over the threshold: landing there re-triggers on the next tick."""
+        h = EngineHarness(temp_home, strategy="pace")
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        outcome = h.tick_with_usage({
+            "1": _usage7(10, 85, _R7_MIDWEEK),  # ahead
+            "2": _usage7(95, 20, _R7_MIDWEEK),  # weekly on pace, 5h over threshold
+        })
+        assert outcome is not TickOutcome.SWITCHED
+        assert h.active_number() == 1
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["no-on-pace-candidate"]
+
+    def test_within_reset_suppression_stays(self, temp_home):
+        """85% at 12h into the week is hugely over expected, and exactly the
+        false positive compute_pace suppresses for the first day."""
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(10, 85, _R7_FRESH),
+            "2": _usage7(0, 10, _R7_MIDWEEK),
+            "3": _usage7(0, 10, _R7_MIDWEEK),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
+
+    def test_respects_cooldown(self, temp_home):
+        h = self._harness(temp_home)  # default cooldown 300s
+        h.tick_with_usage({
+            "1": _usage7(10, 85, _R7_MIDWEEK),
+            "2": _usage7(10, 50, _R7_MIDWEEK),
+            "3": _usage7(10, 55, _R7_MIDWEEK),
+        })
+        assert h.active_number() == 2
+        h.clock.advance(60.0)
+        outcome = h.tick_with_usage({
+            "1": _usage7(10, 85, _R7_MIDWEEK),
+            "2": _usage7(10, 85, _R7_MIDWEEK),  # the landing is now ahead itself
+            "3": _usage7(10, 55, _R7_MIDWEEK),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 2
+        assert "cooldown" in [
+            e.reason for e in h.events if isinstance(e, NoSwitchEvent)
+        ]
+
+    def test_over_threshold_behaves_like_best(self, temp_home):
+        """Above the threshold the pace gate is out of scope: we must move,
+        and any healthy account beats staying, exactly as `best` decides."""
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(95, 20, _R7_MIDWEEK),  # over threshold
+            "2": _usage7(0, 81, _R7_MIDWEEK),   # ahead of pace, 19 pts
+            "3": _usage7(10, 10, _R7_MIDWEEK),  # most headroom
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "proactive"
+
+    def test_weekly_ahead_ignores_the_5h_window(self):
+        from claude_swap.autoswitch import _weekly_ahead
+
+        usage = {
+            "five_hour": {"pct": 99.0, "resets_at": _R7_MIDWEEK},
+            "seven_day": {"pct": 10.0, "resets_at": _R7_MIDWEEK},
+        }
+        assert _weekly_ahead(usage, 1_000_000.0, ()) is False
+
+    def test_weekly_ahead_reads_configured_scoped_windows(self):
+        from claude_swap.autoswitch import _weekly_ahead
+
+        usage = {
+            "five_hour": {"pct": 0.0},
+            "seven_day": {"pct": 10.0, "resets_at": _R7_MIDWEEK},
+            "scoped": [
+                {"name": "Fable", "pct": 90.0, "resets_at": _R7_MIDWEEK},
+            ],
+        }
+        assert _weekly_ahead(usage, 1_000_000.0, ("Fable",)) is True
+        assert _weekly_ahead(usage, 1_000_000.0, ()) is False
+
+    def test_settings_accept_pace_strategy(self):
+        from claude_swap.settings import _clamped
+
+        assert _clamped(AutoSwitchSettings(strategy="pace")).strategy == "pace"

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -7238,6 +7238,61 @@ class TestPerWindowThresholds:
             "100% must still read as at-limit even with both ceilings at 99"
         )
 
+    def test_the_fleet_that_rode_an_account_to_a_hard_limit(self, temp_home):
+        """Observed on a live 3-account fleet under heavy concurrent load.
+
+        Every account sat within a point or two of the single 88 ceiling at
+        once, but on DIFFERENT windows: one on a weekly window days from
+        resetting, one on a 5h window 39 minutes from resetting, and the
+        active one burning. With no candidate under the shared ceiling the
+        engine had nowhere legal to land, reported `no-qualifying-candidate`
+        for eight consecutive ticks, and rode the active account to a real
+        100% before the at-limit escape moved it. A hard rate limit, taken
+        while a peer held a full untouched week of quota.
+
+        The peer was only blocked by a 5h window that heals within the
+        session. Under a split policy it is a legal landing and the limit is
+        never reached, which is the entire point of separating the ceilings.
+        """
+        five_h = _iso_at(1_002_340.0)      # 39 minutes out
+        fleet = {
+            "1": {  # active, burning; 5h past 95 but weekly barely touched
+                "five_hour": {"pct": 96.0, "resets_at": five_h},
+                "seven_day": {"pct": 13.0, "resets_at": _iso_at(1_460_800.0)},
+            },
+            "2": {  # a full untouched week, blocked only by a healing 5h window
+                "five_hour": {"pct": 89.0, "resets_at": five_h},
+                "seven_day": {"pct": 0.0, "resets_at": _iso_at(1_604_800.0)},
+            },
+            "3": {  # genuinely depleted: weekly is days out
+                "five_hour": {"pct": 44.0, "resets_at": _iso_at(1_002_940.0)},
+                "seven_day": {"pct": 88.0, "resets_at": _iso_at(1_241_200.0)},
+            },
+        }
+
+        uniform = self._harness(temp_home, strategy="consume-first", threshold=88.0)
+        assert uniform.tick_with_usage(dict(fleet)) is not TickOutcome.SWITCHED, (
+            "premise: under one ceiling every account is over it, so nothing "
+            "is a legal landing and the active burns on to a hard limit"
+        )
+        assert uniform.active_number() == 1
+
+        # A second, independent home so the two policies cannot share a
+        # store (see EngineHarness.__init__ on per-instance isolation).
+        split_home = temp_home / "split"
+        (split_home / ".claude").mkdir(parents=True)
+        split = self._harness(
+            split_home, strategy="consume-first", **_pw(95.0, 85.0)
+        )
+        assert split.tick_with_usage(dict(fleet)) is TickOutcome.SWITCHED, (
+            "the peer's 5h window is under its own ceiling and its weekly is "
+            "untouched: a legal landing the shared ceiling hid"
+        )
+        assert split.active_number() == 2, (
+            "must land on the account holding a full week, not the one whose "
+            "weekly window is days from resetting"
+        )
+
     def test_thresholds_resolve_and_stay_uniform_when_unset(self):
         from claude_swap.autoswitch import _thresholds_for
 

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,10 +48,12 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "autoswitch.threshold5h",
+            "autoswitch.threshold7d",
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 11
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -67,7 +69,8 @@ class TestConfigList:
         _run(["set", "autoswitch.threshold", "90"], capsys)
         _, out, _ = _run([], capsys)
         threshold_line = next(
-            ln for ln in out.splitlines() if "threshold" in ln
+            ln for ln in out.splitlines()
+            if ln.split()[0] == "autoswitch.threshold"
         )
         assert "(default)" not in threshold_line
 
@@ -78,7 +81,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 11
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -34,6 +34,8 @@ def _args(**kwargs) -> argparse.Namespace:
         "cooldown": None,
         "include_api_key_accounts": None,
         "strategy": None,
+        "threshold_5h": None,
+        "threshold_7d": None,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -262,6 +264,28 @@ class TestMergedWithCli:
         assert merged.threshold == 60.0
         assert merged.interval_seconds == 30.0
         assert merged.cooldown_seconds == 10.0  # untouched
+
+    def test_per_window_flags_beat_settings_and_leave_the_fallback_alone(self):
+        base = AutoSwitchSettings(
+            threshold=88.0, threshold_5h=91.0, threshold_7d=80.0
+        )
+        merged = merged_with_cli(base, _args(threshold_5h=95.0, threshold_7d=85.0))
+        assert (merged.threshold_5h, merged.threshold_7d) == (95.0, 85.0)
+        assert merged.threshold == 88.0, (
+            "the per-window flags must not disturb the fallback threshold"
+        )
+
+    def test_one_per_window_flag_leaves_the_other_from_settings(self):
+        base = AutoSwitchSettings(threshold=88.0, threshold_7d=85.0)
+        merged = merged_with_cli(base, _args(threshold_5h=95.0))
+        assert merged.threshold_5h == 95.0
+        assert merged.threshold_7d == 85.0, (
+            "an unset flag must not clear a value the settings file provided"
+        )
+
+    def test_per_window_cli_values_are_clamped(self):
+        merged = merged_with_cli(AutoSwitchSettings(), _args(threshold_5h=200.0))
+        assert merged.threshold_5h == 99.9
 
     def test_cli_values_are_clamped(self):
         merged = merged_with_cli(AutoSwitchSettings(), _args(interval=1.0))

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1756,3 +1756,73 @@ class TestThemeWiring:
             assert app._theme_name == "light"
             assert app.theme == "cswap-light"
 
+
+
+@pytest.mark.asyncio
+class TestSessionOverrideUnderSplitPolicy:
+    """The session control must move real policy, not a fallback nobody reads.
+
+    Regression: with per-window ceilings set, `apply_threshold` wrote only
+    `settings.threshold`, which `for_label` never consults. The slider
+    displayed a new number, logged a session change, and moved no ceiling.
+    """
+
+    async def test_slider_moves_both_ceilings_and_reports_the_floor(
+        self, tmp_path, fake_engine
+    ):
+        import json as _json
+        from claude_swap.autoswitch import policy_floor
+
+        (tmp_path / "settings.json").write_text(_json.dumps({
+            "schemaVersion": 1,
+            "autoswitch": {
+                "threshold": 88.0, "threshold5h": 95.0, "threshold7d": 85.0,
+            },
+        }))
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(pilot)
+            screen = app.screen
+            assert app.threshold_pct == 85.0  # floor, not the 88 fallback
+            await pilot.press("t", "left", "left", "left")
+            await pilot.pause()
+            s = screen._settings
+            assert (s.threshold_5h, s.threshold_7d) == (92.0, 82.0), (
+                "both ceilings must move together so the configured gap "
+                f"survives - got {s.threshold_5h}/{s.threshold_7d}"
+            )
+            assert policy_floor(s) == 82.0
+            assert app.threshold_pct == 82.0, (
+                "the tick must show the achieved floor, not a fallback value"
+            )
+
+    async def test_uniform_policy_session_override_is_unchanged(
+        self, tmp_path, fake_engine
+    ):
+        """Backward-compatibility pin: with no per-window ceilings the floor
+        is the threshold, so the control behaves exactly as it always did."""
+        import json as _json
+
+        (tmp_path / "settings.json").write_text(_json.dumps({
+            "schemaVersion": 1, "autoswitch": {"threshold": 90.0},
+        }))
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(pilot)
+            screen = app.screen
+            await pilot.press("t", "right", "right")
+            await pilot.pause()
+            assert screen._settings.threshold == 92.0
+            assert screen._settings.threshold_5h is None
+            assert app.threshold_pct == 92.0
+
+    async def _open(self, pilot):
+        await settle(pilot)
+        await pilot.press("g")
+        await pilot.pause()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1385,6 +1385,52 @@ class TestAutoScreen:
             assert fake_engine.instances[0].stopped is True
             assert app._store_only is False
 
+    async def test_tick_shows_the_policy_floor_not_the_fallback(
+        self, tmp_path, fake_engine
+    ):
+        """One tick is drawn against bars for BOTH windows, so under a split
+        policy it must show the FLOOR (the earliest point some window trips),
+        not the account-wide fallback. Rendering 88 while the weekly ceiling
+        is 85 would put the tick above the real limit on the weekly bar, which
+        reads as "still fine" right up to a switch."""
+        import json as _json
+
+        (tmp_path / "settings.json").write_text(_json.dumps({
+            "schemaVersion": 1,
+            "autoswitch": {
+                "threshold": 88.0, "threshold5h": 95.0, "threshold7d": 85.0,
+            },
+        }))
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            assert app.threshold_pct == 85.0, (
+                "the tick must be the policy floor (85), not the fallback "
+                f"threshold (88) or the 5h ceiling (95) - got "
+                f"{app.threshold_pct}"
+            )
+
+    async def test_tick_is_the_plain_threshold_when_policy_is_uniform(
+        self, tmp_path, fake_engine
+    ):
+        """Backward-compatibility pin: with no per-window overrides the floor
+        IS the threshold, so existing behavior is unchanged."""
+        import json as _json
+
+        (tmp_path / "settings.json").write_text(_json.dumps({
+            "schemaVersion": 1, "autoswitch": {"threshold": 82.0},
+        }))
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            assert app.threshold_pct == 82.0
+
     async def test_threshold_adjust_is_session_only(self, tmp_path, fake_engine):
         fake = FakeSwitcher(
             [make_account(1, active=True), make_account(2)], tmp_path


### PR DESCRIPTION
## Motivation

The auto-switch engine is purely reactive today: nothing moves until the binding window crosses `autoswitch.threshold`. An account burning well ahead of its weekly pace therefore gets ridden all the way to the cliff while on-pace peers sit idle, and by the time the threshold trips, that week's quota is effectively gone.

Meanwhile `pace.py` has computed exactly the leading signal for this since #125: expected-versus-actual weekly consumption, noise-gated with the 15-point `AHEAD_THRESHOLD_PCT` and the 24h post-reset suppression. Today it only feeds the menubar `(ahead)` marker and the JSON output; no decision surface consumes it.

Observed on a real 3-account fleet: one account at 81% of its weekly window with 3 days left in the cycle ("ahead of pace" in `cswap list`), while the other two sat near 0%. `best` keeps you parked until the threshold; by then the hot account's week is spent.

## What this adds

An opt-in third strategy, `pace` (`cswap auto --strategy pace`, or `cswap config set autoswitch.strategy pace`). Default behavior is unchanged; `best` and `consume-first` are untouched.

- At/above the threshold, `pace` behaves exactly like `best` (same triggers, same ranking, same hysteresis).
- Below the threshold, when any weekly window of the active account (7d, plus configured scoped per-model windows via the existing `models` filter) is meaningfully ahead of pace, it rotates to the on-pace candidate with the most headroom, with trigger `"pace"`.

## Design choices

- **The trigger is `compute_pace(...).ahead`, unchanged.** No new thresholds: the engine and the UI marker can never disagree about what "ahead" means, and the signal keeps its built-in noise gates (24h suppression, 15-point margin). The sensitive `will_last_to_reset` signal was deliberately not used; acting on "1 point over expected" would be far too twitchy for an automated mover, which is the same reasoning that kept it JSON-only in #125.
- **Landing gate: a target must itself be on pace** (in addition to the existing below-threshold health gate). Moving onto another over-pace account trades one projected exhaustion for the next and invites ping-pong. Unknown pace counts as on pace: suppression covers exactly the first day after a reset when a window is freshest, and an unknowable pace cannot prove a candidate hot.
- **No headroom hysteresis on the pace branch, deliberately.** The point of the move is that raw headroom misleads when burn rates differ: an on-pace account with less headroom than the over-pace active is still the account that lasts the week. Anti-flap comes from the cooldown, the no-return bar, the target-must-be-on-pace gate, and pace's own decay (a departed account stays "ahead" until expected catches its actual, hours at minimum).
- **Everything else is reused, not duplicated:** the below-threshold move takes the consume-first two-phase commit (provisional decision on the stored snapshot, escalated refetch and re-rank before switching) and the per-target `UsageEntry.fresh` gate; cooldown and the no-return bar apply; the API-key last-resort fallback is excluded for the same reason it is for consume-first (an API-key account has no weekly window to pace).
- Weekly windows come through `oauth.relevant_windows` (the canonical window source), so a window that binds a decision can never be invisible to the pace check; the 5h window is excluded per `pace.py`.

## Testing

- 10 new tests in `tests/test_autoswitch.py` (`TestPaceStrategy`), including the discriminating case: an ahead-of-pace candidate with MORE headroom than the on-pace one must be passed over, which a plain headroom sort gets wrong.
- Coverage for: the suppression window holding below threshold, every-candidate-ahead holding with the new `no-on-pace-candidate` reason (NO_ACTION, matching the consume-first hold contract), the landing health gate, cooldown, above-threshold behavior matching `best`, the 5h exclusion, scoped-model windows, and settings validation.
- `tests/test_autoswitch.py`: 270 passed. Full suite: 2095 passed, 3 skipped, plus 3 pre-existing failures in `test_move_accounts`/`test_swap_accounts`/`test_real_store_guard` that fail identically on unmodified `main` in my environment (macOS with a legacy `~/.claude-swap-backup` store layout); untouched by this change.

## Docs

README strategy section and example updated; `--strategy` help, settings spec choices, and the module docstring cover the new value.
