### PR TITLE
fix(menubar): stop leaking a menu of items on every refresh

### DIFF
--- a/src/claude_swap/logging_config.py
+++ b/src/claude_swap/logging_config.py
@@ -4,6 +4,10 @@ import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+# Rotation ceiling for claude-swap.log. Named because the menu bar reads a
+# tail of this file and has to size its window against the same number.
+LOG_MAX_BYTES = 1024 * 1024
+
 
 class _LazyDirRotatingFileHandler(RotatingFileHandler):
     """RotatingFileHandler that creates its parent dir on first emit.
@@ -44,7 +48,7 @@ def setup_logging(log_dir: Path, debug: bool = False) -> logging.Logger:
     log_file = log_dir / "claude-swap.log"
     file_handler = _LazyDirRotatingFileHandler(
         log_file,
-        maxBytes=1024 * 1024,  # 1MB
+        maxBytes=LOG_MAX_BYTES,
         backupCount=3,
         delay=True,
     )

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from claude_swap import pace
+from claude_swap.logging_config import LOG_MAX_BYTES
 from claude_swap.exceptions import ClaudeSwitchError, CredentialReadError
 from claude_swap.switcher import SENTINEL_NOTES
 
@@ -37,6 +38,21 @@ AUTO_THRESHOLD_CHOICES: tuple[int, ...] = (80, 90, 95, 98)
 TITLE_PCT_CHOICES: tuple[str, ...] = ("off", "5h", "7d", "both")
 SWITCH_HISTORY_LIMIT = 10
 NOTIFICATION_BUNDLE_ID = "com.claude-swap.menubar"
+TITLE_PCT_LABELS: dict[str, str] = {
+    "off": "None",
+    "5h": "Session (5h)",
+    "7d": "Weekly (7d)",
+    "both": "Both (5h · 7d)",
+}
+INTERVAL_LABELS: dict[int, str] = {30: "30 seconds", 60: "60 seconds", 300: "5 minutes"}
+NO_ACCOUNTS = "No managed accounts"
+NO_HISTORY = "No switches logged yet"
+# The switch-history submenu needs only the last few matching lines, so the
+# model build reads a tail rather than the whole file. Sized to the log
+# rotation limit (``logging_config.LOG_MAX_BYTES``) so the window can never
+# be the reason an entry is missing: switch lines are sparse among usage
+# lines, and a smaller window silently truncates the history.
+LOG_TAIL_BYTES = LOG_MAX_BYTES
 
 
 def ensure_notification_identity(
@@ -375,6 +391,12 @@ def parse_switch_history(log_text: str, limit: int = SWITCH_HISTORY_LIMIT) -> li
     Reads the ``Switched from account X to Y`` lines the switcher logs and pairs
     each with its timestamp (trimmed to the minute). Returns at most ``limit``
     entries like ``"3 → 1   2026-06-27 02:06"``. Any unparseable line is skipped.
+
+    Repeats collapse. Two identical switches inside one minute render as the
+    same string and carry no extra information, and de-duplicating *before*
+    the limit stops one from consuming a slot an older distinct switch could
+    fill. It also keeps the menu honest: rumps identifies items by title and
+    silently drops a duplicate.
     """
     out: list[str] = []
     for line in log_text.splitlines():
@@ -383,7 +405,7 @@ def parse_switch_history(log_text: str, limit: int = SWITCH_HISTORY_LIMIT) -> li
             continue
         stamp = line.split(" - ", 1)[0].strip()[:16]  # "YYYY-MM-DD HH:MM"
         out.append(f"{m.group(1)} → {m.group(2)}   {stamp}")
-    return out[-limit:][::-1]
+    return list(_unique(reversed(out))[:limit])
 
 
 def _account_display_usage(entry) -> dict | str | None:
@@ -436,6 +458,151 @@ def _adapt_snapshot(snap) -> dict:
         "active_usage": active_usage,
         "active_alias": active_alias,
     }
+
+
+# ---- menu model (pure) ------------------------------------------------------
+# The menu's variable content as plain data, so a refresh tick can decide what
+# the UI needs to do without touching rumps. This exists because rebuilding the
+# whole menu on every tick leaks: rumps registers each MenuItem carrying a
+# callback in the global ``NSApp._ns_to_py_and_callback`` dict and never
+# unregisters it, so every discarded item — and the closure holding the app —
+# stays reachable for the life of the process.
+
+
+def read_log_tail(path: Path, max_bytes: int = LOG_TAIL_BYTES) -> str:
+    """Last ``max_bytes`` of a text file, decoded leniently.
+
+    Returns "" if the file is missing or unreadable. When the file is longer
+    than the window the first (probably partial) line is dropped, so callers
+    only ever see whole lines.
+    """
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - max_bytes))
+            raw = fh.read()
+    except OSError:
+        return ""
+    if size > max_bytes:
+        _, _, raw = raw.partition(b"\n")
+    return raw.decode("utf-8", errors="replace")
+
+
+@dataclass(frozen=True)
+class MenuRow:
+    """One variable menu row: the text shown and its check-mark state."""
+
+    label: str
+    state: int = 0
+
+
+@dataclass(frozen=True)
+class MenuModel:
+    """Everything in the menu that can change between refreshes.
+
+    Two models compare equal exactly when the rendered menu would look
+    identical, so an unchanged tick can skip all UI work. ``shape`` is the part
+    that cannot be fixed up by relabelling: menu callbacks are bound per
+    account slot when the item is created, so a changed slot list has to
+    rebuild rather than relabel — otherwise a row would keep a callback
+    pointing at whichever account used to occupy its position.
+    """
+
+    title: str
+    slots: tuple[str, ...]
+    accounts: tuple[MenuRow, ...]
+    remove: tuple[MenuRow, ...]
+    disable: tuple[MenuRow, ...]
+    history: tuple[str, ...]
+    settings_rows: tuple[MenuRow, ...]
+
+    @property
+    def shape(self) -> tuple:
+        """What must match for an in-place update to be safe."""
+        return (self.slots, len(self.history), len(self.settings_rows))
+
+
+def settings_rows(settings: MenuBarSettings, threshold: int) -> tuple[MenuRow, ...]:
+    """Settings check-marks, in the order the settings submenu builds them."""
+    rows = [MenuRow("Show account name in menu bar", 1 if settings.show_account_name else 0)]
+    rows += [
+        MenuRow(TITLE_PCT_LABELS[mode], 1 if settings.title_pct == mode else 0)
+        for mode in TITLE_PCT_CHOICES
+    ]
+    rows.append(MenuRow("Show model limits in title", 1 if settings.title_scoped else 0))
+    rows += [
+        MenuRow(INTERVAL_LABELS[secs], 1 if settings.refresh_interval == secs else 0)
+        for secs in REFRESH_CHOICES
+    ]
+    rows.append(MenuRow("Auto-switch accounts", 1 if settings.auto_switch_enabled else 0))
+    rows += [
+        MenuRow(f"{pct}%", 1 if threshold == pct else 0) for pct in AUTO_THRESHOLD_CHOICES
+    ]
+    return tuple(rows)
+
+
+def _unique(lines) -> tuple[str, ...]:
+    """De-duplicate while preserving order.
+
+    rumps identifies menu items by title and silently drops a duplicate, so
+    a model that lists one would not match the menu it produces.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in lines:
+        if line not in seen:
+            seen.add(line)
+            out.append(line)
+    return tuple(out)
+
+
+def build_menu_model(
+    snapshot: dict,
+    settings: MenuBarSettings,
+    *,
+    threshold: int,
+    history: list[str] | tuple[str, ...] = (),
+    now: float | None = None,
+) -> MenuModel:
+    """Render the menu's variable content. Pure: no rumps, no I/O."""
+    accounts: list[MenuRow] = []
+    remove: list[MenuRow] = []
+    disable: list[MenuRow] = []
+    slots: list[str] = []
+    for num, email, is_active, display, _last_good, alias, disabled, fetched_at in snapshot["accounts"]:
+        slots.append(str(num))
+        accounts.append(
+            MenuRow(
+                format_account_label(
+                    num, email, display, now, alias=alias,
+                    disabled=disabled, fetched_at=fetched_at,
+                ),
+                1 if is_active else 0,
+            )
+        )
+        named = f"{alias}  ({email})" if alias else email
+        remove.append(MenuRow(f"{num}  {alias}  ({email})" if alias else f"{num}  {email}"))
+        disable.append(MenuRow(f"{num}  {named}", 1 if disabled else 0))
+    if not slots:
+        accounts = [MenuRow(NO_ACCOUNTS)]
+        remove = [MenuRow(NO_ACCOUNTS)]
+        disable = [MenuRow(NO_ACCOUNTS)]
+    return MenuModel(
+        title=format_title(
+            snapshot["active_email"],
+            snapshot["active_usage"],
+            settings,
+            now,
+            alias=snapshot.get("active_alias"),
+        ),
+        slots=tuple(slots),
+        accounts=tuple(accounts),
+        remove=tuple(remove),
+        disable=tuple(disable),
+        history=_unique(history) if history else (NO_HISTORY,),
+        settings_rows=settings_rows(settings, threshold),
+    )
 
 
 def run(switcher) -> int:
@@ -492,6 +659,11 @@ def run(switcher) -> int:
             self._engine = None
             self._engine_events: list = []
             self._event_lock = threading.Lock()
+            # Menu state: the last rendered model plus the live items it
+            # produced, so a refresh can relabel in place instead of
+            # recreating (and stranding) every item.
+            self._model = None
+            self._items: dict[str, list] = {}
             self.rebuild_menu()
             # Background display refresh on the user's interval, plus a fast
             # UI-sync tick that applies snapshots + engine events on the main thread.
@@ -554,7 +726,7 @@ def run(switcher) -> int:
         def on_sync_tick(self, _timer):
             if self._dirty:
                 self._dirty = False
-                self.rebuild_menu()
+                self.sync_menu()
             self._detect_active_change()
             self._drain_engine_events()
 
@@ -647,133 +819,203 @@ def run(switcher) -> int:
                 return 0
 
         # ---- menu construction -----------------------------------------------
-        def rebuild_menu(self):
-            self.title = format_title(
-                self.snapshot["active_email"],
-                self.snapshot["active_usage"],
+        def _menu_model(self):
+            """Current menu content as plain data (see ``build_menu_model``)."""
+            return build_menu_model(
+                self.snapshot,
                 self.settings,
-                alias=self.snapshot.get("active_alias"),
+                threshold=self._threshold(),
+                history=parse_switch_history(read_log_tail(log_path)),
             )
+
+        def sync_menu(self):
+            """Bring the menu in line with the current snapshot.
+
+            Does the least work that can be correct: nothing at all when the
+            rendered content is unchanged, an in-place relabel when only text
+            or check-marks moved, and a full rebuild only when items have to be
+            created or destroyed. Rebuilding unconditionally on every tick is
+            what leaked — see ``MenuModel``.
+            """
+            model = self._menu_model()
+            if model == self._model:
+                return
+            if self._model is None or model.shape != self._model.shape:
+                self.rebuild_menu(model)
+            else:
+                self._apply_model(model)
+
+        def _apply_model(self, model):
+            """Update the existing menu items in place. Creates nothing."""
+            self._model = None  # only restored once the menu matches again
+            self.title = model.title
+            for section in ("accounts", "remove", "disable"):
+                rows = getattr(model, section)
+                for item, row in zip(self._items[section], rows, strict=True):
+                    item.title = row.label
+                    item.state = row.state
+            for item, line in zip(self._items["history"], model.history, strict=True):
+                item.title = line
+            for item, row in zip(self._items["settings"], model.settings_rows, strict=True):
+                item.state = row.state
+            self._model = model
+
+        def rebuild_menu(self, model=None):
+            """Recreate every menu item from scratch.
+
+            Only for structural change — a different set of account slots, a
+            different number of history lines. Every item created here lands in
+            rumps' global callback map, so the outgoing ones are unregistered
+            first.
+            """
+            model = self._menu_model() if model is None else model
+            # Cleared up front: a failure below leaves the menu half-built, and
+            # a stale _model would route the next tick into an in-place update
+            # against items that are no longer there. None forces a rebuild.
+            self._model = None
+            self._forget_menu_items()
+            self._items = {k: [] for k in ("accounts", "remove", "disable", "history", "settings")}
+            self.title = model.title
             self.menu.clear()
-            account_items = []
-            for num, email, is_active, display, _last_good, alias, disabled, fetched_at in self.snapshot["accounts"]:
-                item = rumps.MenuItem(
-                    format_account_label(
-                        num, email, display, alias=alias, disabled=disabled, fetched_at=fetched_at
-                    ),
-                    callback=self._make_switch_to(num),
-                )
-                item.state = 1 if is_active else 0
-                account_items.append(item)
-            if not account_items:
-                account_items.append(rumps.MenuItem("No managed accounts", callback=None))
+
+            for index, row in enumerate(model.accounts):
+                callback = self._make_switch_to(model.slots[index]) if model.slots else None
+                item = rumps.MenuItem(row.label, callback=callback)
+                item.state = row.state
+                self._items["accounts"].append(item)
 
             self.menu = [
-                *account_items,
+                *self._items["accounts"],
                 None,
                 rumps.MenuItem("Rotate to next", callback=self._switch(None)),
                 rumps.MenuItem("Switch to best", callback=self._switch("best")),
                 rumps.MenuItem("Next available", callback=self._switch("next-available")),
                 None,
-                self._add_menu(rumps),
-                self._disable_menu(rumps),
-                self._remove_menu(rumps),
+                self._add_menu(),
+                self._disable_menu(model),
+                self._remove_menu(model),
                 rumps.MenuItem("Refresh current credentials", callback=self.on_refresh_creds),
-                self._history_menu(rumps),
+                self._history_menu(model),
                 None,
-                self._settings_menu(rumps),
+                self._settings_menu(model),
                 rumps.MenuItem("Refresh now", callback=self.on_refresh_now),
                 rumps.MenuItem("Quit", callback=self.on_quit),
             ]
+            self._model = model
 
-        def _add_menu(self, rumps):
+        def _forget_menu_items(self):
+            """Unregister the outgoing menu items from rumps' global callback map.
+
+            ``rumps`` adds every MenuItem carrying a callback to
+            ``NSApp._ns_to_py_and_callback`` and never removes it — ``clear()``
+            only empties the NSMenu. Left alone, each rebuild strands its items,
+            and the closures holding this app, for the life of the process.
+            Guarded: a rumps that reorganises this internal must not break the
+            menu, and the cost of a miss is the old leak, not a crash.
+            """
+            try:
+                registry = rumps.rumps.NSApp._ns_to_py_and_callback
+            except AttributeError:
+                self.switcher._logger.warning(
+                    "rumps callback registry not found; menu rebuilds will leak"
+                )
+                return
+
+            def forget(item):
+                nsitem = getattr(item, "_menuitem", None)
+                if nsitem is not None:
+                    registry.pop(nsitem, None)
+                if isinstance(item, rumps.MenuItem):
+                    for child in list(item.values()):
+                        forget(child)
+
+            try:
+                for item in list(self.menu.values()):
+                    forget(item)
+                # Also the items we hold directly: rumps drops a duplicate
+                # title on the floor, so one can exist without ever having
+                # been reachable from the menu.
+                for tracked in self._items.values():
+                    for item in tracked:
+                        forget(item)
+            except Exception:
+                self.switcher._logger.warning(
+                    "menu registry cleanup skipped", exc_info=True
+                )
+
+        def _add_menu(self):
             menu = rumps.MenuItem("Add account")
             menu.add(rumps.MenuItem("From current login", callback=self.on_add_login))
             if hasattr(self.switcher, "add_account_from_token"):
                 menu.add(rumps.MenuItem("From setup-token…", callback=self.on_add_token))
             return menu
 
-        def _remove_menu(self, rumps):
+        def _remove_menu(self, model):
             menu = rumps.MenuItem("Remove account")
-            accounts = self.snapshot["accounts"]
-            if not accounts:
-                menu.add(rumps.MenuItem("No managed accounts", callback=None))
-            for num, email, _is_active, _display, _last_good, alias, _disabled, _fetched_at in accounts:
-                label = f"{num}  {alias}  ({email})" if alias else f"{num}  {email}"
-                menu.add(rumps.MenuItem(label, callback=self._make_remove(num)))
-            return menu
-
-        def _disable_menu(self, rumps):
-            menu = rumps.MenuItem("Disable / enable account")
-            accounts = self.snapshot["accounts"]
-            if not accounts:
-                menu.add(rumps.MenuItem("No managed accounts", callback=None))
-            for num, email, _is_active, _display, _last_good, alias, disabled, _fetched_at in accounts:
-                name = f"{alias}  ({email})" if alias else email
-                item = rumps.MenuItem(
-                    f"{num}  {name}", callback=self._make_toggle_disabled(num, disabled)
-                )
-                # A check-mark reads as "held out of rotation" — same glyph the
-                # active row uses, but here it means disabled, not selected.
-                item.state = 1 if disabled else 0
+            for index, row in enumerate(model.remove):
+                callback = self._make_remove(model.slots[index]) if model.slots else None
+                item = rumps.MenuItem(row.label, callback=callback)
+                self._items["remove"].append(item)
                 menu.add(item)
             return menu
 
-        def _history_menu(self, rumps):
+        def _disable_menu(self, model):
+            menu = rumps.MenuItem("Disable / enable account")
+            for index, row in enumerate(model.disable):
+                callback = (
+                    self._make_toggle_disabled(model.slots[index]) if model.slots else None
+                )
+                item = rumps.MenuItem(row.label, callback=callback)
+                # A check-mark reads as "held out of rotation" — same glyph the
+                # active row uses, but here it means disabled, not selected.
+                item.state = row.state
+                self._items["disable"].append(item)
+                menu.add(item)
+            return menu
+
+        def _history_menu(self, model):
             menu = rumps.MenuItem("Switch history")
-            try:
-                text = log_path.read_text(encoding="utf-8")
-            except OSError:
-                text = ""
-            entries = parse_switch_history(text)
-            if entries:
-                for line in entries:
-                    menu.add(rumps.MenuItem(line, callback=None))
-            else:
-                menu.add(rumps.MenuItem("No switches logged yet", callback=None))
+            for line in model.history:
+                item = rumps.MenuItem(line, callback=None)
+                self._items["history"].append(item)
+                menu.add(item)
             menu.add(None)
             menu.add(rumps.MenuItem("Open full log…", callback=self.on_open_log))
             return menu
 
-        def _settings_menu(self, rumps):
+        def _settings_menu(self, model):
+            rows = iter(model.settings_rows)
             menu = rumps.MenuItem("Settings")
-            name_item = rumps.MenuItem("Show account name in menu bar", callback=self.on_toggle_name)
-            name_item.state = 1 if self.settings.show_account_name else 0
-            menu.add(name_item)
+
+            def track(item):
+                self._items["settings"].append(item)
+                return item
+
+            def leaf(callback):
+                row = next(rows)
+                item = rumps.MenuItem(row.label, callback=callback)
+                item.state = row.state
+                return track(item)
+
+            menu.add(leaf(self.on_toggle_name))
 
             title_pct = rumps.MenuItem("Title percentage")
-            tp_labels = {"off": "None", "5h": "Session (5h)",
-                         "7d": "Weekly (7d)", "both": "Both (5h · 7d)"}
             for mode in TITLE_PCT_CHOICES:
-                ch = rumps.MenuItem(tp_labels[mode], callback=self._make_title_pct(mode))
-                ch.state = 1 if self.settings.title_pct == mode else 0
-                title_pct.add(ch)
+                title_pct.add(leaf(self._make_title_pct(mode)))
             menu.add(title_pct)
 
-            scoped_item = rumps.MenuItem(
-                "Show model limits in title", callback=self.on_toggle_scoped
-            )
-            scoped_item.state = 1 if self.settings.title_scoped else 0
-            menu.add(scoped_item)
+            menu.add(leaf(self.on_toggle_scoped))
 
             interval = rumps.MenuItem("Refresh interval")
-            labels = {30: "30 seconds", 60: "60 seconds", 300: "5 minutes"}
             for secs in REFRESH_CHOICES:
-                choice = rumps.MenuItem(labels[secs], callback=self._make_interval(secs))
-                choice.state = 1 if self.settings.refresh_interval == secs else 0
-                interval.add(choice)
+                interval.add(leaf(self._make_interval(secs)))
             menu.add(interval)
 
-            auto_item = rumps.MenuItem("Auto-switch accounts", callback=self.on_toggle_autoswitch)
-            auto_item.state = 1 if self.settings.auto_switch_enabled else 0
-            menu.add(auto_item)
+            menu.add(leaf(self.on_toggle_autoswitch))
 
             threshold_menu = rumps.MenuItem("Auto-switch threshold")
-            current = self._threshold()
             for pct in AUTO_THRESHOLD_CHOICES:
-                ch = rumps.MenuItem(f"{pct}%", callback=self._make_threshold(pct))
-                ch.state = 1 if current == pct else 0
-                threshold_menu.add(ch)
+                threshold_menu.add(leaf(self._make_threshold(pct)))
             menu.add(threshold_menu)
 
             return menu
@@ -781,7 +1023,7 @@ def run(switcher) -> int:
         # ---- callbacks --------------------------------------------------------
         def _save_and_rebuild(self):
             self.settings.save(settings_path)
-            self.rebuild_menu()
+            self.sync_menu()
 
         def _guard(self, fn):
             """Run a switcher action, surfacing ClaudeSwitchError via an alert."""
@@ -825,10 +1067,19 @@ def run(switcher) -> int:
                         self.refresh_async()
             return cb
 
-        def _make_toggle_disabled(self, num, disabled):
-            # `disabled` is this row's current state; selecting it flips it.
-            target = not disabled
+        def _slot_disabled(self, num) -> bool:
+            """Whether slot ``num`` is currently held out of rotation."""
+            for account in self.snapshot["accounts"]:
+                if str(account[0]) == str(num):
+                    return bool(account[6])
+            return False
+
+        def _make_toggle_disabled(self, num):
             def cb(_sender):
+                # Read the flag now, not at build time: with in-place menu
+                # updates this row survives a state change, so a captured
+                # value would toggle against a stale reading.
+                target = not self._slot_disabled(num)
                 if self._guard(
                     lambda: self.switcher.set_account_disabled(str(num), target)
                 ):
@@ -935,7 +1186,7 @@ def run(switcher) -> int:
                 self._start_engine()
             else:
                 self._stop_engine()
-            self.rebuild_menu()
+            self.sync_menu()
 
         def _make_threshold(self, pct):
             def cb(_sender):
@@ -945,7 +1196,7 @@ def run(switcher) -> int:
                     rumps.alert(title="claude-swap", message=f"Couldn't set threshold: {e}")
                     return
                 self._restart_engine()  # apply immediately if running
-                self.rebuild_menu()
+                self.sync_menu()
             return cb
 
     MenuBarApp().run()

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -556,3 +556,665 @@ def test_run_without_rumps_raises_clean_error(monkeypatch):
     monkeypatch.setitem(sys.modules, "rumps", None)
     with pytest.raises(ClaudeSwitchError, match=r"claude-swap\[menubar\]"):
         menubar.run(switcher=None)
+
+
+# --- log tail ------------------------------------------------------------------
+
+def test_read_log_tail_returns_whole_short_file(tmp_path: Path):
+    log = tmp_path / "claude-swap.log"
+    log.write_bytes(b"one\ntwo\n")
+    assert menubar.read_log_tail(log, max_bytes=4096) == "one\ntwo\n"
+
+
+def test_read_log_tail_drops_partial_first_line(tmp_path: Path):
+    log = tmp_path / "claude-swap.log"
+    log.write_bytes(b"aaaa\nbbbb\ncccc\n")
+    # A window landing mid-"aaaa" must not yield a truncated line.
+    assert menubar.read_log_tail(log, max_bytes=12) == "bbbb\ncccc\n"
+
+
+def test_read_log_tail_missing_file_is_empty(tmp_path: Path):
+    assert menubar.read_log_tail(tmp_path / "absent.log") == ""
+
+
+# --- menu model ----------------------------------------------------------------
+
+def _account(num, email, *, active=False, usage=None, alias=None,
+             disabled=False, fetched_at=None):
+    """One row of the menu bar's render dict (see ``_adapt_snapshot``)."""
+    return (num, email, active, usage, usage, alias, disabled, fetched_at)
+
+
+def _snapshot(*accounts, active_email=None, active_usage=None, active_alias=None):
+    return {
+        "accounts": list(accounts),
+        "active_email": active_email,
+        "active_usage": active_usage,
+        "active_alias": active_alias,
+    }
+
+
+def _model(snapshot, settings=None, threshold=90, history=()):
+    return menubar.build_menu_model(
+        snapshot,
+        settings or menubar.MenuBarSettings(),
+        threshold=threshold,
+        history=history,
+    )
+
+
+def test_menu_model_rows_track_accounts():
+    model = _model(_snapshot(
+        _account("1", "a@x.com", active=True, usage=_USAGE),
+        _account("2", "b@x.com", alias="dev"),
+    ))
+    assert model.slots == ("1", "2")
+    assert model.accounts[0].label == "1  a@x.com  5h 42% · 7d 18% · $ 30%"
+    assert model.accounts[0].state == 1
+    assert model.accounts[1].state == 0
+    assert model.remove[1].label == "2  dev  (b@x.com)"
+
+
+def test_menu_model_disable_row_state_tracks_disabled():
+    model = _model(_snapshot(
+        _account("1", "a@x.com"),
+        _account("2", "b@x.com", disabled=True),
+    ))
+    assert [row.state for row in model.disable] == [0, 1]
+
+
+def test_menu_model_equal_when_nothing_changed():
+    """An unchanged tick must produce an equal model, so the app can skip it."""
+    snapshot = _snapshot(_account("1", "a@x.com", active=True, usage=_USAGE))
+    assert _model(snapshot) == _model(snapshot)
+
+
+def test_menu_model_usage_change_keeps_shape():
+    """The common case: percentages moved, so relabel in place — never rebuild.
+
+    This is the property the leak fix rests on. Rebuilding here is what stranded
+    a menu's worth of items in rumps' global callback map on every refresh.
+    """
+    before = _model(_snapshot(_account("1", "a@x.com", active=True, usage=_USAGE)))
+    after = _model(_snapshot(_account(
+        "1", "a@x.com", active=True,
+        usage={"five_hour": {"pct": 99.0}, "seven_day": {"pct": 18.0}},
+    )))
+    assert before != after
+    assert before.shape == after.shape
+
+
+def test_menu_model_settings_change_keeps_shape():
+    snapshot = _snapshot(_account("1", "a@x.com"))
+    before = _model(snapshot, menubar.MenuBarSettings(auto_switch_enabled=False))
+    after = _model(snapshot, menubar.MenuBarSettings(auto_switch_enabled=True))
+    assert before != after
+    assert before.shape == after.shape
+
+
+def test_menu_model_added_account_changes_shape():
+    before = _model(_snapshot(_account("1", "a@x.com")))
+    after = _model(_snapshot(_account("1", "a@x.com"), _account("2", "b@x.com")))
+    assert before.shape != after.shape
+
+
+def test_menu_model_reassigned_slot_changes_shape():
+    """A row's callback is bound to its slot, so a changed slot must rebuild.
+
+    Same row count, different account behind row 2: relabelling would leave the
+    row switching to the account that used to occupy it.
+    """
+    before = _model(_snapshot(_account("1", "a@x.com"), _account("2", "b@x.com")))
+    after = _model(_snapshot(_account("1", "a@x.com"), _account("3", "c@x.com")))
+    assert len(before.accounts) == len(after.accounts)
+    assert before.shape != after.shape
+
+
+def test_menu_model_empty_accounts_uses_placeholders():
+    model = _model(_snapshot())
+    assert model.slots == ()
+    assert model.accounts == (menubar.MenuRow(menubar.NO_ACCOUNTS),)
+    assert model.remove == (menubar.MenuRow(menubar.NO_ACCOUNTS),)
+    assert model.disable == (menubar.MenuRow(menubar.NO_ACCOUNTS),)
+
+
+def test_menu_model_first_account_changes_shape_from_empty():
+    """Empty and one-account menus both show one row but need different callbacks."""
+    assert _model(_snapshot()).shape != _model(_snapshot(_account("1", "a@x.com"))).shape
+
+
+def test_menu_model_history_placeholder_when_empty():
+    assert _model(_snapshot()).history == (menubar.NO_HISTORY,)
+
+
+def test_menu_model_history_passthrough():
+    model = _model(_snapshot(), history=["2 → 1   2026-06-27 02:06"])
+    assert model.history == ("2 → 1   2026-06-27 02:06",)
+
+
+def test_settings_rows_reflect_settings_and_threshold():
+    rows = menubar.settings_rows(
+        menubar.MenuBarSettings(show_account_name=True, title_pct="5h", refresh_interval=300),
+        threshold=95,
+    )
+    checked = {row.label for row in rows if row.state}
+    assert checked == {"Show account name in menu bar", "Session (5h)", "5 minutes", "95%"}
+
+
+def test_settings_rows_length_is_fixed():
+    """Settings never change the item count, so they never force a rebuild."""
+    a = menubar.settings_rows(menubar.MenuBarSettings(), threshold=80)
+    b = menubar.settings_rows(menubar.MenuBarSettings(title_pct="off"), threshold=98)
+    assert len(a) == len(b)
+
+
+# --- app-level menu behaviour --------------------------------------------------
+# The fix lives in the app glue -- sync_menu / rebuild_menu / _apply_model and the
+# rumps registry cleanup -- which the pure-helper tests above cannot reach. Rather
+# than import rumps (which this suite must not do, and which needs macOS), stand
+# in a fake that reproduces the semantics the fix depends on: menu items keyed by
+# title, a duplicate title silently dropped, and every callback recorded in one
+# process-global dict that rumps itself never prunes.
+
+class _FakeNSApp:
+    _ns_to_py_and_callback: dict = {}
+
+
+class _FakeSeparator:
+    """Stand-in for rumps.SeparatorMenuItem.
+
+    Deliberately not a MenuItem and deliberately without ``values()`` --
+    that is exactly why ``_forget_menu_items`` has to type-check before it
+    recurses, and a fake that skipped separators could not catch the guard
+    being removed. Never registered: rumps only records items with a
+    callback.
+    """
+
+    def __init__(self):
+        self._menuitem = object()
+
+
+class _FakeMenuItem:
+    def __init__(self, title="", callback=None):
+        self.title = title
+        self.state = 0
+        self._menuitem = object()  # stands in for the NSMenuItem key
+        self._children: dict = {}
+        self._separators = 0
+        _FakeNSApp._ns_to_py_and_callback[self._menuitem] = (self, callback)
+
+    @property
+    def callback(self):
+        return _FakeNSApp._ns_to_py_and_callback[self._menuitem][1]
+
+    def add(self, item):
+        if item is None:
+            self._separators += 1
+            self._children[f"__sep{self._separators}__"] = _FakeSeparator()
+            return
+        if item.title not in self._children:  # rumps drops duplicate titles
+            self._children[item.title] = item
+
+    def values(self):
+        return list(self._children.values())
+
+    def clear(self):
+        self._children.clear()
+
+    def update(self, iterable):
+        for item in iterable:
+            self.add(item)
+
+
+class _FakeApp:
+    def __init__(self, title="", quit_button=None):
+        self.title = title
+        self._menu = _FakeMenuItem("__main__")
+
+    @property
+    def menu(self):
+        return self._menu
+
+    @menu.setter
+    def menu(self, iterable):
+        self._menu.update(iterable)
+
+    def run(self):  # replaced per-test to capture the instance
+        raise AssertionError("the fake app must not enter a run loop")
+
+
+class _FakeTimer:
+    def __init__(self, callback, interval):
+        self.callback, self.interval = callback, interval
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+def _fake_rumps():
+    import types
+
+    module = types.ModuleType("rumps")
+    module.App = _FakeApp
+    module.MenuItem = _FakeMenuItem
+    module.Timer = _FakeTimer
+    module.separator = _FakeSeparator
+    module.alert = lambda *a, **k: 1
+    module.notification = lambda *a, **k: None
+    module.Window = None
+    inner = types.ModuleType("rumps.rumps")
+    inner.NSApp = _FakeNSApp
+    module.rumps = inner
+    return module
+
+
+class _StubSwitcher:
+    def __init__(self, backup_dir: Path):
+        self.backup_dir = backup_dir
+        self._logger = __import__("logging").getLogger("test-menubar")
+        self.disabled_calls: list = []
+        self.switched_to: list = []
+
+    def _get_claude_config_path(self):
+        return self.backup_dir / "claude.json"
+
+    def set_account_disabled(self, num, target):
+        self.disabled_calls.append((num, target))
+
+    def switch_to(self, num):
+        self.switched_to.append(num)
+
+
+def _build_app(monkeypatch, tmp_path: Path):
+    """Construct the real MenuBarApp against the fake rumps, without a run loop."""
+    import claude_swap.snapshot_source as snapshot_source
+
+    _FakeNSApp._ns_to_py_and_callback = {}
+    fake = _fake_rumps()
+    monkeypatch.setitem(sys.modules, "rumps", fake)
+    monkeypatch.setitem(sys.modules, "AppKit", _fake_appkit())
+    monkeypatch.setattr(menubar, "ensure_notification_identity", lambda *a, **k: None)
+    monkeypatch.setattr(snapshot_source, "SnapshotSource", _StubSnapshotSource)
+
+    captured = {}
+    monkeypatch.setattr(_FakeApp, "run", lambda self: captured.setdefault("app", self))
+    switcher = _StubSwitcher(tmp_path)
+    menubar.run(switcher)
+    app = captured["app"]
+    app.refresh_async = lambda full=False: None  # no background worker in tests
+    return app, switcher, _FakeNSApp._ns_to_py_and_callback
+
+
+def _fake_appkit():
+    import types
+
+    module = types.ModuleType("AppKit")
+    module.NSApplicationActivationPolicyAccessory = 1
+    shared = type("_App", (), {"setActivationPolicy_": lambda self, p: None})()
+    module.NSApplication = type("_NSApplication", (), {"sharedApplication": staticmethod(lambda: shared)})
+    return module
+
+
+class _StubSnapshotSource:
+    def __init__(self, switcher):
+        pass
+
+    def take(self, **kwargs):
+        raise AssertionError("tests drive app.snapshot directly")
+
+
+def _submenu(app, title):
+    """Top-level submenu by title, skipping separators."""
+    for item in app.menu.values():
+        if getattr(item, "title", None) == title:
+            return item
+    return None
+
+
+def _snap(*rows, active=0):
+    """Build the render dict for the given (num, pct, disabled) rows."""
+    accounts = []
+    for index, (num, pct, disabled) in enumerate(rows):
+        usage = {"five_hour": {"pct": pct}, "seven_day": {"pct": 20.0}}
+        accounts.append((num, f"a{num}@x.com", index == active, usage, usage,
+                         None, disabled, None))
+    return {
+        "accounts": accounts,
+        "active_email": accounts[active][1] if accounts else None,
+        "active_usage": accounts[active][3] if accounts else None,
+        "active_alias": None,
+    }
+
+
+def test_sync_menu_does_not_grow_the_rumps_registry(monkeypatch, tmp_path: Path):
+    """The regression this whole change exists for.
+
+    rumps never prunes ``NSApp._ns_to_py_and_callback``, so recreating the menu
+    on every refresh stranded a menu's worth of items per tick. Refreshes that
+    only move percentages must not add a single entry.
+    """
+    app, _switcher, registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False), ("2", 20.0, False))
+    app.rebuild_menu()
+    baseline = len(registry)
+
+    for tick in range(50):
+        app.snapshot = _snap(("1", 10.0 + tick, False), ("2", 20.0, False))
+        app.sync_menu()
+
+    assert len(registry) == baseline
+
+
+def test_rebuild_unregisters_the_items_it_discards(monkeypatch, tmp_path: Path):
+    """Structural rebuilds must not leak either."""
+    app, _switcher, registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+    after_first = len(registry)
+
+    for _ in range(20):
+        app.rebuild_menu()
+
+    assert len(registry) == after_first
+
+
+def test_forget_menu_items_keeps_live_items_registered(monkeypatch, tmp_path: Path):
+    """Over-pruning would break clicks: rumps looks callbacks up by NSMenuItem."""
+    app, _switcher, registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False), ("2", 20.0, False))
+    app.rebuild_menu()
+
+    def walk(item):
+        yield item
+        for child in getattr(item, "values", list)():
+            yield from walk(child)
+
+    live = [i for i in walk(app.menu)
+            if i is not app.menu and not isinstance(i, _FakeSeparator)]
+    assert live and all(i._menuitem in registry for i in live)
+
+
+def test_sync_menu_updates_in_place_without_replacing_items(monkeypatch, tmp_path: Path):
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False), ("2", 20.0, False))
+    app.rebuild_menu()
+    identities = [id(i) for i in app._items["accounts"]]
+
+    app.snapshot = _snap(("1", 77.0, False), ("2", 88.0, True), active=1)
+    app.sync_menu()
+
+    assert [id(i) for i in app._items["accounts"]] == identities
+    assert [i.state for i in app._items["accounts"]] == [0, 1]
+    assert "5h 77%" in app._items["accounts"][0].title
+    assert "(disabled)" in app._items["accounts"][1].title
+    assert [i.state for i in app._items["disable"]] == [0, 1]
+
+
+def test_sync_menu_rebuilds_and_rebinds_when_slots_change(monkeypatch, tmp_path: Path):
+    """A row's callback belongs to its slot, so a changed slot set must rebuild."""
+    app, switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False), ("2", 20.0, False))
+    app.rebuild_menu()
+    identities = [id(i) for i in app._items["accounts"]]
+
+    app.snapshot = _snap(("1", 10.0, False), ("3", 20.0, False))
+    app.sync_menu()
+
+    assert [id(i) for i in app._items["accounts"]] != identities
+    app._items["accounts"][1].callback(None)
+    assert switcher.switched_to == ["3"]
+
+
+def test_placeholder_row_is_not_clickable(monkeypatch, tmp_path: Path):
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap()
+    app.rebuild_menu()
+    assert [i.title for i in app._items["accounts"]] == [menubar.NO_ACCOUNTS]
+    assert app._items["accounts"][0].callback is None
+
+
+def test_duplicate_history_lines_keep_items_and_menu_aligned(monkeypatch, tmp_path: Path):
+    """rumps drops a duplicate title, so the model must not list one.
+
+    Two identical switches inside one minute render as the same string (the
+    stamp is trimmed to the minute). If the model kept both, ``_items`` would
+    outnumber the rows actually in the menu -- permanently, because the shape
+    would still match and no rebuild would ever correct it.
+    """
+    log = tmp_path / "claude-swap.log"
+    line = "2026-08-12 02:06:01 - claude-swap - INFO - Switched from account 1 to 2"
+    log.write_bytes(("\n".join([line, line, line.replace("02:06:01", "02:07:30")]) + "\n").encode())
+
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+
+    history_menu = _submenu(app, "Switch history")
+    rendered = [i for i in history_menu.values() if not isinstance(i, _FakeSeparator)]
+    # Identity, not title: a dropped duplicate has the same text as the row
+    # that did make it in, so comparing labels would pass either way.
+    orphans = [i for i in app._items["history"] if not any(r is i for r in rendered)]
+    assert orphans == []
+    assert len(app._model.history) == len(set(app._model.history))
+
+
+def test_failed_rebuild_recovers_on_the_next_tick(monkeypatch, tmp_path: Path):
+    """A rebuild that dies partway must not strand the menu forever.
+
+    rumps swallows exceptions raised inside a timer callback, so a failure here
+    is invisible. Leaving ``_model`` populated would route every later tick into
+    an in-place update against items that were never built.
+    """
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+
+    boom = {"raise": True}
+    original = app._settings_menu
+
+    def flaky(model):
+        if boom["raise"]:
+            raise RuntimeError("simulated failure mid-rebuild")
+        return original(model)
+
+    app._settings_menu = flaky
+    app.snapshot = _snap(("1", 10.0, False), ("2", 20.0, False))
+    with pytest.raises(RuntimeError):
+        app.sync_menu()
+    assert app._model is None  # forces a rebuild rather than an in-place update
+
+    boom["raise"] = False
+    app.sync_menu()
+    assert _submenu(app, "Settings") is not None
+    assert len(app._items["accounts"]) == 2
+
+
+def test_sync_tick_applies_a_dirty_snapshot(monkeypatch, tmp_path: Path):
+    """The refresh timer is the only caller in production."""
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+
+    app.snapshot = _snap(("1", 66.0, False))
+    app._dirty = True
+    app.on_sync_tick(None)
+
+    assert "5h 66%" in app._items["accounts"][0].title
+    assert app._dirty is False
+
+
+def test_unchanged_snapshot_leaves_the_menu_untouched(monkeypatch, tmp_path: Path):
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+    before = app._model
+    app.sync_menu()
+    assert app._model is before  # same object: no model swap, no UI work
+
+
+def test_toggle_disabled_reads_state_at_click_time(monkeypatch, tmp_path: Path):
+    """The row outlives the state change now, so the flag cannot be captured."""
+    app, switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+    toggle = app._items["disable"][0].callback
+
+    toggle(None)
+    assert switcher.disabled_calls[-1] == ("1", True)
+
+    app.snapshot = _snap(("1", 10.0, True))
+    app.sync_menu()
+    toggle(None)
+    assert switcher.disabled_calls[-1] == ("1", False)
+
+
+def test_log_tail_window_covers_a_full_rotation():
+    """The window must never be the reason a switch is missing from the menu.
+
+    Switch lines are sparse among usage lines: a 64KB window found 2 of 10 on a
+    real 514KB log. Asserted against the rotation constant rather than a literal
+    so the two cannot drift apart.
+    """
+    from claude_swap.logging_config import LOG_MAX_BYTES
+
+    assert menubar.LOG_TAIL_BYTES >= LOG_MAX_BYTES
+
+
+def test_read_log_tail_at_exactly_the_window_size(tmp_path: Path):
+    """Boundary: the whole file fits, so no line may be dropped."""
+    log = tmp_path / "claude-swap.log"
+    log.write_bytes(b"abcd\nefgh\n")
+    assert menubar.read_log_tail(log, max_bytes=10) == "abcd\nefgh\n"
+    assert menubar.read_log_tail(log, max_bytes=9) == "efgh\n"
+
+
+def test_switch_history_dedupes_before_applying_the_limit():
+    """A repeated line must not consume a slot an older distinct switch could fill."""
+    stamps = [f"2026-06-27 02:{minute:02d}:00" for minute in range(12)]
+    lines = [f"{s} - claude-swap - INFO - Switched from account 1 to 2" for s in stamps]
+    lines.insert(0, lines[0])  # an exact repeat of the oldest entry
+    out = menubar.parse_switch_history("\n".join(lines), limit=10)
+    assert len(out) == len(set(out)) == 10
+
+
+def test_build_menu_model_dedupes_history_independently():
+    """Held separately from the parser: the model's own invariant is that every
+    row it lists can exist in the menu, whatever the caller hands it."""
+    model = _model(_snapshot(), history=["a", "a", "b"])
+    assert model.history == ("a", "b")
+
+
+def test_repeated_syncs_keep_updating_in_place(monkeypatch, tmp_path: Path):
+    """Two ticks, not one.
+
+    A single sync after a rebuild proves little: `_model` is still whatever the
+    rebuild set. Only the second tick shows the in-place path restored it, and a
+    regression here silently reverts to rebuilding on every refresh.
+    """
+    app, _switcher, registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+    identities = [id(i) for i in app._items["accounts"]]
+    baseline = len(registry)
+
+    for pct in (30.0, 60.0, 90.0):
+        app.snapshot = _snap(("1", pct, False))
+        app.sync_menu()
+        assert [id(i) for i in app._items["accounts"]] == identities
+        assert f"5h {pct:.0f}%" in app._items["accounts"][0].title
+        assert app.title.endswith(f"{pct:.0f}% · 20%")
+
+    assert len(registry) == baseline
+
+
+def test_settings_toggle_moves_its_check_mark_in_place(monkeypatch, tmp_path: Path):
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+    name_item = app._items["settings"][0]
+    before = name_item.state
+
+    name_item.callback(None)  # the menu entry the user would click
+
+    assert name_item.state != before
+    assert app._items["settings"][0] is name_item  # updated, not rebuilt
+
+
+def test_history_rows_follow_the_log_between_syncs(monkeypatch, tmp_path: Path):
+    log = tmp_path / "claude-swap.log"
+
+    def write(*pairs):
+        log.write_bytes("\n".join(
+            f"2026-08-12 02:{m:02d}:00 - claude-swap - INFO - "
+            f"Switched from account {a} to {b}" for a, b, m in pairs
+        ).encode() + b"\n")
+
+    write(("1", "2", 1), ("2", "1", 2))
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+    items = list(app._items["history"])
+    assert [i.title for i in items] == ["2 → 1   2026-08-12 02:02", "1 → 2   2026-08-12 02:01"]
+
+    write(("3", "1", 5), ("1", "3", 6))
+    app.sync_menu()
+
+    assert [id(i) for i in app._items["history"]] == [id(i) for i in items]
+    assert [i.title for i in app._items["history"]] == [
+        "1 → 3   2026-08-12 02:06", "3 → 1   2026-08-12 02:05",
+    ]
+
+
+def test_build_menu_model_title_honours_now():
+    """`now` reaches the title, not just the rows -- the model is fully pure.
+
+    Without this the docstring's "no I/O" claim is false for the title, and a
+    future test pinning a countdown would be reading the wall clock.
+    """
+    # A weekly window rolls to 0% once its reset passes, so the same data reads
+    # differently either side of it -- the one title component `now` governs.
+    usage = {"seven_day": {"pct": 95.0, "resets_at": _iso(1800)}}
+    settings = menubar.MenuBarSettings(show_account_name=False, title_pct="7d")
+    snapshot = _snapshot(_account("1", "a@x.com", active=True, usage=usage),
+                         active_email="a@x.com", active_usage=usage)
+    before = menubar.build_menu_model(snapshot, settings, threshold=90, now=_NOW)
+    after = menubar.build_menu_model(snapshot, settings, threshold=90, now=_NOW + 3600)
+    assert before.title == "⇄ 95%"
+    assert after.title == "⇄ 0%"
+
+
+class _ExplodingItem:
+    """A menu item that refuses to be updated, to fail an in-place pass midway."""
+
+    _menuitem = object()
+
+    def __setattr__(self, name, value):
+        raise RuntimeError("simulated failure mid-apply")
+
+
+def test_failed_in_place_update_recovers_on_the_next_tick(monkeypatch, tmp_path: Path):
+    """An in-place pass dies partway, leaving rows half-updated.
+
+    No model describes that mixed state, so `_model` must not survive it --
+    otherwise the next tick takes the in-place path again and the menu stays
+    wrong forever. Clearing it forces a rebuild, which is the only way back to
+    a known state.
+    """
+    app, _switcher, _registry = _build_app(monkeypatch, tmp_path)
+    app.snapshot = _snap(("1", 10.0, False))
+    app.rebuild_menu()
+    good_history = app._items["history"]
+    app._items["history"] = [_ExplodingItem()]
+
+    app.snapshot = _snap(("1", 55.0, False))
+    with pytest.raises(RuntimeError):
+        app.sync_menu()
+    assert app._model is None
+
+    app._items["history"] = good_history
+    app.sync_menu()
+    assert app._model is not None
+    assert "5h 55%" in app._items["accounts"][0].title


### PR DESCRIPTION
## Problem

The menu bar leaks memory steadily while idle. A real instance reached **1.28 GB RSS over about seven days** at a 30s refresh — roughly **186 MB/day**.

`rumps` records every `MenuItem` carrying a callback in a process-global dict and never removes it:

```python
# rumps/rumps.py:579
NSApp._ns_to_py_and_callback[self._menuitem] = self, callback
```

`Menu.clear()` only empties the `NSMenu`:

```python
# rumps/rumps.py:276
def clear(self):
    self._menu.removeAllItems()
    super(Menu, self).clear()
```

`rebuild_menu()` ran on every refresh tick and recreated all ~38 items each time, so every tick stranded a menu's worth of items — and the closures holding the app — for the life of the process.

## Fix

The menu's variable content is rendered as plain data first (`MenuModel`), so a tick can decide what to do without touching rumps:

- **nothing** when the model is unchanged,
- **in-place relabel** when only text or check-marks moved (the common case: percentages ticking),
- **full rebuild** only when items must be created or destroyed.

`MenuModel.shape` carries the **account slot tuple**, not a row count. Callbacks bind to a slot at creation, so relabelling across a changed slot set would leave a row switching to whichever account previously occupied that position.

`rebuild_menu()` unregisters what it discards, so the now-rare structural rebuild does not leak either. `_model` is cleared before either update path and restored only on success: the old code rebuilt unconditionally and therefore self-healed after a transient failure, and that property had to be preserved rather than traded away.

Falling out of this:

- `_make_toggle_disabled` captured the row's `disabled` flag at build time. A row now outlives a state change, so it reads the flag when clicked.
- `_history_menu` read the entire log on every rebuild to show ten lines. It now reads a tail sized to the rotation ceiling — a smaller window silently truncates the history, because switch lines are sparse among usage lines (a 64KB window found 2 of 10 entries on a real 514KB log).
- Repeated history entries collapse before the limit is applied. Two identical switches inside one minute render as the same string; rumps identifies items by title and drops the duplicate, so a model listing one would not match the menu it produces.

## Incidental fix

`_history_menu` used `read_text(encoding="utf-8")` under `except OSError`. `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so a single bad byte in the log would have taken down `rebuild_menu()` entirely. The tail read decodes with `errors="replace"`.

## Verification

Driven against real `rumps`/`NSMenuItem` objects the way production does it (new snapshot → `sync_menu()`), 1000 refreshes:

| | registry growth | RSS growth | projected/day @30s |
|---|---:|---:|---:|
| before | 38,000 entries | 60.5 MB | ~174 MB |
| after | **0** | 1.9 MB | ~5.5 MB |

The pre-fix projection matches the ~186 MB/day seen on the real instance, which is what confirms this was the dominant leak. 200 forced structural rebuilds grew the registry by 3 entries — the extra slot's rows — not 200 × 38.

Functional checks read titles and check-marks back off the live `NSMenuItem` objects rather than off the model, since silent staleness is the risk of updating instead of rebuilding.

36 new tests. The suite still never imports rumps or AppKit — a stand-in is injected through `sys.modules`, including a separator that is not a `MenuItem` and has no `values()`, which is what makes the type check in the registry walk load-bearing.

The tests were mutation-checked: 14 of 16 mutations to the fix are caught. The two that survive are `strict=True` on the `_apply_model` zips and the `_items` arm of the registry walk — both are defence in depth whose value is that they never fire, and pinning them would mean first breaking the invariant that makes them unnecessary. Recorded here rather than papered over.

Full suite: 2122 passed. Three failures in `test_move_accounts.py`, `test_real_store_guard.py` and `test_swap_accounts.py` pre-date this branch — they reproduce on a clean `main`, and none of those files import `menubar`.

## Upstream note

`Menu.clear()` leaving `_ns_to_py_and_callback` populated is arguably a rumps bug: any app that periodically rebuilds its menu hits it. This works around it locally rather than waiting on a rumps release.
