### PR TITLE
feat(session): share the plugin store across profiles with --share-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,19 @@ cswap run 2                     # launch Claude Code as account 2, here only
 cswap run user@example.com      # by email
 cswap run 2 -- --resume         # everything after '--' is forwarded to claude
 cswap run 2 --share-history     # share your chat history with this account too
+cswap run 2 --share-plugins     # share your installed plugins too
 cswap run 2 --require-session   # refuse rather than run plain claude if 2 is the default login
 ```
 
-Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP servers, etc.), but each account keeps its own chat history — pass `--share-history` if you want your accounts to continue the same conversations.
+Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP servers, etc.), but each account keeps its own chat history and plugin installs — pass `--share-history` if you want your accounts to continue the same conversations, and `--share-plugins` if a plugin installed once should be available everywhere.
 
 Running the account that is already your default login launches plain `claude` on that login instead of a session (a second copy of the active credential would go stale). Scripts that need the isolation guaranteed can pass `--require-session`, which refuses in that case instead.
 
 <details>
-<summary>Sharing details — MCP servers & chat history</summary>
+<summary>Sharing details — MCP servers, chat history & plugins</summary>
 
 - With `--share-history`, a session started under one account shows up in `--resume` under the others, and nothing already saved is lost.
+- With `--share-plugins`, all accounts use one plugin store: installing or updating a plugin in any of them (or in your default profile) makes it available in all. Plugins a profile already had are merged into `~/.claude/plugins` first — nothing is lost, and where both sides have the same plugin the shared copy wins (plugin auto-update converges versions anyway).
 - User-scope MCP servers (`claude mcp add -s user`) are mirrored from your default profile on every launch — manage them there; changes made inside a session don't persist. Definitions are copied as-is (including inline `env`/`headers` values), but MCP OAuth logins are not — HTTP servers may ask you to authenticate once per profile via `/mcp`.
 - `--no-share` turns sharing off and removes the mirrored MCP config (profiles that never mirrored are left alone).
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -131,6 +131,7 @@ Examples:
   cswap run user@example.com
   cswap run 2 --no-share
   cswap run 2 --share-history
+  cswap run 2 --share-plugins
   cswap run 2 --require-session
   cswap run 2 -- --resume
         """,
@@ -164,6 +165,20 @@ Examples:
         ),
     )
     parser.add_argument(
+        "--share-plugins",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Share the plugin store (plugins/) from ~/.claude into the "
+            "session profile, so a plugin installed or updated in any "
+            "account is available in all of them. Plugins the profile "
+            "already accumulated are merged into ~/.claude first (existing "
+            "source entries win). --no-share-plugins reverts to a "
+            "per-account store, re-installing on demand — already-merged "
+            "plugins stay in ~/.claude. Not supported on Windows."
+        ),
+    )
+    parser.add_argument(
         "--require-session",
         action="store_true",
         help=(
@@ -193,6 +208,7 @@ Examples:
                 tail,
                 share=not args.no_share,
                 share_history=args.share_history,
+                share_plugins=args.share_plugins,
                 require_session=args.require_session,
             )
             return  # only reachable in tests where exec/exit is mocked
@@ -205,6 +221,7 @@ Examples:
                 tail,
                 share=not args.no_share,
                 share_history=args.share_history,
+                share_plugins=args.share_plugins,
                 require_session=args.require_session,
             )
             return  # only reachable in tests

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -30,6 +30,13 @@ which would fork history rather than share it. If the profile already
 accumulated its own history, it is merged into ``~/.claude`` first so nothing
 disappears from ``--resume``.
 
+Plugin sharing (``--share-plugins``, opt-in): additionally links ``plugins/``
+(the install store — installed plugins, marketplaces, per-plugin data) from
+``~/.claude``, so a plugin installed or updated in any account is available
+in all of them. POSIX-only, like history. If the profile already accumulated
+its own store, plugins the source lacks are merged into ``~/.claude`` first
+(source wins conflicts) so nothing is lost.
+
 This module must not import ``switcher`` (switcher imports us for the
 session-aware guards); it receives a ``ClaudeAccountSwitcher`` instance.
 """
@@ -53,6 +60,7 @@ from claude_swap.claude_locks import proper_lockfile
 from claude_swap.exceptions import (
     ClaudeCodeLockTimeout,
     CredentialReadError,
+    LockError,
     SessionError,
 )
 from claude_swap.fsutil import replace_with_retry
@@ -67,10 +75,11 @@ if TYPE_CHECKING:
     from claude_swap.switcher import ClaudeAccountSwitcher
 
 # Items mirrored from ~/.claude into session profiles when sharing is on.
-# Deliberately excludes anything account- or instance-scoped: plugins/,
-# sessions/, ide/, .claude.json, .credentials.json, statsig/ and other
-# telemetry. projects/ and history.jsonl are per-account by default and move
-# to HISTORY_ITEMS sharing only with the opt-in --share-history flag.
+# Deliberately excludes anything account- or instance-scoped: sessions/,
+# ide/, .claude.json, .credentials.json, statsig/ and other telemetry.
+# projects/ and history.jsonl are per-account by default and move to
+# HISTORY_ITEMS sharing only with the opt-in --share-history flag; plugins/
+# likewise moves to PLUGIN_ITEMS sharing only with --share-plugins.
 # .claude.json stays excluded as a file, but its one user-scoped key —
 # top-level mcpServers — is mirrored separately by _sync_mcp_servers.
 SHARED_ITEMS = (
@@ -88,6 +97,14 @@ HISTORY_ITEMS = (
     "projects",
     "history.jsonl",
 )
+
+# The plugin store linked additionally under --share-plugins: one store
+# (installed plugins, marketplaces, per-plugin data) for every account.
+# POSIX symlinks only, same reason as HISTORY_ITEMS. Plugin ENABLEMENT
+# already travels with settings.json (`enabledPlugins`) under plain --share;
+# this flag shares the install store those entries point at, closing the
+# gap where a profile shows a plugin as enabled but has no copy of it.
+PLUGIN_ITEMS = ("plugins",)
 
 # Records which entries in a session profile cswap created (so --no-share and
 # re-syncs only ever remove cswap-managed links/copies, never user data).
@@ -204,6 +221,15 @@ _AUTH_STATUS_TIMEOUT = 10.0
 # timeout) plus auth-status probes, so it needs more headroom than the
 # default 10s acquire used by the switch paths.
 _BOOTSTRAP_LOCK_TIMEOUT = 30.0
+
+# Serializes writers of the SHARED plugin store's registry files. The
+# lock-free last-writer-wins posture of the rest of the share sync is safe
+# only for symlinks, which self-heal next launch; a lost registry update
+# after the losing merge already removed its profile store has nothing left
+# to heal from. Not the backup-dir lock: _sync_sharing runs both under it
+# (bootstrap) and outside it (reuse), and FileLock is non-reentrant.
+_PLUGINS_STORE_LOCK = "plugins-share.lock"
+_PLUGINS_STORE_LOCK_TIMEOUT = 30.0
 
 
 def slugify_email(email: str) -> str:
@@ -507,6 +533,7 @@ class SessionManager:
         claude_args: list[str],
         share: bool = True,
         share_history: bool = False,
+        share_plugins: bool = False,
         require_session: bool = False,
     ) -> NoReturn:
         """Launch Claude Code as the given account in the current terminal.
@@ -527,6 +554,12 @@ class SessionManager:
                 "--share-history is not supported on Windows yet: sharing uses "
                 "re-synced copies there, which would fork the history instead "
                 "of sharing it."
+            )
+        if share_plugins and self.switcher.platform == Platform.WINDOWS:
+            raise SessionError(
+                "--share-plugins is not supported on Windows yet: sharing uses "
+                "re-synced copies there, which would fork the plugin store "
+                "instead of sharing it."
             )
 
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
@@ -575,7 +608,7 @@ class SessionManager:
             )
 
         session_dir, account_num, email = self.setup_session(
-            identifier, share, share_history
+            identifier, share, share_history, share_plugins
         )
 
         print(
@@ -639,7 +672,11 @@ class SessionManager:
     # -- bootstrap -------------------------------------------------------
 
     def setup_session(
-        self, identifier: str, share: bool, share_history: bool = False
+        self,
+        identifier: str,
+        share: bool,
+        share_history: bool = False,
+        share_plugins: bool = False,
     ) -> tuple[Path, str, str]:
         """Ensure a valid session profile exists; returns (dir, num, email)."""
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
@@ -656,7 +693,7 @@ class SessionManager:
 
         # Cheap reuse check without the lock: most launches hit this.
         if not stale and self._is_session_valid(session_dir, email, org_uuid):
-            self._sync_sharing(session_dir, share, share_history)
+            self._sync_sharing(session_dir, share, share_history, share_plugins)
             return session_dir, account_num, email
 
         # One refresh so the profile starts with a fresh access token —
@@ -758,11 +795,11 @@ class SessionManager:
                     session_dir, account_num, email
                 ) and profile_is_quiescent(session_dir):
                     self._bootstrap(session_dir, account_num, email, org_uuid)
-                self._sync_sharing(session_dir, share, share_history)
+                self._sync_sharing(session_dir, share, share_history, share_plugins)
                 return session_dir, account_num, email
 
             self._bootstrap(session_dir, account_num, email, org_uuid)
-            self._sync_sharing(session_dir, share, share_history)
+            self._sync_sharing(session_dir, share, share_history, share_plugins)
 
             verdict = self._session_validity(session_dir, email, org_uuid)
             # NEITHER probe-failure verdict may reach `_cleanup_failed_session`
@@ -1016,14 +1053,19 @@ class SessionManager:
     # -- sharing ---------------------------------------------------------
 
     def _sync_sharing(
-        self, session_dir: Path, share: bool, share_history: bool = False
+        self,
+        session_dir: Path,
+        share: bool,
+        share_history: bool = False,
+        share_plugins: bool = False,
     ) -> None:
         """Mirror shared items from ~/.claude into the profile (or undo it).
 
         ``share`` governs SHARED_ITEMS (customizations) and the mcpServers
         mirror (see ``_sync_mcp_servers`` — its --no-share removal is gated
         on the adoption marker); ``share_history`` governs HISTORY_ITEMS
-        (conversation history) — independent concerns, so ``--no-share
+        (conversation history) and ``share_plugins`` PLUGIN_ITEMS (the
+        plugin store) — independent concerns, so ``--no-share
         --share-history`` gives a bare profile with unified history.
         Idempotent; runs on every launch. Deliberately sources from the
         default ``~/.claude`` (not ``get_claude_config_home()``): sharing
@@ -1036,12 +1078,15 @@ class SessionManager:
         if not session_dir.is_dir():
             return
         self._sync_mcp_servers(session_dir, share)
-        # History links are POSIX-only (run() rejects the flag on Windows;
-        # this also drops any links left by a POSIX→Windows profile move).
+        # History and plugin links are POSIX-only (run() rejects the flags on
+        # Windows; this also drops links left by a POSIX→Windows profile move).
         if self.switcher.platform == Platform.WINDOWS:
             share_history = False
-        active_items = (SHARED_ITEMS if share else ()) + (
-            HISTORY_ITEMS if share_history else ()
+            share_plugins = False
+        active_items = (
+            (SHARED_ITEMS if share else ())
+            + (HISTORY_ITEMS if share_history else ())
+            + (PLUGIN_ITEMS if share_plugins else ())
         )
         source_root = Path.home() / ".claude"
         manifest_path = session_dir / SHARE_MANIFEST
@@ -1049,14 +1094,36 @@ class SessionManager:
 
         # A flag turned off since last launch: remove the links we created
         # for it (never plain files/dirs the user accumulated themselves).
-        # For history items that holds even when the manifest claims them:
-        # a stale manifest (lock-free launches race) must never be able to
-        # delete real conversation history — only ever unlink symlinks.
+        # For history and plugin items that holds even when the manifest
+        # claims them: a stale manifest (lock-free launches race) must never
+        # be able to delete real conversation history or a real plugin store
+        # — only ever unlink symlinks.
         for name in managed:
             if name not in active_items:
                 dest = session_dir / name
-                if name in HISTORY_ITEMS and dest.exists() and not dest.is_symlink():
+                if (
+                    name in HISTORY_ITEMS + PLUGIN_ITEMS
+                    and dest.exists()
+                    and not dest.is_symlink()
+                ):
                     continue
+                if name in PLUGIN_ITEMS and dest.is_symlink():
+                    # Claude wrote registry paths spelled through this link
+                    # (see _normalize_registry_paths); removing it before
+                    # they are re-spelled would orphan those entries in the
+                    # SHARED store for every account. If the heal cannot
+                    # run, keep the link and retry next launch.
+                    src = Path.home() / ".claude" / name
+                    try:
+                        points_home = dest.resolve() == src.resolve()
+                    except OSError:
+                        continue
+                    if points_home:
+                        try:
+                            with self._plugins_store_lock():
+                                self._normalize_registry_paths(src, dest)
+                        except (LockError, OSError):
+                            continue
                 self._remove_managed(dest)
         if not active_items:
             manifest_path.unlink(missing_ok=True)
@@ -1070,6 +1137,11 @@ class SessionManager:
             dest = session_dir / name
 
             if name in HISTORY_ITEMS and not self._prepare_history_share(
+                src, dest, session_dir
+            ):
+                continue
+
+            if name in PLUGIN_ITEMS and not self._prepare_plugins_share(
                 src, dest, session_dir
             ):
                 continue
@@ -1426,13 +1498,323 @@ class SessionManager:
                     f.write("\n".join(lines) + "\n")
             dest.unlink()
 
+    def _prepare_plugins_share(
+        self, src: Path, dest: Path, session_dir: Path
+    ) -> bool:
+        """Make the plugin store linkable; returns False to skip this launch.
+
+        Same two departures from a plain shared item as history: the profile
+        may already hold its own plugin store (merged into ``~/.claude``,
+        never discarded — the generic loop would just refuse), and the share
+        source may not exist yet (created empty so there is something to
+        link). A real store is merged even when the manifest claims the
+        entry is managed, for the same stale-manifest reason as history.
+        """
+        if dest.is_symlink():
+            try:
+                already_shared = dest.resolve() == src.resolve()
+            except OSError:
+                return False
+            if already_shared:
+                # Steady state. Claude running in this profile records
+                # registry paths spelled through its own CLAUDE_CONFIG_DIR
+                # — ``<session_dir>/plugins/…`` — which resolve only while
+                # the link exists. Re-spell them at the source so
+                # toggle-off or profile removal cannot orphan them.
+                self._locked_registry_heal(src, dest)
+                return True
+            if dest.exists():
+                # A live symlink to some OTHER store is still the profile's
+                # store; repointing it (the generic loop's adopt) would
+                # abandon that store unmerged. Merging through it is not
+                # obviously right either — leave the decision to the user.
+                print(
+                    dimmed(
+                        f"Not sharing {dest.name}: the profile's "
+                        f"{dest.name} is a symlink to another store — "
+                        "remove it (or merge it yourself) to share plugins."
+                    )
+                )
+                return False
+            return True  # dangling link: nothing behind it; loop repoints
+        if dest.exists() and not dest.is_dir():
+            print(
+                dimmed(
+                    f"Not sharing {dest.name}: the profile has a "
+                    f"non-directory at {dest.name}."
+                )
+            )
+            return False
+        if dest.exists():
+            # Merging moves the store out from under any claude still running
+            # in this profile, so only migrate when the profile is quiescent.
+            if not profile_is_quiescent(session_dir):
+                print(
+                    dimmed(
+                        f"Not sharing {dest.name} yet: another session is "
+                        "using this profile — retrying on the next launch."
+                    )
+                )
+                return False
+            try:
+                with self._plugins_store_lock():
+                    self._merge_plugins_into_source(src, dest)
+            except LockError:
+                print(
+                    dimmed(
+                        f"Not sharing {dest.name} yet: another launch is "
+                        "merging a plugin store — retrying on the next "
+                        "launch."
+                    )
+                )
+                return False
+            except OSError as e:
+                self._logger.warning(
+                    f"Could not merge {dest.name} into {src}: {e}"
+                )
+                print(
+                    dimmed(
+                        f"Not sharing {dest.name}: merging the profile's "
+                        "existing plugin store failed (see log)."
+                    )
+                )
+                return False
+            print(
+                dimmed(
+                    f"Merged the profile's plugin store into {src} — "
+                    "plugins are now shared."
+                )
+            )
+        if not src.exists():
+            try:
+                _mkdir_private(src)
+            except OSError as e:
+                self._logger.warning(f"Could not create {src}: {e}")
+                return False
+        return True
+
+    def _plugins_store_lock(self) -> FileLock:
+        return FileLock(
+            self.switcher.backup_dir / _PLUGINS_STORE_LOCK,
+            timeout=_PLUGINS_STORE_LOCK_TIMEOUT,
+        )
+
+    def _locked_registry_heal(self, src: Path, dest: Path) -> None:
+        """Best-effort ``_normalize_registry_paths`` under the store lock."""
+        try:
+            with self._plugins_store_lock():
+                self._normalize_registry_paths(src, dest)
+        except (LockError, OSError) as e:
+            self._logger.warning(
+                f"Could not re-spell shared plugin registry paths: {e}"
+            )
+
+    def _normalize_registry_paths(self, src: Path, dest: Path) -> None:
+        """Re-spell store paths recorded through a profile's link.
+
+        A pure registry rewrite — every ``dest``-spelled path and its
+        ``src``-spelled equivalent name the same file while the link exists
+        (and after an unlink only the ``src`` spelling still resolves, which
+        is exactly why the rewrite must happen). ``_adopt_entry_paths`` does
+        the rewriting; its copy step no-ops because the target already
+        exists. No-write when nothing is dest-spelled, which is the steady
+        state.
+        """
+        for filename, entries_key, path_keys in (
+            ("installed_plugins.json", "plugins", ("installPath",)),
+            ("known_marketplaces.json", None, ("installLocation",)),
+        ):
+            src_file = src / filename
+            doc = self._load_json_object(src_file)
+            if doc is None:
+                continue
+            mapping = doc.get(entries_key) if entries_key is not None else doc
+            if not isinstance(mapping, dict):
+                continue
+            changed = False
+            for name, entry in mapping.items():
+                adopted = self._adopt_entry_paths(entry, src, dest, path_keys)
+                if adopted != entry:
+                    mapping[name] = adopted
+                    changed = True
+            if changed:
+                atomic_write_json(src_file, doc)
+
+    def _merge_plugins_into_source(self, src: Path, dest: Path) -> None:
+        """Move the profile's own plugin store at ``dest`` into ``src``.
+
+        The merge is additive with source-wins conflicts: plugins and marketplaces
+        the source already has keep the source's copy (the store's own
+        auto-update converges versions), ones only the profile has are copied
+        over with their registry entries re-pointed at ``src``. Per-plugin
+        ``data/`` merges the same way; instance-scoped artifacts (catalog
+        cache, sweep timestamps, blocklist) follow source-wins and are
+        otherwise dropped. Registry-driven copying is the single path even
+        into a fresh ``src`` — a wholesale move would carry ``installPath``
+        values that still point at the removed profile dir. Any failure
+        raises OSError with copied entries left in place — the merge is
+        idempotent, so the next launch resumes where this one stopped.
+        ``dest`` is removed only after everything merged.
+        """
+        _mkdir_private(src)
+        self._merge_plugin_registry(
+            src,
+            dest,
+            "installed_plugins.json",
+            "plugins",
+            path_keys=("installPath",),
+        )
+        self._merge_plugin_registry(
+            src,
+            dest,
+            "known_marketplaces.json",
+            None,
+            path_keys=("installLocation",),
+        )
+
+        data_src, data_dest = src / "data", dest / "data"
+        # Never walk a symlinked data/: moving children would drain the
+        # link's TARGET, which is not this profile's data to take.
+        if data_dest.is_dir() and not data_dest.is_symlink():
+            _mkdir_private(data_src)
+            for child in sorted(data_dest.iterdir()):
+                target = data_src / child.name
+                if not target.exists():
+                    shutil.move(str(child), str(target))
+        shutil.rmtree(dest)
+
+    @staticmethod
+    def _merge_plugin_registry(
+        src: Path,
+        dest: Path,
+        filename: str,
+        entries_key: str | None,
+        path_keys: tuple[str, ...],
+    ) -> None:
+        """Union one registry file (and the content its entries point at).
+
+        ``entries_key`` names the mapping inside the JSON document
+        (``"plugins"``), or ``None`` when the document root is the mapping
+        (``known_marketplaces.json``). Only names missing from the source are
+        adopted; each adopted entry has any ``path_keys`` path that lives
+        under ``dest`` copied to the same relative location under ``src`` and
+        rewritten to point there. A source file that exists but will not
+        parse raises OSError: overwriting it would trade a recoverable file
+        for a silent loss, and skipping the launch is cheap.
+        """
+        dest_doc = SessionManager._load_json_object(dest / filename)
+        if dest_doc is None:
+            return  # nothing mergeable on the profile side
+        src_file = src / filename
+        if src_file.exists():
+            src_doc = SessionManager._load_json_object(src_file)
+            if src_doc is None:
+                raise OSError(f"{src_file} exists but is not a JSON object")
+        elif entries_key is None:
+            src_doc = {}  # the document root IS the mapping — seed it empty
+        else:
+            src_doc = {k: v for k, v in dest_doc.items() if k != entries_key}
+            src_doc[entries_key] = {}
+
+        if entries_key is not None:
+            src_map = src_doc.setdefault(entries_key, {})
+            dest_map = dest_doc.get(entries_key, {})
+        else:
+            src_map, dest_map = src_doc, dest_doc
+        if not isinstance(src_map, dict) or not isinstance(dest_map, dict):
+            raise OSError(f"{filename}: registry mapping is not an object")
+
+        changed = False
+        for name, entry in dest_map.items():
+            if name in src_map:
+                existing = src_map[name]
+                if isinstance(existing, list) and isinstance(entry, list):
+                    # A name on both sides can still hold DISJOINT installs:
+                    # entries are per-scope (user vs project@path). Union by
+                    # scope identity; genuine overlaps keep the shared copy.
+                    have = {
+                        (e.get("scope"), e.get("projectPath"))
+                        for e in existing
+                        if isinstance(e, dict)
+                    }
+                    extra = [
+                        e
+                        for e in entry
+                        if isinstance(e, dict)
+                        and (e.get("scope"), e.get("projectPath")) not in have
+                    ]
+                    if extra:
+                        src_map[name] = existing + [
+                            SessionManager._adopt_entry_paths(
+                                e, src, dest, path_keys
+                            )
+                            for e in extra
+                        ]
+                        changed = True
+                continue
+            src_map[name] = SessionManager._adopt_entry_paths(
+                entry, src, dest, path_keys
+            )
+            changed = True
+        if changed or not src_file.exists():
+            atomic_write_json(src_file, src_doc)
+
+    @staticmethod
+    def _adopt_entry_paths(entry, src: Path, dest: Path, path_keys: tuple[str, ...]):
+        """Copy an entry's dest-relative content to ``src`` and re-point it.
+
+        Entries are dicts or lists of dicts (per-scope installs); anything
+        else passes through untouched. Paths outside ``dest`` (external
+        directory marketplaces) stay as they are. Copies are staged and
+        renamed into place, so an existing target is complete by
+        construction and safe to keep on a resumed merge — adopting an
+        interrupted copy would end with ``dest``'s good copy removed and
+        only the truncated one left.
+        """
+        if isinstance(entry, list):
+            return [
+                SessionManager._adopt_entry_paths(e, src, dest, path_keys)
+                for e in entry
+            ]
+        if not isinstance(entry, dict):
+            return entry
+        adopted = dict(entry)
+        for key in path_keys:
+            raw = adopted.get(key)
+            if not isinstance(raw, str):
+                continue
+            # normpath first: is_relative_to is lexical, and a `..` segment
+            # would pass the guard yet land the copy outside the store.
+            path = Path(os.path.normpath(raw))
+            if not path.is_relative_to(dest):
+                continue
+            target = src / path.relative_to(dest)
+            if path.exists() and not target.exists():
+                _mkdir_private(target.parent)
+                staging = target.with_name(target.name + ".cswap-partial")
+                if staging.is_dir() and not staging.is_symlink():
+                    shutil.rmtree(staging)  # a previous attempt's leftover
+                else:
+                    staging.unlink(missing_ok=True)
+                if path.is_dir():
+                    shutil.copytree(path, staging, symlinks=True)
+                else:
+                    shutil.copy2(path, staging)
+                os.replace(staging, target)
+            adopted[key] = str(target)
+        return adopted
+
     @staticmethod
     def _read_manifest(manifest_path: Path) -> list[str]:
         try:
             data = json.loads(manifest_path.read_text(encoding="utf-8"))
             items = data.get("items", [])
             # Only ever act on names we could have created.
-            return [i for i in items if i in SHARED_ITEMS + HISTORY_ITEMS]
+            return [
+                i
+                for i in items
+                if i in SHARED_ITEMS + HISTORY_ITEMS + PLUGIN_ITEMS
+            ]
         except (OSError, json.JSONDecodeError, AttributeError):
             return []
 

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -1520,7 +1520,10 @@ class SessionManager:
                 # registry paths spelled through its own CLAUDE_CONFIG_DIR
                 # — ``<session_dir>/plugins/…`` — which resolve only while
                 # the link exists. Re-spell them at the source so
-                # toggle-off or profile removal cannot orphan them.
+                # toggle-off cannot orphan them. Profile REMOVAL still can
+                # (nothing heals after the final run), but such entries
+                # self-repair: the content survives src-spelled and claude
+                # reinstalls the registry row.
                 self._locked_registry_heal(src, dest)
                 return True
             if dest.exists():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -588,12 +588,20 @@ class TestRunCommand:
                 claude_args,
                 share=True,
                 share_history=False,
+                share_plugins=False,
                 require_session=False,
             ):
-                calls.append((
-                    "run", identifier, claude_args, share, share_history,
-                    require_session,
-                ))
+                calls.append(
+                    (
+                        "run",
+                        identifier,
+                        claude_args,
+                        share,
+                        share_history,
+                        share_plugins,
+                        require_session,
+                    )
+                )
 
         with patch("claude_swap.session.SessionManager", FakeSessionManager), \
              patch("claude_swap.cli.ClaudeAccountSwitcher"), \
@@ -604,36 +612,46 @@ class TestRunCommand:
 
     def test_run_dispatches_with_defaults(self):
         calls = self._dispatch(["run", "2"])
-        assert ("run", "2", [], True, False, False) in calls
+        assert ("run", "2", [], True, False, False, False) in calls
 
     def test_run_by_email(self):
         calls = self._dispatch(["run", "user@example.com"])
-        assert ("run", "user@example.com", [], True, False, False) in calls
+        assert ("run", "user@example.com", [], True, False, False, False) in calls
 
     def test_no_share_flag(self):
         calls = self._dispatch(["run", "2", "--no-share"])
-        assert ("run", "2", [], False, False, False) in calls
+        assert ("run", "2", [], False, False, False, False) in calls
 
     def test_share_history_flag(self):
         calls = self._dispatch(["run", "2", "--share-history"])
-        assert ("run", "2", [], True, True, False) in calls
+        assert ("run", "2", [], True, True, False, False) in calls
 
     def test_no_share_history_flag(self):
         calls = self._dispatch(["run", "2", "--no-share-history"])
-        assert ("run", "2", [], True, False, False) in calls
+        assert ("run", "2", [], True, False, False, False) in calls
+
+    def test_share_plugins_flag(self):
+        calls = self._dispatch(["run", "2", "--share-plugins"])
+        assert ("run", "2", [], True, False, True, False) in calls
+
+    def test_no_share_plugins_flag(self):
+        calls = self._dispatch(["run", "2", "--no-share-plugins"])
+        assert ("run", "2", [], True, False, False, False) in calls
 
     def test_require_session_flag(self):
         calls = self._dispatch(["run", "2", "--require-session"])
-        assert ("run", "2", [], True, False, True) in calls
+        assert ("run", "2", [], True, False, False, True) in calls
 
     def test_tail_forwarded_verbatim(self):
         calls = self._dispatch(["run", "2", "--", "--resume", "--model", "x"])
-        assert ("run", "2", ["--resume", "--model", "x"], True, False, False) in calls
+        assert (
+            "run", "2", ["--resume", "--model", "x"], True, False, False, False,
+        ) in calls
 
     def test_tail_may_contain_run_flags(self):
         """Args after `--` are NOT parsed by cswap, even if they look like ours."""
         calls = self._dispatch(["run", "2", "--", "--no-share"])
-        assert ("run", "2", ["--no-share"], True, False, False) in calls
+        assert ("run", "2", ["--no-share"], True, False, False, False) in calls
 
     def test_run_unknown_flag_errors(self, capsys):
         with patch.object(sys, "argv", ["claude-swap", "run", "2", "--bogus"]):
@@ -679,6 +697,7 @@ class TestRunCommand:
                 claude_args,
                 share=True,
                 share_history=False,
+                share_plugins=False,
                 require_session=False,
             ):
                 from claude_swap.exceptions import SessionError
@@ -788,6 +807,7 @@ class TestSubcommandAliases:
                 claude_args,
                 share=True,
                 share_history=False,
+                share_plugins=False,
                 require_session=False,
             ):
                 calls.append((identifier, claude_args, share))
@@ -1385,9 +1405,19 @@ class TestRunAutoResolve:
                 claude_args,
                 share=True,
                 share_history=False,
+                share_plugins=False,
                 require_session=False,
             ):
-                calls.append(("run", identifier, claude_args, share, share_history))
+                calls.append(
+                    (
+                        "run",
+                        identifier,
+                        claude_args,
+                        share,
+                        share_history,
+                        share_plugins,
+                    )
+                )
 
             def exec_default(self, claude_args):
                 calls.append(("exec_default", claude_args))
@@ -1431,7 +1461,7 @@ class TestRunAutoResolve:
              patch("os.geteuid", return_value=1000, create=True), \
              patch.object(sys, "argv", ["claude-swap", "run"]):
             cli.main()
-        assert ("run", "2", [], True, False) in calls
+        assert ("run", "2", [], True, False, False) in calls
 
     def test_mapped_subdir_inherits(self, tmp_path, monkeypatch):
         from claude_swap.mappings import MappingStore
@@ -1455,7 +1485,7 @@ class TestRunAutoResolve:
              patch("os.geteuid", return_value=1000, create=True), \
              patch.object(sys, "argv", ["claude-swap", "run"]):
             cli.main()
-        assert ("run", "2", [], True, False) in calls
+        assert ("run", "2", [], True, False, False) in calls
 
     def test_unmapped_dir_falls_back_to_default(self, tmp_path, monkeypatch, capsys):
         backup = tmp_path / "backup"
@@ -1504,7 +1534,7 @@ class TestRunAutoResolve:
              patch("os.geteuid", return_value=1000, create=True), \
              patch.object(sys, "argv", ["claude-swap", "run", "3"]):
             cli.main()
-        assert ("run", "3", [], True, False) in calls
+        assert ("run", "3", [], True, False, False) in calls
 
     def test_no_account_forwards_tail(self, tmp_path, monkeypatch):
         from claude_swap.mappings import MappingStore
@@ -1527,7 +1557,7 @@ class TestRunAutoResolve:
              patch("os.geteuid", return_value=1000, create=True), \
              patch.object(sys, "argv", ["claude-swap", "run", "--", "--resume"]):
             cli.main()
-        assert ("run", "2", ["--resume"], True, False) in calls
+        assert ("run", "2", ["--resume"], True, False, False) in calls
 
     def test_no_account_forwards_share_history(self, tmp_path, monkeypatch):
         """--share-history survives the mapped-account resolution path."""
@@ -1551,7 +1581,7 @@ class TestRunAutoResolve:
              patch("os.geteuid", return_value=1000, create=True), \
              patch.object(sys, "argv", ["claude-swap", "run", "--share-history"]):
             cli.main()
-        assert ("run", "2", [], True, True) in calls
+        assert ("run", "2", [], True, True, False) in calls
 
 
 class TestDisableEnableDispatch:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -20,6 +20,7 @@ from claude_swap.credentials import CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE
 from claude_swap.exceptions import (
     AccountNotFoundError,
     CredentialReadError,
+    LockError,
     SessionError,
     ValidationError,
 )
@@ -1986,6 +1987,506 @@ class TestShareHistoryWindows:
 
         with pytest.raises(SessionError, match="Windows"):
             mgr.run(ACCOUNT_NUM, [], share=True, share_history=True)
+
+
+# ---------------------------------------------------------------------------
+# plugin-store sharing (--share-plugins)
+# ---------------------------------------------------------------------------
+
+
+def _seed_plugin_store(root: Path, plugins: dict, marketplaces: dict) -> None:
+    """A minimal but shape-faithful plugin store under ``root``."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "installed_plugins.json").write_text(
+        json.dumps({"version": 2, "plugins": plugins})
+    )
+    (root / "known_marketplaces.json").write_text(json.dumps(marketplaces))
+
+
+def _plugin_entry(store: Path, marketplace: str, name: str, version: str) -> list:
+    install = store / "cache" / marketplace / name / version
+    install.mkdir(parents=True, exist_ok=True)
+    (install / "plugin.json").write_text(json.dumps({"name": name}))
+    return [{"scope": "user", "version": version, "installPath": str(install)}]
+
+
+def _marketplace_entry(store: Path, name: str) -> dict:
+    location = store / "marketplaces" / name
+    location.mkdir(parents=True, exist_ok=True)
+    (location / "marketplace.json").write_text("{}")
+    return {"source": {"source": "github", "repo": f"x/{name}"},
+            "installLocation": str(location)}
+
+
+@pytest.fixture
+def plugins_setup(share_setup, temp_home: Path):
+    """share_setup plus a populated plugin store on both sides."""
+    source, session_dir, mgr = share_setup
+    src_store = source / "plugins"
+    _seed_plugin_store(
+        src_store,
+        {"alpha@mp": _plugin_entry(src_store, "mp", "alpha", "2.0.0")},
+        {"mp": _marketplace_entry(src_store, "mp")},
+    )
+    dest_store = session_dir / "plugins"
+    _seed_plugin_store(
+        dest_store,
+        {
+            "alpha@mp": _plugin_entry(dest_store, "mp", "alpha", "1.0.0"),
+            "beta@mp": _plugin_entry(dest_store, "mp", "beta", "3.1.0"),
+        },
+        {
+            "mp": _marketplace_entry(dest_store, "mp"),
+            "other": _marketplace_entry(dest_store, "other"),
+        },
+    )
+    return source, session_dir, mgr
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="plugin sharing is POSIX-only")
+class TestSharePluginsPosix:
+    def test_not_shared_by_default(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        mgr._sync_sharing(session_dir, share=True)
+
+        assert not (session_dir / "plugins").is_symlink()
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "plugins" not in manifest["items"]
+
+    def test_links_plugins_dir(self, share_setup):
+        source, session_dir, mgr = share_setup
+        src_store = source / "plugins"
+        _seed_plugin_store(src_store, {}, {})
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        assert (session_dir / "plugins").readlink() == src_store
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "plugins" in manifest["items"]
+
+    def test_creates_missing_source(self, share_setup):
+        source, session_dir, mgr = share_setup  # no plugins/ in ~/.claude yet
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        assert (source / "plugins").is_dir()
+        assert (source / "plugins").stat().st_mode & 0o777 == 0o700
+        assert (session_dir / "plugins").readlink() == source / "plugins"
+
+    def test_merges_missing_plugins_and_repoints_paths(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        src_store = source / "plugins"
+        registry = json.loads(
+            (src_store / "installed_plugins.json").read_text()
+        )["plugins"]
+        # Source's alpha won; profile's beta was adopted and re-pointed.
+        assert registry["alpha@mp"][0]["version"] == "2.0.0"
+        beta = registry["beta@mp"][0]
+        assert beta["installPath"] == str(
+            src_store / "cache" / "mp" / "beta" / "3.1.0"
+        )
+        assert (
+            Path(beta["installPath"]) / "plugin.json"
+        ).read_text() == json.dumps({"name": "beta"})
+        # And the profile now links to the shared store.
+        assert (session_dir / "plugins").readlink() == src_store
+
+    def test_merge_adopts_missing_marketplace(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        src_store = source / "plugins"
+        markets = json.loads(
+            (src_store / "known_marketplaces.json").read_text()
+        )
+        assert markets["other"]["installLocation"] == str(
+            src_store / "marketplaces" / "other"
+        )
+        assert (src_store / "marketplaces" / "other" / "marketplace.json").exists()
+
+    def test_merge_keeps_external_directory_paths(self, share_setup, tmp_path):
+        source, session_dir, mgr = share_setup
+        _seed_plugin_store(source / "plugins", {}, {})
+        external = tmp_path / "my-marketplace"
+        external.mkdir()
+        dest_store = session_dir / "plugins"
+        _seed_plugin_store(
+            dest_store,
+            {},
+            {"local": {"source": {"source": "directory", "path": str(external)},
+                       "installLocation": str(external)}},
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        markets = json.loads(
+            (source / "plugins" / "known_marketplaces.json").read_text()
+        )
+        assert markets["local"]["installLocation"] == str(external)
+
+    def test_merge_populates_fresh_source(self, share_setup):
+        source, session_dir, mgr = share_setup  # no plugins/ in ~/.claude yet
+        dest_store = session_dir / "plugins"
+        _seed_plugin_store(
+            dest_store,
+            {"beta@mp": _plugin_entry(dest_store, "mp", "beta", "3.1.0")},
+            {"mp": _marketplace_entry(dest_store, "mp")},
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        src_store = source / "plugins"
+        registry = json.loads(
+            (src_store / "installed_plugins.json").read_text()
+        )["plugins"]
+        # Adopted entries must point into the shared store, not the removed
+        # profile dir — the reason the merge is registry-driven even here.
+        assert registry["beta@mp"][0]["installPath"] == str(
+            src_store / "cache" / "mp" / "beta" / "3.1.0"
+        )
+        # The marketplace must be adopted the same way — a fresh source has
+        # no known_marketplaces.json, and seeding it from the dest document
+        # verbatim would keep dest-spelled paths while the dirs get removed.
+        markets = json.loads(
+            (src_store / "known_marketplaces.json").read_text()
+        )
+        assert markets["mp"]["installLocation"] == str(
+            src_store / "marketplaces" / "mp"
+        )
+        assert (src_store / "marketplaces" / "mp" / "marketplace.json").exists()
+        assert (session_dir / "plugins").readlink() == src_store
+
+    def test_merges_data_dir(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        (source / "plugins" / "data" / "alpha-mp").mkdir(parents=True)
+        (source / "plugins" / "data" / "alpha-mp" / "state.json").write_text("src")
+        dest_data = session_dir / "plugins" / "data"
+        (dest_data / "alpha-mp").mkdir(parents=True)
+        (dest_data / "alpha-mp" / "state.json").write_text("profile")
+        (dest_data / "beta-mp").mkdir()
+        (dest_data / "beta-mp" / "state.json").write_text("profile-beta")
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        data = source / "plugins" / "data"
+        assert (data / "alpha-mp" / "state.json").read_text() == "src"
+        assert (data / "beta-mp" / "state.json").read_text() == "profile-beta"
+
+    def test_merge_deferred_while_profile_live(self, plugins_setup, monkeypatch):
+        source, session_dir, mgr = plugins_setup
+        monkeypatch.setattr(
+            session_mod, "scan_live_sessions", lambda _dir: ([object()], 0)
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        assert not (session_dir / "plugins").is_symlink()
+        assert (session_dir / "plugins" / "installed_plugins.json").exists()
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "plugins" not in manifest["items"]
+
+    def test_corrupt_source_registry_aborts_merge(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        (source / "plugins" / "installed_plugins.json").write_text("not json")
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        # Profile store untouched, nothing linked, corrupt file not replaced.
+        assert not (session_dir / "plugins").is_symlink()
+        assert (session_dir / "plugins" / "installed_plugins.json").exists()
+        assert (
+            source / "plugins" / "installed_plugins.json"
+        ).read_text() == "not json"
+
+    def test_resumed_merge_keeps_prior_copies(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        # A previous attempt already copied beta's cache dir but died before
+        # the registry write: the resume must keep it and not raise.
+        prior = source / "plugins" / "cache" / "mp" / "beta" / "3.1.0"
+        prior.mkdir(parents=True)
+        (prior / "plugin.json").write_text("prior-copy")
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        assert (prior / "plugin.json").read_text() == "prior-copy"
+        assert (session_dir / "plugins").readlink() == source / "plugins"
+
+    def test_toggle_off_removes_link_keeps_data(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+        mgr._sync_sharing(session_dir, share=True, share_plugins=False)
+
+        assert not (session_dir / "plugins").exists()
+        assert (source / "plugins" / "installed_plugins.json").exists()
+        assert (session_dir / "settings.json").is_symlink()
+
+    def test_share_plugins_independent_of_no_share(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        mgr._sync_sharing(session_dir, share=False, share_plugins=True)
+
+        assert (session_dir / "plugins").is_symlink()
+        assert not (session_dir / "settings.json").exists()
+
+    def test_stale_manifest_never_deletes_real_store(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        (session_dir / SHARE_MANIFEST).write_text(
+            json.dumps({"items": ["plugins"], "mode": "symlink"})
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=False)
+
+        # Real store is user data even when the manifest claims it.
+        assert (session_dir / "plugins" / "installed_plugins.json").exists()
+
+    def test_two_profiles_merge_into_one_source(self, plugins_setup):
+        # The second profile's merge must add to the shared registry, not
+        # replace the first one's contribution.
+        source, session_dir, mgr = plugins_setup
+        other_dir = session_dir.parent / "9-other_x.com"
+        other_dir.mkdir()
+        other_store = other_dir / "plugins"
+        _seed_plugin_store(
+            other_store,
+            {"gamma@mp": _plugin_entry(other_store, "mp", "gamma", "1.1.0")},
+            {"mp": _marketplace_entry(other_store, "mp")},
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+        mgr._sync_sharing(other_dir, share=True, share_plugins=True)
+
+        registry = json.loads(
+            (source / "plugins" / "installed_plugins.json").read_text()
+        )["plugins"]
+        assert {"alpha@mp", "beta@mp", "gamma@mp"} <= set(registry)
+        assert (other_dir / "plugins").readlink() == source / "plugins"
+
+    def test_merge_lock_timeout_fails_open(self, plugins_setup, monkeypatch):
+        source, session_dir, mgr = plugins_setup
+
+        class HeldLock:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                raise LockError("held elsewhere")
+
+            def __exit__(self, *a):
+                return None
+
+        monkeypatch.setattr(session_mod, "FileLock", HeldLock)
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        # Merge skipped, profile store intact, nothing linked or claimed.
+        assert (session_dir / "plugins" / "installed_plugins.json").exists()
+        assert not (session_dir / "plugins").is_symlink()
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "plugins" not in manifest["items"]
+
+    def test_stale_staging_replaced_by_complete_copy(self, plugins_setup):
+        # A previous merge died mid-copy: its staging dir is a truncated
+        # copy and must be discarded, never adopted as the install.
+        source, session_dir, mgr = plugins_setup
+        staging = (
+            source / "plugins" / "cache" / "mp" / "beta" / "3.1.0.cswap-partial"
+        )
+        staging.mkdir(parents=True)
+        (staging / "junk").write_text("truncated")
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        target = source / "plugins" / "cache" / "mp" / "beta" / "3.1.0"
+        assert (target / "plugin.json").read_text() == json.dumps(
+            {"name": "beta"}
+        )
+        assert not staging.exists()
+
+    def test_per_scope_entries_union(self, share_setup, tmp_path):
+        # The same plugin name can hold DISJOINT installs (user vs
+        # project scope); source-wins must not drop the profile's scopes.
+        source, session_dir, mgr = share_setup
+        src_store = source / "plugins"
+        _seed_plugin_store(
+            src_store,
+            {"alpha@mp": _plugin_entry(src_store, "mp", "alpha", "2.0.0")},
+            {"mp": _marketplace_entry(src_store, "mp")},
+        )
+        dest_store = session_dir / "plugins"
+        project_entry = _plugin_entry(dest_store, "mp", "alpha", "1.5.0")
+        project_entry[0]["scope"] = "project"
+        project_entry[0]["projectPath"] = str(tmp_path / "work")
+        _seed_plugin_store(
+            dest_store,
+            {"alpha@mp": project_entry},
+            {"mp": _marketplace_entry(dest_store, "mp")},
+        )
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        registry = json.loads(
+            (src_store / "installed_plugins.json").read_text()
+        )["plugins"]
+        scopes = {
+            (e["scope"], e.get("projectPath")) for e in registry["alpha@mp"]
+        }
+        assert ("user", None) in scopes
+        assert ("project", str(tmp_path / "work")) in scopes
+        adopted = next(
+            e for e in registry["alpha@mp"] if e["scope"] == "project"
+        )
+        assert adopted["installPath"] == str(
+            src_store / "cache" / "mp" / "alpha" / "1.5.0"
+        )
+        assert Path(adopted["installPath"]).is_dir()
+
+    def test_steady_state_respells_profile_paths(self, plugins_setup):
+        # Claude running in a shared profile writes registry paths spelled
+        # through its own link; every launch re-spells them at the source.
+        source, session_dir, mgr = plugins_setup
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+        src_store = source / "plugins"
+        registry_file = src_store / "installed_plugins.json"
+        registry = json.loads(registry_file.read_text())
+        registry["plugins"]["alpha@mp"][0]["installPath"] = str(
+            session_dir / "plugins" / "cache" / "mp" / "alpha" / "2.0.0"
+        )
+        registry_file.write_text(json.dumps(registry))
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        healed = json.loads(registry_file.read_text())["plugins"]
+        assert healed["alpha@mp"][0]["installPath"] == str(
+            src_store / "cache" / "mp" / "alpha" / "2.0.0"
+        )
+        assert (session_dir / "plugins").readlink() == src_store
+
+    def test_toggle_off_respells_before_unlink(self, plugins_setup, temp_home):
+        source, session_dir, mgr = plugins_setup
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+        src_store = source / "plugins"
+        registry_file = src_store / "installed_plugins.json"
+        registry = json.loads(registry_file.read_text())
+        registry["plugins"]["alpha@mp"][0]["installPath"] = str(
+            session_dir / "plugins" / "cache" / "mp" / "alpha" / "2.0.0"
+        )
+        registry_file.write_text(json.dumps(registry))
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=False)
+
+        # Link removed only after the shared registry stopped spelling paths
+        # through it — otherwise every account's copy goes dangling at once.
+        assert not (session_dir / "plugins").exists()
+        healed = json.loads(registry_file.read_text())["plugins"]
+        assert healed["alpha@mp"][0]["installPath"] == str(
+            src_store / "cache" / "mp" / "alpha" / "2.0.0"
+        )
+
+    def test_toggle_off_keeps_link_when_heal_fails(
+        self, plugins_setup, monkeypatch
+    ):
+        source, session_dir, mgr = plugins_setup
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        class HeldLock:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                raise LockError("held elsewhere")
+
+            def __exit__(self, *a):
+                return None
+
+        monkeypatch.setattr(session_mod, "FileLock", HeldLock)
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=False)
+
+        # Better a lingering link than orphaned registry entries.
+        assert (session_dir / "plugins").is_symlink()
+
+    def test_foreign_symlink_skipped(self, share_setup, tmp_path, capsys):
+        source, session_dir, mgr = share_setup
+        _seed_plugin_store(source / "plugins", {}, {})
+        external = tmp_path / "elsewhere"
+        _seed_plugin_store(external, {}, {})
+        (session_dir / "plugins").symlink_to(external)
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        # Neither repointed nor merged — the user decides.
+        assert (session_dir / "plugins").readlink() == external
+        assert (external / "installed_plugins.json").exists()
+        assert "symlink to another store" in capsys.readouterr().out
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "plugins" not in manifest["items"]
+
+    def test_registry_path_escape_not_copied(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        dest_store = session_dir / "plugins"
+        escape = str(dest_store) + "/../../escaped"
+        registry_file = dest_store / "installed_plugins.json"
+        registry = json.loads(registry_file.read_text())
+        registry["plugins"]["evil@mp"] = [
+            {"scope": "user", "version": "1.0.0", "installPath": escape}
+        ]
+        registry_file.write_text(json.dumps(registry))
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        # The lexical prefix check must not be fooled by `..`: nothing is
+        # copied outside the store and the path is carried verbatim.
+        assert not (session_dir.parent / "escaped").exists()
+        merged = json.loads(
+            (source / "plugins" / "installed_plugins.json").read_text()
+        )["plugins"]
+        assert merged["evil@mp"][0]["installPath"] == escape
+
+    def test_file_at_plugins_fails_open(self, share_setup, capsys):
+        source, session_dir, mgr = share_setup
+        _seed_plugin_store(source / "plugins", {}, {})
+        (session_dir / "plugins").write_text("not a store")
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        assert (session_dir / "plugins").read_text() == "not a store"
+        assert "non-directory" in capsys.readouterr().out
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "plugins" not in manifest["items"]
+
+    def test_symlinked_data_dir_not_drained(self, plugins_setup, tmp_path):
+        source, session_dir, mgr = plugins_setup
+        external = tmp_path / "external-data"
+        (external / "alpha-mp").mkdir(parents=True)
+        (external / "alpha-mp" / "state.json").write_text("external")
+        (session_dir / "plugins" / "data").symlink_to(external)
+
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        # The link's target is not this profile's data to take.
+        assert (external / "alpha-mp" / "state.json").read_text() == "external"
+        assert (session_dir / "plugins").readlink() == source / "plugins"
+
+
+class TestSharePluginsWindows:
+    def test_sync_never_links_plugins_in_copy_mode(self, plugins_setup):
+        source, session_dir, mgr = plugins_setup
+        mgr.switcher.platform = Platform.WINDOWS
+        mgr._sync_sharing(session_dir, share=True, share_plugins=True)
+
+        assert not (session_dir / "plugins").is_symlink()
+        manifest = json.loads((session_dir / SHARE_MANIFEST).read_text())
+        assert "plugins" not in manifest["items"]
+
+    def test_run_rejects_flag(self, plugins_setup, monkeypatch):
+        source, session_dir, mgr = plugins_setup
+        mgr.switcher.platform = Platform.WINDOWS
+        monkeypatch.setattr(
+            session_mod.shutil, "which", lambda _name: "/usr/bin/claude"
+        )
+
+        with pytest.raises(SessionError, match="Windows"):
+            mgr.run(ACCOUNT_NUM, [], share=True, share_plugins=True)
 
 
 class TestReadSessionCredentials:


### PR DESCRIPTION
## Summary

Adds an opt-in `--share-plugins` flag to `cswap run`: the session profile's `plugins/` directory (the install store — installed plugins, marketplaces, per-plugin data) is symlinked to `~/.claude/plugins`, so a plugin installed or updated in any account is available in all of them. This closes the gap where `enabledPlugins` already travels with `settings.json` under plain `--share`, but the profile has no copy of the store those entries point at.

## Design

Follows the `--share-history` precedent throughout:

- POSIX-only; `run()` rejects the flag on Windows (copies would fork the store).
- A profile's pre-existing store is merged into `~/.claude` first, never discarded: additive union with source-wins conflicts (plugin auto-update converges versions anyway). Per-scope entries (user vs project@path) under the same name are unioned by scope identity, so a project-scoped install in the profile survives a user-scoped one in the source.
- The merge is registry-driven (`installed_plugins.json`, `known_marketplaces.json`) with adopted entries' content copied under the shared store and their `installPath`/`installLocation` re-pointed. Copies are staged and renamed into place, so an interrupted merge resumes safely. External directory marketplaces keep their paths verbatim.
- A stale share manifest can never delete a real store — only symlinks are ever unlinked, same as history.

One hazard is new relative to history sharing: Claude running in a shared profile records registry paths spelled through its own `CLAUDE_CONFIG_DIR` (`<session>/plugins/...`), which resolve only while the link exists. Every launch re-spells those entries at the source, and toggle-off heals before unlinking, so removing the link cannot orphan registry entries for every other account. Registry writes are serialized by a dedicated file lock (the backup-dir lock is non-reentrant and `_sync_sharing` runs both under and outside it).

## Testing

- 23 new tests covering the merge (fresh source, populated source, per-scope union, external marketplaces, data/ merge), the heals (steady-state, toggle-off, heal-failure keeps the link), fail-open paths (lock timeout, corrupt source registry, live profile, foreign symlink, non-directory), path-escape hardening, resumed/interrupted merges, and Windows behavior.
- Registry shape assumptions validated against a real `~/.claude/plugins` store (v2 `installed_plugins.json` with per-name scope-entry lists, `known_marketplaces.json` with `installLocation`).
- Full suite passes except three failures that also fail on `main` in this environment (unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)