### PR TITLE
fix: rescue a successful retry read instead of discarding it in the usage sentinel

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -3750,7 +3750,16 @@ class ClaudeAccountSwitcher:
                 creds = active.value or ""
                 self._record_active_verdict(active)
             else:
-                creds = self._read_account_credentials(str(num), email)
+                # `_ex` (not the bare reader): a transient Keychain failure
+                # on this read must not be silently indistinguishable from
+                # a genuinely absent backup — the bare variant takes no
+                # `failed` list and always swallows to "". This call site's
+                # `unreadable` verdict isn't threaded further today (the
+                # sentinel does its own independent re-read), but reading
+                # through `_ex` here matches every other backup read site
+                # in this module and keeps the door open without widening
+                # this tuple's shape.
+                creds, _unreadable = self._read_account_credentials_ex(str(num), email)
 
             accounts_info.append((num, email, org_name, org_uuid, is_active, creds, alias))
         return accounts_info
@@ -4469,9 +4478,7 @@ class ClaudeAccountSwitcher:
                 self._active_keychain_unavailable or self._active_read_unreadable
             ):
                 return USAGE_KEYCHAIN_UNAVAILABLE
-            if not is_active and self._read_account_credentials_ex(
-                str(num), email
-            )[1]:
+            if not is_active:
                 # THIS slot's own read, not the process flag — which one
                 # slot's clean read erased for every other slot. Measured with
                 # every read denied and a real backup on slot 2:
@@ -4481,7 +4488,30 @@ class ClaudeAccountSwitcher:
                 #
                 # "no credentials" sends the user to re-add a slot that has one
                 # — the dead end 41313b9 removed from three other sites.
-                return USAGE_KEYCHAIN_UNAVAILABLE
+                retried, unreadable = self._read_account_credentials_ex(
+                    str(num), email
+                )
+                if unreadable:
+                    return USAGE_KEYCHAIN_UNAVAILABLE
+                # The retry above is a SECOND, independent Keychain read —
+                # `_build_accounts_info` already made the first one and its
+                # result is `creds`, which is why we're in this branch at
+                # all. A transient hiccup on that first call (swallowed to
+                # "" — it passes no `failed` list) is not proof the slot is
+                # empty: this retry just reached the Keychain and either
+                # found nothing (genuinely absent, fall through below) or
+                # found the real backup, which the old code discarded —
+                # keeping only "was the retry unreadable" and never asking
+                # "did the retry find something". Rescue it here instead of
+                # reporting "no credentials" out from under a slot that has
+                # one (field case: `security -w` on the same item, moments
+                # later, returned valid JSON while the sentinel still said
+                # "no credentials").
+                if retried:
+                    if looks_like_api_key(retried):
+                        return USAGE_API_KEY
+                    if oauth.extract_access_token(retried):
+                        return None
             return USAGE_NO_CREDENTIALS
         # An expired active token is no longer a static state: the fetch path
         # refreshes it under Claude Code's own lock protocol (owner or not),

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -978,7 +978,7 @@ class TestListAccountsUsage:
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch("claude_swap.oauth.urllib.request.urlopen", return_value=mock_response):
             switcher.list_accounts()
 
@@ -1038,7 +1038,7 @@ class TestListAccountsUsage:
         switcher._write_json(switcher.sequence_file, sample_sequence_data)
 
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch("claude_swap.oauth.urllib.request.urlopen", return_value=mock_response):
             switcher.list_accounts()
 
@@ -1101,7 +1101,7 @@ class TestListAccountsUsage:
             return oauth.RefreshOutcome(refreshed_creds, None)
 
         with patch.object(switcher, "_read_credentials", return_value=active_creds), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch.object(switcher, "_write_credentials") as write_live, \
              patch.object(switcher, "_write_account_credentials") as write_backup, \
              patch.object(switcher, "consume_backup_grant", side_effect=mock_gate), \
@@ -1273,7 +1273,7 @@ class TestListAccountsUsage:
 
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
             switcher.list_accounts()
 
@@ -1314,7 +1314,7 @@ class TestListAccountsUsage:
 
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch("claude_swap.oauth.try_fetch_usage_for_account",
                    return_value=oauth.UsageOutcome(usage_result)) as mock_fetch:
             switcher.list_accounts()
@@ -1344,7 +1344,7 @@ class TestListAccountsUsage:
         }
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch("claude_swap.oauth.try_fetch_usage_for_account",
                    return_value=oauth.UsageOutcome(usage_result)):
             switcher.list_accounts()
@@ -1389,7 +1389,7 @@ class TestListAccountsUsage:
         }
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch("claude_swap.oauth.try_fetch_usage_for_account",
                    return_value=oauth.UsageOutcome(usage_result)) as mock_fetch:
             switcher.list_accounts()
@@ -1435,7 +1435,7 @@ class TestListAccountsUsage:
             "_read_active_credentials",
             return_value=ActiveCredentials(active_creds, False),
         ), patch.object(
-            switcher, "_read_account_credentials", return_value=backup_creds
+            switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)
         ), patch(
             "claude_swap.oauth.try_fetch_usage_for_account",
             return_value=oauth.UsageOutcome(refreshed),
@@ -1536,7 +1536,7 @@ class TestListAccountsUsage:
 
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch("claude_swap.oauth.try_fetch_usage_for_account",
                    return_value=oauth.UsageOutcome(usage_result)) as mock_fetch:
             switcher.list_accounts(fetch=set())
@@ -1545,7 +1545,7 @@ class TestListAccountsUsage:
 
         with patch.object(switcher, "_read_active_credentials",
                           return_value=ActiveCredentials(active_creds, False)), \
-             patch.object(switcher, "_read_account_credentials", return_value=backup_creds), \
+             patch.object(switcher, "_read_account_credentials_ex", return_value=(backup_creds, False)), \
              patch("claude_swap.oauth.try_fetch_usage_for_account",
                    return_value=oauth.UsageOutcome(usage_result)) as mock_fetch:
             switcher.list_accounts(fetch={"2"})
@@ -9076,6 +9076,52 @@ class TestBackupUnreadableDisplay:
         info = (2, "b@example.com", "", "", False, "", "")
         assert s._static_usage_sentinel(info) == USAGE_NO_CREDENTIALS
 
+    def test_idle_slot_stale_empty_creds_but_retry_finds_valid_backup(
+        self, temp_home: Path, block_real_keychain,
+    ):
+        """A slot whose row carries stale EMPTY ``creds`` — as
+        ``_build_accounts_info`` records when its own backup read hit a
+        transient hiccup and swallowed it to ``""`` — must not report 'no
+        credentials' when the sentinel's OWN retry (via
+        ``_read_account_credentials_ex``, called right here) reaches the
+        Keychain and finds a real, healthy credential.
+
+        Reproduces a field case: ``cswap list --token-status`` showed 'no
+        credentials' for an inactive slot while a plain ``security -w``
+        read of that exact item, moments later, returned valid JSON. The
+        retry below IS that later, successful read — the sentinel found it
+        and threw the value away, keeping only the boolean "was it
+        unreadable" (False) instead of asking "did it find something".
+        """
+        from claude_swap.json_output import USAGE_NO_CREDENTIALS
+
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.MACOS
+        s._setup_directories()
+
+        creds = json.dumps({"claudeAiOauth": {
+            "accessToken": "sk-backup", "refreshToken": "rt-backup",
+            "expiresAt": 9999999999000}})
+        # Seed the fake Keychain directly: the backup item genuinely exists
+        # and is healthy, unrelated to whatever made the EARLIER read (the
+        # one that produced this row's stale `creds`) come back empty.
+        block_real_keychain.set_password(
+            SECURITY_SERVICE,
+            s._store._backup_username("2", "b@example.com"),
+            creds,
+        )
+
+        # The row as `_build_accounts_info` would have recorded it after a
+        # transient hiccup on ITS read: `creds` is empty even though the
+        # backup is, right now, readable and real.
+        info = (2, "b@example.com", "", "", False, "", "")
+
+        assert s._static_usage_sentinel(info) != USAGE_NO_CREDENTIALS, (
+            "the retry found a real, readable credential in the Keychain — "
+            "it must not still report 'no credentials' and send the user "
+            "to re-add a slot that already has one"
+        )
+
     # -- I-1: the active-slot branch collapses the same tri-state on Linux --
 
     def test_active_slot_unreadable_credential_shows_keychain_unavailable_on_linux(
@@ -9136,6 +9182,44 @@ class TestBackupUnreadableDisplay:
         s._record_active_verdict(active_bad)
         info_bad = (1, "a@example.com", "", "", True, active_bad.value or "", "")
         assert s._static_usage_sentinel(info_bad) == USAGE_KEYCHAIN_UNAVAILABLE
+
+
+class TestBuildAccountsInfoReadRouting:
+    """_build_accounts_info's inactive-slot read routes through
+    _read_account_credentials_ex, not the bare _read_account_credentials
+    (which takes no `failed` list and always swallows a Keychain read
+    failure to ""). Using the `_ex` variant makes a transient failure at
+    least distinguishable at the read site, matching every other backup
+    read call site in this module (`_read_account_credentials_ex` is
+    already used at the other seven)."""
+
+    def test_inactive_slot_read_uses_the_ex_variant(
+        self, temp_home: Path, block_real_keychain,
+        sample_sequence_data: dict, monkeypatch,
+    ):
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.MACOS
+        s._setup_directories()
+        s._write_json(s.sequence_file, sample_sequence_data)
+
+        calls: list[tuple[str, str]] = []
+        real_ex = s._read_account_credentials_ex
+
+        def spy(account_num, email):
+            calls.append((account_num, email))
+            return real_ex(account_num, email)
+
+        monkeypatch.setattr(s, "_read_account_credentials_ex", spy)
+        monkeypatch.setattr(
+            s, "_read_account_credentials",
+            lambda *a, **k: (_ for _ in ()).throw(
+                AssertionError("must not call the bare (non-_ex) reader")
+            ),
+        )
+        s._build_accounts_info()
+        assert len(calls) == 2, (
+            f"both inactive slots must read through the _ex variant, got {calls}"
+        )
 
 
 class TestSwitchUnreadableBackup:


### PR DESCRIPTION
### What
`_static_usage_sentinel` re-reads an idle slot's backup (`_read_account_credentials_ex`) to distinguish "keychain unavailable" from "no credentials", but only checked whether that retry failed, never whether it succeeded and found real data. Fixes #283.

### Why
A transient hiccup on the EARLIER read in `_build_accounts_info` (silently swallowed to `""`, since that call passes no `failed` list) followed by a clean retry moments later still reported "no credentials" and discarded the retry's valid credential, sending the user to re-add a slot that already has one. Confirmed as a field case: `cswap list --token-status` showed "no credentials" for an inactive slot while a plain `security -w` read of the same item, moments later, returned valid JSON.

### Change
- `_static_usage_sentinel`: capture the retry's `(value, unreadable)`; if not unreadable and the value is real (API-key shaped, or has an extractable OAuth access token), use it, returning `None` so the collect pass proceeds to fetch, instead of falling through to `USAGE_NO_CREDENTIALS`.
- `_build_accounts_info`: inactive-slot read now goes through `_read_account_credentials_ex` (like every other backup read site in this module) instead of the bare `_read_account_credentials`, so a transient failure is at least distinguishable at the read site.

### Tests
- New: `TestBackupUnreadableDisplay::test_idle_slot_stale_empty_creds_but_retry_finds_valid_backup`, reproduces the bug (red without the fix, green with it).
- New: `TestBuildAccountsInfoReadRouting::test_inactive_slot_read_uses_the_ex_variant`, pins the secondary read-routing change.
- Full suite: `uv run pytest -q`, 2089 passed, 3 skipped, 3 pre-existing unrelated failures (macOS sandbox chmod tests, fail identically on main).
