### PR TITLE
Read setup-token usage from rate-limit headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,17 @@ cswap add-token --email user@example.com     # optional label override
 `--email` is optional; omitted values use `setup-token-{slot}@token.local`
 (or `api-key-{slot}@token.local` for API keys). No Anthropic API calls are made.
 
+**Usage for setup-token accounts.** A setup-token is scoped to `user:inference`
+alone, so it cannot read the usage endpoint (that needs profile scope) and such
+accounts used to show a permanent `usage unavailable`, which also hid them from
+`cswap auto` — an account with unknown headroom is never picked as a target.
+Their 5h/7d numbers are instead read from the `anthropic-ratelimit-unified-*`
+headers on a minimal `/v1/messages` call. That probe costs one output token, so
+it is throttled to once per 10 minutes per token (`CLAUDE_SWAP_PROBE_INTERVAL`,
+seconds; `CLAUDE_SWAP_PROBE_MODEL` overrides the model). Per-model weekly
+windows are not in the headers, so `--model` triggers stay blind for these
+accounts.
+
 **API-key accounts.** An `sk-ant-api...` value registers a managed API-key account
 (the kind Claude Code uses after `/login` with a key) rather than an OAuth
 setup-token. It switches like any other account; since API keys have no subscription

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable, Sequence
@@ -374,6 +376,120 @@ def request_usage_data(access_token: str) -> dict:
         return json.loads(resp.read().decode())
 
 
+# --- inference-only (setup-token) usage probe --------------------------------
+# ``claude setup-token`` mints a credential scoped to ``user:inference`` alone.
+# The usage endpoint wants profile scope, so those accounts 401/403 there on
+# every pass and read as "usage unavailable" — which makes them invisible to
+# `cswap auto`, since _rank_candidates skips any account whose headroom is
+# None. The same 5h/7d numbers ride back on every ``/v1/messages`` response as
+# ``anthropic-ratelimit-unified-*`` headers, and inference is exactly what
+# these tokens may do.
+#
+# The probe has to be a *successful* call: rejected requests (400 on an empty
+# messages array, 404 on a bogus model) come back with no rate-limit headers at
+# all — measured, not assumed. So each probe costs one output token, and
+# PROBE_MIN_INTERVAL_S keeps the poll loop from spending the very window it is
+# trying to measure. The model is env-overridable because a hardcoded id
+# eventually gets retired out from under us.
+PROBE_URL = "https://api.anthropic.com/v1/messages"
+PROBE_MODEL = os.environ.get("CLAUDE_SWAP_PROBE_MODEL", "claude-haiku-4-5-20251001")
+PROBE_MIN_INTERVAL_S = float(os.environ.get("CLAUDE_SWAP_PROBE_INTERVAL", "600"))
+
+# token fingerprint -> (monotonic stamp, raw-usage-shaped dict)
+_probe_cache: dict[str, tuple[float, dict]] = {}
+
+
+def is_inference_only(oauth: dict | None) -> bool:
+    """Whether this credential is a setup-token (inference scope only).
+
+    Such tokens can never read the usage endpoint, so callers probe instead of
+    spending a guaranteed 401/403 per pass to learn nothing.
+    """
+    if not isinstance(oauth, dict):
+        return False
+    scopes = oauth.get("scopes")
+    if not isinstance(scopes, list) or not scopes:
+        return False
+    return set(scopes) == {"user:inference"}
+
+
+def _epoch_to_iso(raw: str | None) -> str | None:
+    """Unix seconds (what the headers carry) -> ISO 8601 (what format_reset parses)."""
+    if not raw:
+        return None
+    try:
+        ts = int(float(raw))
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def usage_from_ratelimit_headers(headers) -> dict:
+    """Raw-usage-shaped dict built from ``anthropic-ratelimit-unified-*`` headers.
+
+    Utilization arrives as a 0-1 fraction while the usage API reports 0-100,
+    and ``build_usage_result`` passes the number straight through as ``pct`` —
+    so it is scaled here or every percentage renders 100x low.
+    """
+    out: dict = {}
+    for key, prefix in (("five_hour", "5h"), ("seven_day", "7d")):
+        raw = headers.get(f"anthropic-ratelimit-unified-{prefix}-utilization")
+        if raw is None:
+            continue
+        try:
+            pct = float(raw) * 100.0
+        except (TypeError, ValueError):
+            continue
+        entry: dict = {"utilization": pct}
+        iso = _epoch_to_iso(headers.get(f"anthropic-ratelimit-unified-{prefix}-reset"))
+        if iso:
+            entry["resets_at"] = iso
+        out[key] = entry
+    return out
+
+
+def request_usage_via_probe(access_token: str) -> dict:
+    """Read 5h/7d utilization off a minimal ``/v1/messages`` call's headers.
+
+    Returns data in the raw usage-API shape so ``build_usage_result``
+    normalizes it identically. Per-model (``scoped``) windows are absent from
+    the headers, so a probed account reports 5h/7d only and ``--model``
+    triggers stay blind for it.
+    """
+    body = json.dumps({
+        "model": PROBE_MODEL,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "."}],
+    }).encode()
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": OAUTH_BETA_HEADER,
+        "content-type": "application/json",
+        "User-Agent": "claude-swap/1.0",
+    }
+    req = urllib.request.Request(PROBE_URL, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return usage_from_ratelimit_headers(resp.headers)
+
+
+def probe_usage_throttled(access_token: str, now: float | None = None) -> dict:
+    """``request_usage_via_probe`` behind a per-token minimum interval.
+
+    Keyed by token digest rather than the token itself so the process never
+    holds a second copy of the secret.
+    """
+    now = time.monotonic() if now is None else now
+    key = hashlib.sha256(access_token.encode()).hexdigest()[:16]
+    cached = _probe_cache.get(key)
+    if cached is not None and (now - cached[0]) < PROBE_MIN_INTERVAL_S:
+        return cached[1]
+    data = request_usage_via_probe(access_token)
+    if data:
+        _probe_cache[key] = (now, data)
+    return data
+
+
 def _classify_usage_error(e: Exception) -> tuple[str, float | None]:
     """Map a usage-fetch exception to ``(kind, retry_after_s)``.
 
@@ -668,6 +784,17 @@ def try_fetch_usage_for_account(
             return UsageOutcome(None, error=refresh.error)
         # A transient refresh failure falls through to try the (expired) token;
         # the 401 path below retries the refresh.
+
+    # An inference-only credential can never read the usage endpoint, so probe
+    # the rate-limit headers instead of spending a guaranteed 401/403 per pass.
+    if is_inference_only(oauth):
+        try:
+            data = probe_usage_throttled(access_token)
+            return UsageOutcome(build_usage_result(data) if data else None)
+        except Exception as e:
+            kind, retry_after = _classify_usage_error(e)
+            _log_usage_failure(context, e, kind, retry_after)
+            return UsageOutcome(None, error=kind, retry_after_s=retry_after)
 
     try:
         data = request_usage_data(access_token)

--- a/tests/test_probe_usage.py
+++ b/tests/test_probe_usage.py
@@ -1,0 +1,113 @@
+"""Tests for the inference-only (setup-token) usage probe."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from claude_swap import oauth
+
+# A real response's shape, trimmed to the headers the probe reads.
+HEADERS = {
+    "anthropic-ratelimit-unified-5h-utilization": "0.04",
+    "anthropic-ratelimit-unified-5h-reset": "1787184600",
+    "anthropic-ratelimit-unified-7d-utilization": "0.06",
+    "anthropic-ratelimit-unified-7d-reset": "1787655600",
+}
+
+
+class TestIsInferenceOnly:
+    def test_setup_token_scopes(self):
+        assert oauth.is_inference_only({"scopes": ["user:inference"]})
+
+    def test_full_login_scopes(self):
+        assert not oauth.is_inference_only(
+            {"scopes": ["user:inference", "user:profile"]}
+        )
+
+    def test_missing_or_empty_scopes(self):
+        assert not oauth.is_inference_only({})
+        assert not oauth.is_inference_only({"scopes": []})
+        assert not oauth.is_inference_only(None)
+
+
+class TestUsageFromRatelimitHeaders:
+    def test_fraction_is_scaled_to_percent(self):
+        # 0.04 in the header must read as 4%, not 0.04% — build_usage_result
+        # passes the number straight through as ``pct``.
+        out = oauth.usage_from_ratelimit_headers(HEADERS)
+        assert out["five_hour"]["utilization"] == 4.0
+        assert out["seven_day"]["utilization"] == 6.0
+
+    def test_reset_epoch_becomes_parseable_iso(self):
+        out = oauth.usage_from_ratelimit_headers(HEADERS)
+        iso = out["five_hour"]["resets_at"]
+        assert datetime.fromisoformat(iso) == datetime.fromtimestamp(
+            1787184600, tz=timezone.utc
+        )
+        # The whole point of the ISO round trip: format_reset must accept it.
+        oauth.format_reset(iso)
+
+    def test_normalizes_through_build_usage_result(self):
+        result = oauth.build_usage_result(oauth.usage_from_ratelimit_headers(HEADERS))
+        assert result["five_hour"]["pct"] == 4.0
+        # Headroom is what auto-switch ranks on; None here would keep the
+        # account invisible, which is the bug this whole path fixes.
+        assert oauth.account_headroom(result) == 94.0
+
+    def test_absent_headers_yield_no_windows(self):
+        assert oauth.usage_from_ratelimit_headers({}) == {}
+
+    def test_garbage_utilization_is_skipped(self):
+        out = oauth.usage_from_ratelimit_headers(
+            {"anthropic-ratelimit-unified-5h-utilization": "not-a-number"}
+        )
+        assert out == {}
+
+    def test_window_without_reset_still_reports_pct(self):
+        out = oauth.usage_from_ratelimit_headers(
+            {"anthropic-ratelimit-unified-5h-utilization": "0.5"}
+        )
+        assert out["five_hour"] == {"utilization": 50.0}
+
+
+class TestProbeThrottle:
+    def test_second_call_inside_interval_is_served_from_cache(self, monkeypatch):
+        calls = []
+
+        def fake_probe(token):
+            calls.append(token)
+            return {"five_hour": {"utilization": 1.0}}
+
+        monkeypatch.setattr(oauth, "request_usage_via_probe", fake_probe)
+        monkeypatch.setattr(oauth, "_probe_cache", {})
+
+        oauth.probe_usage_throttled("tok", now=0.0)
+        oauth.probe_usage_throttled("tok", now=oauth.PROBE_MIN_INTERVAL_S - 1)
+        assert len(calls) == 1
+
+    def test_call_after_interval_refetches(self, monkeypatch):
+        calls = []
+
+        def fake_probe(token):
+            calls.append(token)
+            return {"five_hour": {"utilization": 1.0}}
+
+        monkeypatch.setattr(oauth, "request_usage_via_probe", fake_probe)
+        monkeypatch.setattr(oauth, "_probe_cache", {})
+
+        oauth.probe_usage_throttled("tok", now=0.0)
+        oauth.probe_usage_throttled("tok", now=oauth.PROBE_MIN_INTERVAL_S + 1)
+        assert len(calls) == 2
+
+    def test_distinct_tokens_do_not_share_a_slot(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            oauth,
+            "request_usage_via_probe",
+            lambda t: (calls.append(t), {"five_hour": {"utilization": 1.0}})[1],
+        )
+        monkeypatch.setattr(oauth, "_probe_cache", {})
+
+        oauth.probe_usage_throttled("tok-a", now=0.0)
+        oauth.probe_usage_throttled("tok-b", now=0.0)
+        assert len(calls) == 2


### PR DESCRIPTION
## Problem

A `claude setup-token` credential is scoped to `user:inference` alone. The usage endpoint (`/api/oauth/usage`) needs profile scope, so these accounts 401/403 there on every pass and render a permanent `usage unavailable`.

The bigger consequence is invisibility to `cswap auto`: `_rank_candidates` skips any account whose headroom is `None`, so a setup-token account is never chosen as a switch target — and never triggers a switch away from itself, even at 100%.

```
2: user@example.com [personal]
   usage unavailable (http-403)
```

## Approach

Every `/v1/messages` response carries the same 5h/7d numbers in `anthropic-ratelimit-unified-*` headers, and inference is exactly what these tokens are permitted to do:

```
anthropic-ratelimit-unified-5h-utilization: 0.04
anthropic-ratelimit-unified-5h-reset: 1787184600
anthropic-ratelimit-unified-7d-utilization: 0.06
anthropic-ratelimit-unified-7d-reset: 1787655600
```

So for inference-only credentials, probe those headers instead of spending a guaranteed 401/403 per pass. The probe returns data in the *raw* usage-API shape, so `build_usage_result` normalizes it unchanged and nothing downstream needs to know the difference.

Detection is narrow — `scopes == {"user:inference"}` exactly — so full-scope logins keep using the real endpoint.

## Cost, and why it is throttled

The probe has to be a **successful** call. Rejected requests return no rate-limit headers at all; both were measured against the live API:

| request | status | rate-limit headers |
|---|---|---|
| empty `messages` array | 400 | none |
| bogus model name | 404 | none |
| minimal valid call | 200 | present |

So each probe costs one output token. `PROBE_MIN_INTERVAL_S` (default 600s, keyed by token digest) keeps the poll loop from consuming the very window it is measuring. Both the interval and the model are env-overridable (`CLAUDE_SWAP_PROBE_INTERVAL`, `CLAUDE_SWAP_PROBE_MODEL`) — a hardcoded model id eventually gets retired out from under us.

## Result

```
2: user@example.com [personal]
   ├ 5h:   3%   resets 16:00         in 31m
   └ 7d:  98%   resets Aug 22 05:00  in 2d 13h  (ahead of pace)
```

Verified against three real setup-token accounts, each reporting its own distinct utilization and reset times.

## Limitation

Per-model weekly windows are absent from the headers, so `--model` triggers stay blind for probed accounts. Account-wide 5h/7d — the windows that gate everything — now work.

## Tests

`tests/test_probe_usage.py`, 12 cases: scope detection, the 0-1 → 0-100 scaling (getting this wrong renders every percentage 100x low), epoch → ISO round trip through `format_reset`, normalization through `build_usage_result` into a non-`None` `account_headroom`, malformed/absent headers, and the throttle's cache-hit / expiry / per-token isolation.

Full suite: 2099 passed. One pre-existing failure (`test_settings.py::TestAtomicWriteThroughSymlink`) reproduces on a clean checkout of `main` — a WSL `/mnt/c` permissions quirk, unrelated to this change.