### PR TITLE
test(cli): stop leaking one temp dir per xdist worker per run

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -26,7 +25,15 @@ _SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
 # data migration against real accounts (touching the real Keychain on macOS). An empty,
 # isolated HOME has no ``sequence.json`` → the migration skips before any Keychain
 # access, and no ``.claude.json`` → no account to read.
-_ISOLATED_HOME = tempfile.mkdtemp(prefix="cswap-subproc-home-")
+# Allocated under pytest's basetemp so its own retention reclaims it, rather
+# than a sweep at exit that a signal-killed worker never reaches.
+_ISOLATED_HOME: str | None = None
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _isolated_subprocess_home(tmp_path_factory):
+    global _ISOLATED_HOME
+    _ISOLATED_HOME = str(tmp_path_factory.mktemp("subproc-home"))
 
 
 def _subprocess_env(**extra: str) -> dict[str, str]:
@@ -40,6 +47,8 @@ def _subprocess_env(**extra: str) -> dict[str, str]:
     env = {**os.environ, **extra}
     env["PYTHONPATH"] = _SRC_DIR + os.pathsep + env.get("PYTHONPATH", "")
     if "HOME" not in extra:
+        # Falling through here would point the child at the real HOME.
+        assert _ISOLATED_HOME is not None, "_isolated_subprocess_home did not run"
         env["HOME"] = _ISOLATED_HOME
         env["USERPROFILE"] = _ISOLATED_HOME
     elif "USERPROFILE" not in extra:
@@ -1543,3 +1552,29 @@ class TestDisableEnableDispatch:
             with pytest.raises(SystemExit) as excinfo:
                 cli.main()
         assert excinfo.value.code == 2
+
+
+def test_importing_the_module_allocates_no_temp_dir(tmp_path, tmp_path_factory):
+    """Import must allocate nothing; the fixture must allocate inside basetemp.
+
+    The child gets a private TMPDIR of its own rather than watching the shared
+    system one, which several checkouts write to concurrently. Both halves are
+    needed: re-adding the module-level ``mkdtemp`` is caught only by the empty
+    private tmp, and a fixture allocating outside basetemp only by containment.
+    """
+    child_tmp = tmp_path / "childtmp"
+    child_tmp.mkdir()
+    child = subprocess.run(
+        [sys.executable, "-c",
+         "import sys; sys.path.insert(0, sys.argv[1]); import tests.test_cli",
+         str(Path(__file__).resolve().parent.parent)],
+        capture_output=True, text=True,
+        env=_subprocess_env(TMPDIR=str(child_tmp)), timeout=120,
+    )
+    assert child.returncode == 0, child.stderr
+    allocated = list(child_tmp.iterdir())
+    assert not allocated, f"import allocated {[a.name for a in allocated]}"
+
+    home = Path(_subprocess_env()["HOME"])
+    assert home.is_dir(), f"the isolated HOME is not a real directory: {home}"
+    assert home.is_relative_to(tmp_path_factory.getbasetemp()), f"{home} escapes basetemp"


### PR DESCRIPTION
## The leak

`tests/test_cli.py` allocates a throwaway HOME for subprocesses at module scope:

```python
_ISOLATED_HOME = tempfile.mkdtemp(prefix="cswap-subproc-home-")
```

Nothing removes it, anywhere. That line runs once per **process**, so under
`pytest-xdist` every worker of every run leaves a directory in the system temp
root. No test looks at the temp root, so nothing ever fails and it accumulates
silently.

Measured on one Linux host: **37,948** `cswap-subproc-home-*` directories, and a
single `pytest tests/test_cli.py` added **48** more. That 48 is one per xdist
worker on a 48-core box, so the per-run number scales with core count — on a
4-core laptop it is +4 a run. Unbounded either way, just slower.

Reproduce on any checkout:

```bash
ls -1d "${TMPDIR:-/tmp}"/cswap-subproc-home-* 2>/dev/null | wc -l
python -m pytest tests/test_cli.py -q >/dev/null
ls -1d "${TMPDIR:-/tmp}"/cswap-subproc-home-* 2>/dev/null | wc -l   # higher
```

## Where it came from

The line was added in #49, "Isolate tests from the developer's real home,
config, and Keychain". That PR is right about the hazard it was closing: a
spawned `python -m claude_swap` resolving to the real `~/.claude-swap-backup`,
or touching the real Keychain on macOS, is exactly what the in-process autouse
guards cannot reach. The isolation it introduced is not in question here and is
preserved unchanged — the directory it allocates simply had no owner, so
nothing ever removed it.

## What does not change

The isolation itself. Child processes still get a HOME that is not the
developer's, which is the whole point of that line — a spawned
`python -m claude_swap` must not resolve to the real `~/.claude-swap-backup`
or, on macOS, touch the real Keychain. Only the **allocation site** moves.

If the fixture somehow does not run, `_subprocess_env` fails closed rather than
falling through to the real HOME. Under `python -O`, where the assert is
stripped, `env["HOME"] = None` makes `subprocess.run` raise `TypeError` — so
there is no configuration in which this silently points a child at the real
home.

## The fix

Allocate through `tmp_path_factory`, which puts the directory inside pytest's
own basetemp — reclaimed by pytest's retention, with no exit-time code needed.

An `atexit` sweep was written first and **rejected on measurement**: it covers a
clean exit but not a worker killed by a signal.

| variant | clean run | killed mid-run |
| --- | --- | --- |
| unfixed | +48 | +25 |
| `atexit` sweep | 0 | **+24** |
| basetemp (this PR) | 0 | **0** |

Those counts are of stray dirs in the temp **root**. A signal-killed run still
leaves its own `pytest-of-*/pytest-N/`, which pytest reclaims on a later normal
exit. The leak becomes bounded rather than unbounded, which is the point.

## The test

It hands the child a private `TMPDIR` and asserts that directory stays empty,
rather than watching the shared system temp root — several checkouts can run
this suite concurrently, and a sibling's directories landing inside the
measurement window would fail the test for something the child never created.
A private directory also catches a **renamed** prefix, which a glob would not.

Three mutations, three distinct failures:

| mutation | fails with |
| --- | --- |
| the eager module-level `mkdtemp` restored | `import allocated ['cswap-subproc-home-…']` |
| same, but with a renamed prefix | `import allocated ['cswap-renamed-…']` |
| fixture allocates outside basetemp | `… escapes basetemp` |

Whole suite: **2089 passed, 3 skipped**, temp-root delta 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
