### PR TITLE
feat(auth): preserve account selection during re-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ cswap add
 ```
 
 This will update the stored credentials without creating a duplicate.
+For a re-auth flow that must not change the globally active account, use
+`cswap add --preserve-active`. A caller refreshing a specific saved row can
+also pass `--expect-account NUM|EMAIL`, which implies `--preserve-active`; a
+different authenticated account is refused before any saved credential is
+changed. Existing accounts are matched
+by their stable Claude account UUID plus organization first, then by email plus
+organization for older records.
 
 ### Other commands
 
@@ -184,6 +191,8 @@ cswap list --token-status       # Add source-labelled OAuth token diagnostics
 cswap status                    # Show current account
 cswap add --slot 3              # Add account to a specific slot (prompts before overwrite)
 cswap add --alias dev           # Add account and give it a short alias
+cswap add --preserve-active     # Add/refresh without changing the global account
+cswap add --expect-account 2    # Target account 2 and keep the global selection
 cswap remove 2                  # Remove an account
 cswap disable 2                 # Hold an account out of auto-rotation (keeps its login)
 cswap enable 2                  # Return a disabled account to rotation

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -1084,6 +1084,22 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         help="Set a short display alias for the account (use with 'add')",
     )
     parser.add_argument(
+        "--preserve-active",
+        action="store_true",
+        help=(
+            "Keep the currently active global account when adding or "
+            "refreshing an account (use with 'add')"
+        ),
+    )
+    parser.add_argument(
+        "--expect-account",
+        metavar="NUM|EMAIL",
+        help=(
+            "Refuse the add if the authenticated identity is not this existing "
+            "account (use with 'add')"
+        ),
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
         help=(
@@ -1249,6 +1265,12 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
     if args.alias is not None and not args.add_account:
         parser.error("--alias can only be used with 'add'")
 
+    if args.preserve_active and not args.add_account:
+        parser.error("--preserve-active can only be used with 'add'")
+
+    if args.expect_account is not None and not args.add_account:
+        parser.error("--expect-account can only be used with 'add'")
+
     if args.force and not (args.import_ or args.switch_to):
         parser.error("--force can only be used with 'import' or 'switch <num|email>'")
 
@@ -1283,7 +1305,14 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
                 sys.exit(1)
 
         if args.add_account:
-            switcher.add_account(slot=args.slot, alias=args.alias)
+            switcher.add_account(
+                slot=args.slot,
+                alias=args.alias,
+                preserve_active=(
+                    args.preserve_active or args.expect_account is not None
+                ),
+                expect_account=args.expect_account,
+            )
         elif args.add_token is not None:
             switcher.add_account_from_token(
                 token=args.add_token,

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import json
 import logging
@@ -2998,6 +2999,63 @@ class ClaudeAccountSwitcher:
                 return num
         return None
 
+    @staticmethod
+    def _find_account_slot_by_identity(
+        data: dict,
+        email: str,
+        organization_uuid: str,
+        account_uuid: str,
+    ) -> str | None:
+        """Resolve a real Claude identity, preferring account UUID + org.
+
+        Older slots may not carry a UUID, so the established
+        ``(email, organizationUuid)`` composite remains the compatibility
+        fallback only for those legacy rows. A conflicting UUID in the same
+        organization is a different real identity even when the email happens
+        to match; the same person in a different organization remains a
+        separate managed seat. Ambiguous UUID/org or legacy matches are corrupt
+        roster state, never a license to choose whichever slot happens to be
+        iterated first.
+        """
+        accounts = data.get("accounts", {})
+        if account_uuid:
+            uuid_matches = [
+                str(num)
+                for num, account in accounts.items()
+                if (
+                    (account.get("uuid") or "") == account_uuid
+                    and (account.get("organizationUuid", "") or "")
+                    == (organization_uuid or "")
+                )
+            ]
+            if len(uuid_matches) > 1:
+                raise ConfigError(
+                    "Multiple managed accounts have the authenticated Claude "
+                    "account UUID and organization; repair the roster before "
+                    "re-authenticating."
+                )
+            if uuid_matches:
+                return uuid_matches[0]
+        normalized_email = email.strip().casefold()
+        legacy_matches = [
+            str(num)
+            for num, account in accounts.items()
+            if (
+                (not account_uuid or not (account.get("uuid") or ""))
+                and str(account.get("email") or "").strip().casefold()
+                == normalized_email
+                and (account.get("organizationUuid", "") or "")
+                == (organization_uuid or "")
+            )
+        ]
+        if len(legacy_matches) > 1:
+            raise ConfigError(
+                "Multiple managed accounts have the authenticated Claude "
+                "email and organization; repair the roster before "
+                "re-authenticating."
+            )
+        return legacy_matches[0] if legacy_matches else None
+
     def _account_exists(self, email: str, organization_uuid: str) -> bool:
         """Check if account exists by (email, organizationUuid) composite key."""
         data = self._get_sequence_data()
@@ -3389,11 +3447,352 @@ class ClaudeAccountSwitcher:
             data["lastUpdated"] = get_timestamp()
             self._write_json(self.sequence_file, data)
 
+    def _refresh_managed_account(
+        self,
+        *,
+        identity: tuple[str, str, str],
+        current_creds: str,
+        current_config: str,
+        alias: str | None,
+        preserve_active: bool,
+        expect_account: str | None,
+    ) -> tuple[str, str]:
+        """Commit a managed-account credential refresh under the account lock.
+
+        OAuth and credential capture happen before this method: network or user
+        interaction must never hold ``self.lock_file``. Once the bytes are
+        ready, re-resolve both the authenticated identity and the requested
+        target against the locked roster. This makes a concurrent switch win
+        naturally (``preserve_active`` leaves the freshly read selection
+        untouched) and prevents a concurrent move/remove from redirecting the
+        refresh to a stale slot number.
+
+        Returns the refreshed slot number and its organization display name.
+        """
+        current_email, current_org_uuid, current_account_uuid = identity
+
+        with FileLock(self.lock_file):
+            seq = self._get_sequence_data() or {}
+            account_num = self._find_account_slot_by_identity(
+                seq,
+                current_email,
+                current_org_uuid,
+                current_account_uuid,
+            )
+
+            if expect_account is not None:
+                expected_slot = self._resolve_account_identifier(expect_account)
+                if expected_slot is None:
+                    raise AccountNotFoundError(
+                        f"No managed account matches: {expect_account}"
+                    )
+                if account_num != expected_slot:
+                    raise ValidationError(
+                        "The authenticated Claude identity does not match the "
+                        "account requested for re-authentication. No saved "
+                        "credentials were changed."
+                    )
+
+            if account_num is None:
+                raise ConfigError(
+                    "The managed account roster changed while credentials were "
+                    "being captured. No saved credentials were changed; retry "
+                    "the add."
+                )
+
+            existing_record = seq.get("accounts", {}).get(account_num)
+            if not existing_record:
+                raise ConfigError(
+                    "The managed account roster changed while credentials were "
+                    "being captured. No saved credentials were changed; retry "
+                    "the add."
+                )
+            existing_email = existing_record.get("email", current_email)
+            matched_org_name = existing_record.get("organizationName", "")
+
+            if alias is not None:
+                conflict = self._alias_in_use(alias, exclude_num=account_num)
+                if conflict is not None:
+                    raise ValidationError(
+                        f"Alias '{alias}' is already used by account {conflict}"
+                    )
+
+            previous_seq = copy.deepcopy(seq)
+            previous_config = self._read_account_config(
+                account_num, existing_email
+            )
+            previous_creds, previous_creds_unreadable = (
+                self._read_account_credentials_ex(account_num, existing_email)
+            )
+            if previous_creds_unreadable:
+                raise CredentialReadError(
+                    "The existing saved credentials could not be read, so "
+                    "they were not replaced. Retry when the credential store "
+                    "is available."
+                )
+
+            next_record = copy.deepcopy(existing_record)
+            next_record.update({
+                "email": current_email,
+                "uuid": current_account_uuid,
+                "organizationUuid": current_org_uuid,
+            })
+            if alias is not None:
+                next_record["alias"] = alias
+            seq["accounts"][account_num] = next_record
+            if not preserve_active:
+                seq["activeAccountNumber"] = int(account_num)
+            seq["lastUpdated"] = get_timestamp()
+
+            credentials_started = False
+            config_written = False
+            roster_written = False
+            try:
+                # Land the new credential/config under their destination key
+                # before the roster points at them. With an email change the
+                # old key stays intact until the final roster commit, so an
+                # interruption cannot strand the managed row between names.
+                credentials_started = True
+                self._write_account_credentials(
+                    account_num, current_email, current_creds
+                )
+                self._write_account_config(
+                    account_num, current_email, current_config
+                )
+                config_written = True
+                self._write_json(self.sequence_file, seq)
+                roster_written = True
+            except Exception as write_error:
+                rollback_errors: list[Exception] = []
+                if credentials_started:
+                    try:
+                        if existing_email == current_email and previous_creds:
+                            self._write_account_credentials(
+                                account_num, existing_email, previous_creds
+                            )
+                        else:
+                            self._delete_account_credentials(
+                                account_num, current_email
+                            )
+                    except Exception as rollback_error:
+                        rollback_errors.append(rollback_error)
+                if roster_written:
+                    try:
+                        self._write_json(self.sequence_file, previous_seq)
+                    except Exception as rollback_error:
+                        rollback_errors.append(rollback_error)
+                if config_written:
+                    try:
+                        if previous_config:
+                            self._write_account_config(
+                                account_num, existing_email, previous_config
+                            )
+                        new_config_path = (
+                            self.configs_dir
+                            / f".claude-config-{account_num}-{current_email}.json"
+                        )
+                        if existing_email != current_email or not previous_config:
+                            new_config_path.unlink(missing_ok=True)
+                    except Exception as rollback_error:
+                        rollback_errors.append(rollback_error)
+                if rollback_errors:
+                    raise ConfigError(
+                        "Re-authentication could not be committed and rollback "
+                        "was incomplete; the retained previous credential "
+                        "generation may require recovery."
+                    ) from write_error
+                raise
+
+            if existing_email != current_email:
+                self._delete_account_credentials(account_num, existing_email)
+                old_config_path = (
+                    self.configs_dir
+                    / f".claude-config-{account_num}-{existing_email}.json"
+                )
+                try:
+                    old_config_path.unlink(missing_ok=True)
+                except OSError:
+                    self._logger.warning(
+                        "Updated account %s but could not remove its obsolete "
+                        "config backup; the roster uses the new identity.",
+                        account_num,
+                        exc_info=True,
+                    )
+
+            self._usage_store.clear_dead_token(
+                [account_num], {account_num: (current_email, current_org_uuid)}
+            )
+            return account_num, matched_org_name
+
+    def _commit_new_managed_account(
+        self,
+        *,
+        slot: int | None,
+        approved_displace: tuple[str, str, str, str] | None,
+        identity: tuple[str, str, str],
+        current_creds: str,
+        current_config: str,
+        organization_name: str,
+        alias: str | None,
+        preserve_active: bool,
+    ) -> tuple[str, str | None]:
+        """Publish a new slot without overwriting a concurrent roster change.
+
+        The overwrite prompt and all credential capture happen before the
+        lock. Under the lock, verify that any approved occupant is still the
+        same real identity, re-resolve a concurrent move of the authenticated
+        identity, and snapshot the *current* active record. The final active
+        selection is then derived from that locked snapshot, so a switch that
+        completed while capture was in progress is never undone.
+        """
+        current_email, organization_uuid, account_uuid = identity
+
+        with FileLock(self.lock_file):
+            data = self._get_sequence_data() or {}
+            accounts = data.setdefault("accounts", {})
+            data.setdefault("sequence", [])
+            existing_slot = self._find_account_slot_by_identity(
+                data,
+                current_email,
+                organization_uuid,
+                account_uuid,
+            )
+
+            if slot is None:
+                if existing_slot is not None:
+                    raise ConfigError(
+                        "The managed account roster changed while credentials "
+                        "were being captured. The identity is already managed; "
+                        "no duplicate was added. Retry the add to refresh it."
+                    )
+                account_num = str(
+                    max((int(num) for num in accounts), default=0) + 1
+                )
+            else:
+                account_num = str(slot)
+
+            locked_displace: tuple[str, str, str] | None = None
+            target_record = accounts.get(account_num)
+            if target_record and account_num != existing_slot:
+                if approved_displace is None:
+                    raise ConfigError(
+                        f"Slot {account_num} changed while credentials were "
+                        "being captured. Nothing was overwritten; retry and "
+                        "confirm the current occupant."
+                    )
+                approved_num, approved_email, approved_org, approved_uuid = (
+                    approved_displace
+                )
+                approved_still_target = self._find_account_slot_by_identity(
+                    {"accounts": {account_num: target_record}},
+                    approved_email,
+                    approved_org,
+                    approved_uuid,
+                )
+                if approved_num != account_num or approved_still_target != account_num:
+                    raise ConfigError(
+                        f"Slot {account_num} changed while credentials were "
+                        "being captured. Nothing was overwritten; retry and "
+                        "confirm the current occupant."
+                    )
+                locked_displace = (
+                    account_num,
+                    target_record.get("email", ""),
+                    target_record.get("organizationUuid", "") or "",
+                )
+
+            migrate_from = (
+                existing_slot
+                if existing_slot is not None and existing_slot != account_num
+                else None
+            )
+
+            active_number = data.get("activeAccountNumber")
+            active_record = copy.deepcopy(
+                accounts.get(str(active_number))
+            )
+
+            existing_alias = None
+            if target_record and account_num == existing_slot:
+                existing_alias = target_record.get("alias")
+            if migrate_from:
+                existing_alias = (
+                    accounts[migrate_from].get("alias") or existing_alias
+                )
+
+            if alias is not None:
+                conflict = self._alias_in_use(alias, exclude_num=account_num)
+                if conflict is not None and conflict != migrate_from:
+                    raise ValidationError(
+                        f"Alias '{alias}' is already used by account {conflict}"
+                    )
+
+            if locked_displace:
+                d_num, d_email, d_org = locked_displace
+                self._delete_account_files(d_num, d_email)
+                if int(d_num) in data["sequence"]:
+                    data["sequence"].remove(int(d_num))
+                del accounts[d_num]
+
+            if migrate_from:
+                old_email = accounts[migrate_from].get("email", "")
+                self._delete_account_files(migrate_from, old_email)
+                if int(migrate_from) in data["sequence"]:
+                    data["sequence"].remove(int(migrate_from))
+                del accounts[migrate_from]
+
+            self._write_account_credentials(
+                account_num, current_email, current_creds
+            )
+            self._write_account_config(
+                account_num, current_email, current_config
+            )
+
+            accounts[account_num] = {
+                "email": current_email,
+                "uuid": account_uuid,
+                "organizationUuid": organization_uuid,
+                "organizationName": organization_name,
+                "added": get_timestamp(),
+            }
+            carried_alias = alias if alias is not None else existing_alias
+            if carried_alias:
+                accounts[account_num]["alias"] = carried_alias
+            if int(account_num) not in data["sequence"]:
+                data["sequence"].append(int(account_num))
+                data["sequence"].sort()
+
+            if preserve_active and active_record:
+                preserved_slot = self._find_account_slot_by_identity(
+                    data,
+                    active_record.get("email", ""),
+                    active_record.get("organizationUuid", "") or "",
+                    active_record.get("uuid", "") or "",
+                )
+                data["activeAccountNumber"] = (
+                    int(preserved_slot)
+                    if preserved_slot is not None
+                    else int(account_num)
+                )
+            else:
+                data["activeAccountNumber"] = int(account_num)
+            data["lastUpdated"] = get_timestamp()
+            self._write_json(self.sequence_file, data)
+
+            if locked_displace:
+                self._prune_mappings(d_email, d_org)
+            self._usage_store.clear_dead_token(
+                [account_num], {account_num: (current_email, organization_uuid)}
+            )
+            return account_num, migrate_from
+
     def add_account(
         self,
         slot: int | None = None,
         assume_yes: bool = False,
         alias: str | None = None,
+        preserve_active: bool = False,
+        expect_account: str | None = None,
     ) -> None:
         """Add current account to managed accounts.
 
@@ -3406,11 +3805,27 @@ class ClaudeAccountSwitcher:
                   confirmation UI, e.g. the TUI, confirm before calling).
             alias: Optional short display alias to set on this account.
                   When omitted, an existing alias on the slot is preserved.
+            preserve_active: Keep the global active account selected before
+                  this add. If the roster was empty, the new account becomes
+                  active as usual.
+            expect_account: Existing NUM|EMAIL identity this OAuth result must
+                  match. A mismatch fails before any managed credential write.
         """
         self._refuse_session_shell()
         self._setup_directories()
-        self._init_sequence_file()
-        self._migrate_org_fields()
+        # Initialization and the legacy roster migration both write
+        # sequence.json. Serialize them with switch/move/refresh before OAuth
+        # capture begins; otherwise a migration that read the old active slot
+        # could publish it after a concurrent switch and make the later
+        # preserve-active commit faithfully preserve the wrong selection.
+        with FileLock(self.lock_file):
+            self._init_sequence_file()
+            self._migrate_org_fields()
+
+        # A targeted re-auth is selection-preserving by definition. Keep the
+        # invariant even for direct API callers that omit the redundant flag.
+        if expect_account is not None:
+            preserve_active = True
 
         if alias is not None:
             try:
@@ -3423,19 +3838,31 @@ class ClaudeAccountSwitcher:
             raise ConfigError("No active Claude account found. Please log in first.")
         current_email, current_org_uuid, current_account_uuid = identity
 
-        # When no slot specified and account already exists, refresh credentials in place
-        if slot is None and self._account_exists(current_email, current_org_uuid):
-            seq = self._get_sequence_data()
-            account_num = self._find_account_slot(seq, current_email, current_org_uuid)
-            matched_org_name = seq["accounts"][account_num].get("organizationName", "") if account_num else ""
+        initial_data = self._get_sequence_data() or {}
+        existing_slot = self._find_account_slot_by_identity(
+            initial_data,
+            current_email,
+            current_org_uuid,
+            current_account_uuid,
+        )
 
-            if alias is not None:
-                conflict = self._alias_in_use(alias, exclude_num=account_num)
-                if conflict is not None:
-                    raise ValidationError(
-                        f"Alias '{alias}' is already used by account {conflict}"
-                    )
+        if expect_account is not None:
+            expected_slot = self._resolve_account_identifier(expect_account)
+            if expected_slot is None:
+                raise AccountNotFoundError(
+                    f"No managed account matches: {expect_account}"
+                )
+            if existing_slot != expected_slot:
+                raise ValidationError(
+                    "The authenticated Claude identity does not match the "
+                    "account requested for re-authentication. No saved "
+                    "credentials were changed."
+                )
 
+        # When no slot specified and the real identity already exists, refresh
+        # credentials in place. UUID-first matching prevents an email/slot alias
+        # from creating a duplicate row.
+        if slot is None and existing_slot is not None:
             current_creds = self._read_capture_credentials()
             if current_creds is None:
                 raise CredentialReadError("Failed to read credentials for current account")
@@ -3469,18 +3896,14 @@ class ClaudeAccountSwitcher:
             # on a race.
             self._reject_identity_drift_since_verify(identity)
 
-            self._write_account_credentials(account_num, current_email, current_creds)
-            self._write_account_config(account_num, current_email, current_config)
-            self._usage_store.clear_dead_token(
-                [account_num], {account_num: (current_email, current_org_uuid)}
+            account_num, matched_org_name = self._refresh_managed_account(
+                identity=identity,
+                current_creds=current_creds,
+                current_config=current_config,
+                alias=alias,
+                preserve_active=preserve_active,
+                expect_account=expect_account,
             )
-
-            if alias is not None:
-                seq["accounts"][account_num]["alias"] = alias
-
-            seq["activeAccountNumber"] = int(account_num)
-            seq["lastUpdated"] = get_timestamp()
-            self._write_json(self.sequence_file, seq)
 
             tag = self._get_display_tag(current_email, matched_org_name, current_org_uuid)
             self._logger.info(f"Updated credentials for account {account_num}: {current_email}")
@@ -3493,7 +3916,6 @@ class ClaudeAccountSwitcher:
         # Determine slot number and collect confirmation decisions
         # (no destructive operations until new account is verified readable)
         displace_slot = None  # slot to clean up (occupied by different account)
-        migrate_from = None   # old slot to clean up (same account, different slot)
 
         if slot is not None:
             if slot < 1:
@@ -3501,20 +3923,11 @@ class ClaudeAccountSwitcher:
             account_num = str(slot)
             data = self._get_sequence_data()
 
-            # Find if current account already exists in a different slot
-            if self._account_exists(current_email, current_org_uuid):
-                old_num = self._find_account_slot(
-                    data, current_email, current_org_uuid
-                )
-                if old_num and old_num != account_num:
-                    migrate_from = old_num
-
             # Check if target slot is occupied by a different account
             if account_num in data.get("accounts", {}):
                 existing = data["accounts"][account_num]
                 existing_email = existing.get("email", "unknown")
-                is_same = (existing_email == current_email
-                           and existing.get("organizationUuid", "") == current_org_uuid)
+                is_same = account_num == existing_slot
                 if not is_same:
                     existing_tag = self._get_display_tag(
                         existing_email,
@@ -3538,22 +3951,10 @@ class ClaudeAccountSwitcher:
                         account_num,
                         existing_email,
                         existing.get("organizationUuid", "") or "",
+                        existing.get("uuid", "") or "",
                     )
         else:
             account_num = str(self._get_next_account_number())
-
-        # Capture any alias to carry forward before destructive cleanup below
-        # deletes the old record (same account moving slots, or refreshing in place).
-        existing_alias = None
-        if slot is not None:
-            prior = data.get("accounts", {}).get(account_num) or {}
-            if (
-                prior.get("email") == current_email
-                and prior.get("organizationUuid", "") == current_org_uuid
-            ):
-                existing_alias = prior.get("alias")
-            if migrate_from:
-                existing_alias = data["accounts"][migrate_from].get("alias") or existing_alias
 
         if alias is not None:
             conflict = self._alias_in_use(alias, exclude_num=account_num)
@@ -3582,61 +3983,27 @@ class ClaudeAccountSwitcher:
         except PermissionError:
             raise ConfigError("Permission denied reading Claude config")
 
-        # Get account UUID and org fields
+        # Get organization display fields from the captured profile config.
         config_data = self._read_json(config_path)
         oauth_data = config_data.get("oauthAccount", {})
-        account_uuid = oauth_data.get("accountUuid", "") or ""
         organization_uuid = oauth_data.get("organizationUuid", "") or ""
         organization_name = oauth_data.get("organizationName", "") or ""
 
         self._reject_identity_drift_since_verify(identity)
 
-        # Now safe to perform destructive cleanup (new account data is in memory)
-        if displace_slot:
-            d_num, d_email, d_org = displace_slot
-            self._delete_account_files(d_num, d_email)
-            data = self._get_sequence_data()
-            if int(d_num) in data["sequence"]:
-                data["sequence"].remove(int(d_num))
-            del data["accounts"][d_num]
-            self._write_json(self.sequence_file, data)
-            self._prune_mappings(d_email, d_org)
-
-        if migrate_from:
-            data = self._get_sequence_data()
-            old_email = data["accounts"][migrate_from].get("email", "")
-            self._delete_account_files(migrate_from, old_email)
-            if int(migrate_from) in data["sequence"]:
-                data["sequence"].remove(int(migrate_from))
-            del data["accounts"][migrate_from]
-            self._write_json(self.sequence_file, data)
-
-        # Store backups
-        self._write_account_credentials(account_num, current_email, current_creds)
-        self._write_account_config(account_num, current_email, current_config)
-        self._usage_store.clear_dead_token(
-            [account_num], {account_num: (current_email, organization_uuid)}
+        # All captures are complete. Publish under the account lock and derive
+        # the preserved selection from the latest roster, not the pre-capture
+        # snapshot used only for confirmation UI.
+        account_num, migrate_from = self._commit_new_managed_account(
+            slot=slot,
+            approved_displace=displace_slot,
+            identity=identity,
+            current_creds=current_creds,
+            current_config=current_config,
+            organization_name=organization_name,
+            alias=alias,
+            preserve_active=preserve_active,
         )
-
-        # Update sequence.json
-        data = self._get_sequence_data()
-        data["accounts"][account_num] = {
-            "email": current_email,
-            "uuid": account_uuid,
-            "organizationUuid": organization_uuid,
-            "organizationName": organization_name,
-            "added": get_timestamp(),
-        }
-        carried_alias = alias if alias is not None else existing_alias
-        if carried_alias:
-            data["accounts"][account_num]["alias"] = carried_alias
-        if int(account_num) not in data["sequence"]:
-            data["sequence"].append(int(account_num))
-            data["sequence"].sort()
-        data["activeAccountNumber"] = int(account_num)
-        data["lastUpdated"] = get_timestamp()
-
-        self._write_json(self.sequence_file, data)
         tag = self._get_display_tag(current_email, organization_name, organization_uuid)
         self._logger.info(f"Added account {account_num}: {current_email} (org: {organization_uuid or 'personal'})")
         if migrate_from:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,6 +279,50 @@ class TestCLI:
         )
         assert "--slot" in result.stdout
 
+    def test_preserve_active_and_expected_account_forwarded(self):
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", [
+                 "claude-swap", "add", "--preserve-active",
+                 "--expect-account", "2",
+             ]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.add_account.assert_called_once_with(
+            slot=None,
+            alias=None,
+            preserve_active=True,
+            expect_account="2",
+        )
+
+    def test_expected_account_implies_preserve_active(self):
+        with patch("claude_swap.cli.ClaudeAccountSwitcher") as switcher_cls, \
+             patch.object(sys, "argv", [
+                 "claude-swap", "add", "--expect-account", "2",
+             ]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+        switcher_cls.return_value.add_account.assert_called_once_with(
+            slot=None,
+            alias=None,
+            preserve_active=True,
+            expect_account="2",
+        )
+
+    @pytest.mark.parametrize("flag", ["--preserve-active", "--expect-account"])
+    def test_reauth_flags_require_add(self, flag, capsys):
+        argv = ["claude-swap", "--list", flag]
+        if flag == "--expect-account":
+            argv.append("2")
+        with patch.object(sys, "argv", argv):
+            with pytest.raises(SystemExit) as excinfo:
+                cli.main()
+        assert excinfo.value.code == 2
+        assert f"{flag} can only be used with 'add'" in capsys.readouterr().err
+
     def test_account_flag_requires_export(self, capsys):
         """--account should only be accepted alongside --export."""
         with patch.object(

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -6,6 +6,7 @@ import base64
 import json
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -8402,6 +8403,361 @@ class TestAddAccountAlias:
              patch.object(switcher, "_delete_account_credentials"):
             with pytest.raises(ValidationError):
                 switcher.add_account(alias="dev")
+
+
+class TestAddAccountPreserveActive:
+    @staticmethod
+    def _seed(switcher: ClaudeAccountSwitcher) -> None:
+        switcher._setup_directories()
+        switcher._init_sequence_file()
+        data = switcher._get_sequence_data()
+        data["accounts"] = {
+            "1": {
+                "email": "selected@example.com",
+                "uuid": "uuid-selected",
+                "organizationUuid": "",
+                "organizationName": "",
+                "added": "2026-01-01T00:00:00Z",
+            },
+            "2": {
+                "email": "refresh@example.com",
+                "uuid": "uuid-refresh",
+                "organizationUuid": "",
+                "organizationName": "",
+                "added": "2026-01-01T00:00:00Z",
+            },
+        }
+        data["sequence"] = [1, 2]
+        data["activeAccountNumber"] = 1
+        switcher._write_json(switcher.sequence_file, data)
+        for number, email, uuid in (
+            ("1", "selected@example.com", "uuid-selected"),
+            ("2", "refresh@example.com", "uuid-refresh"),
+        ):
+            switcher._write_account_credentials(
+                number,
+                email,
+                json.dumps({"claudeAiOauth": {"accessToken": f"old-{number}"}}),
+            )
+            switcher._write_account_config(
+                number,
+                email,
+                json.dumps({"oauthAccount": {
+                    "emailAddress": email,
+                    "accountUuid": uuid,
+                    "organizationUuid": "",
+                }}),
+            )
+
+    @staticmethod
+    def _land_login(
+        switcher: ClaudeAccountSwitcher,
+        *,
+        email: str = "refresh@example.com",
+        uuid: str = "uuid-refresh",
+    ) -> None:
+        switcher._get_claude_config_path().write_text(
+            json.dumps({"oauthAccount": {
+                "emailAddress": email,
+                "accountUuid": uuid,
+                "organizationUuid": "",
+                "organizationName": "",
+            }}),
+            encoding="utf-8",
+        )
+
+    def test_refresh_keeps_global_selection_and_updates_real_identity(
+        self, temp_home: Path,
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        self._land_login(switcher)
+        fresh = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+
+        with patch.object(switcher, "_read_capture_credentials", return_value=fresh), \
+             patch.object(
+                 switcher,
+                 "_reject_foreign_credential_capture",
+                 side_effect=lambda credentials, *_: credentials,
+             ):
+            switcher.add_account(
+                preserve_active=True,
+                expect_account="2",
+            )
+
+        data = switcher._get_sequence_data()
+        assert data["activeAccountNumber"] == 1
+        assert set(data["accounts"]) == {"1", "2"}
+        assert "fresh" in switcher._read_account_credentials(
+            "2", "refresh@example.com"
+        )
+
+    def test_concurrent_switch_after_capture_wins_over_preserved_reauth(
+        self, temp_home: Path,
+    ):
+        from claude_swap.locking import FileLock
+
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        self._land_login(switcher)
+        fresh = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+        captured = threading.Event()
+        selection_changed = threading.Event()
+        failures: list[BaseException] = []
+
+        def capture_then_wait() -> str:
+            captured.set()
+            assert selection_changed.wait(timeout=5)
+            return fresh
+
+        def run_reauth() -> None:
+            try:
+                switcher.add_account(
+                    preserve_active=True,
+                    expect_account="2",
+                )
+            except BaseException as exc:  # surfaced in the assertion below
+                failures.append(exc)
+
+        with patch.object(
+            switcher,
+            "_read_capture_credentials",
+            side_effect=capture_then_wait,
+        ), patch.object(
+            switcher,
+            "_reject_foreign_credential_capture",
+            side_effect=lambda credentials, *_: credentials,
+        ):
+            worker = threading.Thread(target=run_reauth)
+            worker.start()
+            try:
+                assert captured.wait(timeout=5)
+                # Model a lock-honoring `cswap switch 2` that lands after the
+                # re-auth captured its pre-OAuth roster but before publication.
+                with FileLock(switcher.lock_file):
+                    data = switcher._get_sequence_data()
+                    data["activeAccountNumber"] = 2
+                    switcher._write_json(switcher.sequence_file, data)
+            finally:
+                selection_changed.set()
+            worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        assert failures == []
+        data = switcher._get_sequence_data()
+        assert data["activeAccountNumber"] == 2
+        assert "fresh" in switcher._read_account_credentials(
+            "2", "refresh@example.com"
+        )
+
+    def test_legacy_org_migration_is_serialized_with_account_switches(
+        self, temp_home: Path,
+    ):
+        from claude_swap.locking import FileLock
+
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        legacy = switcher._get_sequence_data()
+        for account in legacy["accounts"].values():
+            account.pop("organizationUuid", None)
+            account.pop("organizationName", None)
+        switcher._write_json(switcher.sequence_file, legacy)
+        self._land_login(switcher)
+        fresh = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+        real_migrate = switcher._migrate_org_fields
+        lock_observed: list[bool] = []
+
+        def verify_lock_then_migrate() -> None:
+            contender = FileLock(switcher.lock_file, timeout=0)
+            acquired = contender.acquire(timeout=0)
+            lock_observed.append(not acquired)
+            if acquired:
+                contender.release()
+            real_migrate()
+
+        with patch.object(
+            switcher,
+            "_migrate_org_fields",
+            side_effect=verify_lock_then_migrate,
+        ), patch.object(
+            switcher,
+            "_read_capture_credentials",
+            return_value=fresh,
+        ), patch.object(
+            switcher,
+            "_reject_foreign_credential_capture",
+            side_effect=lambda credentials, *_: credentials,
+        ):
+            switcher.add_account(
+                preserve_active=True,
+                expect_account="2",
+            )
+
+        assert lock_observed == [True]
+        assert switcher._get_sequence_data()["activeAccountNumber"] == 1
+
+    def test_targeted_reauth_repairs_a_genuinely_missing_credential(
+        self, temp_home: Path,
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        switcher._delete_account_credentials("2", "refresh@example.com")
+        assert not switcher._read_account_credentials(
+            "2", "refresh@example.com"
+        )
+        self._land_login(switcher)
+        fresh = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+
+        with patch.object(switcher, "_read_capture_credentials", return_value=fresh), \
+             patch.object(
+                 switcher,
+                 "_reject_foreign_credential_capture",
+                 side_effect=lambda credentials, *_: credentials,
+             ):
+            switcher.add_account(
+                preserve_active=True,
+                expect_account="2",
+            )
+
+        data = switcher._get_sequence_data()
+        assert data["activeAccountNumber"] == 1
+        assert "fresh" in switcher._read_account_credentials(
+            "2", "refresh@example.com"
+        )
+
+    def test_uuid_dedup_refreshes_in_place_after_email_change(
+        self, temp_home: Path,
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        self._land_login(switcher, email="renamed@example.com")
+        fresh = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+
+        with patch.object(switcher, "_read_capture_credentials", return_value=fresh), \
+             patch.object(
+                 switcher,
+                 "_reject_foreign_credential_capture",
+                 side_effect=lambda credentials, *_: credentials,
+             ):
+            switcher.add_account(preserve_active=True, expect_account="2")
+
+        data = switcher._get_sequence_data()
+        assert set(data["accounts"]) == {"1", "2"}
+        assert data["accounts"]["2"]["email"] == "renamed@example.com"
+        assert data["activeAccountNumber"] == 1
+
+    def test_expected_identity_mismatch_writes_nothing(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        self._land_login(switcher)
+        before = switcher.sequence_file.read_bytes()
+        before_selected = switcher._read_account_credentials(
+            "1", "selected@example.com"
+        )
+
+        with pytest.raises(ValidationError, match="does not match"):
+            switcher.add_account(
+                preserve_active=True,
+                expect_account="1",
+            )
+
+        assert switcher.sequence_file.read_bytes() == before
+        assert switcher._read_account_credentials(
+            "1", "selected@example.com"
+        ) == before_selected
+
+    def test_expected_identity_rejects_same_email_with_different_uuid(
+        self, temp_home: Path,
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        self._land_login(switcher, uuid="uuid-different-person")
+        before = switcher.sequence_file.read_bytes()
+
+        with pytest.raises(ValidationError, match="does not match"):
+            switcher.add_account(
+                preserve_active=True,
+                expect_account="2",
+            )
+
+        assert switcher.sequence_file.read_bytes() == before
+        assert "old-2" in switcher._read_account_credentials(
+            "2", "refresh@example.com"
+        )
+
+    def test_failed_credential_commit_restores_roster_and_config(
+        self, temp_home: Path,
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        self._land_login(switcher)
+        before_sequence = switcher.sequence_file.read_bytes()
+        before_config = switcher._read_account_config(
+            "2", "refresh@example.com"
+        )
+        fresh = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+        real_write = switcher._write_account_credentials
+
+        def fail_fresh(number: str, email: str, credentials: str) -> None:
+            if credentials == fresh:
+                raise OSError("simulated credential-store failure")
+            real_write(number, email, credentials)
+
+        with patch.object(switcher, "_read_capture_credentials", return_value=fresh), \
+             patch.object(
+                 switcher,
+                 "_reject_foreign_credential_capture",
+                 side_effect=lambda credentials, *_: credentials,
+             ), \
+             patch.object(
+                 switcher,
+                 "_write_account_credentials",
+                 side_effect=fail_fresh,
+             ):
+            with pytest.raises(OSError, match="simulated"):
+                switcher.add_account(
+                    preserve_active=True,
+                    expect_account="2",
+                )
+
+        assert switcher.sequence_file.read_bytes() == before_sequence
+        assert switcher._read_account_config(
+            "2", "refresh@example.com"
+        ) == before_config
+        assert "old-2" in switcher._read_account_credentials(
+            "2", "refresh@example.com"
+        )
+
+    def test_failed_config_commit_restores_previous_credentials(
+        self, temp_home: Path,
+    ):
+        switcher = ClaudeAccountSwitcher()
+        self._seed(switcher)
+        self._land_login(switcher)
+        before_sequence = switcher.sequence_file.read_bytes()
+        fresh = json.dumps({"claudeAiOauth": {"accessToken": "fresh"}})
+
+        with patch.object(switcher, "_read_capture_credentials", return_value=fresh), \
+             patch.object(
+                 switcher,
+                 "_reject_foreign_credential_capture",
+                 side_effect=lambda credentials, *_: credentials,
+             ), \
+             patch.object(
+                 switcher,
+                 "_write_account_config",
+                 side_effect=OSError("simulated config-store failure"),
+             ):
+            with pytest.raises(OSError, match="config-store"):
+                switcher.add_account(
+                    preserve_active=True,
+                    expect_account="2",
+                )
+
+        assert switcher.sequence_file.read_bytes() == before_sequence
+        assert "old-2" in switcher._read_account_credentials(
+            "2", "refresh@example.com"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add `cswap add --preserve-active` for selection-preserving account registration and refresh
- add `--expect-account NUM|EMAIL` for targeted re-authentication with real-identity validation
- deduplicate Claude accounts by account UUID plus organization, with a legacy email fallback
- publish refreshes transactionally under the account lock so concurrent switches win and failures retain prior credentials

## Safety

- OAuth capture remains outside the account lock
- a mismatched identity is rejected before any managed credential write
- credential/config/roster failures roll back the previous generation
- no credentials or OAuth material are added to logs or command output

## Testing

- `uv run pytest tests/test_switcher.py -q`
- targeted CLI and re-authentication tests
- full test suite (known unrelated platform-sensitive failures reproduce on the base branch)
- `git diff --check`

## Risk and rollback

Risk is limited to the add/re-auth commit path. Reverting this commit restores the previous CLI and persistence behavior.
