### PR TITLE
fix: don't manufacture a dead-token verdict from an unreadable backup

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -4809,7 +4809,15 @@ class ClaudeAccountSwitcher:
             # strike costs one pass of "re-login needed" on a row that
             # already took AUTH_DEAD_STRIKES invalid_grants; erasing it costs
             # the quarantine itself.
-            return True
+            #
+            # Gated on an actual strike existing (``entry.token_dead()``, no
+            # ``stored_fp`` — we can't verify which generation, so this only
+            # asks whether the count itself has reached threshold): the
+            # first check above already proved the LIVE credential doesn't
+            # carry the struck generation, so a row with zero strikes has
+            # nothing to hold — an unreadable backup on an otherwise-healthy
+            # account must not manufacture "re-login needed" out of nothing.
+            return entry.token_dead()
         return bool(backup) and entry.token_dead(
             stored_fp=oauth.credential_fingerprint(backup)
         )

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -11671,6 +11671,36 @@ class TestUnreadableBackupIsNotAbsent:
             "one unreadable pass erased the persisted struck fingerprint"
         )
 
+    # -- C-2b: the dead-token second-source check with NO strike to hold -
+
+    def test_active_slot_with_zero_strikes_and_unreadable_backup_is_not_dead(
+        self, temp_home: Path, sample_sequence_data: dict, monkeypatch,
+        block_real_keychain,
+    ):
+        """A transient Keychain read must not manufacture a dead verdict
+        for a row that was never struck.
+
+        The ``unreadable`` branch's own comment justifies holding a strike
+        because the row "already took AUTH_DEAD_STRIKES invalid_grants" —
+        but the code returns ``True`` unconditionally, with no check that
+        any strike actually exists. A healthy active account (zero
+        ``auth_dead_strikes``) whose backup read merely times out must not
+        be reported as "re-login needed".
+        """
+        s = self._macos_switcher(sample_sequence_data, email="b@example.com")
+        live = json.dumps({
+            "claudeAiOauth": {"accessToken": "sk-live",
+                              "refreshToken": "rt-live",
+                              "expiresAt": 9999999999000}})
+        identities = {"1": ("b@example.com", "")}
+        entry = s._usage_store.entries(identities, [])["1"]
+        assert entry.auth_dead_strikes == 0, "the row must never have been struck"
+
+        monkeypatch.setattr(macos_keychain, "get_password", _raise_locked)
+        assert not s._entry_token_dead(entry, "1", "b@example.com", live, True), (
+            "zero strikes plus an unreadable backup must not report dead"
+        )
+
     # -- C-3: the import auto-heal's verdict -----------------------------
 
     def test_unreadable_backup_is_not_a_dead_slot_for_import(


### PR DESCRIPTION
## Problem
`_entry_token_dead`'s active-slot check treats a merely-*unreadable* backup Keychain item as proof of a dead refresh token, regardless of whether any `invalid_grant` strike was ever recorded. A healthy active account can show "re-login needed" from nothing more than Keychain read contention.

## Fix
One-line change: the `unreadable` branch now returns `entry.token_dead()` instead of `True`, asking whether the row has genuinely reached `AUTH_DEAD_STRIKES` rather than assuming it has.

## Testing
TDD: added `test_active_slot_with_zero_strikes_and_unreadable_backup_is_not_dead`, watched it fail against the unpatched code, applied the fix, confirmed green. `test_unreadable_backup_never_erases_a_live_dead_token_strike` (the existing test covering the "hold a real strike" case) still passes unchanged. Full suite: 2087 passed, 3 skipped, 3 pre-existing failures unrelated to this change (unchanged before/after).

Fixes #281
