### PR TITLE
Add fish shell completions for cswap

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ uv tool upgrade claude-swap
 pipx upgrade claude-swap
 ```
 
+### Shell completions
+
+Fish completions live in [`completions/cswap.fish`](completions/cswap.fish) — every
+subcommand and flag, plus account numbers/emails completed live from `cswap list --json`.
+
+```bash
+curl -o ~/.config/fish/completions/cswap.fish \
+  https://raw.githubusercontent.com/realiti4/claude-swap/main/completions/cswap.fish
+```
+
+(fish picks up new files under `~/.config/fish/completions/` automatically, no restart needed)
+
 ## Usage
 
 ### Add your first account

--- a/README.md
+++ b/README.md
@@ -36,15 +36,19 @@ pipx upgrade claude-swap
 
 ### Shell completions
 
-Fish completions live in [`completions/cswap.fish`](completions/cswap.fish) — every
-subcommand and flag, plus account numbers/emails completed live from `cswap list --json`.
+Fish completions live in [`completions/`](completions) — every subcommand and flag,
+plus account numbers, emails and aliases completed from your local account list, and
+setting keys and values for `cswap config`.
 
 ```bash
-curl -o ~/.config/fish/completions/cswap.fish \
-  https://raw.githubusercontent.com/realiti4/claude-swap/main/completions/cswap.fish
+base=https://raw.githubusercontent.com/realiti4/claude-swap/main/completions
+curl -o ~/.config/fish/completions/cswap.fish $base/cswap.fish
+curl -o ~/.config/fish/completions/claude-swap.fish $base/claude-swap.fish
 ```
 
-(fish picks up new files under `~/.config/fish/completions/` automatically, no restart needed)
+Fish picks up new files under `~/.config/fish/completions/` automatically, so there is
+nothing to restart. The second file is only needed if you use the long-form
+`claude-swap` command.
 
 ## Usage
 

--- a/completions/claude-swap.fish
+++ b/completions/claude-swap.fish
@@ -1,0 +1,3 @@
+# `claude-swap` is the long-form console script for the same CLI as `cswap`
+# (both are declared in pyproject.toml), so it reuses one completion set.
+complete -c claude-swap --wraps cswap

--- a/completions/cswap.fish
+++ b/completions/cswap.fish
@@ -1,0 +1,189 @@
+# Fish completions for cswap (claude-swap) — https://github.com/realiti4/claude-swap
+#
+# Install: save as ~/.config/fish/completions/cswap.fish (auto-loaded by fish).
+
+# --- helpers -----------------------------------------------------------
+
+# True when no subcommand has been typed yet.
+function __cswap_no_subcommand
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 1
+end
+
+# True when $argv[1] is the subcommand currently being completed.
+function __cswap_using_subcommand
+    set -l cmd (commandline -opc)
+    test (count $cmd) -gt 1
+    and test "$cmd[2]" = "$argv[1]"
+end
+
+# Candidates for NUM|EMAIL positions: "1", "2", ... and each account's email,
+# both annotated with the org name / active marker. Falls back to nothing
+# (plain no-op) if cswap isn't configured yet or python3 is unavailable.
+function __cswap_accounts
+    cswap list --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for a in data.get("accounts", []):
+    num = a.get("number")
+    email = a.get("email", "")
+    org = a.get("organizationName", "")
+    tag = " (active)" if a.get("active") else ""
+    desc = f"{org}{tag}".strip()
+    if num is not None:
+        print(f"{num}\t{email or desc}")
+    if email:
+        print(f"{email}\t{desc}" if desc else email)
+' 2>/dev/null
+end
+
+# --- top-level subcommands ---------------------------------------------
+
+complete -c cswap -n __cswap_no_subcommand -f -a help -d 'show this help'
+complete -c cswap -n __cswap_no_subcommand -f -a list -d 'list managed accounts'
+complete -c cswap -n __cswap_no_subcommand -f -a ls -d 'alias for list'
+complete -c cswap -n __cswap_no_subcommand -f -a status -d 'show current account'
+complete -c cswap -n __cswap_no_subcommand -f -a switch -d 'switch account (rotate, or to <num|email>)'
+complete -c cswap -n __cswap_no_subcommand -f -a add -d 'add the current account'
+complete -c cswap -n __cswap_no_subcommand -f -a add-token -d 'register a setup-token or API key'
+complete -c cswap -n __cswap_no_subcommand -f -a remove -d 'remove an account'
+complete -c cswap -n __cswap_no_subcommand -f -a rm -d 'alias for remove'
+complete -c cswap -n __cswap_no_subcommand -f -a disable -d 'hold an account out of auto-rotation'
+complete -c cswap -n __cswap_no_subcommand -f -a enable -d 'return a disabled account to rotation'
+complete -c cswap -n __cswap_no_subcommand -f -a run -d 'run as an account, this terminal only'
+complete -c cswap -n __cswap_no_subcommand -f -a map -d 'map a directory to an account'
+complete -c cswap -n __cswap_no_subcommand -f -a unmap -d 'remove a directory mapping'
+complete -c cswap -n __cswap_no_subcommand -f -a alias -d 'set/remove/list an account alias'
+complete -c cswap -n __cswap_no_subcommand -f -a swap -d "exchange two accounts' slot numbers"
+complete -c cswap -n __cswap_no_subcommand -f -a move -d 'assign an account to a slot'
+complete -c cswap -n __cswap_no_subcommand -f -a auto -d 'auto-switch when nearing rate limits'
+complete -c cswap -n __cswap_no_subcommand -f -a config -d 'show or change settings'
+complete -c cswap -n __cswap_no_subcommand -f -a unclaimed -d 'list or drop stashed credential entries'
+complete -c cswap -n __cswap_no_subcommand -f -a export -d 'export accounts'
+complete -c cswap -n __cswap_no_subcommand -f -a import -d 'import accounts'
+complete -c cswap -n __cswap_no_subcommand -f -a tui -d 'interactive dashboard'
+complete -c cswap -n __cswap_no_subcommand -f -a watch -d 'dashboard on the live watch page'
+complete -c cswap -n __cswap_no_subcommand -f -a menubar -d 'macOS menu bar app'
+complete -c cswap -n __cswap_no_subcommand -f -a upgrade -d 'self-upgrade to latest'
+complete -c cswap -n __cswap_no_subcommand -f -a update -d 'alias for upgrade'
+complete -c cswap -n __cswap_no_subcommand -f -a purge -d 'remove all claude-swap data'
+
+complete -c cswap -n __cswap_no_subcommand -l version -d "show program's version number"
+complete -c cswap -n __cswap_no_subcommand -l help -s h -d 'show this help'
+
+# --debug is accepted (and useful) after every subcommand.
+complete -c cswap -l debug -f -d 'enable debug logging'
+
+# --- switch --------------------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand switch' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_using_subcommand switch' -l strategy -f -a 'best next-available' -d 'target-selection strategy'
+complete -c cswap -n '__cswap_using_subcommand switch' -l model -f -d 'also compare these models\' weekly limits'
+complete -c cswap -n '__cswap_using_subcommand switch' -l json -f -d 'emit machine-readable JSON'
+complete -c cswap -n '__cswap_using_subcommand switch' -l force -f -d "don't back up the current login first"
+
+# --- list / ls -------------------------------------------------------------
+
+for c in list ls
+    complete -c cswap -n "__cswap_using_subcommand $c" -l json -f -d 'emit machine-readable JSON'
+    complete -c cswap -n "__cswap_using_subcommand $c" -l token-status -f -d 'show OAuth token diagnostics'
+end
+
+# --- status ----------------------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand status' -l json -f -d 'emit machine-readable JSON'
+
+# --- add / add-token ---------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand add' -l slot -x -d 'slot number to add into'
+complete -c cswap -n '__cswap_using_subcommand add' -l alias -x -d 'short display alias for the account'
+
+complete -c cswap -n '__cswap_using_subcommand add-token' -f -a '-' -d 'read the token from stdin'
+complete -c cswap -n '__cswap_using_subcommand add-token' -l slot -x -d 'slot number to add into'
+complete -c cswap -n '__cswap_using_subcommand add-token' -l email -x -d 'email to label the account with'
+
+# --- remove / rm / disable / enable -----------------------------------
+
+for c in remove rm disable enable
+    complete -c cswap -n "__cswap_using_subcommand $c" -f -a '(__cswap_accounts)'
+end
+
+# --- run ---------------------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand run' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_using_subcommand run' -l no-share -f -d "don't share ~/.claude settings into the session"
+complete -c cswap -n '__cswap_using_subcommand run' -l share-history -f -d 'share conversation history across accounts'
+complete -c cswap -n '__cswap_using_subcommand run' -l no-share-history -f -d 'per-account history (default)'
+
+# --- map / unmap ---------------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand map' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_using_subcommand map' -f -a '(__fish_complete_directories)'
+complete -c cswap -n '__cswap_using_subcommand unmap' -f -a '(__fish_complete_directories)'
+
+# --- alias ---------------------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand alias' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_using_subcommand alias' -l unset -f -d "remove the account's alias"
+
+# --- swap / move ---------------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand swap' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_using_subcommand move' -f -a '(__cswap_accounts)'
+
+# --- auto ------------------------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand auto' -l once -f -d 'evaluate once and exit'
+complete -c cswap -n '__cswap_using_subcommand auto' -l json -f -d 'one JSON event per line'
+complete -c cswap -n '__cswap_using_subcommand auto' -l interval -x -d 'poll interval in seconds (default 60)'
+complete -c cswap -n '__cswap_using_subcommand auto' -l threshold -x -d 'switch above this % used (default 90)'
+complete -c cswap -n '__cswap_using_subcommand auto' -l cooldown -x -d 'min seconds between switches (default 300)'
+complete -c cswap -n '__cswap_using_subcommand auto' -l model -x -d 'also switch on these models\' weekly limits'
+complete -c cswap -n '__cswap_using_subcommand auto' -l include-api-key-accounts -f -d 'allow switching onto API-key accounts'
+complete -c cswap -n '__cswap_using_subcommand auto' -l no-include-api-key-accounts -f -d 'exclude API-key accounts (default)'
+complete -c cswap -n '__cswap_using_subcommand auto' -l strategy -f -a 'best consume-first' -d 'target-selection strategy'
+complete -c cswap -n '__cswap_using_subcommand auto' -l dry-run -f -d 'report but never switch'
+
+# --- config ------------------------------------------------------------
+
+set -l cswap_config_keys autoswitch.threshold autoswitch.intervalSeconds \
+    autoswitch.cooldownSeconds autoswitch.hysteresisPct autoswitch.strategy \
+    autoswitch.includeApiKeyAccounts autoswitch.unhealthyTicks autoswitch.model \
+    ui.theme
+
+function __cswap_using_config_action
+    set -l cmd (commandline -opc)
+    test (count $cmd) -gt 2
+    and test "$cmd[2]" = config
+    and test "$cmd[3]" = "$argv[1]"
+end
+
+function __cswap_config_no_action
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 2
+    and test "$cmd[2]" = config
+end
+
+complete -c cswap -n __cswap_config_no_action -f -a list -d 'show all effective settings (default)'
+complete -c cswap -n __cswap_config_no_action -f -a get -d "print one setting's effective value"
+complete -c cswap -n __cswap_config_no_action -f -a set -d 'validate and persist one setting'
+complete -c cswap -n __cswap_config_no_action -f -a unset -d 'remove one setting (revert to default)'
+complete -c cswap -n __cswap_config_no_action -f -a path -d 'print the settings.json location'
+complete -c cswap -n '__cswap_using_subcommand config' -l json -f -d 'emit machine-readable JSON'
+
+for action in get set unset
+    complete -c cswap -n "__cswap_using_config_action $action" -f -a "$cswap_config_keys"
+end
+
+# --- unclaimed -----------------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand unclaimed' -l purge -x -d 'delete this stashed entry by id'
+
+# --- export / import -------------------------------------------------
+
+complete -c cswap -n '__cswap_using_subcommand export' -l account -x -a '(__cswap_accounts)' -d 'limit export to one account'
+complete -c cswap -n '__cswap_using_subcommand export' -l full -f -d 'include full ~/.claude.json'
+complete -c cswap -n '__cswap_using_subcommand import' -l force -f -d 'overwrite existing accounts'

--- a/completions/cswap.fish
+++ b/completions/cswap.fish
@@ -1,189 +1,272 @@
-# Fish completions for cswap (claude-swap) — https://github.com/realiti4/claude-swap
+# Fish completions for cswap (claude-swap).
 #
-# Install: save as ~/.config/fish/completions/cswap.fish (auto-loaded by fish).
+# Install: copy to ~/.config/fish/completions/cswap.fish (fish auto-loads it).
 
-# --- helpers -----------------------------------------------------------
+# --- account candidates -------------------------------------------------
+#
+# Read straight from the local sequence.json rather than shelling out to
+# `cswap list --json`. `list` is an on-demand usage caller: entries older than
+# SERVE_TTL_S (180s) are refetched over HTTPS with a 5s per-account timeout,
+# so driving completions from it would freeze the prompt for seconds on every
+# Tab once the cache went stale. sequence.json holds the number, email, and
+# alias — everything a completion needs — and costs one local read.
 
-# True when no subcommand has been typed yet.
-function __cswap_no_subcommand
+function __cswap_sequence_file --description 'Path to cswap sequence.json, if present'
+    # Linux/WSL use the XDG data dir; macOS and the legacy layout use ~/.claude-swap-backup.
+    if set -q XDG_DATA_HOME; and string match -q -- '/*' "$XDG_DATA_HOME"
+        set -l xdg "$XDG_DATA_HOME/claude-swap/sequence.json"
+        if test -r $xdg
+            echo $xdg
+            return 0
+        end
+    end
+    for candidate in "$HOME/.local/share/claude-swap/sequence.json" "$HOME/.claude-swap-backup/sequence.json"
+        if test -r $candidate
+            echo $candidate
+            return 0
+        end
+    end
+    return 1
+end
+
+function __cswap_accounts --description 'Account numbers, emails and aliases with descriptions'
+    set -l file (__cswap_sequence_file); or return 0
+    awk '
+        function value(   rest) {
+            rest = substr($0, index($0, ":") + 1)
+            if (match(rest, /"[^"]*"/)) return substr(rest, RSTART + 1, RLENGTH - 2)
+            return ""
+        }
+        function flush(   tag, label) {
+            if (num == "") return
+            tag = (num == active) ? " (active)" : ""
+            label = (email == "") ? "account " num : email
+            if (alias != "") label = label " [" alias "]"
+            print num "\t" label tag
+            if (email != "") print email "\t#" num tag
+            if (alias != "") print alias "\t#" num " " email tag
+            num = ""; email = ""; alias = ""
+        }
+        /"activeAccountNumber"[ \t]*:/ {
+            if (match($0, /[0-9]+/)) active = substr($0, RSTART, RLENGTH)
+            next
+        }
+        /^[ \t]*"[0-9]+"[ \t]*:[ \t]*\{/ {
+            flush()
+            match($0, /"[0-9]+"/)
+            num = substr($0, RSTART + 1, RLENGTH - 2)
+            next
+        }
+        num != "" && /"email"[ \t]*:/ { email = value(); next }
+        num != "" && /"alias"[ \t]*:/ { alias = value(); next }
+        END { flush() }
+    ' $file 2>/dev/null
+    # A corrupt or unreadable file yields no candidates, never an error.
+    return 0
+end
+
+# --- context helpers ----------------------------------------------------
+
+# The CLI dispatches on argv[0], so the subcommand is always token 2 and
+# global flags have to follow it (`cswap list --json`, not `cswap --json list`).
+function __cswap_no_subcommand --description 'No subcommand typed yet'
+    test (count (commandline -opc)) -eq 1
+end
+
+function __cswap_subcommand --description 'Current subcommand is $argv[1]'
     set -l cmd (commandline -opc)
-    test (count $cmd) -eq 1
+    test (count $cmd) -gt 1; and contains -- "$cmd[2]" $argv
 end
 
-# True when $argv[1] is the subcommand currently being completed.
-function __cswap_using_subcommand
+# Positional args already given after the subcommand. Only used for
+# subcommands whose flags are all boolean (--debug, --unset), so a value-taking
+# flag can never be miscounted as a positional here.
+function __cswap_positionals --description 'Count of positional args after the subcommand'
     set -l cmd (commandline -opc)
-    test (count $cmd) -gt 1
-    and test "$cmd[2]" = "$argv[1]"
+    set -l n 0
+    if test (count $cmd) -ge 3
+        for token in $cmd[3..-1]
+            string match -q -- '-*' $token; or set n (math $n + 1)
+        end
+    end
+    echo $n
 end
 
-# Candidates for NUM|EMAIL positions: "1", "2", ... and each account's email,
-# both annotated with the org name / active marker. Falls back to nothing
-# (plain no-op) if cswap isn't configured yet or python3 is unavailable.
-function __cswap_accounts
-    cswap list --json 2>/dev/null | python3 -c '
-import json, sys
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-for a in data.get("accounts", []):
-    num = a.get("number")
-    email = a.get("email", "")
-    org = a.get("organizationName", "")
-    tag = " (active)" if a.get("active") else ""
-    desc = f"{org}{tag}".strip()
-    if num is not None:
-        print(f"{num}\t{email or desc}")
-    if email:
-        print(f"{email}\t{desc}" if desc else email)
-' 2>/dev/null
+function __cswap_positional_is --description 'Next positional slot equals $argv[1]'
+    test (__cswap_positionals) -eq (math $argv[1] - 1)
 end
 
-# --- top-level subcommands ---------------------------------------------
+# --- subcommands --------------------------------------------------------
 
-complete -c cswap -n __cswap_no_subcommand -f -a help -d 'show this help'
-complete -c cswap -n __cswap_no_subcommand -f -a list -d 'list managed accounts'
-complete -c cswap -n __cswap_no_subcommand -f -a ls -d 'alias for list'
-complete -c cswap -n __cswap_no_subcommand -f -a status -d 'show current account'
-complete -c cswap -n __cswap_no_subcommand -f -a switch -d 'switch account (rotate, or to <num|email>)'
-complete -c cswap -n __cswap_no_subcommand -f -a add -d 'add the current account'
-complete -c cswap -n __cswap_no_subcommand -f -a add-token -d 'register a setup-token or API key'
-complete -c cswap -n __cswap_no_subcommand -f -a remove -d 'remove an account'
-complete -c cswap -n __cswap_no_subcommand -f -a rm -d 'alias for remove'
-complete -c cswap -n __cswap_no_subcommand -f -a disable -d 'hold an account out of auto-rotation'
-complete -c cswap -n __cswap_no_subcommand -f -a enable -d 'return a disabled account to rotation'
-complete -c cswap -n __cswap_no_subcommand -f -a run -d 'run as an account, this terminal only'
-complete -c cswap -n __cswap_no_subcommand -f -a map -d 'map a directory to an account'
-complete -c cswap -n __cswap_no_subcommand -f -a unmap -d 'remove a directory mapping'
-complete -c cswap -n __cswap_no_subcommand -f -a alias -d 'set/remove/list an account alias'
-complete -c cswap -n __cswap_no_subcommand -f -a swap -d "exchange two accounts' slot numbers"
-complete -c cswap -n __cswap_no_subcommand -f -a move -d 'assign an account to a slot'
-complete -c cswap -n __cswap_no_subcommand -f -a auto -d 'auto-switch when nearing rate limits'
-complete -c cswap -n __cswap_no_subcommand -f -a config -d 'show or change settings'
-complete -c cswap -n __cswap_no_subcommand -f -a unclaimed -d 'list or drop stashed credential entries'
-complete -c cswap -n __cswap_no_subcommand -f -a export -d 'export accounts'
-complete -c cswap -n __cswap_no_subcommand -f -a import -d 'import accounts'
-complete -c cswap -n __cswap_no_subcommand -f -a tui -d 'interactive dashboard'
-complete -c cswap -n __cswap_no_subcommand -f -a watch -d 'dashboard on the live watch page'
+complete -c cswap -n __cswap_no_subcommand -f -a help -d 'Show help'
+complete -c cswap -n __cswap_no_subcommand -f -a list -d 'List managed accounts'
+complete -c cswap -n __cswap_no_subcommand -f -a ls -d 'List managed accounts'
+complete -c cswap -n __cswap_no_subcommand -f -a status -d 'Show the current account'
+complete -c cswap -n __cswap_no_subcommand -f -a switch -d 'Rotate, or switch to an account'
+complete -c cswap -n __cswap_no_subcommand -f -a add -d 'Add the currently logged-in account'
+complete -c cswap -n __cswap_no_subcommand -f -a add-token -d 'Register a setup-token or API key'
+complete -c cswap -n __cswap_no_subcommand -f -a remove -d 'Remove an account'
+complete -c cswap -n __cswap_no_subcommand -f -a rm -d 'Remove an account'
+complete -c cswap -n __cswap_no_subcommand -f -a disable -d 'Hold an account out of auto-rotation'
+complete -c cswap -n __cswap_no_subcommand -f -a enable -d 'Return a disabled account to rotation'
+complete -c cswap -n __cswap_no_subcommand -f -a run -d 'Run Claude as an account, this terminal only'
+complete -c cswap -n __cswap_no_subcommand -f -a map -d 'Map a directory to an account'
+complete -c cswap -n __cswap_no_subcommand -f -a unmap -d 'Remove a directory mapping'
+complete -c cswap -n __cswap_no_subcommand -f -a alias -d "Set, remove or list an account's alias"
+complete -c cswap -n __cswap_no_subcommand -f -a swap -d "Exchange two accounts' slot numbers"
+complete -c cswap -n __cswap_no_subcommand -f -a move -d 'Assign an account to a slot'
+complete -c cswap -n __cswap_no_subcommand -f -a auto -d 'Auto-switch when nearing rate limits'
+complete -c cswap -n __cswap_no_subcommand -f -a config -d 'Show or change settings'
+complete -c cswap -n __cswap_no_subcommand -f -a unclaimed -d 'List or drop stashed credential entries'
+complete -c cswap -n __cswap_no_subcommand -f -a export -d 'Export accounts to a file'
+complete -c cswap -n __cswap_no_subcommand -f -a import -d 'Import accounts from a file'
+complete -c cswap -n __cswap_no_subcommand -f -a tui -d 'Interactive dashboard'
+complete -c cswap -n __cswap_no_subcommand -f -a watch -d 'Dashboard, on the live watch page'
 complete -c cswap -n __cswap_no_subcommand -f -a menubar -d 'macOS menu bar app'
-complete -c cswap -n __cswap_no_subcommand -f -a upgrade -d 'self-upgrade to latest'
-complete -c cswap -n __cswap_no_subcommand -f -a update -d 'alias for upgrade'
-complete -c cswap -n __cswap_no_subcommand -f -a purge -d 'remove all claude-swap data'
+complete -c cswap -n __cswap_no_subcommand -f -a upgrade -d 'Self-upgrade to the latest version'
+complete -c cswap -n __cswap_no_subcommand -f -a update -d 'Self-upgrade to the latest version'
+complete -c cswap -n __cswap_no_subcommand -f -a purge -d 'Remove all claude-swap data'
 
-complete -c cswap -n __cswap_no_subcommand -l version -d "show program's version number"
-complete -c cswap -n __cswap_no_subcommand -l help -s h -d 'show this help'
+complete -c cswap -n __cswap_no_subcommand -f -l version -d "Show the program's version"
 
-# --debug is accepted (and useful) after every subcommand.
-complete -c cswap -l debug -f -d 'enable debug logging'
+# Accepted alongside every subcommand. Deliberately not -f: an unconditional
+# -f would switch the whole command to no-file mode and break the path
+# completion that `export`/`import` need.
+complete -c cswap -s h -l help -d 'Show help'
+complete -c cswap -l debug -d 'Enable debug logging'
 
-# --- switch --------------------------------------------------------------
+# A path is only ever an argument to export/import (a file) or map/unmap (a
+# directory, completed below). Everywhere else fish's default file list is
+# noise — `cswap alias 2 <TAB>` wants a new name, not a filename.
+complete -c cswap -n 'not __cswap_subcommand export import map unmap' -f
 
-complete -c cswap -n '__cswap_using_subcommand switch' -f -a '(__cswap_accounts)'
-complete -c cswap -n '__cswap_using_subcommand switch' -l strategy -f -a 'best next-available' -d 'target-selection strategy'
-complete -c cswap -n '__cswap_using_subcommand switch' -l model -f -d 'also compare these models\' weekly limits'
-complete -c cswap -n '__cswap_using_subcommand switch' -l json -f -d 'emit machine-readable JSON'
-complete -c cswap -n '__cswap_using_subcommand switch' -l force -f -d "don't back up the current login first"
+# --- switch -------------------------------------------------------------
 
-# --- list / ls -------------------------------------------------------------
+complete -c cswap -n '__cswap_subcommand switch' -f -a '(__cswap_accounts)'
+# -x, not -f: --strategy takes a value, so its candidates belong to the next token.
+complete -c cswap -n '__cswap_subcommand switch' -x -l strategy -a best -d 'Jump to the account with the most quota left'
+complete -c cswap -n '__cswap_subcommand switch' -x -l strategy -a next-available -d 'Rotate, skipping rate-limited accounts'
+complete -c cswap -n '__cswap_subcommand switch' -x -l model -a 'Fable Opus Sonnet Haiku all' -d "Also compare these models' weekly limits"
+complete -c cswap -n '__cswap_subcommand switch' -f -l json -d 'Emit machine-readable JSON'
+complete -c cswap -n '__cswap_subcommand switch' -f -l force -d "Activate without backing up the current login"
 
-for c in list ls
-    complete -c cswap -n "__cswap_using_subcommand $c" -l json -f -d 'emit machine-readable JSON'
-    complete -c cswap -n "__cswap_using_subcommand $c" -l token-status -f -d 'show OAuth token diagnostics'
-end
+# --- list / status ------------------------------------------------------
 
-# --- status ----------------------------------------------------------------
+complete -c cswap -n '__cswap_subcommand list ls' -f -l json -d 'Emit machine-readable JSON'
+complete -c cswap -n '__cswap_subcommand list ls' -f -l token-status -d 'Show OAuth token diagnostics'
+complete -c cswap -n '__cswap_subcommand status' -f -l json -d 'Emit machine-readable JSON'
 
-complete -c cswap -n '__cswap_using_subcommand status' -l json -f -d 'emit machine-readable JSON'
+# --- add / add-token ----------------------------------------------------
 
-# --- add / add-token ---------------------------------------------------
+complete -c cswap -n '__cswap_subcommand add' -x -l slot -d 'Slot number to add into'
+complete -c cswap -n '__cswap_subcommand add' -x -l alias -d 'Short display alias for the account'
 
-complete -c cswap -n '__cswap_using_subcommand add' -l slot -x -d 'slot number to add into'
-complete -c cswap -n '__cswap_using_subcommand add' -l alias -x -d 'short display alias for the account'
+complete -c cswap -n '__cswap_subcommand add-token' -f -a '-' -d 'Read the token from stdin'
+complete -c cswap -n '__cswap_subcommand add-token' -x -l slot -d 'Slot number to add into'
+complete -c cswap -n '__cswap_subcommand add-token' -x -l email -d 'Email to label the account with'
 
-complete -c cswap -n '__cswap_using_subcommand add-token' -f -a '-' -d 'read the token from stdin'
-complete -c cswap -n '__cswap_using_subcommand add-token' -l slot -x -d 'slot number to add into'
-complete -c cswap -n '__cswap_using_subcommand add-token' -l email -x -d 'email to label the account with'
+# --- account-target subcommands ----------------------------------------
 
-# --- remove / rm / disable / enable -----------------------------------
+complete -c cswap -n '__cswap_subcommand remove rm disable enable' -f -a '(__cswap_accounts)'
 
-for c in remove rm disable enable
-    complete -c cswap -n "__cswap_using_subcommand $c" -f -a '(__cswap_accounts)'
-end
+# --- run ----------------------------------------------------------------
 
-# --- run ---------------------------------------------------------------
+complete -c cswap -n '__cswap_subcommand run; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand run' -f -l no-share -d "Don't share ~/.claude settings into the session"
+complete -c cswap -n '__cswap_subcommand run' -f -l share-history -d 'Share conversation history across accounts'
+complete -c cswap -n '__cswap_subcommand run' -f -l no-share-history -d 'Keep per-account history (default)'
 
-complete -c cswap -n '__cswap_using_subcommand run' -f -a '(__cswap_accounts)'
-complete -c cswap -n '__cswap_using_subcommand run' -l no-share -f -d "don't share ~/.claude settings into the session"
-complete -c cswap -n '__cswap_using_subcommand run' -l share-history -f -d 'share conversation history across accounts'
-complete -c cswap -n '__cswap_using_subcommand run' -l no-share-history -f -d 'per-account history (default)'
+# --- map / unmap --------------------------------------------------------
+#
+# `map <NUM|EMAIL> [PATH]`: account first, directory second.
 
-# --- map / unmap ---------------------------------------------------------
+complete -c cswap -n '__cswap_subcommand map; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand map; and __cswap_positional_is 2' -f -a '(__fish_complete_directories)'
+complete -c cswap -n '__cswap_subcommand unmap; and __cswap_positional_is 1' -f -a '(__fish_complete_directories)'
 
-complete -c cswap -n '__cswap_using_subcommand map' -f -a '(__cswap_accounts)'
-complete -c cswap -n '__cswap_using_subcommand map' -f -a '(__fish_complete_directories)'
-complete -c cswap -n '__cswap_using_subcommand unmap' -f -a '(__fish_complete_directories)'
+# --- alias --------------------------------------------------------------
+#
+# `alias <NUM|EMAIL> <NAME>`: the second positional is a new name, so it has
+# no candidates — offering accounts there would be actively misleading.
 
-# --- alias ---------------------------------------------------------------
+complete -c cswap -n '__cswap_subcommand alias; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand alias' -f -l unset -d "Remove the account's alias"
 
-complete -c cswap -n '__cswap_using_subcommand alias' -f -a '(__cswap_accounts)'
-complete -c cswap -n '__cswap_using_subcommand alias' -l unset -f -d "remove the account's alias"
+# --- swap / move --------------------------------------------------------
 
-# --- swap / move ---------------------------------------------------------
+complete -c cswap -n '__cswap_subcommand swap; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand swap; and __cswap_positional_is 2' -f -a '(__cswap_accounts)'
+# `move <NUM|EMAIL|ALIAS> <SLOT>`: only slot numbers make sense second.
+complete -c cswap -n '__cswap_subcommand move; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand move; and __cswap_positional_is 2' -f -a '(__cswap_accounts | string match -r "^[0-9]+\t.*")' -d 'Destination slot'
 
-complete -c cswap -n '__cswap_using_subcommand swap' -f -a '(__cswap_accounts)'
-complete -c cswap -n '__cswap_using_subcommand move' -f -a '(__cswap_accounts)'
+# --- auto ---------------------------------------------------------------
 
-# --- auto ------------------------------------------------------------------
+complete -c cswap -n '__cswap_subcommand auto' -f -l once -d 'Evaluate once and exit'
+complete -c cswap -n '__cswap_subcommand auto' -f -l json -d 'One JSON event per line'
+complete -c cswap -n '__cswap_subcommand auto' -x -l interval -d 'Poll interval, seconds (15-3600, default 60)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l threshold -d 'Switch above this pct used (50-99.9, default 90)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l cooldown -d 'Min seconds between switches (default 300)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l model -a 'Fable Opus Sonnet Haiku all' -d "Also switch on these models' weekly limits"
+complete -c cswap -n '__cswap_subcommand auto' -f -l include-api-key-accounts -d 'Allow rotating onto API-key accounts'
+complete -c cswap -n '__cswap_subcommand auto' -f -l no-include-api-key-accounts -d 'Exclude API-key accounts (default)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l strategy -a best -d 'Account with the most quota left (default)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l strategy -a consume-first -d 'Account whose weekly window resets soonest'
+complete -c cswap -n '__cswap_subcommand auto' -f -l dry-run -d 'Report decisions but never switch'
 
-complete -c cswap -n '__cswap_using_subcommand auto' -l once -f -d 'evaluate once and exit'
-complete -c cswap -n '__cswap_using_subcommand auto' -l json -f -d 'one JSON event per line'
-complete -c cswap -n '__cswap_using_subcommand auto' -l interval -x -d 'poll interval in seconds (default 60)'
-complete -c cswap -n '__cswap_using_subcommand auto' -l threshold -x -d 'switch above this % used (default 90)'
-complete -c cswap -n '__cswap_using_subcommand auto' -l cooldown -x -d 'min seconds between switches (default 300)'
-complete -c cswap -n '__cswap_using_subcommand auto' -l model -x -d 'also switch on these models\' weekly limits'
-complete -c cswap -n '__cswap_using_subcommand auto' -l include-api-key-accounts -f -d 'allow switching onto API-key accounts'
-complete -c cswap -n '__cswap_using_subcommand auto' -l no-include-api-key-accounts -f -d 'exclude API-key accounts (default)'
-complete -c cswap -n '__cswap_using_subcommand auto' -l strategy -f -a 'best consume-first' -d 'target-selection strategy'
-complete -c cswap -n '__cswap_using_subcommand auto' -l dry-run -f -d 'report but never switch'
+# --- config -------------------------------------------------------------
 
-# --- config ------------------------------------------------------------
-
-set -l cswap_config_keys autoswitch.threshold autoswitch.intervalSeconds \
-    autoswitch.cooldownSeconds autoswitch.hysteresisPct autoswitch.strategy \
-    autoswitch.includeApiKeyAccounts autoswitch.unhealthyTicks autoswitch.model \
-    ui.theme
-
-function __cswap_using_config_action
+# Only at the KEY slot (`config get <here>`); once a key is typed the value
+# candidates take over, so the key list must stop firing.
+function __cswap_config_key --description 'Completing the KEY of config get/set/unset'
     set -l cmd (commandline -opc)
-    test (count $cmd) -gt 2
-    and test "$cmd[2]" = config
-    and test "$cmd[3]" = "$argv[1]"
+    test (count $cmd) -eq 3; and test "$cmd[2]" = config
+    and contains -- "$cmd[3]" get set unset
 end
 
-function __cswap_config_no_action
+function __cswap_config_bare --description 'config with no action yet'
     set -l cmd (commandline -opc)
-    test (count $cmd) -eq 2
-    and test "$cmd[2]" = config
+    test (count $cmd) -eq 2; and test "$cmd[2]" = config
 end
 
-complete -c cswap -n __cswap_config_no_action -f -a list -d 'show all effective settings (default)'
-complete -c cswap -n __cswap_config_no_action -f -a get -d "print one setting's effective value"
-complete -c cswap -n __cswap_config_no_action -f -a set -d 'validate and persist one setting'
-complete -c cswap -n __cswap_config_no_action -f -a unset -d 'remove one setting (revert to default)'
-complete -c cswap -n __cswap_config_no_action -f -a path -d 'print the settings.json location'
-complete -c cswap -n '__cswap_using_subcommand config' -l json -f -d 'emit machine-readable JSON'
+complete -c cswap -n __cswap_config_bare -f -a list -d 'Show all effective settings (default)'
+complete -c cswap -n __cswap_config_bare -f -a get -d "Print one setting's effective value"
+complete -c cswap -n __cswap_config_bare -f -a set -d 'Validate and persist one setting'
+complete -c cswap -n __cswap_config_bare -f -a unset -d 'Remove one setting (revert to default)'
+complete -c cswap -n __cswap_config_bare -f -a path -d 'Print the settings.json location'
+complete -c cswap -n '__cswap_subcommand config' -f -l json -d 'Emit machine-readable JSON'
 
-for action in get set unset
-    complete -c cswap -n "__cswap_using_config_action $action" -f -a "$cswap_config_keys"
+# Keys, mirroring SETTING_SPECS in src/claude_swap/settings.py.
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.threshold -d 'Switch at this pct used (50-99.9, default 90)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.intervalSeconds -d 'Auto-loop poll interval (15-3600, default 60)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.cooldownSeconds -d 'Min seconds between switches (default 300)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.hysteresisPct -d 'Target must beat active by this pct (default 10)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.strategy -d 'How auto-switch picks a target (default best)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.includeApiKeyAccounts -d 'Rotate onto API-key accounts (default false)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.unhealthyTicks -d 'Failed polls before unhealthy (default 3)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.model -d "Also switch on these models' weekly limits"
+complete -c cswap -n '__cswap_config_key' -f -a ui.theme -d 'Color theme (default auto)'
+
+# Values, for the keys with a closed set.
+function __cswap_config_setting_is --description 'config set KEY where KEY is $argv[1]'
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 4; and test "$cmd[2]" = config; and test "$cmd[3]" = set
+    and test "$cmd[4]" = "$argv[1]"
 end
 
-# --- unclaimed -----------------------------------------------------------
+complete -c cswap -n '__cswap_config_setting_is autoswitch.strategy' -f -a 'best consume-first'
+complete -c cswap -n '__cswap_config_setting_is autoswitch.includeApiKeyAccounts' -f -a 'true false'
+complete -c cswap -n '__cswap_config_setting_is ui.theme' -f -a 'dark light auto'
 
-complete -c cswap -n '__cswap_using_subcommand unclaimed' -l purge -x -d 'delete this stashed entry by id'
+# --- unclaimed ----------------------------------------------------------
 
-# --- export / import -------------------------------------------------
+complete -c cswap -n '__cswap_subcommand unclaimed' -x -l purge -d 'Delete this stashed entry by id'
 
-complete -c cswap -n '__cswap_using_subcommand export' -l account -x -a '(__cswap_accounts)' -d 'limit export to one account'
-complete -c cswap -n '__cswap_using_subcommand export' -l full -f -d 'include full ~/.claude.json'
-complete -c cswap -n '__cswap_using_subcommand import' -l force -f -d 'overwrite existing accounts'
+# --- export / import ----------------------------------------------------
+#
+# Both take a PATH positional, so file completion stays on (see the --debug
+# note above).
+
+complete -c cswap -n '__cswap_subcommand export' -x -l account -a '(__cswap_accounts)' -d 'Limit the export to one account'
+complete -c cswap -n '__cswap_subcommand export' -f -l full -d 'Include the full ~/.claude.json'
+complete -c cswap -n '__cswap_subcommand import' -f -l force -d 'Overwrite existing accounts'


### PR DESCRIPTION
## Summary

Adds fish completions for the CLI: `completions/cswap.fish`, plus a two-line
`completions/claude-swap.fish` so the long-form console script gets them too.

Covered:

- every subcommand — `list`/`ls`, `status`, `switch`, `add`, `add-token`, `remove`/`rm`,
  `disable`, `enable`, `run`, `map`, `unmap`, `alias`, `swap`, `move`, `auto`, `config`,
  `unclaimed`, `export`, `import`, `tui`, `watch`, `menubar`, `upgrade`/`update`, `purge`
- each subcommand's flags, with descriptions and value candidates taken from the CLI
  help (`--strategy best|next-available`, `--model`, `--include-api-key-accounts`, …)
- account targets complete by **number, email, and alias**, labelled with the active
  marker — `switch`, `remove`, `disable`, `enable`, `run`, `map`, `alias`, `swap`, `move`
- `config get/set/unset` complete the keys from `SETTING_SPECS`, and `config set`
  completes values for the closed-set keys (`ui.theme`, `autoswitch.strategy`,
  `autoswitch.includeApiKeyAccounts`)
- positions are respected: `alias <acct> <NAME>` offers nothing for the new name,
  `move <acct> <SLOT>` offers only slot numbers, `map`/`unmap` complete directories,
  `export`/`import` complete file paths, and everything else suppresses file noise

Also adds a short "Shell completions" section to the README under Installation.

## One design note worth your call

Account candidates are read from the local `sequence.json`, **not** from
`cswap list --json`.

`list` is an on-demand usage caller: entries older than `SERVE_TTL_S` (180s) get
refetched over HTTPS with a 5s per-account timeout. Driving completions from it meant a
Tab press could block the prompt for seconds — and a stale cache is the common case,
since you don't run `cswap` every three minutes. Reading `sequence.json` is ~40x faster
on the warm path and never touches the network:

```
20 iterations, local read:        0.073s
20 iterations, cswap list --json: 3.041s   (warm cache; cold adds network round-trips)
```

The tradeoff is that the completion now depends on the on-disk shape of `sequence.json`
(number / email / alias) rather than the versioned `--json` contract. If you'd rather it
went through a supported interface, I'm happy to switch it to a hidden plumbing
subcommand (e.g. `cswap __complete accounts`) that reads local state only — just say the
word and I'll add it with tests.

Path resolution follows `paths.get_backup_root()`: `$XDG_DATA_HOME/claude-swap` (ignored
when relative, per the XDG spec), then `~/.local/share/claude-swap`, then
`~/.claude-swap-backup`.

## Testing

fish 4.8.1 on macOS, driving real completions with `complete -C` against a live install
across every subcommand and flag context. Checked specifically:

```
> complete -C "cswap switch "
1                        arefe.rohani@gmail.com [aref] (active)
2                        hazrati.dev@gmail.com [me]
aref                     #1 arefe.rohani@gmail.com (active)
...

> complete -C "cswap auto --strategy "
best           Account with the most quota left (default)
consume-first  Account whose weekly window resets soonest

> complete -C "cswap config set ui.theme "
auto
dark
light
```

Degradation cases, all of which yield no candidates and no error rather than breaking
the prompt: no `sequence.json` (fresh install), empty file, truncated JSON, binary
garbage, and a relative `XDG_DATA_HOME`. Verified autoload from a clean
`XDG_CONFIG_HOME` (not just an explicit `source`), and that `claude-swap` inherits the
set via `--wraps`.

`completions/` sits outside `[tool.hatch.build.targets.wheel]` (`src/claude_swap`), so
packaging is unaffected, and CI is Python-only so nothing new runs there.

The awk parser sticks to POSIX (`[ \t]` rather than `[[:space:]]`, which older mawk
handles inconsistently); it was exercised against BSD awk locally, so a sanity check on
gawk/mawk would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)