### PR TITLE
feat(menubar): optional all-accounts and reset-countdown menu bar title

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ uv tool install 'claude-swap[menubar]'   # or: pipx install 'claude-swap[menubar
 cswap menubar
 ```
 
-Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. The title itself shows the active account; turn on *Settings → Show all accounts in title* to keep every managed account's percentages on screen without opening the menu. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
+Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. The title itself shows the active account; turn on *Settings → Show all accounts in title* to keep every managed account's percentages on screen without opening the menu. Add *Settings → Show reset countdown in title* to put each window's time-to-reset (e.g. `42% (2h 53m)`) beside its percentage. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ uv tool install 'claude-swap[menubar]'   # or: pipx install 'claude-swap[menubar
 cswap menubar
 ```
 
-Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
+Shows every account's 5h / 7d / spend usage and switches with a click (specific / rotate / best / next-available), plus the TUI's add / disable-enable / remove / refresh actions. The title itself shows the active account; turn on *Settings → Show all accounts in title* to keep every managed account's percentages on screen without opening the menu. Enable *Settings → Auto-switch accounts* to run the same engine as [`cswap auto`](#automatic-switching) in the background; it shares the `autoswitch.*` settings, so the menu bar and CLI stay in sync. Off until you turn it on.
 
 </details>
 

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -35,6 +35,7 @@ ICON = "⇄"
 REFRESH_CHOICES: tuple[int, ...] = (30, 60, 300)
 AUTO_THRESHOLD_CHOICES: tuple[int, ...] = (80, 90, 95, 98)
 TITLE_PCT_CHOICES: tuple[str, ...] = ("off", "5h", "7d", "both")
+TITLE_SEP = " | "  # between accounts when title_all_accounts is on
 SWITCH_HISTORY_LIMIT = 10
 NOTIFICATION_BUNDLE_ID = "com.claude-swap.menubar"
 
@@ -95,6 +96,7 @@ class MenuBarSettings:
     show_account_name: bool = True
     title_pct: str = "both"  # one of TITLE_PCT_CHOICES
     title_scoped: bool = False  # append per-model weekly limits (e.g. Fable) to the title
+    title_all_accounts: bool = False  # render every managed account in the title, not just the active one
     refresh_interval: int = 60
     auto_switch_enabled: bool = False
 
@@ -296,41 +298,70 @@ def _local_part(email: str, limit: int = 12) -> str:
     return local
 
 
+def _account_segments(
+    label: str,
+    usage: dict | str | None,
+    settings: MenuBarSettings,
+    now: float,
+) -> list[str]:
+    """Title segments for one account, in display order.
+
+    Shared by the active account and — under ``title_all_accounts`` — every
+    other managed account, so one account always reads the same either way.
+    """
+    segments: list[str] = []
+    if settings.show_account_name and label:
+        segments.append(label)
+    if settings.title_pct in ("5h", "both"):
+        p = _window_pct(usage, "five_hour")
+        if p is not None:
+            segments.append(f"{p:.0f}%")
+    if settings.title_pct in ("7d", "both"):
+        seven = usage.get("seven_day") if isinstance(usage, dict) else None
+        seven = _rolled_weekly_window(seven, now)  # reflect a passed weekly reset
+        p = seven["pct"] if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)) else None
+        if p is not None:
+            segments.append(f"{p:.0f}%")
+    if settings.title_scoped and isinstance(usage, dict):
+        # Per-model weekly limits (e.g. Fable), same shape/roll-forward as the
+        # dropdown rows; named so multiple scoped models stay distinguishable.
+        for window in usage.get("scoped") or []:
+            window = _rolled_weekly_window(window, now)
+            if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)) and window.get("name"):
+                segments.append(f"{window['name']} {window['pct']:.0f}%")
+    return segments
+
+
 def format_title(
     active_email: str | None,
     active_usage: dict | str | None,
     settings: MenuBarSettings,
     now: float | None = None,
     alias: str | None = None,
+    others: list[tuple[str, dict | str | None]] | None = None,
 ) -> str:
-    """Build the menu-bar title from the active account and settings."""
+    """Build the menu-bar title from the active account and settings.
+
+    ``others`` carries ``(label, usage)`` for the non-active accounts. It is
+    rendered after the active account, ``TITLE_SEP``-separated, only when
+    ``title_all_accounts`` is on; an account with nothing to show is skipped.
+    """
     if active_email is None:
         return ICON
     if now is None:
         now = time.time()
-    segments: list[str] = []
-    if settings.show_account_name:
-        segments.append(alias if alias else _local_part(active_email))
-    if settings.title_pct in ("5h", "both"):
-        p = _window_pct(active_usage, "five_hour")
-        if p is not None:
-            segments.append(f"{p:.0f}%")
-    if settings.title_pct in ("7d", "both"):
-        seven = active_usage.get("seven_day") if isinstance(active_usage, dict) else None
-        seven = _rolled_weekly_window(seven, now)  # reflect a passed weekly reset
-        p = seven["pct"] if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)) else None
-        if p is not None:
-            segments.append(f"{p:.0f}%")
-    if settings.title_scoped and isinstance(active_usage, dict):
-        # Per-model weekly limits (e.g. Fable), same shape/roll-forward as the
-        # dropdown rows; named so multiple scoped models stay distinguishable.
-        for window in active_usage.get("scoped") or []:
-            window = _rolled_weekly_window(window, now)
-            if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)) and window.get("name"):
-                segments.append(f"{window['name']} {window['pct']:.0f}%")
+    segments = _account_segments(
+        alias if alias else _local_part(active_email), active_usage, settings, now
+    )
     if not segments:
         return ICON
-    return f"{ICON} " + " · ".join(segments)
+    groups = [" · ".join(segments)]
+    if settings.title_all_accounts:
+        for label, usage in others or []:
+            other = _account_segments(label, usage, settings, now)
+            if other:
+                groups.append(" · ".join(other))
+    return f"{ICON} " + TITLE_SEP.join(groups)
 
 
 def format_usage_log(email: str, usage: dict | str | None) -> str | None:
@@ -648,11 +679,20 @@ def run(switcher) -> int:
 
         # ---- menu construction -----------------------------------------------
         def rebuild_menu(self):
+            # Non-active accounts for the title. A sentinel display string says
+            # nothing useful in a menu bar, so fall back to the last good read.
+            others = [
+                (alias or _local_part(email), display if isinstance(display, dict) else last_good)
+                for _num, email, is_active, display, last_good, alias, _disabled, _fetched
+                in self.snapshot["accounts"]
+                if not is_active
+            ]
             self.title = format_title(
                 self.snapshot["active_email"],
                 self.snapshot["active_usage"],
                 self.settings,
                 alias=self.snapshot.get("active_alias"),
+                others=others,
             )
             self.menu.clear()
             account_items = []
@@ -755,6 +795,12 @@ def run(switcher) -> int:
             )
             scoped_item.state = 1 if self.settings.title_scoped else 0
             menu.add(scoped_item)
+
+            all_accounts_item = rumps.MenuItem(
+                "Show all accounts in title", callback=self.on_toggle_all_accounts
+            )
+            all_accounts_item.state = 1 if self.settings.title_all_accounts else 0
+            menu.add(all_accounts_item)
 
             interval = rumps.MenuItem("Refresh interval")
             labels = {30: "30 seconds", 60: "60 seconds", 300: "5 minutes"}
@@ -908,6 +954,10 @@ def run(switcher) -> int:
 
         def on_toggle_scoped(self, _sender):
             self.settings.title_scoped = not self.settings.title_scoped
+            self._save_and_rebuild()
+
+        def on_toggle_all_accounts(self, _sender):
+            self.settings.title_all_accounts = not self.settings.title_all_accounts
             self._save_and_rebuild()
 
         def _make_title_pct(self, mode):

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -97,6 +97,7 @@ class MenuBarSettings:
     title_pct: str = "both"  # one of TITLE_PCT_CHOICES
     title_scoped: bool = False  # append per-model weekly limits (e.g. Fable) to the title
     title_all_accounts: bool = False  # render every managed account in the title, not just the active one
+    title_countdown: bool = False  # append each window's live reset countdown to the title
     refresh_interval: int = 60
     auto_switch_enabled: bool = False
 
@@ -298,6 +299,24 @@ def _local_part(email: str, limit: int = 12) -> str:
     return local
 
 
+def _with_countdown(
+    text: str,
+    window: dict | str | None,
+    settings: MenuBarSettings,
+    now: float,
+) -> str:
+    """A title segment with its window's live reset countdown appended.
+
+    Same ``_live_countdown`` the dropdown rows use, so title and dropdown never
+    disagree. Returns ``text`` unchanged when the setting is off or the window
+    has no usable ``resets_at``.
+    """
+    if not settings.title_countdown:
+        return text
+    left = _live_countdown(window, now)
+    return f"{text} ({left})" if left else text
+
+
 def _account_segments(
     label: str,
     usage: dict | str | None,
@@ -315,20 +334,23 @@ def _account_segments(
     if settings.title_pct in ("5h", "both"):
         p = _window_pct(usage, "five_hour")
         if p is not None:
-            segments.append(f"{p:.0f}%")
+            five = usage.get("five_hour") if isinstance(usage, dict) else None
+            segments.append(_with_countdown(f"{p:.0f}%", five, settings, now))
     if settings.title_pct in ("7d", "both"):
         seven = usage.get("seven_day") if isinstance(usage, dict) else None
         seven = _rolled_weekly_window(seven, now)  # reflect a passed weekly reset
         p = seven["pct"] if isinstance(seven, dict) and isinstance(seven.get("pct"), (int, float)) else None
         if p is not None:
-            segments.append(f"{p:.0f}%")
+            segments.append(_with_countdown(f"{p:.0f}%", seven, settings, now))
     if settings.title_scoped and isinstance(usage, dict):
         # Per-model weekly limits (e.g. Fable), same shape/roll-forward as the
         # dropdown rows; named so multiple scoped models stay distinguishable.
         for window in usage.get("scoped") or []:
             window = _rolled_weekly_window(window, now)
             if isinstance(window, dict) and isinstance(window.get("pct"), (int, float)) and window.get("name"):
-                segments.append(f"{window['name']} {window['pct']:.0f}%")
+                segments.append(_with_countdown(
+                    f"{window['name']} {window['pct']:.0f}%", window, settings, now
+                ))
     return segments
 
 
@@ -802,6 +824,12 @@ def run(switcher) -> int:
             all_accounts_item.state = 1 if self.settings.title_all_accounts else 0
             menu.add(all_accounts_item)
 
+            countdown_item = rumps.MenuItem(
+                "Show reset countdown in title", callback=self.on_toggle_countdown
+            )
+            countdown_item.state = 1 if self.settings.title_countdown else 0
+            menu.add(countdown_item)
+
             interval = rumps.MenuItem("Refresh interval")
             labels = {30: "30 seconds", 60: "60 seconds", 300: "5 minutes"}
             for secs in REFRESH_CHOICES:
@@ -958,6 +986,10 @@ def run(switcher) -> int:
 
         def on_toggle_all_accounts(self, _sender):
             self.settings.title_all_accounts = not self.settings.title_all_accounts
+            self._save_and_rebuild()
+
+        def on_toggle_countdown(self, _sender):
+            self.settings.title_countdown = not self.settings.title_countdown
             self._save_and_rebuild()
 
         def _make_title_pct(self, mode):

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -348,6 +348,47 @@ def test_format_title_all_accounts_with_no_others_is_unchanged():
     assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄ loc · 42%"
 
 
+def test_format_title_countdown_appends_reset_time():
+    s = menubar.MenuBarSettings(
+        show_account_name=True, title_pct="both", title_countdown=True
+    )
+    now = _NOW
+    usage = {
+        "five_hour": {"pct": 42.0, "resets_at": _iso(2 * 3600 + 53 * 60)},
+        "seven_day": {"pct": 18.0, "resets_at": _iso(26 * 3600)},
+    }
+    assert menubar.format_title(
+        "loc@papaya.asia", usage, s, now=now
+    ) == "\u21c4 loc · 42% (2h 53m) · 18% (1d 2h)"
+
+
+def test_format_title_countdown_off_by_default():
+    s = menubar.MenuBarSettings(show_account_name=True, title_pct="5h")
+    now = _NOW
+    usage = {"five_hour": {"pct": 42.0, "resets_at": _iso(3600)}}
+    assert menubar.format_title("loc@papaya.asia", usage, s, now=now) == "\u21c4 loc · 42%"
+
+
+def test_format_title_countdown_skips_window_without_resets_at():
+    # pct still renders; only the countdown is dropped when resets_at is absent.
+    s = menubar.MenuBarSettings(
+        show_account_name=False, title_pct="5h", title_countdown=True
+    )
+    assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "\u21c4 42%"
+
+
+def test_format_title_countdown_applies_to_other_accounts():
+    s = menubar.MenuBarSettings(
+        show_account_name=True, title_pct="5h",
+        title_all_accounts=True, title_countdown=True,
+    )
+    now = _NOW
+    other = {"five_hour": {"pct": 7.0, "resets_at": _iso(45 * 60)}}
+    assert menubar.format_title(
+        "loc@papaya.asia", _USAGE, s, now=now, others=[("work", other)]
+    ) == "\u21c4 loc · 42% | work · 7% (45m)"
+
+
 def test_format_title_icon_only_when_off():
     s = menubar.MenuBarSettings(show_account_name=False, title_pct="off")
     assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄"

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -312,6 +312,42 @@ def test_format_title_both_windows_with_name():
     assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄ loc · 42% · 18%"
 
 
+_OTHER = {"five_hour": {"pct": 7.0}, "seven_day": {"pct": 3.0}}
+
+
+def test_format_title_ignores_others_by_default():
+    s = menubar.MenuBarSettings(show_account_name=True, title_pct="both")
+    assert menubar.format_title(
+        "loc@papaya.asia", _USAGE, s, others=[("work", _OTHER)]
+    ) == "⇄ loc · 42% · 18%"
+
+
+def test_format_title_all_accounts_appends_others():
+    s = menubar.MenuBarSettings(
+        show_account_name=True, title_pct="both", title_all_accounts=True
+    )
+    assert menubar.format_title(
+        "loc@papaya.asia", _USAGE, s, others=[("work", _OTHER)]
+    ) == "⇄ loc · 42% · 18% | work · 7% · 3%"
+
+
+def test_format_title_all_accounts_skips_accounts_with_nothing_to_show():
+    s = menubar.MenuBarSettings(
+        show_account_name=False, title_pct="5h", title_all_accounts=True
+    )
+    # "no credentials" is a sentinel string, not a usage dict — no pct to render.
+    assert menubar.format_title(
+        "loc@papaya.asia", _USAGE, s, others=[("work", "no credentials")]
+    ) == "⇄ 42%"
+
+
+def test_format_title_all_accounts_with_no_others_is_unchanged():
+    s = menubar.MenuBarSettings(
+        show_account_name=True, title_pct="5h", title_all_accounts=True
+    )
+    assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄ loc · 42%"
+
+
 def test_format_title_icon_only_when_off():
     s = menubar.MenuBarSettings(show_account_name=False, title_pct="off")
     assert menubar.format_title("loc@papaya.asia", _USAGE, s) == "⇄"


### PR DESCRIPTION
Two opt-in title toggles, both default `False`, so existing titles are byte-identical unless turned on.

**1. *Settings → Show all accounts in title***

The title only ever renders the active account, so keeping an eye on a second account's headroom means opening the dropdown every time.

`⇄ p · 3% · 22% | w · 7% · 3%`

- Extracted `_account_segments()` from `format_title()` — the active account and the appended ones go through the same builder, so `title_pct` / `title_scoped` / `show_account_name` apply consistently and one account reads identically either way.
- `format_title()` takes a new optional `others=[(label, usage)]`; `rebuild_menu()` fills it from the snapshot, preferring a last-good read over a sentinel display string (a sentinel says nothing useful in a menu bar).
- An account with nothing to render is skipped rather than shown blank.

**2. *Settings → Show reset countdown in title***

The dropdown rows already show each window's time-to-reset; the title only carried percentages, so "when does this free up?" also meant opening the menu.

`⇄ p · 42% (2h 53m) · 18% (1d 2h)`

- Appends the countdown to every percentage segment — 5h, 7d, and scoped model windows — for the active account and, under the toggle above, the others too.
- Reuses `_live_countdown()` (derived from `resets_at`) rather than the cached `countdown` string, so a stale last-known-good entry never shows a wrong remaining time and title and dropdown cannot disagree.
- A window with no usable `resets_at` still renders its percentage; only the countdown is dropped.

Tests: 8 new cases in `tests/test_menubar.py`. Full suite passes apart from 3 failures that also fail on a clean `main` here (`test_real_store_guard`, `test_move_accounts`, `test_swap_accounts` — the unreadable-source/chmod ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)