### PR TITLE
Adopt an exited session's credential into its backup before it is activated or refreshed

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ cswap run 2 --share-history     # share your chat history with this account too
 
 Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP servers, etc.), but each account keeps its own chat history — pass `--share-history` if you want your accounts to continue the same conversations.
 
+A session refreshes its own copy of the account's token, so once it exits, the credential it rotated is captured back into the account's stored backup before a switch or usage check uses that backup. While a session is still running, `cswap switch` refuses to move the default login onto its account if the stored backup has already fallen behind (activating it could only fail); exit the session first, or pick another account.
+
 <details>
 <summary>Sharing details — MCP servers & chat history</summary>
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -2775,6 +2775,95 @@ class ClaudeAccountSwitcher:
             f"Invalidated session credentials for account {account_num}"
         )
 
+    def _session_profile_ahead(
+        self, account_num: str, email: str, org_uuid: str
+    ) -> str | None:
+        """The session profile's credential when it is a newer generation of
+        this slot's family than the stored backup, else None.
+
+        Claude rotates the token family inside a session profile and the
+        backup never follows, so after any session that refreshed, the backup
+        holds a consumed generation: activated, its first refresh gets
+        invalid_grant. Generations are told apart by fingerprint and ordered
+        by access-token issue time (``expiresAt``: every refresh, and every
+        login, issues a token that expires later than the last), which also
+        keeps a fresh re-login in the backup from reading as drift -- there
+        the backup is the later one.
+
+        Three shapes answer None outright: a profile that an in-session
+        /login re-pointed at another account (a different family, not a
+        newer generation of this one); a profile flagged stale (the backup
+        moved under it while it was live, and cswap has already decided it
+        re-bootstraps); and anything unreadable, because a read error is not
+        evidence of drift.
+        """
+        from claude_swap.session import (
+            is_session_stale,
+            read_session_credentials,
+            session_identity_drifted,
+        )
+
+        session_dir = self._session_dir(account_num, email)
+        if is_session_stale(session_dir):
+            return None
+        profile = read_session_credentials(session_dir)
+        if not profile or session_identity_drifted(session_dir, email, org_uuid):
+            return None
+        backup, unreadable = self._read_account_credentials_ex(account_num, email)
+        if unreadable:
+            return None
+        if oauth.credential_fingerprint(profile) == oauth.credential_fingerprint(
+            backup
+        ):
+            return None
+        issued = oauth.extract_oauth_data(profile) or {}
+        stored = oauth.extract_oauth_data(backup) or {}
+        try:
+            newer = float(issued.get("expiresAt") or 0) > float(
+                stored.get("expiresAt") or 0
+            )
+        except (TypeError, ValueError):
+            return None
+        return profile if newer else None
+
+    def _adopt_session_credential(
+        self, account_num: str, email: str, org_uuid: str
+    ) -> bool:
+        """Capture a quiescent session profile's credential into the slot backup.
+
+        The complement of ``_post_backup_write``: that direction invalidates
+        a profile when the backup moves, this one advances the backup when
+        the profile did. Without it a drifted backup is a landmine -- a
+        switch activates a consumed generation whose first refresh gets
+        invalid_grant, and the collector's backup path POSTs that dead grant
+        and strikes a healthy slot -- and nothing ever defuses it, because
+        the profile keeps passing the local reuse check and is never
+        re-bootstrapped.
+
+        Only while the profile is quiescent: a live claude is rotating that
+        family and owns it. Decided and written under cswap's own lock, since
+        ``_bootstrap`` and the consume gate's persist move the same two
+        copies. The store write is deliberately the pure one:
+        ``_post_backup_write`` would invalidate the very profile just
+        captured, and the two now hold the same generation. Returns whether
+        the backup was advanced.
+        """
+        from claude_swap.session import profile_is_quiescent
+
+        session_dir = self._session_dir(account_num, email)
+        with FileLock(self.lock_file):
+            if not profile_is_quiescent(session_dir):
+                return False
+            profile = self._session_profile_ahead(account_num, email, org_uuid)
+            if profile is None:
+                return False
+            self._store._write_account_credentials(account_num, email, profile)
+        self._logger.info(
+            f"Adopted account {account_num}'s session profile credential "
+            "into its backup"
+        )
+        return True
+
     def _delete_session_profile(self, account_num: str, email: str) -> None:
         """Remove an account's session profile dir and its keychain entry.
 
@@ -4736,12 +4825,13 @@ class ClaudeAccountSwitcher:
 
         # A session profile supersedes the backup copy as this account's
         # credential truth: claude rotates the token family inside the profile
-        # and nothing syncs it back, so once a session has run, the backup's
-        # refresh token is a consumed generation the server 401s forever —
-        # usage would silently freeze at the last pre-session measurement.
-        # Fetch with the profile's newest credential, strictly read-only
-        # (is_active=True: no refresh, no persist): rotating the profile's
-        # family here would log the next `cswap run` out the same way.
+        # and the backup only catches up once the session exits (adopted
+        # below), so while one is live the backup's refresh token is a
+        # consumed generation the server 401s forever — usage would silently
+        # freeze at the last pre-session measurement. Fetch with the profile's
+        # newest credential, strictly read-only (is_active=True: no refresh,
+        # no persist): rotating the profile's family here would log the live
+        # claude out the same way.
         session_dir = self._session_dir(str(num), email)
         session_creds = read_session_credentials(session_dir)
         if session_creds and session_identity_drifted(session_dir, email, org_uuid):
@@ -4757,6 +4847,22 @@ class ClaudeAccountSwitcher:
             )
             session_creds = None
             has_live_session = False
+        if session_creds and not has_live_session:
+            # The session has exited, so its family is nobody's to rotate but
+            # the store's: adopt the profile head into the backup (which is a
+            # consumed generation until then) and take the idle path below,
+            # refresh included, on that credential. A profile already on the
+            # backup's generation, or behind a fresh re-login in the backup,
+            # needs no adoption and takes the same path on the backup. An
+            # adoption refused for any other reason (lock contention, a
+            # session record that could not be read) leaves both copies as
+            # they were.
+            try:
+                if self._adopt_session_credential(str(num), email, org_uuid):
+                    creds = session_creds
+            except LockError:
+                pass
+            session_creds = None
         if session_creds:
             session_oauth = oauth.extract_oauth_data(session_creds)
             if session_oauth and session_oauth.get("accessToken"):
@@ -4769,16 +4875,10 @@ class ClaudeAccountSwitcher:
                         error=outcome.error,
                         retry_after_s=outcome.retry_after_s,
                     )
-                if has_live_session:
-                    # The live claude refreshes lazily on its next API call;
-                    # requesting now would just 401 (same rule as the owned
-                    # active account in _fetch_active_usage).
-                    return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
-                # Expired profile credential and no live session: fall through
-                # to the backup path — cswap must not rotate the profile's
-                # family, but a backup family that is still alive (e.g. the
-                # account was re-added after the profile last ran) can serve
-                # and heal via the normal refresh machinery below.
+                # The live claude refreshes lazily on its next API call;
+                # requesting now would just 401 (same rule as the owned
+                # active account in _fetch_active_usage).
+                return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
 
         outcome = oauth.try_fetch_usage_for_account(
             str(num), email, creds,
@@ -6552,31 +6652,60 @@ class ClaudeAccountSwitcher:
         The post-switch display runs after the lock releases so that persist
         callbacks inside list_accounts() can re-acquire it.
         """
+        from claude_swap.session import scan_live_sessions
+
         self._refuse_session_shell()
         warnings_out: list[str] = []
-        # Session-mode drift warning (warn, never block): switching the
-        # default login to an account that also has a live session profile
-        # puts the same refresh token in two config dirs — if the server
-        # rotates it, one copy goes stale.
+        # Session-mode drift. Switching the default login to an account that
+        # also has a live session profile puts the same refresh token in two
+        # config dirs — if the server rotates it, one copy goes stale — which
+        # is a warning. But once the profile has already rotated past the
+        # backup, the backup is a consumed generation and activating it is
+        # certain to fail: refuse. With nothing running against the profile
+        # the fix is simpler still — adopt its credential into the backup
+        # first, and the switch activates the live generation.
         pre_data = self._get_sequence_data() or {}
-        pre_email = (
-            pre_data.get("accounts", {}).get(target_account, {}).get("email", "")
-        )
+        pre_account = pre_data.get("accounts", {}).get(target_account, {})
+        pre_email = pre_account.get("email", "")
         if pre_email:
-            pids = self._live_session_pids(target_account, pre_email)
-            if pids:
-                msg = (
-                    f"Account-{target_account} ({pre_email}) has a live session-mode "
-                    f"Claude instance (PID {', '.join(map(str, pids))}). Running the "
-                    "same account as both the default login and a session can make "
-                    "one copy's token go stale if the server rotates it. If the "
-                    "session later fails to authenticate, exit it and re-run "
-                    f"'cswap run {target_account}'."
-                )
-                if emit_output:
-                    warning(msg)
-                else:
-                    warnings_out.append(msg)
+            pre_org = pre_account.get("organizationUuid", "") or ""
+            sessions, unreadable = scan_live_sessions(
+                self._session_dir(target_account, pre_email)
+            )
+            pids = [s.pid for s in sessions]
+            if pids or unreadable:
+                if self._session_profile_ahead(target_account, pre_email, pre_org):
+                    who = (
+                        "a live session-mode Claude instance "
+                        f"(PID {', '.join(map(str, pids))})"
+                        if pids
+                        else f"{unreadable} session record(s) that could not be read"
+                    )
+                    raise SwitchError(
+                        f"Account-{target_account} ({pre_email}) has {who}, and "
+                        "its session profile's credential has rotated past the "
+                        "stored backup: the backup is a consumed generation, and "
+                        "activating it would fail with invalid_grant on its first "
+                        "refresh. Exit the session (its credential is adopted into "
+                        "the backup once nothing runs against it), or switch to "
+                        "another account."
+                    )
+                if pids:
+                    msg = (
+                        f"Account-{target_account} ({pre_email}) has a live "
+                        "session-mode Claude instance "
+                        f"(PID {', '.join(map(str, pids))}). Running the same "
+                        "account as both the default login and a session can make "
+                        "one copy's token go stale if the server rotates it. If the "
+                        "session later fails to authenticate, exit it and re-run "
+                        f"'cswap run {target_account}'."
+                    )
+                    if emit_output:
+                        warning(msg)
+                    else:
+                        warnings_out.append(msg)
+            else:
+                self._adopt_session_credential(target_account, pre_email, pre_org)
 
         # Pre-lock identity resolution (may hit the network — must happen
         # before the locks). Callers that already resolved (self-switch

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -21,6 +21,7 @@ from claude_swap.exceptions import (
     AccountNotFoundError,
     CredentialReadError,
     SessionError,
+    SwitchError,
     ValidationError,
 )
 from claude_swap.models import Platform
@@ -1534,6 +1535,54 @@ class TestGuards:
         assert "live session-mode" in out
         data = seeded_switcher._get_sequence_data()
         assert data["activeAccountNumber"] == int(ACCOUNT_NUM)
+
+    def test_switch_refuses_live_target_whose_profile_is_ahead(
+        self, seeded_switcher, monkeypatch
+    ):
+        """Once the live session has rotated past the backup, the backup is a
+        consumed generation and activating it could only fail."""
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        (session_dir / ".credentials.json").write_text(ROTATED_CREDS)
+        (session_dir / ".claude.json").write_text(CONFIG)
+        make_live(session_dir)
+        monkeypatch.setattr(seeded_switcher, "_get_current_account", lambda: None)
+
+        with pytest.raises(SwitchError, match="rotated past the stored backup"):
+            seeded_switcher._perform_switch(ACCOUNT_NUM)
+
+        data = seeded_switcher._get_sequence_data()
+        assert data["activeAccountNumber"] == 1
+        assert (
+            seeded_switcher.read_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
+            == CREDS
+        )
+
+    def test_switch_adopts_exited_session_credential_first(
+        self, seeded_switcher, monkeypatch
+    ):
+        """Nothing running against the profile: its newer generation becomes
+        the backup, and that is what the switch activates."""
+        session_dir = session_dir_for(
+            seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+        )
+        session_dir.mkdir(parents=True)
+        (session_dir / ".credentials.json").write_text(ROTATED_CREDS)
+        (session_dir / ".claude.json").write_text(CONFIG)
+        monkeypatch.setattr(seeded_switcher, "_get_current_account", lambda: None)
+        monkeypatch.setattr(seeded_switcher, "list_accounts", lambda **kw: None)
+
+        seeded_switcher._perform_switch(ACCOUNT_NUM)
+
+        assert (
+            seeded_switcher.read_account_credentials(ACCOUNT_NUM, ACCOUNT_EMAIL)
+            == ROTATED_CREDS
+        )
+        assert seeded_switcher._read_credentials() == ROTATED_CREDS
+        # The profile is the source of that generation, not a stale seed.
+        assert (session_dir / ".credentials.json").read_text() == ROTATED_CREDS
 
     def test_backup_credential_write_invalidates_stale_profile(
         self, seeded_switcher, block_real_keychain

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -27,6 +27,7 @@ from claude_swap.usage_store import FetchRecord, UsageEntry, UsageStore
 from claude_swap.macos_keychain import KeychainError
 from claude_swap.models import Platform, normalize_alias
 from claude_swap.paths import get_backup_root, get_credentials_path
+from claude_swap.session import mark_session_stale
 from claude_swap.credentials import ActiveCredentials
 from claude_swap.switcher import (
     CLAUDE_CODE_KEYCHAIN_SERVICE,
@@ -790,10 +791,14 @@ class TestFetchAccountUsageSessionProfile:
     def test_expired_session_credentials_without_live_session_falls_back(
         self, temp_home: Path
     ):
-        """No live session: the backup path (with refresh machinery) still runs."""
+        """No live session, and the backup is the FRESHER credential (a
+        re-login after the profile last ran): the backup path runs, refresh
+        machinery included, and the older profile is not adopted over it."""
         switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
         backup = _oauth_creds("sk-backup", 7200)
         session = _oauth_creds("sk-session", -60)
+        switcher._write_account_credentials("2", "test@example.com", backup)
 
         with patch.object(switcher, "_live_session_pids", return_value=[]), \
              patch("claude_swap.session.read_session_credentials",
@@ -807,6 +812,52 @@ class TestFetchAccountUsageSessionProfile:
         assert args[2] == backup
         assert kwargs.get("is_active") is False
         assert kwargs.get("refresh_via") is not None  # consume gate replaces persist
+        assert switcher.read_account_credentials("2", "test@example.com") == backup
+
+    def test_exited_session_ahead_of_backup_is_adopted(self, temp_home: Path):
+        """No live session and the profile is the newer generation: its
+        credential becomes the backup, and the fetch runs on it through the
+        idle path (refresh allowed — nothing else rotates that family now)
+        instead of POSTing the backup's dead grant."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", 7200)
+        switcher._write_account_credentials("2", "test@example.com", backup)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 9}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.usage == {"five_hour": {"pct": 9}}
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == session
+        assert kwargs.get("is_active") is False
+        assert kwargs.get("refresh_via") is not None
+        assert switcher.read_account_credentials("2", "test@example.com") == session
+
+    def test_live_session_ahead_of_backup_is_not_adopted(self, temp_home: Path):
+        """A live claude owns its profile's family: read-only fetch, backup untouched."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", 7200)
+        switcher._write_account_credentials("2", "test@example.com", backup)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 5}})) as mock_fetch:
+            switcher._fetch_account_usage(self._info(backup))
+
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == session
+        assert kwargs.get("is_active") is True
+        assert switcher.read_account_credentials("2", "test@example.com") == backup
 
     def test_no_session_profile_uses_backup_path(self, temp_home: Path):
         """Accounts without a session profile behave exactly as before."""
@@ -915,6 +966,92 @@ class TestFetchAccountUsageSessionProfile:
         args, kwargs = mock_fetch.call_args
         assert args[2] == session
         assert kwargs.get("is_active") is True
+
+
+class TestAdoptSessionCredential:
+    """An exited session's profile holds the slot's newest generation; the
+    backup only learns about it through adoption."""
+
+    EMAIL = "test@example.com"
+
+    def _switcher(self, backup: str) -> ClaudeAccountSwitcher:
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        switcher._write_account_credentials("2", self.EMAIL, backup)
+        return switcher
+
+    def _seed_profile(
+        self, switcher, creds: str, email: str = EMAIL, org: str = "org-uuid"
+    ) -> Path:
+        session_dir = switcher._session_dir("2", self.EMAIL)
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / ".credentials.json").write_text(creds)
+        (session_dir / ".claude.json").write_text(json.dumps({
+            "oauthAccount": {"emailAddress": email, "organizationUuid": org}
+        }))
+        return session_dir
+
+    def test_quiescent_profile_ahead_is_adopted(self, temp_home: Path):
+        backup = _oauth_creds("sk-backup", -3600)
+        profile = _oauth_creds("sk-session", 7200)
+        switcher = self._switcher(backup)
+        session_dir = self._seed_profile(switcher, profile)
+
+        assert switcher._adopt_session_credential("2", self.EMAIL, "org-uuid") is True
+        assert switcher.read_account_credentials("2", self.EMAIL) == profile
+        # The profile is the source of that generation, not a stale seed.
+        assert (session_dir / ".credentials.json").read_text() == profile
+
+    def test_live_profile_is_not_adopted(self, temp_home: Path):
+        backup = _oauth_creds("sk-backup", -3600)
+        profile = _oauth_creds("sk-session", 7200)
+        switcher = self._switcher(backup)
+        session_dir = self._seed_profile(switcher, profile)
+        records = session_dir / "sessions"
+        records.mkdir()
+        (records / f"{os.getpid()}.json").write_text(json.dumps({"pid": os.getpid()}))
+
+        assert switcher._adopt_session_credential("2", self.EMAIL, "org-uuid") is False
+        assert switcher.read_account_credentials("2", self.EMAIL) == backup
+
+    def test_stale_marked_profile_is_not_adopted(self, temp_home: Path):
+        """The backup moved under this profile while it was live; cswap has
+        already decided the profile re-bootstraps, and the marker stays."""
+        backup = _oauth_creds("sk-backup", -3600)
+        profile = _oauth_creds("sk-session", 7200)
+        switcher = self._switcher(backup)
+        session_dir = self._seed_profile(switcher, profile)
+        mark_session_stale(session_dir)
+
+        assert switcher._adopt_session_credential("2", self.EMAIL, "org-uuid") is False
+        assert switcher.read_account_credentials("2", self.EMAIL) == backup
+
+    def test_profile_behind_a_fresh_relogin_is_not_adopted(self, temp_home: Path):
+        backup = _oauth_creds("sk-backup", 7200)
+        profile = _oauth_creds("sk-session", -60)
+        switcher = self._switcher(backup)
+        self._seed_profile(switcher, profile)
+
+        assert switcher._adopt_session_credential("2", self.EMAIL, "org-uuid") is False
+        assert switcher.read_account_credentials("2", self.EMAIL) == backup
+
+    def test_profile_on_the_backup_generation_is_not_adopted(self, temp_home: Path):
+        creds = _oauth_creds("sk-same", 7200)
+        switcher = self._switcher(creds)
+        self._seed_profile(switcher, creds)
+
+        assert switcher._adopt_session_credential("2", self.EMAIL, "org-uuid") is False
+
+    def test_profile_logged_in_as_another_account_is_not_adopted(
+        self, temp_home: Path
+    ):
+        backup = _oauth_creds("sk-backup", -3600)
+        profile = _oauth_creds("sk-session", 7200)
+        switcher = self._switcher(backup)
+        self._seed_profile(switcher, profile, email="other@example.com")
+
+        assert switcher._adopt_session_credential("2", self.EMAIL, "org-uuid") is False
+        assert switcher.read_account_credentials("2", self.EMAIL) == backup
 
 
 class TestLiveSessionGuardOnAnUnreadableRecord:


### PR DESCRIPTION
Claude rotates the OAuth token family inside a session profile, and nothing ever synced it back, so once a session has refreshed even once the slot's stored backup holds a consumed generation. The usage collector already works around that by fetching with the profile's credential, which is exactly why the account keeps looking healthy right up until `cswap switch` activates the backup: its first refresh gets `invalid_grant`, Claude Code wipes the login, and the slot is struck as needing a re-login. The collector had the same landmine on its expired-profile path, where it fell back to POSTing the dead backup grant. In practice a switch onto an account with a session running took the default login down within two minutes.

This adds adoption of a quiescent session profile's credential into the slot backup whenever the profile is a newer generation of the same family, decided and written under cswap's own lock and without the invalidation a normal backup write triggers, since the profile is the source rather than a stale seed. Generations are ordered by access-token issue time so a fresh re-login in the backup is never mistaken for drift, and profiles that were re-pointed at another account or flagged stale are left alone. The switch adopts before activating and the collector adopts before taking the idle refresh path, so the common case simply works. While a session is still live its family is claude's to rotate, so the switch now refuses to activate a backup the profile has already rotated past rather than warning and installing a credential that can only fail; the existing warning stays for the case where both copies are still on the same generation.