### PR TITLE
Ignore session records whose pid has been recycled

### DIFF
--- a/src/claude_swap/process_detection.py
+++ b/src/claude_swap/process_detection.py
@@ -7,9 +7,11 @@ currently running. Uses the same mechanism Claude Code itself uses internally.
 
 from __future__ import annotations
 
+import calendar
 import json
 import logging
 import os
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -17,6 +19,18 @@ from pathlib import Path
 from claude_swap.paths import get_claude_config_home
 
 logger = logging.getLogger(__name__)
+
+# A session record names a pid, and the OS recycles pids: once the claude
+# that wrote the record is gone, the number can belong to anything. The
+# record also carries claude's reading of its own start (``procStart``): on
+# Linux the ``/proc/<pid>/stat`` start time in clock ticks since boot, fixed
+# for the process's lifetime, and elsewhere ``ps -o lstart``, a wall-clock
+# time. Only the latter needs slack, for the small clock steps that move a
+# ``ps`` start time on some platforms.
+PID_REUSE_SLACK_S = 120
+
+_MONTHS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun",
+           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
 
 
 @dataclass
@@ -86,8 +100,138 @@ def _is_pid_alive_windows(pid: int) -> bool:
         return False
 
 
+def _ps(pid: int, *columns: str) -> str | None:
+    """``ps -o`` ``columns`` for ``pid``, or None when unknowable.
+
+    POSIX only, under ``LC_ALL=C TZ=UTC`` like claude's own reading. Windows
+    and every failure answer None: not knowing must never be read as "not
+    the recorded process".
+    """
+    if sys.platform == "win32":
+        return None
+    try:
+        proc = subprocess.run(
+            ["ps", "-o", ",".join(f"{c}=" for c in columns), "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    text = proc.stdout.strip()
+    if proc.returncode != 0 or not text:
+        return None
+    return text
+
+
+def process_started_at(pid: int) -> int | None:
+    """Epoch seconds at which ``pid`` started, or None when unknowable.
+
+    Read the way claude stamps ``procStart`` into its record, ``ps -o
+    lstart=`` under ``LC_ALL=C TZ=UTC``, so the two agree to the second for
+    the same process.
+    """
+    text = _ps(pid, "lstart")
+    if text is None:
+        return None
+    try:
+        return _lstart_seconds(text)
+    except ValueError:
+        return None
+
+
+def _lstart_seconds(text: str) -> int:
+    """``Wed Sep  2 20:35:59 2026``, the ``ps -o lstart`` format under
+    ``LC_ALL=C TZ=UTC``, as epoch seconds. Parsed by hand because ``strptime``
+    reads month names in the process locale."""
+    parts = text.split()
+    if len(parts) != 5 or parts[1] not in _MONTHS:
+        raise ValueError(text)
+    _, month, day, clock, year = parts
+    hours, minutes, seconds = (int(p) for p in clock.split(":"))
+    return calendar.timegm(
+        (int(year), _MONTHS.index(month) + 1, int(day), hours, minutes, seconds, 0, 0, 0)
+    )
+
+
+def process_start_ticks(pid: int) -> str | None:
+    """``/proc/<pid>/stat``'s start time, in clock ticks since boot, or None
+    when unreadable. Linux by construction: the file exists nowhere else."""
+    try:
+        text = Path(f"/proc/{pid}/stat").read_text(encoding="ascii", errors="replace")
+    except OSError:
+        return None
+    return _stat_start_ticks(text)
+
+
+def _stat_start_ticks(text: str) -> str | None:
+    """Field 22 of a ``/proc/<pid>/stat`` line, as the string claude stamps
+    into ``procStart``. The command name sits in parentheses before the
+    numeric fields and may itself contain spaces or parentheses, so the
+    fields are counted from the last closing one."""
+    _, _, rest = text.rpartition(")")
+    fields = rest.split()
+    if len(fields) <= 19 or not fields[19].isdigit():
+        return None
+    return fields[19]
+
+
+def process_is_claude(pid: int) -> bool | None:
+    """Does the process at ``pid`` look like a claude, or None when unknowable.
+
+    Judged from ``ps -o comm=,args=``: the native binary and the symlink to
+    it are named ``claude``, and an npm install runs ``cli.js`` out of a
+    ``claude-code`` package directory.
+    """
+    text = _ps(pid, "comm", "args")
+    if text is None:
+        return None
+    return "claude" in text.lower()
+
+
+def pid_matches_record(pid: int, proc_start: str | None) -> bool:
+    """Is the live process at ``pid`` the one that wrote a record stamped
+    ``proc_start``, claude's reading of its own start?
+
+    On Linux the stamp is the ``/proc/<pid>/stat`` start time in clock ticks
+    since boot, which a process keeps for life and no two processes at one
+    pid share, so equality is the whole test and no clock domain is
+    involved. Elsewhere it is ``ps -o lstart``, a wall-clock time: a
+    recycled pid belongs to a process that started after the recorded claude
+    did, and only that direction disqualifies, and only a stranger. Some
+    ``ps`` builds derive every start time from a boot time that moves with
+    each wall-clock step (a WSL2 resume re-syncing the clock steps it by the
+    whole sleep), so a live session can read as younger than its own record;
+    a claude at the pid is kept either way, and a pid genuinely recycled by
+    another claude lingers only for that process's lifetime, which is what
+    happened before this check. Everything unknowable (Windows, whose stamp
+    is a FILETIME with no ``/proc`` to check it against, ``ps`` unavailable,
+    an unstamped or unparseable record) passes, because "cannot tell" must
+    never turn a live session into "nobody there".
+    """
+    if not proc_start:
+        return True
+    if proc_start.isdigit():
+        ticks = process_start_ticks(pid)
+        return ticks is None or ticks == proc_start
+    try:
+        recorded = _lstart_seconds(proc_start)
+    except ValueError:
+        return True
+    started = process_started_at(pid)
+    if started is None or started <= recorded + PID_REUSE_SLACK_S:
+        return True
+    return process_is_claude(pid) is not False
+
+
 def scan_sessions(claude_dir: Path | None = None) -> tuple[list[ClaudeSession], int]:
     """Live sessions, and how many records could NOT be read.
+
+    A record counts as live only when its pid is alive AND still belongs to
+    the claude that wrote it (see ``pid_matches_record``): a crashed claude
+    leaves its record behind, and the OS can hand the number to something
+    else.
 
     Two kinds of caller read this directory and they need opposite things from
     an unparseable record:
@@ -114,6 +258,11 @@ def scan_sessions(claude_dir: Path | None = None) -> tuple[list[ClaudeSession], 
             data = json.loads(path.read_text(encoding="utf-8"))
             pid = data["pid"]
             if not is_pid_alive(pid):
+                continue
+            if not pid_matches_record(pid, data.get("procStart")):
+                logger.debug(
+                    "Skipping session file %s: pid %s was recycled", path, pid
+                )
                 continue
             sessions.append(ClaudeSession(
                 pid=pid,

--- a/tests/test_process_detection.py
+++ b/tests/test_process_detection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -11,13 +12,20 @@ from unittest.mock import patch
 import pytest
 
 from claude_swap.process_detection import (
+    PID_REUSE_SLACK_S,
     ClaudeSession,
     IdeInstance,
+    _lstart_seconds,
+    _stat_start_ticks,
     get_claude_dir,
     get_running_instances,
     is_pid_alive,
     list_ide_instances,
     list_sessions,
+    pid_matches_record,
+    process_is_claude,
+    process_start_ticks,
+    process_started_at,
 )
 from claude_swap.printer import abbreviate_path, entrypoint_label, format_age
 
@@ -85,6 +93,220 @@ class TestIsPidAlive:
         assert is_pid_alive(-1) is False
 
 
+# --- process start time / pid reuse ---
+
+
+LSTART = "Wed Sep  2 20:35:59 2026"
+LSTART_S = 1788381359
+TICKS = "11485"
+# /proc/<pid>/stat: pid, (comm), then the numeric fields; start time is 22nd.
+STAT = (
+    "4242 (claude) S 1 4242 4242 0 -1 4194560 1234 0 0 0 10 5 0 0 20 0 8 0 "
+    f"{TICKS} 123456789 4321 18446744073709551615 1 1 0 0 0 0 0 0 0 0 0 0 0 "
+    "17 3 0 0 0 0 0 0 0 0 0 0 0 0 0\n"
+)
+
+
+class TestLstartSeconds:
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            (LSTART, LSTART_S),
+            ("Thu Jan  1 00:00:00 1970", 0),
+            ("Tue Nov 14 22:13:20 2023", 1_700_000_000),
+        ],
+    )
+    def test_parses_ps_lstart(self, text, expected):
+        assert _lstart_seconds(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        ["", "abc", "Wed Sep 2 20:35 2026", "Wed Foo  2 20:35:59 2026",
+         "Wed Sep  2 20:35:59", "Wed Sep  2 20:35:xx 2026"],
+    )
+    def test_rejects_garbage(self, text):
+        with pytest.raises(ValueError):
+            _lstart_seconds(text)
+
+
+class TestStatStartTicks:
+    def test_reads_field_22(self):
+        assert _stat_start_ticks(STAT) == TICKS
+
+    def test_counts_from_the_last_parenthesis(self):
+        """The command name may contain spaces and parentheses of its own."""
+        assert _stat_start_ticks(STAT.replace("(claude)", "(my (odd) name)")) == TICKS
+
+    @pytest.mark.parametrize(
+        "text", ["", "4242 (claude) S 1 2 3", STAT.replace(TICKS, "x")]
+    )
+    def test_rejects_garbage(self, text):
+        assert _stat_start_ticks(text) is None
+
+
+class TestProcessStartTicks:
+    def test_unreadable_is_unknowable(self):
+        with patch.object(Path, "read_text", side_effect=OSError("no /proc")):
+            assert process_start_ticks(4242) is None
+
+    def test_reads_proc_stat(self):
+        with patch.object(Path, "read_text", autospec=True, return_value=STAT) as read:
+            assert process_start_ticks(4242) == TICKS
+        assert read.call_args[0][0] == Path("/proc/4242/stat")
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="/proc is Linux")
+    def test_own_process_matches_proc_self(self):
+        expected = _stat_start_ticks(Path("/proc/self/stat").read_text())
+        assert process_start_ticks(os.getpid()) == expected
+
+
+class TestProcessStartedAt:
+    def test_windows_is_unknowable(self):
+        with patch("claude_swap.process_detection.sys.platform", "win32"), \
+             patch("claude_swap.process_detection.subprocess.run") as run:
+            assert process_started_at(1234) is None
+        run.assert_not_called()
+
+    def test_ps_failure_is_unknowable(self):
+        with patch("claude_swap.process_detection.sys.platform", "linux"), \
+             patch("claude_swap.process_detection.subprocess.run",
+                   side_effect=OSError("no ps")):
+            assert process_started_at(1234) is None
+
+    def test_unknown_pid_is_unknowable(self):
+        proc = subprocess_result(returncode=1, stdout="")
+        with patch("claude_swap.process_detection.sys.platform", "linux"), \
+             patch("claude_swap.process_detection.subprocess.run", return_value=proc):
+            assert process_started_at(1234) is None
+
+    def test_garbage_is_unknowable(self):
+        proc = subprocess_result(returncode=0, stdout="??\n")
+        with patch("claude_swap.process_detection.sys.platform", "linux"), \
+             patch("claude_swap.process_detection.subprocess.run", return_value=proc):
+            assert process_started_at(1234) is None
+
+    def test_reads_lstart_the_way_claude_does(self):
+        """The record's ``procStart`` is claude's own ``LC_ALL=C TZ=UTC ps -o
+        lstart=`` output; the live reading must match it to the second."""
+        proc = subprocess_result(returncode=0, stdout=f"{LSTART}    \n")
+        with patch("claude_swap.process_detection.sys.platform", "linux"), \
+             patch("claude_swap.process_detection.subprocess.run",
+                   return_value=proc) as run:
+            assert process_started_at(1234) == LSTART_S
+        args, kwargs = run.call_args
+        assert args[0] == ["ps", "-o", "lstart=", "-p", "1234"]
+        assert kwargs["env"]["LC_ALL"] == "C"
+        assert kwargs["env"]["TZ"] == "UTC"
+
+    @pytest.mark.skipif(os.name != "posix", reason="ps is POSIX")
+    def test_own_process_started_in_the_past(self):
+        started = process_started_at(os.getpid())
+        assert started is not None
+        assert started <= time.time()
+
+
+def subprocess_result(returncode: int, stdout: str):
+    from subprocess import CompletedProcess
+
+    return CompletedProcess(["ps"], returncode, stdout=stdout, stderr="")
+
+
+class TestProcessIsClaude:
+    def test_ps_failure_is_unknowable(self):
+        with patch("claude_swap.process_detection.sys.platform", "linux"), \
+             patch("claude_swap.process_detection.subprocess.run",
+                   side_effect=OSError("no ps")):
+            assert process_is_claude(1234) is None
+
+    @pytest.mark.parametrize(
+        "line, expected",
+        [
+            ("claude           claude --resume 2d6cbe5d", True),
+            ("node             node /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js", True),
+            ("2.1.258          /home/u/.local/share/claude/versions/2.1.258", True),
+            ("vim              vim notes.md", False),
+        ],
+    )
+    def test_judges_comm_and_args(self, line, expected):
+        proc = subprocess_result(returncode=0, stdout=f"{line}\n")
+        with patch("claude_swap.process_detection.sys.platform", "linux"), \
+             patch("claude_swap.process_detection.subprocess.run",
+                   return_value=proc) as run:
+            assert process_is_claude(1234) is expected
+        assert run.call_args[0][0] == ["ps", "-o", "comm=,args=", "-p", "1234"]
+
+
+class TestPidMatchesRecord:
+    @pytest.mark.parametrize("proc_start", [None, "", "garbage"])
+    def test_unstamped_or_garbage_record_passes(self, proc_start):
+        with patch("claude_swap.process_detection.process_started_at") as started:
+            assert pid_matches_record(1234, proc_start) is True
+        started.assert_not_called()
+
+    def test_unknowable_start_passes(self):
+        with patch("claude_swap.process_detection.process_started_at",
+                   return_value=None), \
+             patch("claude_swap.process_detection.process_is_claude") as is_claude:
+            assert pid_matches_record(1234, LSTART) is True
+        is_claude.assert_not_called()
+
+    def test_same_start_ticks_is_the_recorded_process(self):
+        """A Linux record stamps the /proc start time in ticks since boot,
+        which the process keeps for life: equality is the whole test."""
+        with patch("claude_swap.process_detection.process_start_ticks",
+                   return_value=TICKS), \
+             patch("claude_swap.process_detection.process_started_at") as started:
+            assert pid_matches_record(1234, TICKS) is True
+        started.assert_not_called()
+
+    def test_other_start_ticks_is_a_recycled_pid(self):
+        with patch("claude_swap.process_detection.process_start_ticks",
+                   return_value="998877"), \
+             patch("claude_swap.process_detection.process_is_claude") as is_claude:
+            assert pid_matches_record(1234, TICKS) is False
+        is_claude.assert_not_called()
+
+    def test_unreadable_ticks_pass(self):
+        """A FILETIME on Windows, or /proc hidden: no comparison is possible."""
+        with patch("claude_swap.process_detection.process_start_ticks",
+                   return_value=None):
+            assert pid_matches_record(1234, "134332352612628209") is True
+
+    @pytest.mark.parametrize(
+        "started", [LSTART_S, LSTART_S - 3600, LSTART_S + PID_REUSE_SLACK_S // 2]
+    )
+    def test_process_not_younger_than_record_passes(self, started):
+        with patch("claude_swap.process_detection.process_started_at",
+                   return_value=started), \
+             patch("claude_swap.process_detection.process_is_claude") as is_claude:
+            assert pid_matches_record(1234, LSTART) is True
+        is_claude.assert_not_called()
+
+    def test_stranger_younger_than_record_is_a_recycled_pid(self):
+        with patch("claude_swap.process_detection.process_started_at",
+                   return_value=LSTART_S + 86400), \
+             patch("claude_swap.process_detection.process_is_claude",
+                   return_value=False):
+            assert pid_matches_record(1234, LSTART) is False
+
+    def test_claude_younger_than_record_is_kept(self):
+        """Linux ps derives start times from a boot time that moves with the
+        wall clock, so after a clock step a live session reads as younger
+        than its own record. A claude at the pid is never a recycled pid."""
+        with patch("claude_swap.process_detection.process_started_at",
+                   return_value=LSTART_S + 86400), \
+             patch("claude_swap.process_detection.process_is_claude",
+                   return_value=True):
+            assert pid_matches_record(1234, LSTART) is True
+
+    def test_unknowable_identity_is_kept(self):
+        with patch("claude_swap.process_detection.process_started_at",
+                   return_value=LSTART_S + 86400), \
+             patch("claude_swap.process_detection.process_is_claude",
+                   return_value=None):
+            assert pid_matches_record(1234, LSTART) is True
+
+
 # --- list_sessions ---
 
 
@@ -132,6 +354,55 @@ class TestListSessions:
 
         assert len(result) == 1
         assert result[0].pid == 1001
+
+    def test_filters_recycled_pids(self, tmp_path):
+        """A crashed claude's record survives it; the OS may hand its pid to
+        something else. Only a process that started when the record says its
+        claude did is the recorded one."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        _write_session(sessions_dir, 1001, procStart=LSTART)
+        _write_session(sessions_dir, 1002, procStart=LSTART)
+
+        def started(pid):
+            return LSTART_S if pid == 1002 else LSTART_S + 86400
+
+        with patch("claude_swap.process_detection.is_pid_alive", return_value=True), \
+             patch("claude_swap.process_detection.process_started_at",
+                   side_effect=started), \
+             patch("claude_swap.process_detection.process_is_claude",
+                   return_value=False):
+            result = list_sessions(tmp_path)
+
+        assert [s.pid for s in result] == [1002]
+
+    def test_filters_recycled_pids_by_start_ticks(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        _write_session(sessions_dir, 1001, procStart=TICKS)
+        _write_session(sessions_dir, 1002, procStart=TICKS)
+
+        def ticks(pid):
+            return TICKS if pid == 1002 else "998877"
+
+        with patch("claude_swap.process_detection.is_pid_alive", return_value=True), \
+             patch("claude_swap.process_detection.process_start_ticks",
+                   side_effect=ticks):
+            result = list_sessions(tmp_path)
+
+        assert [s.pid for s in result] == [1002]
+
+    def test_unknowable_start_time_keeps_session(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        _write_session(sessions_dir, 1001, procStart=LSTART)
+
+        with patch("claude_swap.process_detection.is_pid_alive", return_value=True), \
+             patch("claude_swap.process_detection.process_started_at",
+                   return_value=None):
+            result = list_sessions(tmp_path)
+
+        assert [s.pid for s in result] == [1001]
 
     def test_missing_sessions_dir(self, tmp_path):
         assert list_sessions(tmp_path) == []


### PR DESCRIPTION
A session record is written by the claude that started it and outlives a crash, and `scan_sessions` only checked that the recorded pid was still alive. Once the OS hands that number to an unrelated process, the record reads as a live session indefinitely: the account's profile can never be re-bootstrapped or removed, and every guard that asks whether a claude is running against it answers yes.

Claude Code stamps each record with `procStart`, its own reading of `ps -o lstart=` for its process under `LC_ALL=C TZ=UTC`. The scan now takes the same reading of the live process and drops the record when that process started after the recorded one, which is the one thing a recycled pid cannot avoid. On Linux, `ps` builds every start time from the boot time in `/proc/stat`, and the kernel moves that with each wall-clock step, so after a WSL2 resume re-syncs the clock a live session can read as younger than its own record. A record is therefore only dropped when the process at the pid is also not a claude; a pid genuinely recycled by another claude lingers for that process's lifetime, which is today's behaviour. Records without `procStart`, Windows, and any failure to read the process keep today's behaviour too, since not knowing must never turn a live session into nobody there.
