### PR TITLE
Add --require-session to cswap run

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,12 @@ cswap run 2                     # launch Claude Code as account 2, here only
 cswap run user@example.com      # by email
 cswap run 2 -- --resume         # everything after '--' is forwarded to claude
 cswap run 2 --share-history     # share your chat history with this account too
+cswap run 2 --require-session   # refuse rather than run plain claude if 2 is the default login
 ```
 
 Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP servers, etc.), but each account keeps its own chat history — pass `--share-history` if you want your accounts to continue the same conversations.
+
+Running the account that is already your default login launches plain `claude` on that login instead of a session (a second copy of the active credential would go stale). Scripts that need the isolation guaranteed can pass `--require-session`, which refuses in that case instead.
 
 <details>
 <summary>Sharing details — MCP servers & chat history</summary>

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -131,6 +131,7 @@ Examples:
   cswap run user@example.com
   cswap run 2 --no-share
   cswap run 2 --share-history
+  cswap run 2 --require-session
   cswap run 2 -- --resume
         """,
     )
@@ -163,6 +164,15 @@ Examples:
         ),
     )
     parser.add_argument(
+        "--require-session",
+        action="store_true",
+        help=(
+            "Refuse to launch when the account is already the active default "
+            "login, instead of running plain claude on that login (which a "
+            "later switch could pull out from under the session)"
+        ),
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -183,6 +193,7 @@ Examples:
                 tail,
                 share=not args.no_share,
                 share_history=args.share_history,
+                require_session=args.require_session,
             )
             return  # only reachable in tests where exec/exit is mocked
 
@@ -194,6 +205,7 @@ Examples:
                 tail,
                 share=not args.no_share,
                 share_history=args.share_history,
+                require_session=args.require_session,
             )
             return  # only reachable in tests
         if email is not None:

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -507,8 +507,16 @@ class SessionManager:
         claude_args: list[str],
         share: bool = True,
         share_history: bool = False,
+        require_session: bool = False,
     ) -> NoReturn:
-        """Launch Claude Code as the given account in the current terminal."""
+        """Launch Claude Code as the given account in the current terminal.
+
+        ``require_session`` turns the same-account fast path (a plain claude
+        launch on the default login) into a refusal: a wrapper that hands a
+        terminal to one account per session needs the isolation guaranteed,
+        and a session on the default login is the one thing an account
+        switch can later pull out from under it.
+        """
         claude_bin = shutil.which("claude")
         if not claude_bin:
             raise SessionError(
@@ -542,6 +550,15 @@ class SessionManager:
             # refresh token.
             current = self.switcher._get_current_account()
             if current is not None and current == (email, org_uuid):
+                if require_session:
+                    raise SessionError(
+                        f"Account-{account_num} ({email}) is the active default "
+                        "login, so this launch would run plain claude on the "
+                        "default login rather than in a session profile (a "
+                        "second copy of the active credential would drift). "
+                        "Switch the default login to another account first, "
+                        "or run `claude` directly."
+                    )
                 print(
                     dimmed(
                         f"Account-{account_num} ({email}) is already the active "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -582,8 +582,18 @@ class TestRunCommand:
             def __init__(self, switcher):
                 calls.append(("init", switcher))
 
-            def run(self, identifier, claude_args, share=True, share_history=False):
-                calls.append(("run", identifier, claude_args, share, share_history))
+            def run(
+                self,
+                identifier,
+                claude_args,
+                share=True,
+                share_history=False,
+                require_session=False,
+            ):
+                calls.append((
+                    "run", identifier, claude_args, share, share_history,
+                    require_session,
+                ))
 
         with patch("claude_swap.session.SessionManager", FakeSessionManager), \
              patch("claude_swap.cli.ClaudeAccountSwitcher"), \
@@ -594,32 +604,36 @@ class TestRunCommand:
 
     def test_run_dispatches_with_defaults(self):
         calls = self._dispatch(["run", "2"])
-        assert ("run", "2", [], True, False) in calls
+        assert ("run", "2", [], True, False, False) in calls
 
     def test_run_by_email(self):
         calls = self._dispatch(["run", "user@example.com"])
-        assert ("run", "user@example.com", [], True, False) in calls
+        assert ("run", "user@example.com", [], True, False, False) in calls
 
     def test_no_share_flag(self):
         calls = self._dispatch(["run", "2", "--no-share"])
-        assert ("run", "2", [], False, False) in calls
+        assert ("run", "2", [], False, False, False) in calls
 
     def test_share_history_flag(self):
         calls = self._dispatch(["run", "2", "--share-history"])
-        assert ("run", "2", [], True, True) in calls
+        assert ("run", "2", [], True, True, False) in calls
 
     def test_no_share_history_flag(self):
         calls = self._dispatch(["run", "2", "--no-share-history"])
-        assert ("run", "2", [], True, False) in calls
+        assert ("run", "2", [], True, False, False) in calls
+
+    def test_require_session_flag(self):
+        calls = self._dispatch(["run", "2", "--require-session"])
+        assert ("run", "2", [], True, False, True) in calls
 
     def test_tail_forwarded_verbatim(self):
         calls = self._dispatch(["run", "2", "--", "--resume", "--model", "x"])
-        assert ("run", "2", ["--resume", "--model", "x"], True, False) in calls
+        assert ("run", "2", ["--resume", "--model", "x"], True, False, False) in calls
 
     def test_tail_may_contain_run_flags(self):
         """Args after `--` are NOT parsed by cswap, even if they look like ours."""
         calls = self._dispatch(["run", "2", "--", "--no-share"])
-        assert ("run", "2", ["--no-share"], True, False) in calls
+        assert ("run", "2", ["--no-share"], True, False, False) in calls
 
     def test_run_unknown_flag_errors(self, capsys):
         with patch.object(sys, "argv", ["claude-swap", "run", "2", "--bogus"]):
@@ -659,7 +673,14 @@ class TestRunCommand:
             def __init__(self, switcher):
                 pass
 
-            def run(self, identifier, claude_args, share=True, share_history=False):
+            def run(
+                self,
+                identifier,
+                claude_args,
+                share=True,
+                share_history=False,
+                require_session=False,
+            ):
                 from claude_swap.exceptions import SessionError
 
                 raise SessionError("boom")
@@ -761,7 +782,14 @@ class TestSubcommandAliases:
             def __init__(self, switcher):
                 pass
 
-            def run(self, identifier, claude_args, share=True, share_history=False):
+            def run(
+                self,
+                identifier,
+                claude_args,
+                share=True,
+                share_history=False,
+                require_session=False,
+            ):
                 calls.append((identifier, claude_args, share))
 
         with patch("claude_swap.session.SessionManager", FakeSessionManager), \
@@ -1351,7 +1379,14 @@ class TestRunAutoResolve:
             def __init__(self, switcher):
                 pass
 
-            def run(self, identifier, claude_args, share=True, share_history=False):
+            def run(
+                self,
+                identifier,
+                claude_args,
+                share=True,
+                share_history=False,
+                require_session=False,
+            ):
                 calls.append(("run", identifier, claude_args, share, share_history))
 
             def exec_default(self, claude_args):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1322,6 +1322,29 @@ class TestRun:
         assert "CLAUDE_CONFIG_DIR" not in exc.value.env
         assert "already the active default login" in capsys.readouterr().out
 
+    def test_require_session_refuses_fast_path(
+        self, manager, capture_exec, monkeypatch
+    ):
+        monkeypatch.setattr(
+            manager.switcher,
+            "_get_current_account",
+            lambda: (ACCOUNT_EMAIL, ORG_UUID),
+        )
+        # SessionError, not _ExecCalled: nothing may launch.
+        with pytest.raises(SessionError, match="active default login"):
+            manager.run("2", [], require_session=True)
+
+    def test_require_session_is_inert_off_the_active_account(
+        self, manager, capture_exec, auth_status_tracks_seed, refresh_rotates
+    ):
+        with pytest.raises(_ExecCalled) as exc:
+            manager.run("2", [], require_session=True)
+
+        session_dir = session_dir_for(
+            manager.switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        assert exc.value.env["CLAUDE_CONFIG_DIR"] == str(session_dir)
+
     def test_preset_config_dir_disables_fast_path(
         self,
         manager,


### PR DESCRIPTION
When the account named in `cswap run` is already the active default login, the fast path launches plain claude on that login instead of creating a session profile, because a second copy of the active credential would drift. That is the right default, but a wrapper that hands each terminal to one account and relies on session isolation has no way to notice it happened: the launch silently lands on the default login, and a later `cswap switch` pulls that login out from under the running session.

This adds a `--require-session` flag that turns the fast path into a refusal with a clear message, so such wrappers can guarantee they only ever run in a session profile. Nothing changes without the flag.