### PR TITLE
usage_store: never let a hollow probe overwrite a real cached reading

### DIFF
--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -481,6 +481,35 @@ def _earliest_reset(last_good: dict | None, models: tuple[str, ...] = ()) -> flo
     return min(resets) if resets else None
 
 
+def _usage_has_real_detail(usage: dict | None) -> bool:
+    """Whether a usage reading carries real evidence, not a hollow placeholder.
+
+    Confirmed field case (2026-09-01): the usage endpoint can 200 for a
+    non-active/idle credential with every window's ``utilization`` sent back
+    as ``0`` and no ``resets_at`` anywhere — a "nothing to report" placeholder,
+    not a genuine zero-usage measurement (matches upstream claude-swap#146's
+    "empty 5h rows are what the server sends for idle accounts" finding). A
+    genuine reading, including a real 0%, carries a ``resets_at`` because the
+    window it describes is open; one with neither a reset time nor a positive
+    percentage anywhere is evidence-free. Uses ``oauth.relevant_windows`` (the
+    canonical window source; the ``"all"`` sentinel model pulls in every
+    scoped window too) so this stays in sync with whatever windows the API
+    adds there.
+    """
+    if not isinstance(usage, dict):
+        return False
+    for _, pct, resets_at in oauth.relevant_windows(usage, models=("all",)):
+        if resets_at:
+            return True
+        if pct > 0:
+            return True
+    # extra-usage spend carries its own used/limit evidence independent of
+    # the rate-limit windows; build_usage_result only populates it when
+    # used_credits/monthly_limit/utilization are all non-null, so its mere
+    # presence here is already real.
+    return isinstance(usage.get("spend"), dict)
+
+
 def _rate_limited_trust_ok(
     last_good: dict | None,
     age_s: float | None,
@@ -1054,7 +1083,10 @@ class UsageStore:
         in the same transaction as its measurement. Sentinel records clear
         only the claim and are otherwise never persisted. Unfenced callers
         (no ``claims``) defer to a live lease but never to an expired one.
-        Returns the accepted slots.
+        A "success" carrying no real detail (see ``_usage_has_real_detail``)
+        never overwrites a real cached measurement either — same as a
+        failure, it is discarded, only advancing the poll plan. Returns the
+        accepted slots.
         """
         if not outcomes:
             return set()
@@ -1070,6 +1102,25 @@ class UsageStore:
                 return
             row["lastAttemptAt"] = now
             if rec.error is None:
+                if not _usage_has_real_detail(rec.usage) and _usage_has_real_detail(
+                    row.get("lastGood")
+                ):
+                    # A hollow "nothing to report" success must never
+                    # overwrite a real cached measurement — discard it.
+                    # Still advance the poll plan so cadence progresses and
+                    # this isn't re-fetched immediately, but leave
+                    # lastGood/fetchedAt/failure bookkeeping untouched: age
+                    # must accrue honestly against the last REAL
+                    # measurement, not reset on a hollow round trip. That
+                    # reset-on-hollow-success is exactly what let a
+                    # non-active account's stale-but-real usage silently
+                    # read as a fresh 0% for as long as the placeholder
+                    # kept arriving (usageAgeSeconds stayed near-zero while
+                    # the value was wrong).
+                    plan = plans.get(num) if plans is not None else None
+                    if plan is not None:
+                        row["nextPollAt"], row["pollIntervalS"] = plan
+                    return
                 row["lastGood"] = rec.usage
                 row["fetchedAt"] = now
                 # Replace the old, possibly due plan in the outcome transaction

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -119,6 +119,129 @@ class TestStaleOnError:
         assert entry.decision_value() is None
 
 
+# The exact placeholder shape confirmed to come back for a non-active/idle
+# credential (2026-09-01 field case; matches upstream claude-swap#146):
+# ``utilization: 0`` on every window and no ``resets_at`` anywhere.
+HOLLOW_ZERO = {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 0.0}}
+
+
+class TestHollowSuccessNeverOverwritesRealCache:
+    """A "success" carrying no real detail must never clobber a real cache.
+
+    The bug: the background probe for a non-active account can 200 with
+    ``HOLLOW_ZERO`` instead of a real measurement. Before this guard,
+    ``record()`` treated ANY error-free round trip as a real update — writing
+    ``lastGood`` and resetting ``fetchedAt`` to now — so the hollow read
+    silently overwrote a real cached value AND kept ``usageAgeSeconds``
+    artificially fresh, masking the loss for as long as the placeholder kept
+    arriving (Matt's proof: activating each account one at a time showed real
+    numbers, which reverted to 0.0 within ~60s of switching away).
+    """
+
+    def test_hollow_zero_is_discarded_against_a_real_cache(self, store, clock):
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        clock.advance(30)
+        store.record({"1": FetchRecord(usage=HOLLOW_ZERO)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        # The real measurement survives untouched...
+        assert entry.last_good == USAGE
+        # ...and its age is measured from the REAL fetch, not reset by the
+        # hollow one — this is the field symptom (age stayed near-zero while
+        # the value silently went to 0.0).
+        assert entry.age_s == 30.0
+        assert entry.decision_value() == USAGE
+
+    def test_hollow_zero_does_not_touch_failure_bookkeeping(self, store, clock):
+        # No information was gained from a hollow round trip — it must not
+        # be read as proof of health either: prior failure/backoff state is
+        # left exactly as it was.
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        store.record({"1": FetchRecord(error="timeout")}, IDENT)
+        before = store.entries(IDENT)["1"]
+        store.record({"1": FetchRecord(usage=HOLLOW_ZERO)}, IDENT)
+        after = store.entries(IDENT)["1"]
+        assert after.consecutive_failures == before.consecutive_failures == 1
+        assert after.last_error == before.last_error == "timeout"
+        assert after.backoff_until == before.backoff_until
+
+    def test_hollow_zero_still_advances_the_poll_plan(self, store, clock):
+        # Discarding the measurement must not stall the schedule: a supplied
+        # plan still commits so the next fetch isn't due immediately.
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        store.record(
+            {"1": FetchRecord(usage=HOLLOW_ZERO)},
+            IDENT,
+            plans={"1": (clock.now + 900.0, 900.0)},
+        )
+        entry = store.entries(IDENT)["1"]
+        assert entry.next_poll_at == clock.now + 900.0
+        assert entry.poll_interval_s == 900.0
+        assert entry.last_good == USAGE  # measurement itself still untouched
+
+    # -- must-say-NO: the guard is scoped to hollow reads, not a blanket
+    # refusal to ever update a slot that already has real data. --
+
+    def test_a_hollow_zero_is_stored_when_there_is_nothing_to_protect(
+        self, store
+    ):
+        # No prior real lastGood exists, so there is nothing to discard
+        # against — the hollow reading is recorded like any other success
+        # (same as the pre-existing test_success_with_no_windows).
+        store.record({"1": FetchRecord(usage=HOLLOW_ZERO)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.last_good == HOLLOW_ZERO
+        assert entry.fetched_at is not None
+
+    def test_a_genuine_zero_with_a_reset_time_does_overwrite(self, store, clock):
+        # A real 0% carries a resets_at because its window is open — that IS
+        # real detail, and must overwrite normally, not be mistaken for the
+        # hollow placeholder just because its percentages are also 0.
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        clock.advance(30)
+        genuine_zero = self._usage_resetting_at_zero(clock)
+        store.record({"1": FetchRecord(usage=genuine_zero)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.last_good == genuine_zero
+        assert entry.age_s == 0.0
+
+    def test_a_positive_reading_with_no_reset_does_overwrite(self, store, clock):
+        # A positive percentage is real evidence on its own, resets_at or
+        # not — only "0 and no reset time, everywhere" is hollow.
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        clock.advance(30)
+        positive_no_reset = {
+            "five_hour": {"pct": 5.0}, "seven_day": {"pct": 0.0},
+        }
+        store.record({"1": FetchRecord(usage=positive_no_reset)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.last_good == positive_no_reset
+        assert entry.age_s == 0.0
+
+    def test_hollow_zero_after_hollow_zero_stays_discarded(self, store, clock):
+        # Repeated hollow probes don't eventually "win" by attrition.
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        for _ in range(5):
+            clock.advance(10)
+            store.record({"1": FetchRecord(usage=HOLLOW_ZERO)}, IDENT)
+        entry = store.entries(IDENT)["1"]
+        assert entry.last_good == USAGE
+        assert entry.age_s == 50.0
+
+    @staticmethod
+    def _usage_resetting_at_zero(clock):
+        from datetime import datetime, timezone
+
+        iso = (
+            datetime.fromtimestamp(clock.now + 3600, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+        return {
+            "five_hour": {"pct": 0.0, "resets_at": iso},
+            "seven_day": {"pct": 0.0, "resets_at": iso},
+        }
+
+
 class TestExtendedTrust:
     """Deliberate staleness (failure state, scheduler cadence) stays trusted."""
 


### PR DESCRIPTION
Fixes #306.

Adds `_usage_has_real_detail()` (a `resets_at` on any window, a positive `pct` anywhere, or a populated `spend` block) and uses it in `UsageStore.record()`'s success branch: a hollow "nothing to report" reading is discarded against a row whose `lastGood` already carries real evidence, instead of overwriting it. The poll plan still advances (cadence isn't stalled); `lastGood`/`fetchedAt`/failure bookkeeping are left untouched so staleness accrues honestly against the last real measurement.

Branched from `v0.25.0` (the currently-released tag) rather than `main`/HEAD, since `usage_store.py` is unchanged between the two — happy to rebase onto HEAD if you'd rather land it there.

New tests in `TestHollowSuccessNeverOverwritesRealCache` (`tests/test_usage_store.py`):
- hollow read is discarded against a real cache; age keeps accruing from the real fetch, not the hollow one
- hollow read doesn't touch failure/backoff bookkeeping
- hollow read still advances the supplied poll plan
- must-say-NO: a hollow read is stored normally when there's nothing real to protect (empty row)
- must-say-NO: a genuine 0% *with* a reset time overwrites normally (not mistaken for hollow)
- must-say-NO: a positive pct with no reset time overwrites normally
- repeated hollow reads don't eventually "win" by attrition

Full suite: `2088 passed, 3 skipped` (was `2081 passed, 3 skipped` before this change — 7 new tests, 0 regressions). Also ran a mutation control locally (revert the guard, confirm 4 of the 7 new tests fail) before submitting — not included in the diff, just a local sanity check.
