### PR TITLE
feat(auto): desktop notifications for the headless cswap auto loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Let claude-swap watch your usage and switch for you. When the active account's 5
 cswap auto                     # foreground loop, polls every 60s
 cswap auto --threshold 80      # switch earlier
 cswap auto --model Fable       # also switch when the Fable weekly limit is hit
+cswap auto --notify            # desktop notification on switch/quarantine/exhaustion
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
 cswap auto --strategy consume-first   # burn the soonest-resetting account first
@@ -105,6 +106,7 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
+- **Desktop notifications** (`--notify`, or `cswap config set autoswitch.notify true`): pop up a native notification when the loop switches accounts, quarantines one, or finds every account exhausted — useful when `cswap auto` lives in a corner terminal you don't watch. Off by default, because the [menu bar](#menu-bar-macos) already notifies on its own; turn it on if you run the CLI loop without the menu bar. Poll ticks and no-switch reasons stay terminal-only. macOS uses `osascript`, Linux needs `notify-send`; delivery is best-effort and never affects switching.
 
 For cron/systemd timers, `--once` reports the outcome in its exit code (`0` switched, `1` error, `2` nothing to do, `3` blocked — no viable target), and `--json` emits one JSON event per line:
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -594,6 +594,7 @@ Examples:
   cswap auto --threshold 80        # switch earlier
   cswap auto --model Fable         # also switch when the Fable weekly limit is hit
   cswap auto --json                # one JSON event per line (for scripts)
+  cswap auto --notify              # desktop notification on switch/exhaustion
   cswap auto --once; echo $?       # single tick, outcome in exit code
   cswap auto --dry-run             # log decisions, never actually switch
 
@@ -666,6 +667,16 @@ Defaults live in settings.json in the backup root; flags override them.
         help="Evaluate and report, but never switch or write state",
     )
     parser.add_argument(
+        "--notify",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Send a desktop notification when the engine switches accounts, "
+            "quarantines one, or finds all exhausted (default: off; the "
+            "menu bar already notifies on its own)"
+        ),
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -698,10 +709,15 @@ Defaults live in settings.json in the backup root; flags override them.
                 sys.exit(1)
 
         settings = merged_with_cli(load_settings(switcher.backup_dir), args)
+        emit = jsonl_emit if args.json else human_emit
+        if settings.notify:
+            from claude_swap.notifications import make_notifying_emit
+
+            emit = make_notifying_emit(emit)
         engine = AutoSwitchEngine(
             switcher,
             settings,
-            jsonl_emit if args.json else human_emit,
+            emit,
             dry_run=args.dry_run,
         )
 

--- a/src/claude_swap/notifications.py
+++ b/src/claude_swap/notifications.py
@@ -1,0 +1,143 @@
+"""Native desktop notifications for the headless ``cswap auto`` loop.
+
+The menu bar already surfaces engine events through ``rumps.notification``
+(menubar.py); the foreground CLI loop had no equivalent — a user who parks
+``cswap auto`` in a corner terminal only learns a switch happened when they
+next look at it, by which time a rate-limit-parked Claude Code session has
+often been sitting idle for minutes.
+
+This module is that equivalent, with the same shape as everything else the
+engine reports through:
+
+- **Opt-in** — ``autoswitch.notify`` in settings.json (default off), or
+  ``cswap auto --notify`` for a one-off. The menu bar notifies on its own;
+  users running both would otherwise get duplicate popups.
+- **Best-effort, never fatal** — a failed or missing notifier is logged at
+  debug and forgotten; the engine's own reporting is unchanged.
+- **No new dependencies** — macOS goes through ``osascript``, Linux through
+  ``notify-send`` when present, Windows is a documented no-op.
+
+The event set mirrors the menu bar's: ``switch``, ``account-quarantined``,
+``all-exhausted``. Poll ticks and no-switch reasons stay in the terminal —
+notifying once a minute about "below-threshold" would train the user to
+dismiss everything.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+
+from claude_swap.autoswitch import AutoSwitchEvent
+
+_logger = logging.getLogger(__name__)
+
+# Same set menubar.py notifies on (switch / quarantined / all-exhausted).
+# Anything quieter stays terminal-only.
+NOTIFIED_KINDS = frozenset({"switch", "account-quarantined", "all-exhausted"})
+
+_NOTIFICATION_TITLE = "claude-swap auto"
+
+# The engine ticks can be frequent; a hung notifier must not stack up.
+_NOTIFY_TIMEOUT_SECONDS = 5.0
+
+
+def _applescript_escape(text: str) -> str:
+    """Escape ``text`` for a double-quoted AppleScript string literal.
+
+    Backslash first, then the quote itself; newlines become a literal
+    ``\\n`` escape so a multi-line ``human()`` line cannot inject a second
+    AppleScript statement.
+    """
+    return (
+        text.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "")
+    )
+
+
+def _notify_darwin(title: str, body: str) -> None:
+    script = (
+        f'display notification "{_applescript_escape(body)}" '
+        f'with title "{_applescript_escape(title)}"'
+    )
+    subprocess.run(
+        ["osascript", "-e", script],
+        timeout=_NOTIFY_TIMEOUT_SECONDS,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+def _notify_linux(title: str, body: str) -> None:
+    if shutil.which("notify-send") is None:
+        _logger.debug("notify-send not found; skipping desktop notification")
+        return
+    subprocess.run(
+        ["notify-send", "--app-name", "claude-swap", title, body],
+        timeout=_NOTIFY_TIMEOUT_SECONDS,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+def _notify_windows(title: str, body: str) -> None:  # pragma: no cover
+    # No dependency-free channel worth its failure modes (win10toast pulls
+    # in dependencies and needs a stub exe for the tray icon). The engine
+    # keeps its terminal output; users on Windows lose only the popup.
+    _logger.debug("desktop notifications are not implemented on Windows")
+
+
+_DISPATCHERS = {
+    "darwin": _notify_darwin,
+    "linux": _notify_linux,
+    "win32": _notify_windows,
+}
+
+
+def send_notification(title: str, body: str) -> None:
+    """Show one native desktop notification, swallowing every failure.
+
+    Delivery problems (missing notifier binary, timeout, OS refusal) are
+    debug-logged, never raised — the engine must keep switching accounts
+    even when the popup cannot be shown.
+    """
+    dispatcher = _DISPATCHERS.get(sys.platform)
+    if dispatcher is None:  # e.g. cygwin, freebsd — same deal as Windows
+        _logger.debug(
+            "no desktop notification dispatcher for platform %r", sys.platform
+        )
+        return
+    try:
+        dispatcher(title, body)
+    except (OSError, subprocess.SubprocessError) as exc:
+        _logger.debug("desktop notification failed: %s", exc)
+
+
+def make_notifying_emit(
+    inner: Callable[[AutoSwitchEvent], None],
+) -> Callable[[AutoSwitchEvent], None]:
+    """Wrap an engine ``on_event`` callback with desktop notifications.
+
+    The inner callback always runs first — terminal/JSONL output is the
+    source of truth and must not depend on the notifier's health. Only the
+    kinds in :data:`NOTIFIED_KINDS` pop up; a dry-run switch event says
+    "would switch" in its own ``human()`` text, so it stays honest with no
+    special case here.
+    """
+
+    def emit(event: AutoSwitchEvent) -> None:
+        inner(event)
+        if event.kind in NOTIFIED_KINDS:
+            try:
+                send_notification(_NOTIFICATION_TITLE, event.human())
+            except Exception as exc:  # noqa: BLE001 — never kill the engine loop
+                _logger.debug("desktop notification raised: %s", exc)
+
+    return emit

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -57,6 +57,10 @@ class AutoSwitchSettings:
     # 5h/7d windows still have headroom. None = account-wide 5h/7d only
     # (default).
     model: str | None = None
+    # Desktop notification when the headless `cswap auto` loop switches,
+    # quarantines, or finds everything exhausted (menubar.py already
+    # notifies for menu-bar users; this serves the CLI-only ones).
+    notify: bool = False
 
 
 @dataclass(frozen=True)
@@ -134,6 +138,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         SettingSpec(
             "autoswitch", "model", "model", "string",
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
+        ),
+        SettingSpec(
+            "autoswitch", "notify", "notify", "bool",
+            help="Desktop notification when cswap auto switches/quarantines/exhausts",
         ),
         SettingSpec(
             "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
@@ -431,6 +439,7 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
         ("include_api_key_accounts", "include_api_key_accounts"),
         ("model", "model"),
         ("strategy", "strategy"),
+        ("notify", "notify"),
     ):
         value = getattr(args, attr, None)
         if value is not None:

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,10 +48,11 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "autoswitch.notify",
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,7 +79,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,138 @@
+"""Tests for the headless ``cswap auto`` desktop notifications."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from unittest import mock
+
+from claude_swap.autoswitch import (
+    AllExhaustedEvent,
+    NoSwitchEvent,
+    PollEvent,
+    QuarantineEvent,
+    SwitchEvent,
+)
+from claude_swap.notifications import (
+    _applescript_escape,
+    _NOTIFY_TIMEOUT_SECONDS,
+    make_notifying_emit,
+    send_notification,
+)
+from claude_swap.settings import AutoSwitchSettings, merged_with_cli
+
+
+def _switch_event() -> SwitchEvent:
+    return SwitchEvent(
+        trigger="proactive",
+        from_ref={"number": "1", "email": "a@example.com"},
+        to_ref={"number": "2", "email": "b@example.com"},
+    )
+
+
+class TestMakeNotifyingEmit:
+    def test_inner_callback_always_runs(self):
+        inner = mock.Mock()
+        with mock.patch("claude_swap.notifications.send_notification") as sent:
+            emit = make_notifying_emit(inner)
+            emit(NoSwitchEvent(reason="below-threshold", detail="87% < 90%"))
+        inner.assert_called_once()
+        sent.assert_not_called()
+
+    def test_switch_quarantine_exhausted_notify(self):
+        inner = mock.Mock()
+        events = [
+            _switch_event(),
+            QuarantineEvent(number="3", email="c@example.com", reason="dead-refresh-token"),
+            AllExhaustedEvent(earliest_reset_at="2026-08-30T17:00:00Z"),
+        ]
+        with mock.patch("claude_swap.notifications.send_notification") as sent:
+            emit = make_notifying_emit(inner)
+            for event in events:
+                emit(event)
+        assert inner.call_count == 3
+        assert sent.call_count == 3
+        bodies = [call.args[1] for call in sent.call_args_list]
+        assert bodies == [event.human() for event in events]
+
+    def test_poll_and_no_switch_stay_silent(self):
+        inner = mock.Mock()
+        poll = PollEvent(
+            active={"number": "1", "email": "a@example.com"},
+            headroom={"1": 20.0},
+            threshold=90.0,
+        )
+        with mock.patch("claude_swap.notifications.send_notification") as sent:
+            emit = make_notifying_emit(inner)
+            emit(poll)
+            emit(NoSwitchEvent(reason="below-threshold"))
+        assert inner.call_count == 2
+        sent.assert_not_called()
+
+    def test_dispatch_failure_does_not_break_the_stream(self):
+        inner = mock.Mock()
+        with mock.patch(
+            "claude_swap.notifications.send_notification",
+            side_effect=OSError("notification daemon gone"),
+        ):
+            emit = make_notifying_emit(inner)
+            emit(_switch_event())  # must not raise
+        inner.assert_called_once()
+
+
+class TestAppleScriptEscaping:
+    def test_quotes_and_backslashes(self):
+        assert _applescript_escape('say "hi" \\ done') == 'say \\"hi\\" \\\\ done'
+
+    def test_newline_becomes_literal_escape(self):
+        assert _applescript_escape("line1\nline2") == "line1\\nline2"
+
+
+class TestSendNotification:
+    def test_dispatcher_exception_is_swallowed(self, caplog):
+        with mock.patch.dict(
+            "claude_swap.notifications._DISPATCHERS",
+            {"darwin": mock.Mock(side_effect=OSError("no osascript"))},
+        ):
+            send_notification("t", "b")  # must not raise
+
+    def test_subprocess_timeout_is_swallowed(self):
+        boom = subprocess.TimeoutExpired(cmd="osascript", timeout=1)
+        with mock.patch.dict(
+            "claude_swap.notifications._DISPATCHERS",
+            {"darwin": mock.Mock(side_effect=boom)},
+        ):
+            send_notification("t", "b")  # must not raise
+
+    def test_unknown_platform_is_a_debug_noop(self):
+        with mock.patch.dict(
+            "claude_swap.notifications._DISPATCHERS", {}, clear=True
+        ):
+            send_notification("t", "b")  # must not raise
+
+    def test_darwin_dispatcher_passes_escaped_script(self):
+        with mock.patch("claude_swap.notifications.subprocess.run") as run:
+            with mock.patch("sys.platform", "darwin"):
+                send_notification('ti"tle', 'bo\ndy')
+        run.assert_called_once()
+        argv = run.call_args.args[0]
+        assert argv[:2] == ["osascript", "-e"]
+        assert '\\"' in argv[2] and "\\n" in argv[2]
+        assert run.call_args.kwargs["timeout"] == _NOTIFY_TIMEOUT_SECONDS
+        assert run.call_args.kwargs["check"] is False
+
+
+class TestSettingsWiring:
+    def test_notify_defaults_off_and_clamps_bool(self):
+        assert AutoSwitchSettings().notify is False
+        coerced = merged_with_cli(AutoSwitchSettings(), argparse.Namespace())
+        assert coerced.notify is False
+
+    def test_cli_flag_overrides(self):
+        args = argparse.Namespace(notify=True)
+        assert merged_with_cli(AutoSwitchSettings(), args).notify is True
+
+    def test_cli_none_leaves_setting_untouched(self):
+        settings = AutoSwitchSettings(notify=True)
+        args = argparse.Namespace(notify=None)
+        assert merged_with_cli(settings, args).notify is True


### PR DESCRIPTION
## The problem

The menu bar already surfaces engine events through `rumps.notification` (menubar.py). The foreground `cswap auto` loop has no equivalent — a user who parks it in a corner terminal (or runs it under a daemon, nohup, a tmux pane) learns a switch happened only when they next look at the terminal. By then a Claude Code session parked on a rate-limit timer has often been sitting idle for minutes, even though a healthy account has been active the whole time.

## The change

Opt-in desktop notifications for the CLI loop:

- `autoswitch.notify` setting (default off) + `cswap auto --notify` / `--no-notify` flag
- Notifies on the **same event set the menu bar notifies on**: `switch`, `account-quarantined`, `all-exhausted`. Poll ticks and no-switch reasons stay terminal-only — notifying once a minute about "below-threshold" would train the user to dismiss everything.
- New module `src/claude_swap/notifications.py`; wiring in `cli.py` wraps the existing `emit` callback (terminal/JSONL output runs first and never depends on the notifier), plus one `SettingSpec` and one line in `merged_with_cli`.

Design constraints, mirroring the repo's existing shapes:

- **No new dependencies.** macOS → `osascript`, Linux → `notify-send` when present, Windows → documented no-op.
- **Best-effort, never fatal.** Dispatcher failures are debug-logged and forgotten; the emit wrapper additionally catches an unexpected raise from the notifier itself so the engine loop keeps running even if the notifier has a bug.
- **Off by default** because menu-bar users already get `rumps` notifications; running both would duplicate popups.
- AppleScript bodies are escaped (backslash, quote, newline → literal `\n`), so a multi-line `human()` string cannot inject a second AppleScript statement.
- `--notify` also works with `--json` (the JSONL stream is unchanged; the popup is additive) and with `--dry-run` (a dry-run switch says "would switch" in its own text, so the notification stays honest with no special case).

## Testing

- `tests/test_notifications.py` (new): event-set selection (switch/quarantine/exhausted notify; poll/no-switch silent), inner-callback independence, notifier-failure containment (OSError, `TimeoutExpired`, unknown platform), AppleScript escaping, settings wiring (default off, CLI override, `None` leaves the stored value).
- Updated the two `cswap config` key-count assertions for the new `autoswitch.notify` key.
- Full suite: `2099 passed, 3 skipped`; the 3 failures (`test_move_accounts`, `test_swap_accounts`, `test_real_store_guard`) reproduce on a clean `main` checkout and are untouched by this diff.
- Live smoke on macOS: a real `display notification` fired from the wrapped emit.