### PR TITLE
feat(switch): optional per-account MCP servers (swap.mcpServers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,27 @@ cswap config path                         # where settings.json lives
 
 </details>
 
+### Per-account MCP servers
+
+A switch rewrites only the `oauthAccount` block of `~/.claude.json`, so everything else in it — including the user-scope `mcpServers` block — is machine-wide and shared by every account. That is usually what you want: one set of MCP servers, whichever account you are on.
+
+If your accounts belong to different orgs and want different servers, turn on:
+
+```bash
+cswap config set swap.mcpServers true
+```
+
+Now `mcpServers` travels with the slot. Each account's servers are saved into its own backup when you switch away and restored when you switch back, so you can `claude mcp add` under one account without it showing up under the other. Off by default.
+
+Two things worth knowing:
+
+- **Nothing is wiped when you turn it on.** A slot added before you enabled this has no `mcpServers` of its own yet, so switching to it leaves your current servers in place and seeds the slot from them on the way out. Give each account one switch to pick up its own set.
+- **MCP server *logins* stay shared.** The `mcpOAuth` tokens in the credential store remain machine-wide (see [How it works](#how-it-works)), so a server you have authenticated once does not ask again after a switch. This setting moves the server *definitions*, not their sessions.
+
+- **Session mode still mirrors the default profile.** `cswap run` mirrors whatever `mcpServers` the default profile currently holds (issue #139), which under this setting is the set belonging to the account active there — not necessarily the account the session runs as. Sourcing a session's mirror from its own slot would change #139's single-source-of-truth design, so it is left alone here.
+
+Project-scope servers (`.mcp.json`, and per-project entries under `projects` in `~/.claude.json`) are untouched either way — those belong to the directory, not the account.
+
 ### Backup and migration
 
 Move account data between machines or back it up:

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -67,7 +67,29 @@ class UiSettings:
     theme: str = "auto"
 
 
-_SECTION_DEFAULT_SOURCES = {"autoswitch": AutoSwitchSettings, "ui": UiSettings}
+@dataclass(frozen=True)
+class SwapSettings:
+    """What a switch carries across accounts, beyond the login itself.
+
+    A switch normally rewrites only ``oauthAccount`` in ``~/.claude.json``,
+    so everything else — including the user-scope ``mcpServers`` block — is
+    machine-wide and shared by every account. ``mcp_servers=True`` makes that
+    block travel with the slot instead: each account keeps its own MCP server
+    set, restored on arrival from the slot's config backup.
+
+    Off by default: sharing is the long-standing behavior, and an account
+    whose backup predates this setting has no ``mcpServers`` of its own to
+    restore.
+    """
+
+    mcp_servers: bool = False
+
+
+_SECTION_DEFAULT_SOURCES = {
+    "autoswitch": AutoSwitchSettings,
+    "ui": UiSettings,
+    "swap": SwapSettings,
+}
 
 
 @dataclass(frozen=True)
@@ -138,6 +160,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         SettingSpec(
             "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
             help="Color theme; auto follows the terminal background",
+        ),
+        SettingSpec(
+            "swap", "mcpServers", "mcp_servers", "bool",
+            help="Give each account its own MCP servers instead of sharing one set",
         ),
     )
 }
@@ -246,6 +272,23 @@ def load_ui_settings(backup_root: Path) -> UiSettings:
         )
         return default
     return UiSettings(theme=theme)
+
+
+def load_swap_settings(backup_root: Path) -> SwapSettings:
+    """Load the swap section; missing/corrupt file or non-bool field → defaults."""
+    raw = _read_raw(settings_path(backup_root))
+    section = raw.get("swap")
+    default = SwapSettings()
+    if not isinstance(section, dict):
+        return default
+    value = section.get("mcpServers", default.mcp_servers)
+    if not isinstance(value, bool):
+        _logger.warning(
+            "settings.json: swap.mcpServers must be true or false, got %r; using %r",
+            value, default.mcp_servers,
+        )
+        return default
+    return SwapSettings(mcp_servers=value)
 
 
 def save_settings(backup_root: Path, settings: AutoSwitchSettings) -> None:
@@ -412,6 +455,7 @@ def effective_settings(backup_root: Path) -> list[tuple[SettingSpec, object, boo
     loaded = {
         "autoswitch": load_settings(backup_root),
         "ui": load_ui_settings(backup_root),
+        "swap": load_swap_settings(backup_root),
     }
     rows = []
     for spec in SETTING_SPECS.values():

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -84,7 +84,12 @@ from claude_swap.paths import (
 )
 from claude_swap.process_detection import get_running_instances
 from claude_swap import poll_policy
-from claude_swap.settings import load_settings, parse_model_names, settings_path
+from claude_swap.settings import (
+    load_settings,
+    load_swap_settings,
+    parse_model_names,
+    settings_path,
+)
 from claude_swap.usage_store import (
     FetchRecord,
     UsageEntry,
@@ -494,6 +499,29 @@ class ClaudeAccountSwitcher:
                 )
             return None
         return data
+
+    def _apply_swapped_mcp_servers(
+        self, live_config: dict, target_config_data: dict
+    ) -> None:
+        """Install the target slot's user-scope ``mcpServers``, if opted in.
+
+        A switch rewrites only ``oauthAccount``, so every other key in
+        ``~/.claude.json`` is machine-wide. With ``swap.mcpServers`` on, the
+        user-scope ``mcpServers`` block travels with the slot instead. The
+        departing account's copy needs no special handling: Step 1 of the
+        switch already backs the live config up into its own slot.
+
+        Only a key the target's backup actually HAS is applied. A slot added
+        before this setting existed has no ``mcpServers`` of its own, and
+        treating that absence as "an empty set" would delete the servers the
+        user is already running — the first switch after enabling the setting
+        would wipe them. Absence leaves the live block alone, and the next
+        switch away seeds the slot from it.
+        """
+        if not load_swap_settings(self.backup_dir).mcp_servers:
+            return
+        if "mcpServers" in target_config_data:
+            live_config["mcpServers"] = target_config_data["mcpServers"]
 
     def _salvage_unreadable(
         self, path: Path, emit_output: bool, warnings_out: list[str]
@@ -6750,6 +6778,9 @@ class ClaudeAccountSwitcher:
                         # the user it "could not be parsed", which is the same
                         # ""-vs-None conflation this branch exists to separate.
                         existing_config["oauthAccount"] = target_oauth
+                        self._apply_swapped_mcp_servers(
+                            existing_config, target_config_data
+                        )
                         self._write_json(config_path, existing_config)
                     else:
                         if config_path.exists():
@@ -7015,6 +7046,9 @@ class ClaudeAccountSwitcher:
                 current_config_data = self._read_json(config_path)
                 if current_config_data is not None:
                     current_config_data["oauthAccount"] = oauth_section
+                    self._apply_swapped_mcp_servers(
+                        current_config_data, target_config_data
+                    )
                     self._write_json(config_path, current_config_data)
                 else:
                     if config_path.exists():

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -49,9 +49,10 @@ class TestConfigList:
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
             "ui.theme",
+            "swap.mcpServers",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,7 +79,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,9 +15,11 @@ from claude_swap.settings import (
     SETTING_SPECS,
     atomic_write_json,
     AutoSwitchSettings,
+    SwapSettings,
     UiSettings,
     effective_settings,
     load_settings,
+    load_swap_settings,
     load_ui_settings,
     merged_with_cli,
     save_settings,
@@ -152,6 +154,38 @@ class TestUiSettings:
             set_setting(tmp_path, "ui.theme", "purple")
 
 
+class TestSwapSettings:
+    def test_missing_file_defaults_to_off(self, tmp_path: Path):
+        assert load_swap_settings(tmp_path) == SwapSettings(mcp_servers=False)
+
+    def test_reads_true(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"swap": {"mcpServers": True}})
+        )
+        assert load_swap_settings(tmp_path).mcp_servers is True
+
+    def test_non_bool_falls_back_to_default(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"swap": {"mcpServers": "yes"}})
+        )
+        assert load_swap_settings(tmp_path).mcp_servers is False
+
+    def test_set_and_unset_swap_mcp_servers(self, tmp_path: Path):
+        assert set_setting(tmp_path, "swap.mcpServers", "true") is True
+        raw = json.loads(settings_path(tmp_path).read_text())
+        assert raw == {"schemaVersion": 1, "swap": {"mcpServers": True}}
+        assert unset_setting(tmp_path, "swap.mcpServers") is True
+        assert "swap" not in json.loads(settings_path(tmp_path).read_text())
+
+    def test_effective_settings_reports_the_swap_row(self, tmp_path: Path):
+        set_setting(tmp_path, "swap.mcpServers", "true")
+        by_key = {
+            spec.dotted: (value, is_set)
+            for spec, value, is_set in effective_settings(tmp_path)
+        }
+        assert by_key["swap.mcpServers"] == (True, True)
+
+
 class TestSettingSpecs:
     def test_registry_covers_every_dataclass_field(self):
         by_section: dict[str, set[str]] = {}
@@ -165,7 +199,11 @@ class TestSettingSpecs:
         }
 
     def test_defaults_match_dataclass(self):
-        sources = {"autoswitch": AutoSwitchSettings(), "ui": UiSettings()}
+        sources = {
+            "autoswitch": AutoSwitchSettings(),
+            "ui": UiSettings(),
+            "swap": SwapSettings(),
+        }
         for spec in SETTING_SPECS.values():
             assert spec.default == getattr(sources[spec.section], spec.field)
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -27,6 +27,7 @@ from claude_swap.usage_store import FetchRecord, UsageEntry, UsageStore
 from claude_swap.macos_keychain import KeychainError
 from claude_swap.models import Platform, normalize_alias
 from claude_swap.paths import get_backup_root, get_credentials_path
+from claude_swap.settings import set_setting
 from claude_swap.credentials import ActiveCredentials
 from claude_swap.switcher import (
     CLAUDE_CODE_KEYCHAIN_SERVICE,
@@ -12134,3 +12135,124 @@ class TestSessionShellGuardCoversEveryMutator:
         s = self._switcher(sample_sequence_data, monkeypatch)
         with pytest.raises(SwitchError):
             s.unset_alias("2")
+
+
+class TestSwapMcpServers:
+    """`swap.mcpServers` gives each account its own MCP server set.
+
+    A switch rewrites only `oauthAccount`, so `mcpServers` is machine-wide by
+    default. With the setting on it travels with the slot instead.
+    """
+
+    _setup_two_accounts = TestPerformSwitchPostDisplay._setup_two_accounts
+    _install_store_patches = staticmethod(
+        TestPerformSwitchPostDisplay._install_store_patches
+    )
+
+    LIVE_SERVERS = {"live-server": {"command": "live"}}
+    TARGET_SERVERS = {"target-server": {"command": "target"}}
+    TARGET_CONFIG = {
+        "oauthAccount": {
+            "emailAddress": "account2@example.com", "accountUuid": "uuid-2",
+        },
+        "mcpServers": TARGET_SERVERS,
+    }
+
+    def _switch(
+        self, temp_home, sample_sequence_data, *, target_config: dict,
+    ) -> tuple[dict, dict]:
+        """Run a 1 -> 2 switch.
+
+        Returns (live ~/.claude.json after the switch, the config backup store).
+        """
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        config_path = temp_home / ".claude.json"
+        config_path.write_text(json.dumps({
+            "oauthAccount": {
+                "emailAddress": "test@example.com",
+                "accountUuid": "test-uuid-1234",
+            },
+            "mcpServers": self.LIVE_SERVERS,
+        }))
+        configs_store[("2", "account2@example.com")] = json.dumps(target_config)
+        live_state = {"creds": json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "sk-live-1", "refreshToken": "rt-live-1",
+            },
+        })}
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, live_state,
+        )
+        try:
+            with patch.object(switcher, "list_accounts"):
+                switcher._perform_switch("2", emit_output=False)
+        finally:
+            for p in patches:
+                p.stop()
+        return json.loads(config_path.read_text()), configs_store
+
+    def test_off_by_default_the_live_servers_stay(
+        self, temp_home, sample_sequence_data,
+    ):
+        config, _ = self._switch(
+            temp_home, sample_sequence_data, target_config=self.TARGET_CONFIG,
+        )
+
+        assert config["mcpServers"] == self.LIVE_SERVERS
+        assert config["oauthAccount"]["emailAddress"] == "account2@example.com"
+
+    def test_enabled_installs_the_target_slots_servers(
+        self, temp_home, sample_sequence_data,
+    ):
+        set_setting(get_backup_root(), "swap.mcpServers", "true")
+
+        config, _ = self._switch(
+            temp_home, sample_sequence_data, target_config=self.TARGET_CONFIG,
+        )
+
+        assert config["mcpServers"] == self.TARGET_SERVERS
+
+    def test_enabled_carries_an_empty_set_across(
+        self, temp_home, sample_sequence_data,
+    ):
+        # An account that genuinely runs no MCP servers must arrive with none,
+        # not inherit whichever set happened to be live.
+        set_setting(get_backup_root(), "swap.mcpServers", "true")
+        target = dict(self.TARGET_CONFIG, mcpServers={})
+
+        config, _ = self._switch(
+            temp_home, sample_sequence_data, target_config=target,
+        )
+
+        assert config["mcpServers"] == {}
+
+    def test_a_slot_predating_the_setting_keeps_the_live_servers(
+        self, temp_home, sample_sequence_data,
+    ):
+        # No `mcpServers` in the backup is "this slot never stored any", not
+        # "this slot wants none" — wiping here would delete the servers the
+        # user is running the moment they turn the setting on.
+        set_setting(get_backup_root(), "swap.mcpServers", "true")
+        target = {k: v for k, v in self.TARGET_CONFIG.items() if k != "mcpServers"}
+
+        config, _ = self._switch(
+            temp_home, sample_sequence_data, target_config=target,
+        )
+
+        assert config["mcpServers"] == self.LIVE_SERVERS
+
+    def test_the_departing_slot_keeps_its_own_servers(
+        self, temp_home, sample_sequence_data,
+    ):
+        # Step 1 of the switch backs the live config into the departing slot,
+        # so the round trip is lossless without any extra capture step.
+        set_setting(get_backup_root(), "swap.mcpServers", "true")
+
+        _, configs_store = self._switch(
+            temp_home, sample_sequence_data, target_config=self.TARGET_CONFIG,
+        )
+
+        backed_up = json.loads(configs_store[("1", "test@example.com")])
+        assert backed_up["mcpServers"] == self.LIVE_SERVERS


### PR DESCRIPTION
## The problem

A switch rewrites only `oauthAccount` in `~/.claude.json` and leaves the rest of the file in place. That is the right call — it is what keeps `projects`, `userID` and everything else from being clobbered by a slot's older snapshot — but it also means the user-scope `mcpServers` block is machine-wide. Every account shares one set of MCP servers.

Usually that is what you want. It stops being what you want when the accounts belong to different orgs: a work account with internal HTTP servers and a personal one that should not see them, `claude mcp add` under one account silently showing up under the other.

## The change

```bash
cswap config set swap.mcpServers true
```

Off by default. With it on, the user-scope `mcpServers` block travels with the slot: saved into the departing account's backup on the way out, restored from the arriving account's backup on the way in.

The restore side is all that was needed. Step 1 of a switch already backs the live config into the departing slot (`_write_account_config(current_account, current_email, original_config)`), so the capture half of the round trip was already there — the patch adds two lines at each of the two splice sites:

```python
current_config_data["oauthAccount"] = oauth_section
self._apply_swapped_config_sections(current_config_data, target_config_data)
```

Everything else — `cswap config get/set/unset`, `--json`, range validation, the `--help` key listing — comes free from the existing `SettingSpec` registry. The only non-additive edits are registering the new section in `effective_settings` and in the two tests that assert a registry count.

## Turning it on cannot wipe you

This is the one behavior worth reviewing closely. A slot added before this setting existed has no `mcpServers` key in its backup. Reading that absence as "this account wants no servers" would delete the servers the user is running, on the very first switch after they enable the setting.

So only a key the target's backup **actually has** is applied. Absence leaves the live block alone and seeds the slot on the way out, which costs each account one switch to pick up its own set. An explicit `{}` does travel, so an account that genuinely runs none arrives with none. Both cases are pinned by tests.

## Scope, deliberately narrow

- **User-scope `mcpServers` only.** Project-scope entries (`.mcp.json`, `projects[…].mcpServers`) stay put — they belong to the directory, not the account.
- **`mcpOAuth` stays machine-shared** via `SHARED_CREDENTIAL_KEYS`. A server you have already authenticated does not re-prompt after a switch. This moves server *definitions*, not their sessions.
- **Session mode is unchanged.** `cswap run` still mirrors the default profile's `mcpServers` (#139), which under this setting is the set belonging to the account active *there* — not necessarily the account the session runs as. Sourcing a session's mirror from its own slot would change #139's single-source-of-truth design, so I did not decide that here. Happy to do it as a follow-up if you want it.

## Tests

Merged `main` in to pick up fixes landed since this was opened (resolved one conflicting import in `tests/test_switcher.py` — `main` added `mark_session_stale`, this branch added `set_setting`; kept both). Full suite on the merged tree: `2272 passed, 4 skipped, 0 failed`. The three failures noted in an earlier version of this description (`test_real_store_guard`, `TestSwapUnreadableSourceIsNotAbsent`, `TestMoveUnreadableSourceIsNotAbsent`) were fixed on `main` since (#291 among others) and no longer reproduce.

New coverage:

- `TestSwapMcpServers` (5) — off by default leaves live servers; on installs the target slot's; `{}` travels; a pre-setting slot keeps the live set; the departing slot keeps its own.
- `TestSwapSettings` (5) — default off, reads `true`, non-bool falls back with a warning, set/unset round trip, `effective_settings` reports the row.

Also smoke-tested end to end against an isolated `HOME`: `cswap config set swap.mcpServers true` writes `{"schemaVersion": 1, "swap": {"mcpServers": true}}`, the key lists correctly with and without `(default)`, and `cswap config set swap.mcpServers maybe` exits 1 with `expects true or false (or 1/0, yes/no)`.


## Known edges

Two things I hit while reviewing this that you should weigh, neither of which I tried to solve here:

**Turning the setting back off.** Off means "stop swapping", so whatever set happens to be live at that moment becomes the shared set again — it is not a restore to some pre-feature state. That follows from the existing semantics rather than being new behavior, but it is the kind of thing worth a sentence in the docs if you would rather it were louder.

**Ownership-mismatch switches skip the config backup.** The `foreign` / `known-foreign` / unknown and `foreign-synced` branches deliberately do not call `_write_account_config`, so on those switches the departing account's MCP edits since its last good backup are not captured while the arriving account's set still gets installed. That is pre-existing policy — cswap refuses to write into a slot whose ownership it cannot establish — and this PR just inherits it. Making the config backup independent of the credential-ownership verdict felt like your call, not mine, so I left it.

