### PR TITLE
feat(completions): complete subcommands, flags and accounts for fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ uv tool upgrade claude-swap
 pipx upgrade claude-swap
 ```
 
+### Shell completions
+
+Fish completions live in [`completions/`](completions) — every subcommand and flag,
+plus account numbers, emails and aliases completed from your local account list, and
+setting keys and values for `cswap config`.
+
+```bash
+base=https://raw.githubusercontent.com/realiti4/claude-swap/main/completions
+curl -o ~/.config/fish/completions/cswap.fish $base/cswap.fish
+curl -o ~/.config/fish/completions/claude-swap.fish $base/claude-swap.fish
+```
+
+Fish picks up new files under `~/.config/fish/completions/` automatically, so there is
+nothing to restart. The second file is only needed if you use the long-form
+`claude-swap` command.
+
 ## Usage
 
 ### Add your first account

--- a/completions/claude-swap.fish
+++ b/completions/claude-swap.fish
@@ -1,0 +1,3 @@
+# `claude-swap` is the long-form console script for the same CLI as `cswap`
+# (both are declared in pyproject.toml), so it reuses one completion set.
+complete -c claude-swap --wraps cswap

--- a/completions/cswap.fish
+++ b/completions/cswap.fish
@@ -1,0 +1,272 @@
+# Fish completions for cswap (claude-swap).
+#
+# Install: copy to ~/.config/fish/completions/cswap.fish (fish auto-loads it).
+
+# --- account candidates -------------------------------------------------
+#
+# Read straight from the local sequence.json rather than shelling out to
+# `cswap list --json`. `list` is an on-demand usage caller: entries older than
+# SERVE_TTL_S (180s) are refetched over HTTPS with a 5s per-account timeout,
+# so driving completions from it would freeze the prompt for seconds on every
+# Tab once the cache went stale. sequence.json holds the number, email, and
+# alias — everything a completion needs — and costs one local read.
+
+function __cswap_sequence_file --description 'Path to cswap sequence.json, if present'
+    # Linux/WSL use the XDG data dir; macOS and the legacy layout use ~/.claude-swap-backup.
+    if set -q XDG_DATA_HOME; and string match -q -- '/*' "$XDG_DATA_HOME"
+        set -l xdg "$XDG_DATA_HOME/claude-swap/sequence.json"
+        if test -r $xdg
+            echo $xdg
+            return 0
+        end
+    end
+    for candidate in "$HOME/.local/share/claude-swap/sequence.json" "$HOME/.claude-swap-backup/sequence.json"
+        if test -r $candidate
+            echo $candidate
+            return 0
+        end
+    end
+    return 1
+end
+
+function __cswap_accounts --description 'Account numbers, emails and aliases with descriptions'
+    set -l file (__cswap_sequence_file); or return 0
+    awk '
+        function value(   rest) {
+            rest = substr($0, index($0, ":") + 1)
+            if (match(rest, /"[^"]*"/)) return substr(rest, RSTART + 1, RLENGTH - 2)
+            return ""
+        }
+        function flush(   tag, label) {
+            if (num == "") return
+            tag = (num == active) ? " (active)" : ""
+            label = (email == "") ? "account " num : email
+            if (alias != "") label = label " [" alias "]"
+            print num "\t" label tag
+            if (email != "") print email "\t#" num tag
+            if (alias != "") print alias "\t#" num " " email tag
+            num = ""; email = ""; alias = ""
+        }
+        /"activeAccountNumber"[ \t]*:/ {
+            if (match($0, /[0-9]+/)) active = substr($0, RSTART, RLENGTH)
+            next
+        }
+        /^[ \t]*"[0-9]+"[ \t]*:[ \t]*\{/ {
+            flush()
+            match($0, /"[0-9]+"/)
+            num = substr($0, RSTART + 1, RLENGTH - 2)
+            next
+        }
+        num != "" && /"email"[ \t]*:/ { email = value(); next }
+        num != "" && /"alias"[ \t]*:/ { alias = value(); next }
+        END { flush() }
+    ' $file 2>/dev/null
+    # A corrupt or unreadable file yields no candidates, never an error.
+    return 0
+end
+
+# --- context helpers ----------------------------------------------------
+
+# The CLI dispatches on argv[0], so the subcommand is always token 2 and
+# global flags have to follow it (`cswap list --json`, not `cswap --json list`).
+function __cswap_no_subcommand --description 'No subcommand typed yet'
+    test (count (commandline -opc)) -eq 1
+end
+
+function __cswap_subcommand --description 'Current subcommand is $argv[1]'
+    set -l cmd (commandline -opc)
+    test (count $cmd) -gt 1; and contains -- "$cmd[2]" $argv
+end
+
+# Positional args already given after the subcommand. Only used for
+# subcommands whose flags are all boolean (--debug, --unset), so a value-taking
+# flag can never be miscounted as a positional here.
+function __cswap_positionals --description 'Count of positional args after the subcommand'
+    set -l cmd (commandline -opc)
+    set -l n 0
+    if test (count $cmd) -ge 3
+        for token in $cmd[3..-1]
+            string match -q -- '-*' $token; or set n (math $n + 1)
+        end
+    end
+    echo $n
+end
+
+function __cswap_positional_is --description 'Next positional slot equals $argv[1]'
+    test (__cswap_positionals) -eq (math $argv[1] - 1)
+end
+
+# --- subcommands --------------------------------------------------------
+
+complete -c cswap -n __cswap_no_subcommand -f -a help -d 'Show help'
+complete -c cswap -n __cswap_no_subcommand -f -a list -d 'List managed accounts'
+complete -c cswap -n __cswap_no_subcommand -f -a ls -d 'List managed accounts'
+complete -c cswap -n __cswap_no_subcommand -f -a status -d 'Show the current account'
+complete -c cswap -n __cswap_no_subcommand -f -a switch -d 'Rotate, or switch to an account'
+complete -c cswap -n __cswap_no_subcommand -f -a add -d 'Add the currently logged-in account'
+complete -c cswap -n __cswap_no_subcommand -f -a add-token -d 'Register a setup-token or API key'
+complete -c cswap -n __cswap_no_subcommand -f -a remove -d 'Remove an account'
+complete -c cswap -n __cswap_no_subcommand -f -a rm -d 'Remove an account'
+complete -c cswap -n __cswap_no_subcommand -f -a disable -d 'Hold an account out of auto-rotation'
+complete -c cswap -n __cswap_no_subcommand -f -a enable -d 'Return a disabled account to rotation'
+complete -c cswap -n __cswap_no_subcommand -f -a run -d 'Run Claude as an account, this terminal only'
+complete -c cswap -n __cswap_no_subcommand -f -a map -d 'Map a directory to an account'
+complete -c cswap -n __cswap_no_subcommand -f -a unmap -d 'Remove a directory mapping'
+complete -c cswap -n __cswap_no_subcommand -f -a alias -d "Set, remove or list an account's alias"
+complete -c cswap -n __cswap_no_subcommand -f -a swap -d "Exchange two accounts' slot numbers"
+complete -c cswap -n __cswap_no_subcommand -f -a move -d 'Assign an account to a slot'
+complete -c cswap -n __cswap_no_subcommand -f -a auto -d 'Auto-switch when nearing rate limits'
+complete -c cswap -n __cswap_no_subcommand -f -a config -d 'Show or change settings'
+complete -c cswap -n __cswap_no_subcommand -f -a unclaimed -d 'List or drop stashed credential entries'
+complete -c cswap -n __cswap_no_subcommand -f -a export -d 'Export accounts to a file'
+complete -c cswap -n __cswap_no_subcommand -f -a import -d 'Import accounts from a file'
+complete -c cswap -n __cswap_no_subcommand -f -a tui -d 'Interactive dashboard'
+complete -c cswap -n __cswap_no_subcommand -f -a watch -d 'Dashboard, on the live watch page'
+complete -c cswap -n __cswap_no_subcommand -f -a menubar -d 'macOS menu bar app'
+complete -c cswap -n __cswap_no_subcommand -f -a upgrade -d 'Self-upgrade to the latest version'
+complete -c cswap -n __cswap_no_subcommand -f -a update -d 'Self-upgrade to the latest version'
+complete -c cswap -n __cswap_no_subcommand -f -a purge -d 'Remove all claude-swap data'
+
+complete -c cswap -n __cswap_no_subcommand -f -l version -d "Show the program's version"
+
+# Accepted alongside every subcommand. Deliberately not -f: an unconditional
+# -f would switch the whole command to no-file mode and break the path
+# completion that `export`/`import` need.
+complete -c cswap -s h -l help -d 'Show help'
+complete -c cswap -l debug -d 'Enable debug logging'
+
+# A path is only ever an argument to export/import (a file) or map/unmap (a
+# directory, completed below). Everywhere else fish's default file list is
+# noise — `cswap alias 2 <TAB>` wants a new name, not a filename.
+complete -c cswap -n 'not __cswap_subcommand export import map unmap' -f
+
+# --- switch -------------------------------------------------------------
+
+complete -c cswap -n '__cswap_subcommand switch' -f -a '(__cswap_accounts)'
+# -x, not -f: --strategy takes a value, so its candidates belong to the next token.
+complete -c cswap -n '__cswap_subcommand switch' -x -l strategy -a best -d 'Jump to the account with the most quota left'
+complete -c cswap -n '__cswap_subcommand switch' -x -l strategy -a next-available -d 'Rotate, skipping rate-limited accounts'
+complete -c cswap -n '__cswap_subcommand switch' -x -l model -a 'Fable Opus Sonnet Haiku all' -d "Also compare these models' weekly limits"
+complete -c cswap -n '__cswap_subcommand switch' -f -l json -d 'Emit machine-readable JSON'
+complete -c cswap -n '__cswap_subcommand switch' -f -l force -d "Activate without backing up the current login"
+
+# --- list / status ------------------------------------------------------
+
+complete -c cswap -n '__cswap_subcommand list ls' -f -l json -d 'Emit machine-readable JSON'
+complete -c cswap -n '__cswap_subcommand list ls' -f -l token-status -d 'Show OAuth token diagnostics'
+complete -c cswap -n '__cswap_subcommand status' -f -l json -d 'Emit machine-readable JSON'
+
+# --- add / add-token ----------------------------------------------------
+
+complete -c cswap -n '__cswap_subcommand add' -x -l slot -d 'Slot number to add into'
+complete -c cswap -n '__cswap_subcommand add' -x -l alias -d 'Short display alias for the account'
+
+complete -c cswap -n '__cswap_subcommand add-token' -f -a '-' -d 'Read the token from stdin'
+complete -c cswap -n '__cswap_subcommand add-token' -x -l slot -d 'Slot number to add into'
+complete -c cswap -n '__cswap_subcommand add-token' -x -l email -d 'Email to label the account with'
+
+# --- account-target subcommands ----------------------------------------
+
+complete -c cswap -n '__cswap_subcommand remove rm disable enable' -f -a '(__cswap_accounts)'
+
+# --- run ----------------------------------------------------------------
+
+complete -c cswap -n '__cswap_subcommand run; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand run' -f -l no-share -d "Don't share ~/.claude settings into the session"
+complete -c cswap -n '__cswap_subcommand run' -f -l share-history -d 'Share conversation history across accounts'
+complete -c cswap -n '__cswap_subcommand run' -f -l no-share-history -d 'Keep per-account history (default)'
+
+# --- map / unmap --------------------------------------------------------
+#
+# `map <NUM|EMAIL> [PATH]`: account first, directory second.
+
+complete -c cswap -n '__cswap_subcommand map; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand map; and __cswap_positional_is 2' -f -a '(__fish_complete_directories)'
+complete -c cswap -n '__cswap_subcommand unmap; and __cswap_positional_is 1' -f -a '(__fish_complete_directories)'
+
+# --- alias --------------------------------------------------------------
+#
+# `alias <NUM|EMAIL> <NAME>`: the second positional is a new name, so it has
+# no candidates — offering accounts there would be actively misleading.
+
+complete -c cswap -n '__cswap_subcommand alias; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand alias' -f -l unset -d "Remove the account's alias"
+
+# --- swap / move --------------------------------------------------------
+
+complete -c cswap -n '__cswap_subcommand swap; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand swap; and __cswap_positional_is 2' -f -a '(__cswap_accounts)'
+# `move <NUM|EMAIL|ALIAS> <SLOT>`: only slot numbers make sense second.
+complete -c cswap -n '__cswap_subcommand move; and __cswap_positional_is 1' -f -a '(__cswap_accounts)'
+complete -c cswap -n '__cswap_subcommand move; and __cswap_positional_is 2' -f -a '(__cswap_accounts | string match -r "^[0-9]+\t.*")' -d 'Destination slot'
+
+# --- auto ---------------------------------------------------------------
+
+complete -c cswap -n '__cswap_subcommand auto' -f -l once -d 'Evaluate once and exit'
+complete -c cswap -n '__cswap_subcommand auto' -f -l json -d 'One JSON event per line'
+complete -c cswap -n '__cswap_subcommand auto' -x -l interval -d 'Poll interval, seconds (15-3600, default 60)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l threshold -d 'Switch above this pct used (50-99.9, default 90)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l cooldown -d 'Min seconds between switches (default 300)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l model -a 'Fable Opus Sonnet Haiku all' -d "Also switch on these models' weekly limits"
+complete -c cswap -n '__cswap_subcommand auto' -f -l include-api-key-accounts -d 'Allow rotating onto API-key accounts'
+complete -c cswap -n '__cswap_subcommand auto' -f -l no-include-api-key-accounts -d 'Exclude API-key accounts (default)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l strategy -a best -d 'Account with the most quota left (default)'
+complete -c cswap -n '__cswap_subcommand auto' -x -l strategy -a consume-first -d 'Account whose weekly window resets soonest'
+complete -c cswap -n '__cswap_subcommand auto' -f -l dry-run -d 'Report decisions but never switch'
+
+# --- config -------------------------------------------------------------
+
+# Only at the KEY slot (`config get <here>`); once a key is typed the value
+# candidates take over, so the key list must stop firing.
+function __cswap_config_key --description 'Completing the KEY of config get/set/unset'
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 3; and test "$cmd[2]" = config
+    and contains -- "$cmd[3]" get set unset
+end
+
+function __cswap_config_bare --description 'config with no action yet'
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 2; and test "$cmd[2]" = config
+end
+
+complete -c cswap -n __cswap_config_bare -f -a list -d 'Show all effective settings (default)'
+complete -c cswap -n __cswap_config_bare -f -a get -d "Print one setting's effective value"
+complete -c cswap -n __cswap_config_bare -f -a set -d 'Validate and persist one setting'
+complete -c cswap -n __cswap_config_bare -f -a unset -d 'Remove one setting (revert to default)'
+complete -c cswap -n __cswap_config_bare -f -a path -d 'Print the settings.json location'
+complete -c cswap -n '__cswap_subcommand config' -f -l json -d 'Emit machine-readable JSON'
+
+# Keys, mirroring SETTING_SPECS in src/claude_swap/settings.py.
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.threshold -d 'Switch at this pct used (50-99.9, default 90)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.intervalSeconds -d 'Auto-loop poll interval (15-3600, default 60)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.cooldownSeconds -d 'Min seconds between switches (default 300)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.hysteresisPct -d 'Target must beat active by this pct (default 10)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.strategy -d 'How auto-switch picks a target (default best)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.includeApiKeyAccounts -d 'Rotate onto API-key accounts (default false)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.unhealthyTicks -d 'Failed polls before unhealthy (default 3)'
+complete -c cswap -n '__cswap_config_key' -f -a autoswitch.model -d "Also switch on these models' weekly limits"
+complete -c cswap -n '__cswap_config_key' -f -a ui.theme -d 'Color theme (default auto)'
+
+# Values, for the keys with a closed set.
+function __cswap_config_setting_is --description 'config set KEY where KEY is $argv[1]'
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq 4; and test "$cmd[2]" = config; and test "$cmd[3]" = set
+    and test "$cmd[4]" = "$argv[1]"
+end
+
+complete -c cswap -n '__cswap_config_setting_is autoswitch.strategy' -f -a 'best consume-first'
+complete -c cswap -n '__cswap_config_setting_is autoswitch.includeApiKeyAccounts' -f -a 'true false'
+complete -c cswap -n '__cswap_config_setting_is ui.theme' -f -a 'dark light auto'
+
+# --- unclaimed ----------------------------------------------------------
+
+complete -c cswap -n '__cswap_subcommand unclaimed' -x -l purge -d 'Delete this stashed entry by id'
+
+# --- export / import ----------------------------------------------------
+#
+# Both take a PATH positional, so file completion stays on (see the --debug
+# note above).
+
+complete -c cswap -n '__cswap_subcommand export' -x -l account -a '(__cswap_accounts)' -d 'Limit the export to one account'
+complete -c cswap -n '__cswap_subcommand export' -f -l full -d 'Include the full ~/.claude.json'
+complete -c cswap -n '__cswap_subcommand import' -f -l force -d 'Overwrite existing accounts'

--- a/tests/test_completions_contract.py
+++ b/tests/test_completions_contract.py
@@ -1,0 +1,175 @@
+"""Fish completion contract tests.
+
+`completions/cswap.fish` completes account targets by reading `sequence.json`
+directly instead of shelling out to `cswap list --json`. That keeps Tab off the
+network — `list` refetches usage over HTTPS once an entry passes
+`SERVE_TTL_S` — but it couples the completion to the on-disk shape of the file
+rather than to the versioned `--json` payload. These tests are that coupling's
+guard rail.
+
+Two layers:
+
+1. **Contract** (every platform): the fields the completion reads —
+   `activeAccountNumber`, and each account's `email` and `alias` — are the
+   fields the switcher actually writes, in a pretty-printed layout that a
+   line-oriented parser can read. Renaming or inlining any of them fails here
+   rather than silently emptying someone's completions.
+
+2. **Parser** (POSIX only): the awk program is extracted from the shipped
+   `.fish` file and run against a real `sequence.json`, so the test exercises
+   the code that ships rather than a copy of it. Skipped on Windows, which has
+   no awk and no fish.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+COMPLETION_FILE = Path(__file__).resolve().parent.parent / "completions" / "cswap.fish"
+
+requires_awk = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("awk") is None,
+    reason="needs a POSIX awk; the fish completion does not target Windows",
+)
+
+
+def _awk_program() -> str:
+    """The awk source embedded in the completion, so tests track the real thing."""
+    text = COMPLETION_FILE.read_text(encoding="utf-8")
+    start = text.index("awk '") + len("awk '")
+    end = text.index("' $file", start)
+    return text[start:end]
+
+
+def _write_sequence(data: dict) -> Path:
+    """Persist ``data`` through the switcher's own writer and return the path."""
+    switcher = ClaudeAccountSwitcher()
+    switcher._setup_directories()
+    switcher._write_json(switcher.sequence_file, data)
+    return switcher.sequence_file
+
+
+def _candidates(path: Path) -> dict[str, str]:
+    """Run the shipped awk program, returning {completion: description}."""
+    result = subprocess.run(
+        ["awk", _awk_program(), str(path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pairs = {}
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        value, _, description = line.partition("\t")
+        pairs[value] = description
+    return pairs
+
+
+class TestSequenceJsonContract:
+    """Layer 1: what the completion reads is what the switcher writes."""
+
+    def test_fields_the_completion_reads_are_present(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        sample_sequence_data["accounts"]["1"]["alias"] = "work"
+        path = _write_sequence(sample_sequence_data)
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+
+        assert "activeAccountNumber" in data
+        assert data["accounts"]["1"]["email"] == "account1@example.com"
+        assert data["accounts"]["1"]["alias"] == "work"
+
+    def test_alias_survives_a_real_set_alias_call(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """`cswap alias` must land in the key the completion looks for."""
+        _write_sequence(sample_sequence_data)
+        switcher = ClaudeAccountSwitcher()
+        switcher.set_alias("2", "personal")
+
+        data = json.loads(switcher.sequence_file.read_text(encoding="utf-8"))
+
+        assert data["accounts"]["2"]["alias"] == "personal"
+
+    def test_layout_stays_line_oriented(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """The awk parser is line-based; compact JSON would silently break it."""
+        path = _write_sequence(sample_sequence_data)
+        text = path.read_text(encoding="utf-8")
+
+        assert "\n" in text, "sequence.json must not be written on one line"
+        # Each account opens its own block, which is what anchors the parser.
+        assert '"1": {' in text
+
+
+@requires_awk
+class TestCompletionParser:
+    """Layer 2: the shipped awk program against a real file."""
+
+    def test_offers_number_email_and_alias(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        sample_sequence_data["accounts"]["1"]["alias"] = "work"
+        candidates = _candidates(_write_sequence(sample_sequence_data))
+
+        assert "1" in candidates
+        assert "account1@example.com" in candidates
+        assert "work" in candidates
+        assert "2" in candidates
+        assert "account2@example.com" in candidates
+
+    def test_marks_only_the_active_account(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        sample_sequence_data["activeAccountNumber"] = 2
+        candidates = _candidates(_write_sequence(sample_sequence_data))
+
+        assert "(active)" in candidates["2"]
+        assert "(active)" not in candidates["1"]
+
+    def test_account_without_an_alias_still_completes(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """No alias set is the default state, not an edge case."""
+        candidates = _candidates(_write_sequence(sample_sequence_data))
+
+        assert "1" in candidates
+        assert candidates["1"].startswith("account1@example.com")
+
+    def test_aliases_do_not_leak_between_accounts(
+        self, temp_home: Path, sample_sequence_data: dict
+    ):
+        """Account 1's alias must not be carried onto account 2 by the parser."""
+        sample_sequence_data["accounts"]["1"]["alias"] = "work"
+        candidates = _candidates(_write_sequence(sample_sequence_data))
+
+        assert "work" not in candidates["2"]
+
+    @pytest.mark.parametrize(
+        "content",
+        ["", "{", '{"accounts": {"1": {"email": "truncated', "\x00\x01\x02not json"],
+        ids=["empty", "brace", "truncated", "binary"],
+    )
+    def test_unusable_file_yields_no_candidates(self, tmp_path: Path, content: str):
+        """A corrupt file must empty the menu, never break the prompt."""
+        path = tmp_path / "sequence.json"
+        path.write_text(content, encoding="utf-8", errors="ignore")
+
+        result = subprocess.run(
+            ["awk", _awk_program(), str(path)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary

Fish completions for the CLI: `completions/cswap.fish`, plus a two-line
`completions/claude-swap.fish` so the long-form console script inherits the same set.

- every subcommand — `list`/`ls`, `status`, `switch`, `add`, `add-token`, `remove`/`rm`,
  `disable`, `enable`, `run`, `map`, `unmap`, `alias`, `swap`, `move`, `auto`, `config`,
  `unclaimed`, `export`, `import`, `tui`, `watch`, `menubar`, `upgrade`/`update`, `purge`
- each subcommand's flags, with descriptions and value candidates from the CLI help
  (`--strategy best|next-available`, `--model`, `--include-api-key-accounts`, …)
- account targets complete by **number, email and alias**, labelled with the active
  marker — `switch`, `remove`, `disable`, `enable`, `run`, `map`, `alias`, `swap`, `move`
- `config get/set/unset` complete the keys from `SETTING_SPECS`, and `config set`
  completes values for the closed-set keys (`ui.theme`, `autoswitch.strategy`,
  `autoswitch.includeApiKeyAccounts`)
- positions are respected: `alias <acct> <NAME>` offers nothing for the new name,
  `move <acct> <SLOT>` offers only slot numbers, `map`/`unmap` complete directories,
  `export`/`import` complete file paths, everything else suppresses file noise

A README section under Installation documents the install.

## Why not `cswap list --json`

Account candidates are read from the local `sequence.json`.

`list` is an on-demand usage caller: an entry older than `SERVE_TTL_S` (180s) is
refetched over HTTPS with a 5s per-account timeout. A stale cache is the common case —
you don't run `cswap` every three minutes — so driving completions from it meant a Tab
press could block the prompt for seconds, or ~10s on two accounts with a dead network.

```
20 iterations, local read:        0.073s
20 iterations, cswap list --json: 3.041s   (warm cache; cold adds network round-trips)
```

Path resolution follows `paths.get_backup_root()`: `$XDG_DATA_HOME/claude-swap` (ignored
when relative, per the XDG spec), then `~/.local/share/claude-swap`, then
`~/.claude-swap-backup`.

## Safety

The completion only ever reads. A missing, empty, truncated or binary `sequence.json`
yields no candidates rather than an error, so a broken state file empties the menu
instead of breaking the prompt. No network access on any path.

The tradeoff is that this couples the completion to the on-disk shape of
`sequence.json` rather than the versioned `--json` payload, so
`tests/test_completions_contract.py` guards it in two layers:

1. **Contract** (every platform): the fields the parser reads — `activeAccountNumber`,
   each account's `email` and `alias` — asserted against what the switcher actually
   writes, including that the layout stays line-oriented. Renaming or inlining any of
   them fails CI instead of silently emptying completions.
2. **Parser** (POSIX only, skipped on Windows): the awk program is extracted from the
   shipped `.fish` file and run against a real `sequence.json`, so the test exercises
   the code that ships rather than a copy.

If you'd rather this went through a supported interface, I'm happy to switch it to a
hidden plumbing subcommand (e.g. `cswap __complete accounts`) that reads local state
only — say the word and I'll add it with tests.

## Validation

- `uv run pytest tests/test_completions_contract.py -q` — **11 passed**
- `uv run pytest -q` — **2097 passed, 3 skipped**, 3 failed
- the 3 failures are **pre-existing on my machine**: `test_move_accounts.py`,
  `test_swap_accounts.py` (permission/rollback) and `test_real_store_guard.py`. They
  reproduce identically on a clean `upstream/main` — verified by stashing this change —
  and are unrelated to completions.
- mutation-checked both guards rather than trusting a green run: switching the switcher
  to compact `json.dumps` fails 5 tests, and pointing the parser at a renamed alias key
  fails the alias test.
- `fish -n` on both completion files, and real completions driven with `complete -C` on
  **fish 4.8.1 / macOS** across every subcommand and flag context:

```
> complete -C "cswap switch "
1                        arefe.rohani@gmail.com [aref] (active)
2                        hazrati.dev@gmail.com [me]
aref                     #1 arefe.rohani@gmail.com (active)

> complete -C "cswap auto --strategy "
best           Account with the most quota left (default)
consume-first  Account whose weekly window resets soonest

> complete -C "cswap config set ui.theme "
auto
dark
light
```

- verified autoload from a clean `XDG_CONFIG_HOME` (not just an explicit `source`), and
  that `claude-swap` inherits the set via `--wraps`
- `completions/` sits outside `[tool.hatch.build.targets.wheel]` (`src/claude_swap`), so
  packaging is unaffected

The awk parser sticks to POSIX (`[ \t]` rather than `[[:space:]]`, which older mawk
handles inconsistently). It was exercised against BSD awk locally; CI's ubuntu runner
covers gawk/mawk through the layer-2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)