### PR TITLE
fix(menubar): stop unbounded memory growth by purging the rumps callback registry on rebuild

### DIFF
--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -654,8 +654,23 @@ def run(switcher) -> int:
                 self.settings,
                 alias=self.snapshot.get("active_alias"),
             )
+            # Stop a rumps memory leak: rumps registers each menu item's callback
+            # in the process-global NSApp._ns_to_py_and_callback, but Menu.clear()
+            # never removes them, so rebuilding the whole menu on every refresh
+            # leaks every item forever (~1GB after days on a busy machine). Purge
+            # this menu's entries before we tear it down. We walk the *native*
+            # NSMenu tree (itemArray, recursing into submenus) rather than the
+            # rumps Python dict: that dict is keyed by title and silently drops
+            # same-title items, which would leave leaked entries behind.
+            _reg = rumps.rumps.NSApp._ns_to_py_and_callback
+            def _purge(nsmenu):
+                for _it in nsmenu.itemArray():
+                    _reg.pop(_it, None)
+                    _sub = _it.submenu()
+                    if _sub is not None:
+                        _purge(_sub)
+            _purge(self.menu._menu)
             self.menu.clear()
-            account_items = []
             for num, email, is_active, display, _last_good, alias, disabled, fetched_at in self.snapshot["accounts"]:
                 item = rumps.MenuItem(
                     format_account_label(

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -662,15 +662,19 @@ def run(switcher) -> int:
             # NSMenu tree (itemArray, recursing into submenus) rather than the
             # rumps Python dict: that dict is keyed by title and silently drops
             # same-title items, which would leave leaked entries behind.
-            _reg = rumps.rumps.NSApp._ns_to_py_and_callback
-            def _purge(nsmenu):
-                for _it in nsmenu.itemArray():
-                    _reg.pop(_it, None)
-                    _sub = _it.submenu()
-                    if _sub is not None:
-                        _purge(_sub)
-            _purge(self.menu._menu)
+            # Guard the private rumps attribute: if a future rumps release renames
+            # it, degrade to "leaks again" rather than crashing on every rebuild.
+            _reg = getattr(rumps.rumps.NSApp, "_ns_to_py_and_callback", None)
+            if _reg is not None:
+                def _purge(nsmenu):
+                    for _it in nsmenu.itemArray():
+                        _reg.pop(_it, None)
+                        _sub = _it.submenu()
+                        if _sub is not None:
+                            _purge(_sub)
+                _purge(self.menu._menu)
             self.menu.clear()
+            account_items = []
             for num, email, is_active, display, _last_good, alias, disabled, fetched_at in self.snapshot["accounts"]:
                 item = rumps.MenuItem(
                     format_account_label(


### PR DESCRIPTION
## Problem

The menu-bar process (`cswap menubar`) grows its memory without bound. On a machine that runs Claude Code sessions continuously it reached **~962 MB RSS after ~8 days** of uptime. A sibling `cswap auto` process of the same version, running just as long but drawing no menu, stayed at ~39 MB — which points at the menu, not the tool as a whole.

## Root cause

`rumps` registers every menu item's callback in a **module-global plain dict**, `NSApp._ns_to_py_and_callback` (`rumps/rumps.py`: written in `MenuItem.set_callback`, defined on the `NSApp` class). `Menu.clear()` only calls `self._menu.removeAllItems()` + `super().clear()` — it **never deletes entries from that global dict**.

`MenuBarApp.rebuild_menu()` tears down and recreates the *entire* menu on every refresh, and a refresh fires on the 60 s display timer **plus every time `~/.claude.json` changes** — which Claude Code rewrites very frequently on a busy machine. So each rebuild permanently adds one dict entry per menu item (accounts + submenu children ≈ 20+), and they are never freed. Each retained entry keeps the `NSMenuItem`, the Python `MenuItem` wrapper, and the callback closure alive → unbounded growth.

## Reproduction

Rebuilding a rumps menu in a loop (draining an autorelease pool each iteration to mimic the run loop):

| rebuilds | `_ns_to_py_and_callback` size | RSS (approx) |
|---:|---:|---:|
| 5,000 | 75,000 | ~130 MB |
| 10,000 | 150,000 | ~225 MB |
| 20,000 | 300,000 | ~410 MB |

The registry grows by exactly the item count per rebuild and never shrinks; RSS climbs linearly with it (the RSS figures vary a little run to run, the registry size is deterministic). Consistent with the observed 962 MB over 8 days.

## Fix

Before `rebuild_menu()` clears the menu, purge this menu's entries from the registry. The traversal walks the **native `NSMenu` tree** (`itemArray()`, recursing into submenus) rather than the rumps Python `Menu` dict, because that dict is keyed by title and silently collapses same-title items — walking it would leave the shadowed items' entries leaked.

```python
_reg = rumps.rumps.NSApp._ns_to_py_and_callback
def _purge(nsmenu):
    for _it in nsmenu.itemArray():
        _reg.pop(_it, None)
        _sub = _it.submenu()
        if _sub is not None:
            _purge(_sub)
_purge(self.menu._menu)
self.menu.clear()
```

With the fix, the same 20,000-rebuild reproduction holds the registry at a constant size and RSS flat at ~44 MB.

## Testing

- Reproduction above, before/after.
- Duplicate-title edge: two same-title submenu children register 2 entries but the Python dict shows 1; the native traversal purges both (4→0), a `.values()` traversal leaves 1 behind.
- Applied to a live install: the 962 MB process was replaced and the new process has stayed flat (short-term; long-run flatness is inferred from the accelerated reproduction).
- Thread-safety: `rebuild_menu` runs on the main thread and callbacks dispatch on the main thread (default run-loop mode), so no locking is needed.

## Scope

This is a targeted workaround inside claude-swap. The underlying bug is in `rumps` (`Menu.clear()` not purging the registry); a naive `pop()` inside `rumps` `clear()` is **not** a safe general fix (it breaks re-used items and misses `SliderMenuItem`/text-field targets), so fixing it here — scoped to how this app rebuilds its menu — is the safer immediate change. Reported upstream separately.


Upstream rumps issue: https://github.com/jaredks/rumps/issues/232
