### PR TITLE
feat: add guarded five-hour window warming

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ cswap auto --model Fable       # also switch when the Fable weekly limit is hit
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
 cswap auto --strategy consume-first   # burn the soonest-resetting account first
+
+# One process can also keep five-hour windows started:
+cswap config set autoswitch.warmupFiveHour true
+cswap auto
 ```
 
 <details>
@@ -105,6 +109,7 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
+- Five-hour warm-up is opt-in. Enable it with `cswap config set autoswitch.warmupFiveHour true`, or open the TUI's Auto screen (`cswap`, then `g`) and press `w`. The same `cswap auto` process then checks warm-up eligibility every ten minutes after making its switch decision. Do not also run the standalone `cswap warmup` loop; the shared lock prevents duplicate requests, but using one loop avoids needless contention and error messages.
 
 For cron/systemd timers, `--once` reports the outcome in its exit code (`0` switched, `1` error, `2` nothing to do, `3` blocked — no viable target), and `--json` emits one JSON event per line:
 
@@ -119,8 +124,10 @@ Defaults like the threshold and cooldown are configurable with `cswap config set
 ### Keep five-hour windows warm (opt-in)
 
 `cswap warmup` keeps stored OAuth accounts ready by checking usage every ten
-minutes and sending one minimal Haiku request only when an account has no live
-five-hour window:
+minutes and sending one minimal Haiku request when an account has no live
+five-hour window. It remains available for people who want warming without
+automatic switching; otherwise enable `autoswitch.warmupFiveHour` and run only
+`cswap auto`:
 
 ```bash
 cswap warmup --once --dry-run   # inspect every decision; spend no quota
@@ -129,19 +136,21 @@ cswap warmup                    # keep checking in the foreground
 cswap warmup --interval 900     # check every 15 minutes
 ```
 
-This feature consumes real five-hour and weekly quota and is off until you run
-it. It skips disabled, API-key, weekly-exhausted, and uncertain accounts. It
-also treats an all-zero response with no reset timestamps as uncertain because
-the provider can return that hollow shape for inactive credentials.
+This feature consumes real five-hour and weekly quota and is opt-in. It skips
+disabled, API-key, non-switchable, and accounts with known exhausted weekly quota.
+If usage remains missing, stale, errored, or hollow after a fresh probe, it
+attempts one guarded request rather than leaving the window cold. Reliable
+evidence of a live five-hour window still skips the request.
 It never switches the global Claude login: other accounts use isolated session
 profiles with customizations and tools disabled. Immediately before sending,
 it verifies that the exact launch profile still uses the expected first-party
 Claude OAuth identity; cloud-provider or changed-account profiles are skipped.
-Successful and in-progress warms are recorded in `warmup_state.json`,
-preventing repeat requests from a stale usage snapshot or a second warmer
-process. The account lock stays held for each short warm request, so a
-simultaneous `cswap switch` may wait or time out instead of racing the request
-onto the wrong login.
+Successful and potentially accepted warms are recorded in `warmup_state.json`,
+preventing an unavailable or stale usage snapshot from becoming a request on
+every ten-minute poll, and preventing duplicates from a second warmer process.
+The account lock stays held for each short warm request, so a simultaneous
+`cswap switch` may wait or time out instead of racing the request onto the wrong
+login.
 
 ### Run multiple accounts at the same time (session mode)
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ Defaults like the threshold and cooldown are configurable with `cswap config set
 
 </details>
 
+### Keep five-hour windows warm (opt-in)
+
+`cswap warmup` keeps stored OAuth accounts ready by checking usage every ten
+minutes and sending one minimal Haiku request only when an account has no live
+five-hour window:
+
+```bash
+cswap warmup --once --dry-run   # inspect every decision; spend no quota
+cswap warmup --once             # warm confirmed-cold accounts once
+cswap warmup                    # keep checking in the foreground
+cswap warmup --interval 900     # check every 15 minutes
+```
+
+This feature consumes real five-hour and weekly quota and is off until you run
+it. It skips disabled, API-key, weekly-exhausted, and uncertain accounts. It
+also treats an all-zero response with no reset timestamps as uncertain because
+the provider can return that hollow shape for inactive credentials.
+It never switches the global Claude login: other accounts use isolated session
+profiles with customizations and tools disabled. Successful and in-progress
+warms are recorded in `warmup_state.json`, preventing repeat requests from a
+stale usage snapshot or a second warmer process. The account lock stays held
+for each short warm request, so a simultaneous `cswap switch` may wait or time
+out instead of racing the request onto the wrong login.
+
 ### Run multiple accounts at the same time (session mode)
 
 Launch Claude Code as a specific account in the current terminal only — every other terminal and the VS Code extension stay on your default account, so two accounts can work in parallel.
@@ -183,6 +207,7 @@ This will update the stored credentials without creating a duplicate.
 ```bash
 cswap run 2                     # Run an account in this terminal only (session mode)
 cswap auto                      # Auto-switch when nearing rate limits (see above)
+cswap warmup                    # Keep five-hour windows ready (opt-in quota spend)
 cswap config                    # Show or edit settings (see Configuration below)
 cswap list                      # Show all accounts with 5h/7d usage and reset times
 cswap list --token-status       # Add source-labelled OAuth token diagnostics
@@ -230,7 +255,7 @@ The original flag spellings (`cswap --switch`, `cswap --list`, ...) keep working
 | macOS | macOS Keychain | `~/.claude-swap-backup/` |
 | Linux / WSL | File-based (inside the backup directory, under `credentials/`) | `${XDG_DATA_HOME:-~/.local/share}/claude-swap/` |
 
-Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`. Tool preferences (`settings.json`) and auto-switch state (`autoswitch_state.json` — cooldown and quarantined accounts; delete it to reset) live in the backup directory root.
+Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`. Tool preferences (`settings.json`), auto-switch state (`autoswitch_state.json` — cooldown and quarantined accounts; delete it to reset), and five-hour warmer state (`warmup_state.json`) live in the backup directory root.
 
 On Linux/WSL, set `XDG_DATA_HOME` to override the default location.
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,14 @@ it. It skips disabled, API-key, weekly-exhausted, and uncertain accounts. It
 also treats an all-zero response with no reset timestamps as uncertain because
 the provider can return that hollow shape for inactive credentials.
 It never switches the global Claude login: other accounts use isolated session
-profiles with customizations and tools disabled. Successful and in-progress
-warms are recorded in `warmup_state.json`, preventing repeat requests from a
-stale usage snapshot or a second warmer process. The account lock stays held
-for each short warm request, so a simultaneous `cswap switch` may wait or time
-out instead of racing the request onto the wrong login.
+profiles with customizations and tools disabled. Immediately before sending,
+it verifies that the exact launch profile still uses the expected first-party
+Claude OAuth identity; cloud-provider or changed-account profiles are skipped.
+Successful and in-progress warms are recorded in `warmup_state.json`,
+preventing repeat requests from a stale usage snapshot or a second warmer
+process. The account lock stays held for each short warm request, so a
+simultaneous `cswap switch` may wait or time out instead of racing the request
+onto the wrong login.
 
 ### Run multiple accounts at the same time (session mode)
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -514,9 +514,10 @@ class WarmupAutoEvent(AutoSwitchEvent):
         }
 
     def human(self) -> str:
+        suffix = " (5h warm-up sent)" if self.action == "warmed" else ""
         return (
             f"warm-up {self.action} Account-{self.number} ({self.email}): "
-            f"{self.detail}"
+            f"{self.detail}{suffix}"
         )
 
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -54,6 +54,11 @@ from claude_swap.poll_policy import (
 from claude_swap.settings import AutoSwitchSettings, atomic_write_json, parse_model_names
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.usage_store import due_candidate, plan_oversleeps_interval
+from claude_swap.warmup import (
+    DEFAULT_INTERVAL_SECONDS as WARMUP_INTERVAL_SECONDS,
+    WarmupEngine,
+    WarmupEvent,
+)
 
 STATE_FILENAME = "autoswitch_state.json"
 STATE_SCHEMA_VERSION = 1
@@ -491,6 +496,30 @@ class ConfigWarningEvent(AutoSwitchEvent):
         return f"warning: {self.message}"
 
 
+@dataclass(frozen=True)
+class WarmupAutoEvent(AutoSwitchEvent):
+    """One guarded five-hour warm-up decision emitted by ``cswap auto``."""
+
+    kind: ClassVar[str] = "warmup"
+    action: str
+    number: str
+    email: str
+    detail: str
+
+    def _fields(self) -> dict:
+        return {
+            "action": self.action,
+            "account": {"number": self.number, "email": self.email},
+            "detail": self.detail,
+        }
+
+    def human(self) -> str:
+        return (
+            f"warm-up {self.action} Account-{self.number} ({self.email}): "
+            f"{self.detail}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Engine
 # ---------------------------------------------------------------------------
@@ -684,6 +713,60 @@ class AutoSwitchEngine:
         # warned) on the first tick where every relevant account has readable
         # usage — adaptive polling legitimately leaves gaps before that.
         self._model_check_done = not self._models
+        self._warmup: WarmupEngine | None = None
+        self._next_warmup_at: float | None = None
+        if settings.warmup_five_hour:
+            self._enable_warmup()
+
+    def _enable_warmup(self) -> None:
+        self._warmup = WarmupEngine(
+            self.switcher,
+            emit=self._emit_warmup,
+            dry_run=self.dry_run,
+            clock=self.clock,
+        )
+        # A newly enabled or newly started auto process checks immediately.
+        # The warmer's persistent state still suppresses duplicate requests.
+        self._next_warmup_at = self.clock()
+
+    def _emit_warmup(self, event: WarmupEvent) -> None:
+        self._emit(
+            WarmupAutoEvent(
+                action=event.kind,
+                number=event.account_number,
+                email=event.email,
+                detail=event.detail,
+            )
+        )
+
+    def _run_warmup_if_due(self) -> bool:
+        """Run one integrated pass when due; return whether that pass failed."""
+        warmer = self._warmup
+        due = self._next_warmup_at
+        now = self.clock()
+        if self._stop.is_set() or warmer is None or due is None or now < due:
+            return False
+
+        try:
+            return warmer.tick().failed > 0
+        except ClaudeSwitchError as exc:
+            self._emit(
+                ErrorEvent(message=f"five-hour warm-up: {exc}", transient=True)
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - defensive boundary
+            self._emit(
+                ErrorEvent(
+                    message=f"five-hour warm-up: {type(exc).__name__}: {exc}",
+                    transient=True,
+                )
+            )
+            return True
+        finally:
+            # Schedule from completion so a slow pass cannot make the next
+            # auto-switch tick immediately run another full account sweep.
+            if self._warmup is warmer:
+                self._next_warmup_at = self.clock() + WARMUP_INTERVAL_SECONDS
 
     # -- state file ---------------------------------------------------------
 
@@ -877,17 +960,20 @@ class AutoSwitchEngine:
     # -- tick -----------------------------------------------------------------
 
     def tick(self) -> TickOutcome:
-        """Evaluate once: poll usage, maybe switch. Never raises."""
+        """Evaluate once: maybe switch, then run a due warm-up pass. Never raises."""
         try:
-            return self._tick_inner()
+            outcome = self._tick_inner()
         except ClaudeSwitchError as e:
             self._emit(ErrorEvent(message=str(e), transient=True))
-            return TickOutcome.ERROR
+            outcome = TickOutcome.ERROR
         except Exception as e:  # pragma: no cover - safety net
             self._emit(
                 ErrorEvent(message=f"{type(e).__name__}: {e}", transient=True)
             )
+            outcome = TickOutcome.ERROR
+        if self._run_warmup_if_due():
             return TickOutcome.ERROR
+        return outcome
 
     def _tick_inner(self) -> TickOutcome:
         self._sleep_until_ts = None
@@ -2270,6 +2356,8 @@ class AutoSwitchEngine:
         exits immediately (engines are single-use)."""
         self._stop.set()
         self._wake.set()
+        if self._warmup is not None:
+            self._warmup.stop()
 
     def wake(self) -> None:
         """Cut the current inter-tick sleep short and tick now."""
@@ -2283,15 +2371,29 @@ class AutoSwitchEngine:
         self.settings = replace(self.settings, threshold=threshold)
         self.switcher.set_poll_policy_inputs(threshold, self._models)
 
+    def apply_warmup_enabled(self, enabled: bool) -> None:
+        """Apply the TUI's persisted warm-up toggle to this running engine."""
+        if enabled == self.settings.warmup_five_hour:
+            return
+        self.settings = replace(self.settings, warmup_five_hour=enabled)
+        if self._warmup is not None:
+            self._warmup.stop()
+        self._warmup = None
+        self._next_warmup_at = None
+        if enabled:
+            self._enable_warmup()
+        self._wake.set()
+
     def _next_delay(self, outcome: TickOutcome) -> float:
         interval = self.settings.interval_seconds
+        delay: float | None = None
         if outcome is TickOutcome.BLOCKED:
             if self._sleep_until_ts is not None:
-                delay = self._sleep_until_ts - self.clock()
-                return min(max(delay, interval), MAX_SLEEP_S)
-            if self._blocked_wait_long:
+                until_reset = self._sleep_until_ts - self.clock()
+                delay = min(max(until_reset, interval), MAX_SLEEP_S)
+            elif self._blocked_wait_long:
                 # Truly exhausted with no reset time known / no candidates.
-                return max(interval, NO_RESET_FALLBACK_S)
+                delay = max(interval, NO_RESET_FALLBACK_S)
             # Blocked on something that can resolve any tick (hysteresis,
             # unreadable usage) — keep the normal cadence so the at-limit
             # escape isn't missed.
@@ -2299,9 +2401,21 @@ class AutoSwitchEngine:
             # Idle-hold: Claude is idle on an expired token — nothing changes
             # until the user comes back, so crawl. Worst case protection
             # resumes one slow tick after they do.
-            return max(interval, NO_RESET_FALLBACK_S)
-        # ±10% jitter so multiple machines don't synchronize their API hits.
-        return self._respect_poll_plan(interval * (0.9 + 0.2 * random.random()))
+            delay = max(interval, NO_RESET_FALLBACK_S)
+        if delay is None:
+            # ±10% jitter so multiple machines don't synchronize their API hits.
+            delay = self._respect_poll_plan(
+                interval * (0.9 + 0.2 * random.random())
+            )
+        return self._respect_warmup_deadline(delay)
+
+    def _respect_warmup_deadline(self, delay: float) -> float:
+        """Do not let a slow auto cadence delay an enabled warm-up sweep."""
+        warmer = self._warmup
+        due = self._next_warmup_at
+        if warmer is None or due is None:
+            return delay
+        return min(delay, max(0.0, due - self.clock()))
 
     def _respect_poll_plan(self, delay: float) -> float:
         """Shorten a normal-cadence sleep to the store's own next-poll time.

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -745,6 +745,133 @@ Defaults live in settings.json in the backup root; flags override them.
         sys.exit(130)
 
 
+def _warmup_command(argv: list[str]) -> None:
+    """Handle ``cswap warmup`` without ever changing the default account."""
+    import math
+    import signal
+    import time as _time
+
+    from claude_swap.warmup import (
+        DEFAULT_INTERVAL_SECONDS,
+        DEFAULT_MODEL,
+        DEFAULT_TIMEOUT_SECONDS,
+        MIN_INTERVAL_SECONDS,
+        WarmupEngine,
+        WarmupEvent,
+    )
+    from claude_swap.printer import yellowed
+
+    parser = argparse.ArgumentParser(
+        prog="cswap warmup",
+        description=(
+            "Keep stored OAuth accounts' five-hour windows ready. A minimal "
+            "Haiku request is sent only when fresh usage data confirms that "
+            "the account has no live five-hour window. This consumes real "
+            "five-hour and weekly quota."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  cswap warmup                         # check every 10 minutes
+  cswap warmup --interval 900          # check every 15 minutes
+  cswap warmup --once                  # one check, then exit
+  cswap warmup --once --dry-run        # show decisions; spend no quota
+
+The globally active Claude login is never switched. Non-active accounts run
+through cswap's isolated session profiles. Ctrl-C stops loop mode.
+        """,
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Check once, warm eligible accounts, and exit",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=DEFAULT_INTERVAL_SECONDS,
+        metavar="SECONDS",
+        help="Seconds between checks in loop mode (min 300; default 600)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        metavar="SECONDS",
+        help="Maximum time for each minimal Claude request (default 120)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Check and report only; never send a Claude request",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    if not math.isfinite(args.interval) or args.interval < MIN_INTERVAL_SECONDS:
+        parser.error(f"--interval must be at least {MIN_INTERVAL_SECONDS:.0f} seconds")
+    if not math.isfinite(args.timeout) or not 1 <= args.timeout <= 600:
+        parser.error("--timeout must be between 1 and 600 seconds")
+
+    def human_emit(event: WarmupEvent) -> None:
+        stamp = _time.strftime("%H:%M:%S")
+        label = f"Account-{event.account_number} ({event.email})"
+        line = f"{label}: {event.detail}"
+        if event.kind in ("warmed", "would-warm"):
+            line = accent(line)
+        elif event.kind == "failed":
+            line = yellowed(line)
+        else:
+            line = dimmed(line)
+        print(f"{stamp}  {line}", flush=True)
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+        engine = WarmupEngine(
+            switcher,
+            emit=human_emit,
+            interval_seconds=args.interval,
+            timeout_seconds=args.timeout,
+            model=DEFAULT_MODEL,
+            dry_run=args.dry_run,
+        )
+
+        if args.once:
+            if not args.dry_run:
+                print(
+                    yellowed(
+                        "Warm-up sends real requests: each cold account uses "
+                        "five-hour and weekly quota."
+                    )
+                )
+            summary = engine.tick()
+            sys.exit(1 if summary.failed else 0)
+
+        signal.signal(signal.SIGTERM, lambda *_: engine.stop())
+        print(
+            dimmed(
+                f"Five-hour warm-up running every {args.interval:.0f}s with "
+                f"{DEFAULT_MODEL}{' (dry-run; no quota spent)' if args.dry_run else ''} "
+                "— Ctrl-C to stop"
+            )
+        )
+        if not args.dry_run:
+            print(
+                yellowed(
+                    "Warm-up is opt-in and sends real requests: each cold account "
+                    "uses five-hour and weekly quota."
+                )
+            )
+        sys.exit(engine.run_loop())
+    except ClaudeSwitchError as exc:
+        error(f"Error: {exc}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Five-hour warm-up stopped')}")
+        sys.exit(130)
+
+
 def _config_command(argv: list[str]) -> None:
     """Handle `cswap config [list|get KEY|set KEY VALUE|unset KEY|path]`.
 
@@ -976,12 +1103,15 @@ def main() -> None:
     except Exception:
         pass  # theme is cosmetic; never block the CLI on it
 
-    # `run` and `auto` keep their dedicated pre-dispatch parsers.
+    # `run`, `auto`, and `warmup` keep their dedicated pre-dispatch parsers.
     if argv and argv[0] == "run":
         _run_command(argv[1:])
         return  # only reachable in tests where exec/exit is mocked
     if argv and argv[0] == "auto":
         _auto_command(argv[1:])
+        return  # only reachable in tests where sys.exit is mocked
+    if argv and argv[0] == "warmup":
+        _warmup_command(argv[1:])
         return  # only reachable in tests where sys.exit is mocked
     if len(sys.argv) > 1 and sys.argv[1] == "config":
         _config_command(sys.argv[2:])
@@ -1043,6 +1173,7 @@ Commands:
   %(prog)s swap <a> <b>               exchange two accounts' slot numbers
   %(prog)s move <a> <slot>            assign an account to a slot (swaps if taken)
   %(prog)s auto                       auto-switch when nearing rate limits
+  %(prog)s warmup                     keep five-hour windows ready (opt-in spend)
   %(prog)s config [set KEY VALUE]     show or change settings (settings.json)
   %(prog)s unclaimed [--purge ID]     list or drop stashed credential entries
   %(prog)s export <path>              export accounts
@@ -1066,6 +1197,7 @@ Aliases: ls=list  rm=remove  update=upgrade""",
   %(prog)s add-token sk-ant-oat01-... --email me@example.com
   %(prog)s run 2 -- --resume                 # forward args after '--' to claude
   %(prog)s auto --once                       # single auto-switch tick (cron-friendly)
+  %(prog)s warmup --once --dry-run            # inspect warm-up decisions, spend nothing
   %(prog)s config set autoswitch.threshold 80
 
 The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep working.

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -696,7 +696,9 @@ Defaults live in settings.json in the backup root; flags override them.
         line = event.human()
         if event.kind == "switch":
             line = accent(line)
-        elif event.kind in ("error", "account-quarantined"):
+        elif event.kind in ("error", "account-quarantined") or (
+            event.kind == "warmup" and getattr(event, "action", None) == "failed"
+        ):
             line = yellowed(line)
         elif event.kind in ("poll", "no-switch", "sleep"):
             line = dimmed(line)
@@ -717,6 +719,14 @@ Defaults live in settings.json in the backup root; flags override them.
             dry_run=args.dry_run,
         )
 
+        if settings.warmup_five_hour and not args.dry_run and not args.json:
+            print(
+                yellowed(
+                    "Five-hour warm-up is enabled: cold or unconfirmed OAuth "
+                    "accounts may receive one minimal Haiku request per window."
+                )
+            )
+
         if args.once:
             sys.exit(engine.tick().value)
 
@@ -727,6 +737,7 @@ Defaults live in settings.json in the backup root; flags override them.
                 dimmed(
                     f"Auto-switch running: threshold {settings.threshold:.0f}%, "
                     f"every {settings.interval_seconds:.0f}s"
+                    f" · 5h warm-up {'on' if settings.warmup_five_hour else 'off'}"
                     f"{' (dry-run)' if args.dry_run else ''} — Ctrl-C to stop"
                 )
             )
@@ -765,9 +776,9 @@ def _warmup_command(argv: list[str]) -> None:
         prog="cswap warmup",
         description=(
             "Keep stored OAuth accounts' five-hour windows ready. A minimal "
-            "Haiku request is sent only when fresh usage data confirms that "
-            "the account has no live five-hour window. This consumes real "
-            "five-hour and weekly quota."
+            "Haiku request is sent when usage shows no live window, or once "
+            "under a five-hour guard when usage remains unavailable. This "
+            "consumes real five-hour and weekly quota."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""

--- a/src/claude_swap/exceptions.py
+++ b/src/claude_swap/exceptions.py
@@ -43,6 +43,18 @@ class SessionError(ClaudeSwitchError):
     pass
 
 
+class PromptOutcomeUnknown(SessionError):
+    """A non-interactive Claude prompt may have reached the service."""
+
+    pass
+
+
+class WarmupError(ClaudeSwitchError):
+    """Error while checking or warming five-hour usage windows."""
+
+    pass
+
+
 class LockError(ClaudeSwitchError):
     """Error acquiring lock."""
 

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -638,6 +638,8 @@ def run(switcher) -> int:
                     # engine emits it once per run; dropping it would leave a
                     # menu-bar user with a silently inert filter.
                     rumps.notification("claude-swap", "Configuration warning", ev.human())
+                elif ev.kind == "warmup" and getattr(ev, "action", None) == "failed":
+                    rumps.notification("claude-swap", "Five-hour warm-up failed", ev.human())
 
         def _threshold(self) -> int:
             """Current auto-switch threshold from core settings (for the menu)."""

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -627,6 +627,11 @@ class SessionManager:
         profile; every other account uses its existing isolated session
         profile, so no global credential switch occurs.
 
+        Immediately before the paid prompt, the exact launch environment is
+        probed with ``claude --safe-mode auth status --json``. This catches
+        admin-managed cloud-provider settings that cannot be neutralized by
+        removing process environment overrides.
+
         A nested ``CLAUDE_CONFIG_DIR`` is refused because active-account
         detection would describe that profile while the child environment is
         deliberately normalized to the real default profile. Proceeding could
@@ -667,15 +672,23 @@ class SessionManager:
                 env["CLAUDE_CONFIG_DIR"] = str(session_dir)
             return env
 
+        def run_verified(
+            env: dict[str, str], account_num: str, email: str, org_uuid: str
+        ) -> subprocess.CompletedProcess[str]:
+            self._verify_prompt_auth(
+                claude_bin, env, account_num, email, org_uuid
+            )
+            return self._run_prompt_process(
+                claude_bin, claude_args, env, timeout, account_num, email
+            )
+
         # Serialize the active verdict through child completion. Every cswap
         # switch takes this same lock, so the default login cannot change
         # between selecting it and sending the request.
         with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
             account_num, email, org_uuid = resolve_target()
             if self.switcher._get_current_account() == (email, org_uuid):
-                return self._run_prompt_process(
-                    claude_bin, claude_args, prompt_env(), timeout, account_num, email
-                )
+                return run_verified(prompt_env(), account_num, email, org_uuid)
 
         # setup_session takes the account lock internally and must run outside
         # the context above. Keep the slot identifier: email alone is ambiguous
@@ -683,7 +696,12 @@ class SessionManager:
         # expected-identity check below fails closed if the slot moved while
         # its profile was prepared.
         session_dir, _account_num, _email = self.setup_session(
-            account_num, share=False, share_history=False
+            account_num,
+            share=False,
+            share_history=False,
+            sync_sharing=False,
+            refresh_credentials=False,
+            expected_identity=(email, org_uuid),
         )
 
         # A switch may have landed while the profile was prepared. Revalidate
@@ -696,13 +714,70 @@ class SessionManager:
                 if self.switcher._get_current_account() == (email, org_uuid)
                 else session_dir
             )
-            return self._run_prompt_process(
-                claude_bin,
-                claude_args,
-                prompt_env(selected_dir),
-                timeout,
-                account_num,
+            if selected_dir is not None and read_session_identity(selected_dir) != (
                 email,
+                org_uuid,
+            ):
+                raise SessionError(
+                    f"Account-{account_num}'s prepared profile identity does not "
+                    "match the usage snapshot; refusing the warm-up request."
+                )
+            return run_verified(
+                prompt_env(selected_dir), account_num, email, org_uuid
+            )
+
+    @staticmethod
+    def _verify_prompt_auth(
+        claude_bin: str,
+        env: dict[str, str],
+        account_num: str,
+        email: str,
+        org_uuid: str,
+    ) -> None:
+        """Fail closed unless the exact prompt environment is the expected OAuth."""
+        try:
+            result = subprocess.run(
+                [claude_bin, "--safe-mode", "auth", "status", "--json"],
+                env=env,
+                shell=False,
+                capture_output=True,
+                text=True,
+                timeout=_AUTH_STATUS_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise SessionError(
+                f"Could not verify first-party Claude OAuth for Account-{account_num} "
+                f"({email}): auth status timed out. No warm-up was sent."
+            ) from exc
+        except OSError as exc:
+            raise SessionError(
+                f"Could not verify first-party Claude OAuth for Account-{account_num} "
+                f"({email}): {exc}. No warm-up was sent."
+            ) from exc
+
+        try:
+            status = json.loads(result.stdout) if result.returncode == 0 else None
+        except json.JSONDecodeError:
+            status = None
+        if not isinstance(status, dict):
+            raise SessionError(
+                f"Could not verify first-party Claude OAuth for Account-{account_num} "
+                f"({email}); auth status was unavailable. No warm-up was sent."
+            )
+        if (
+            status.get("loggedIn") is not True
+            or status.get("authMethod") != "claude.ai"
+            or status.get("apiProvider") != "firstParty"
+        ):
+            raise SessionError(
+                f"Account-{account_num} ({email}) is not using first-party Claude "
+                "OAuth in the warm-up environment. No warm-up was sent."
+            )
+        status_org = status.get("orgId") or ""
+        if status.get("email") != email or status_org != (org_uuid or ""):
+            raise SessionError(
+                f"Account-{account_num}'s authenticated identity changed before "
+                "the warm-up request. No warm-up was sent."
             )
 
     @staticmethod
@@ -772,10 +847,27 @@ class SessionManager:
     # -- bootstrap -------------------------------------------------------
 
     def setup_session(
-        self, identifier: str, share: bool, share_history: bool = False
+        self,
+        identifier: str,
+        share: bool,
+        share_history: bool = False,
+        *,
+        sync_sharing: bool = True,
+        refresh_credentials: bool = True,
+        expected_identity: tuple[str, str] | None = None,
     ) -> tuple[Path, str, str]:
-        """Ensure a valid session profile exists; returns (dir, num, email)."""
+        """Ensure a valid session profile exists; returns (dir, num, email).
+
+        Housekeeping callers can disable sharing changes and pre-bootstrap
+        refreshes, then bind every mutating step to ``expected_identity``.
+        Interactive ``cswap run`` retains the existing defaults.
+        """
         account_num, email, org_uuid = self.switcher.resolve_account(identifier)
+        if expected_identity is not None and (email, org_uuid) != expected_identity:
+            raise SessionError(
+                f"Account-{account_num} changed before its session profile could "
+                "be prepared; refusing to touch a different identity."
+            )
         # Defense-in-depth: also guard here (run() guards before its fast path).
         self._ensure_not_api_key(account_num, email)
         session_dir = session_dir_for(self.switcher.backup_dir, account_num, email)
@@ -789,7 +881,8 @@ class SessionManager:
 
         # Cheap reuse check without the lock: most launches hit this.
         if not stale and self._is_session_valid(session_dir, email, org_uuid):
-            self._sync_sharing(session_dir, share, share_history)
+            if sync_sharing:
+                self._sync_sharing(session_dir, share, share_history)
             return session_dir, account_num, email
 
         # One refresh so the profile starts with a fresh access token —
@@ -801,7 +894,11 @@ class SessionManager:
         # valid, and claude refreshes on its own at runtime. Setup-token
         # accounts (--add-token) have no refresh token by design — skip
         # silently instead of warning about a flow that can't happen.
-        pre_creds = self.switcher.read_account_credentials(account_num, email)
+        pre_creds = (
+            self.switcher.read_account_credentials(account_num, email)
+            if refresh_credentials
+            else ""
+        )
         if pre_creds and self._has_refresh_token(pre_creds):
             outcome = self.switcher.consume_backup_grant(
                 account_num, email, pre_creds
@@ -861,6 +958,19 @@ class SessionManager:
                 )
 
         with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
+            if expected_identity is not None:
+                locked_num, locked_email, locked_org = self.switcher.resolve_account(
+                    identifier
+                )
+                if (locked_email, locked_org) != expected_identity:
+                    raise SessionError(
+                        f"Account-{locked_num} changed while its session profile "
+                        "was being prepared; refusing to touch a different identity."
+                    )
+                account_num, email, org_uuid = locked_num, locked_email, locked_org
+                session_dir = session_dir_for(
+                    self.switcher.backup_dir, account_num, email
+                )
             # Re-evaluate the marker under the lock, then re-check validity:
             # another `cswap run` may have bootstrapped while we waited.
             if is_session_stale(session_dir) and profile_is_quiescent(session_dir):
@@ -891,11 +1001,13 @@ class SessionManager:
                     session_dir, account_num, email
                 ) and profile_is_quiescent(session_dir):
                     self._bootstrap(session_dir, account_num, email, org_uuid)
-                self._sync_sharing(session_dir, share, share_history)
+                if sync_sharing:
+                    self._sync_sharing(session_dir, share, share_history)
                 return session_dir, account_num, email
 
             self._bootstrap(session_dir, account_num, email, org_uuid)
-            self._sync_sharing(session_dir, share, share_history)
+            if sync_sharing:
+                self._sync_sharing(session_dir, share, share_history)
 
             verdict = self._session_validity(session_dir, email, org_uuid)
             # NEITHER probe-failure verdict may reach `_cleanup_failed_session`

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -53,6 +53,7 @@ from claude_swap.claude_locks import proper_lockfile
 from claude_swap.exceptions import (
     ClaudeCodeLockTimeout,
     CredentialReadError,
+    PromptOutcomeUnknown,
     SessionError,
 )
 from claude_swap.fsutil import replace_with_retry
@@ -192,9 +193,15 @@ def mark_session_stale(session_dir: Path) -> bool:
 AUTH_OVERRIDE_ENV_VARS = (
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
     "CLAUDE_CODE_OAUTH_TOKEN",
     "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR",
     "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "CLAUDE_CODE_USE_MANTLE",
+    "CLAUDE_CODE_USE_ANTHROPIC_AWS",
 )
 
 # `claude auth status` is a local check (no API call) but spawns the full CLI.
@@ -603,6 +610,132 @@ class SessionManager:
                 "'claude' was not found on PATH. Install Claude Code first."
             )
         self._exec(claude_bin, claude_args, env=dict(os.environ))
+
+    def run_prompt(
+        self,
+        identifier: str,
+        claude_args: list[str],
+        *,
+        timeout: float,
+        expected_identity: tuple[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run one bounded non-interactive prompt as a stored OAuth account.
+
+        Unlike :meth:`run`, this method returns to its caller and captures the
+        child output. It is intended for small housekeeping requests such as
+        the opt-in five-hour warmer. The active account uses Claude's default
+        profile; every other account uses its existing isolated session
+        profile, so no global credential switch occurs.
+
+        A nested ``CLAUDE_CONFIG_DIR`` is refused because active-account
+        detection would describe that profile while the child environment is
+        deliberately normalized to the real default profile. Proceeding could
+        therefore send the request on the wrong account.
+        """
+        claude_bin = shutil.which("claude")
+        if not claude_bin:
+            raise SessionError(
+                "'claude' was not found on PATH. Install Claude Code first."
+            )
+        if os.environ.get("CLAUDE_CONFIG_DIR") or os.environ.get(
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR"
+        ):
+            raise SessionError(
+                "Warm-up must run outside a Claude session: unset "
+                "CLAUDE_CONFIG_DIR and CLAUDE_SECURESTORAGE_CONFIG_DIR first."
+            )
+
+        def resolve_target() -> tuple[str, str, str]:
+            account_num, email, org_uuid = self.switcher.resolve_account(identifier)
+            self._ensure_not_api_key(account_num, email)
+            if expected_identity is not None and (email, org_uuid) != expected_identity:
+                raise SessionError(
+                    f"Account-{account_num} changed since the usage check; "
+                    "refusing to run a warm-up request on a different identity."
+                )
+            return account_num, email, org_uuid
+
+        def prompt_env(session_dir: Path | None = None) -> dict[str, str]:
+            env = {
+                key: value
+                for key, value in os.environ.items()
+                if key not in AUTH_OVERRIDE_ENV_VARS
+                and key
+                not in ("CLAUDE_CONFIG_DIR", "CLAUDE_SECURESTORAGE_CONFIG_DIR")
+            }
+            if session_dir is not None:
+                env["CLAUDE_CONFIG_DIR"] = str(session_dir)
+            return env
+
+        # Serialize the active verdict through child completion. Every cswap
+        # switch takes this same lock, so the default login cannot change
+        # between selecting it and sending the request.
+        with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
+            account_num, email, org_uuid = resolve_target()
+            if self.switcher._get_current_account() == (email, org_uuid):
+                return self._run_prompt_process(
+                    claude_bin, claude_args, prompt_env(), timeout, account_num, email
+                )
+
+        # setup_session takes the account lock internally and must run outside
+        # the context above. Keep the slot identifier: email alone is ambiguous
+        # when personal and organization accounts share an address. The final
+        # expected-identity check below fails closed if the slot moved while
+        # its profile was prepared.
+        session_dir, _account_num, _email = self.setup_session(
+            account_num, share=False, share_history=False
+        )
+
+        # A switch may have landed while the profile was prepared. Revalidate
+        # the snapshot identity, choose the now-correct profile, and hold the
+        # lock until Claude exits so another cswap switch cannot interleave.
+        with FileLock(self.switcher.lock_file, timeout=_BOOTSTRAP_LOCK_TIMEOUT):
+            account_num, email, org_uuid = resolve_target()
+            selected_dir = (
+                None
+                if self.switcher._get_current_account() == (email, org_uuid)
+                else session_dir
+            )
+            return self._run_prompt_process(
+                claude_bin,
+                claude_args,
+                prompt_env(selected_dir),
+                timeout,
+                account_num,
+                email,
+            )
+
+    @staticmethod
+    def _run_prompt_process(
+        claude_bin: str,
+        claude_args: list[str],
+        env: dict[str, str],
+        timeout: float,
+        account_num: str,
+        email: str,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run the child without a shell; timeout leaves outcome ambiguous."""
+        argv = [claude_bin, *claude_args]
+        try:
+            return subprocess.run(
+                argv,
+                env=env,
+                shell=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise PromptOutcomeUnknown(
+                f"Claude warm-up timed out after {timeout:.0f}s for "
+                f"Account-{account_num} ({email}); the request may have been "
+                "accepted, so retries remain temporarily protected."
+            ) from exc
+        except OSError as exc:
+            raise SessionError(
+                f"Claude warm-up could not start for Account-{account_num} "
+                f"({email}): {exc}"
+            ) from exc
 
     def _exec(self, claude_bin: str, claude_args: list[str], env: dict[str, str]) -> NoReturn:
         """Hand the terminal over to claude. Never returns.

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -57,6 +57,9 @@ class AutoSwitchSettings:
     # 5h/7d windows still have headroom. None = account-wide 5h/7d only
     # (default).
     model: str | None = None
+    # Opt-in: let `cswap auto` also keep OAuth accounts' five-hour windows
+    # started. The warmer keeps its own five-hour duplicate-spend guard.
+    warmup_five_hour: bool = False
 
 
 @dataclass(frozen=True)
@@ -136,6 +139,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
         ),
         SettingSpec(
+            "autoswitch", "warmupFiveHour", "warmup_five_hour", "bool",
+            help="Let cswap auto start cold or unconfirmed five-hour windows",
+        ),
+        SettingSpec(
             "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
             help="Color theme; auto follows the terminal background",
         ),
@@ -184,7 +191,12 @@ def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:
             clamped = num(value, spec.default, spec.lo, spec.hi)
             kwargs[spec.field] = int(clamped) if spec.kind == "int" else clamped
         elif spec.kind == "bool":
-            kwargs[spec.field] = bool(value)
+            if spec.field == "warmup_five_hour":
+                # This opt-in can spend quota; only a real JSON boolean may
+                # enable it. In particular, the string "false" is truthy.
+                kwargs[spec.field] = value if isinstance(value, bool) else spec.default
+            else:
+                kwargs[spec.field] = bool(value)
         elif spec.kind == "string":
             # A non-empty string keeps as-is; anything else reverts to default
             # (None) so a null/garbage settings.json value disables the filter.

--- a/src/claude_swap/tui/autoview.py
+++ b/src/claude_swap/tui/autoview.py
@@ -51,18 +51,24 @@ _EVENT_ROLES = {
     "account-quarantined": "sev_warn",
     "all-exhausted": "sev_crit",
 }
+_WARMUP_ACTION_ROLES = {
+    "warmed": "accent",
+    "would-warm": "accent",
+    "failed": "sev_warn",
+}
 _QUIET_KINDS = {"poll", "no-switch", "sleep", "account-unquarantined"}
 
 
 def event_text(event: AutoSwitchEvent, *, palette: Palette = Palette.DARK) -> Text:
     """Log line for one engine event, styled like the CLI's human renderer."""
     role = _EVENT_ROLES.get(event.kind)
-    if event.kind == "warmup" and getattr(event, "action", None) == "failed":
-        role = "sev_warn"
+    if event.kind == "warmup":
+        role = _WARMUP_ACTION_ROLES.get(getattr(event, "action", None))
     if role is not None:
         style = getattr(palette, role)
     else:
-        style = palette.muted if event.kind in _QUIET_KINDS else palette.foreground
+        is_quiet = event.kind in _QUIET_KINDS or event.kind == "warmup"
+        style = palette.muted if is_quiet else palette.foreground
     text = Text()
     text.append(f"{data.clock_stamp()}  ", style=palette.muted)
     text.append(event.human(), style=style)

--- a/src/claude_swap/tui/autoview.py
+++ b/src/claude_swap/tui/autoview.py
@@ -31,7 +31,12 @@ from claude_swap.autoswitch import (
     pct_label,
 )
 from claude_swap.models import AccountsSnapshot
-from claude_swap.settings import SETTING_SPECS, load_settings, parse_model_names
+from claude_swap.settings import (
+    SETTING_SPECS,
+    load_settings,
+    parse_model_names,
+    set_setting,
+)
 from claude_swap.tui import data
 from claude_swap.tui.modals import ConfirmModal
 from claude_swap.tui.theme import Palette
@@ -52,6 +57,8 @@ _QUIET_KINDS = {"poll", "no-switch", "sleep", "account-unquarantined"}
 def event_text(event: AutoSwitchEvent, *, palette: Palette = Palette.DARK) -> Text:
     """Log line for one engine event, styled like the CLI's human renderer."""
     role = _EVENT_ROLES.get(event.kind)
+    if event.kind == "warmup" and getattr(event, "action", None) == "failed":
+        role = "sev_warn"
     if role is not None:
         style = getattr(palette, role)
     else:
@@ -65,6 +72,7 @@ def event_text(event: AutoSwitchEvent, *, palette: Palette = Palette.DARK) -> Te
 class AutoScreen(Screen):
     BINDINGS = [
         Binding("l", "toggle_live", "Go live / dry-run"),
+        Binding("w", "toggle_warmup", "5h warm-up"),
         Binding("t", "adjust_threshold", "Threshold"),
         Binding("left", "threshold_step(-1)", "-1%"),
         Binding("right", "threshold_step(1)", "+1%"),
@@ -200,9 +208,69 @@ class AutoScreen(Screen):
         if self._settings.threshold != self._configured_threshold:
             text.append(" (session)", style=palette.muted)
         text.append(f" · poll every {self._settings.interval_seconds:.0f}s")
+        text.append(" · 5h warm-up ")
+        text.append(
+            "on" if self._settings.warmup_five_hour else "off",
+            style=palette.accent if self._settings.warmup_five_hour else palette.muted,
+        )
         if self._adjusting:
             text.append("   ← → adjust · enter done", style=palette.muted)
         self.query_one("#auto-summary", Static).update(text)
+
+    # -- five-hour warm-up -------------------------------------------------
+
+    def action_toggle_warmup(self) -> None:
+        if self._settings.warmup_five_hour:
+            self._set_warmup_enabled(False)
+            return
+        live = self._engine is not None and not self._engine.dry_run
+        mode_note = (
+            "Auto is LIVE, so eligible requests may begin immediately."
+            if live
+            else "This screen remains spend-free until you Go live."
+        )
+        self.app.push_screen(
+            ConfirmModal(
+                "Enable five-hour warm-up for `cswap auto`?\n\n"
+                "When live, it may send one minimal Haiku request after a "
+                "window expires or when usage remains unavailable. Successful "
+                "and uncertain attempts are protected against rapid repeats.\n\n"
+                f"{mode_note}",
+                title="Enable 5h warm-up",
+                yes_label="Enable",
+            ),
+            self._on_warmup_confirm,
+        )
+
+    def _on_warmup_confirm(self, confirmed: bool | None) -> None:
+        if confirmed:
+            self._set_warmup_enabled(True)
+
+    def _set_warmup_enabled(self, enabled: bool) -> None:
+        try:
+            set_setting(
+                self.app.switcher.backup_dir,
+                "autoswitch.warmupFiveHour",
+                "true" if enabled else "false",
+            )
+        except Exception as exc:
+            self.app.notify(
+                f"Could not save five-hour warm-up setting: {exc}",
+                severity="warning",
+            )
+            return
+        self._settings = replace(self._settings, warmup_five_hour=enabled)
+        if self._engine is not None:
+            self._engine.apply_warmup_enabled(enabled)
+        self._update_summary()
+        state = "enabled" if enabled else "disabled"
+        self.query_one("#event-log", RichLog).write(
+            Text(
+                f"— five-hour warm-up {state} for cswap auto —",
+                style=Palette.from_theme(self.app.current_theme).muted,
+            )
+        )
+        self.app.notify(f"Five-hour warm-up {state}")
 
     # -- engine -------------------------------------------------------------
 

--- a/src/claude_swap/warmup.py
+++ b/src/claude_swap/warmup.py
@@ -1,9 +1,11 @@
 """Opt-in keeper for Claude subscription five-hour usage windows.
 
-The usage endpoint is checked first. A real, minimal Haiku request is sent only
-when a fresh, evidence-bearing snapshot says the five-hour window is absent (or
-its advertised reset is already past). Hollow, unknown, failed, disabled,
-non-OAuth, and weekly-exhausted accounts fail closed.
+The usage endpoint is checked first. A real, minimal Haiku request is sent when
+the five-hour window is absent or expired. If usage remains unavailable after a
+fresh probe, one guarded request is still attempted: successful and ambiguous
+outcomes are protected in state so the fallback cannot become a request every
+poll. Disabled, non-OAuth, non-switchable, and known-weekly-exhausted accounts
+still fail closed.
 
 Warm requests run through persistent per-account session profiles, never by
 switching the globally active login. A small state file prevents duplicate
@@ -19,7 +21,6 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 
-from claude_swap import oauth
 from claude_swap.exceptions import ClaudeSwitchError, PromptOutcomeUnknown, WarmupError
 from claude_swap.locking import FileLock
 from claude_swap.models import AccountSnapshot
@@ -37,17 +38,10 @@ MIN_INTERVAL_SECONDS = 300.0
 DEFAULT_TIMEOUT_SECONDS = 120.0
 DEFAULT_MODEL = "claude-haiku-4-5"
 FIVE_HOUR_SECONDS = 5 * 60 * 60
-PENDING_GUARD_SECONDS = 10 * 60
-STATE_SCHEMA_VERSION = 1
+PENDING_GUARD_SECONDS = FIVE_HOUR_SECONDS
+STATE_SCHEMA_VERSION = 2
+LEGACY_STATE_SCHEMA_VERSION = 1
 WARMUP_PROMPT = "Reply only: OK"
-
-
-def _usage_has_real_detail(usage: dict) -> bool:
-    """Whether a usage snapshot contains evidence beyond a hollow zero row."""
-    for _, pct, resets_at in oauth.relevant_windows(usage, models=("all",)):
-        if resets_at or pct > 0:
-            return True
-    return isinstance(usage.get("spend"), dict)
 
 
 @dataclass(frozen=True)
@@ -71,7 +65,7 @@ class WarmupSummary:
 
 
 class WarmupEngine:
-    """Inspect all managed accounts and warm only confirmed-cold windows."""
+    """Inspect managed accounts and warm cold or unconfirmed five-hour windows."""
 
     def __init__(
         self,
@@ -113,7 +107,11 @@ class WarmupEngine:
 
     def tick(self) -> WarmupSummary:
         """Run one serialized usage-check and warm pass."""
+        if self._stopped.is_set():
+            return WarmupSummary()
         with FileLock(self.lock_path, timeout=1.0):
+            if self._stopped.is_set():
+                return WarmupSummary()
             return self._tick_locked()
 
     def _tick_locked(self) -> WarmupSummary:
@@ -134,7 +132,10 @@ class WarmupEngine:
         warmed = would_warm = skipped = failed = 0
 
         for account in snapshot.accounts:
-            reason = self._skip_reason(account, state, now)
+            if self._stopped.is_set():
+                break
+            account_now = self.clock()
+            reason = self._skip_reason(account, state, account_now)
             if reason is not None:
                 skipped += 1
                 self._emit(account, reason, self._reason_detail(reason))
@@ -149,8 +150,16 @@ class WarmupEngine:
                 )
                 continue
 
-            self._mark_pending(state, account, now)
+            attempt_at = self.clock()
+            # Persist the latest possible acceptance time before launch. If
+            # this process dies inside run_prompt, the on-disk guard still
+            # covers a request accepted at the end of the timeout window.
+            self._mark_pending(state, account, attempt_at + self.timeout_seconds)
             self._save_state(state)
+            if self._stopped.is_set():
+                self._clear_pending(state, account)
+                self._save_state(state)
+                break
             try:
                 result = self.sessions.run_prompt(
                     account.number,
@@ -160,8 +169,10 @@ class WarmupEngine:
                 )
             except PromptOutcomeUnknown as exc:
                 # Anthropic may have accepted the request before the local
-                # timeout. Keep pendingAt so a stale cold snapshot cannot cause
-                # an immediate duplicate; its expiry forces a fresh usage probe.
+                # timeout. Keep pendingAt for a full window so unavailable
+                # usage cannot turn ambiguity into one request every poll.
+                self._mark_pending(state, account, self.clock())
+                self._save_state(state)
                 failed += 1
                 self._emit(account, "failed", self._clean_detail(str(exc)))
                 continue
@@ -175,6 +186,8 @@ class WarmupEngine:
             if result.returncode != 0:
                 # A child can exit nonzero after the service accepted its
                 # message. Preserve pendingAt and require a later fresh probe.
+                self._mark_pending(state, account, self.clock())
+                self._save_state(state)
                 failed += 1
                 self._emit(
                     account,
@@ -183,7 +196,7 @@ class WarmupEngine:
                 )
                 continue
 
-            self._mark_warmed(state, account, now)
+            self._mark_warmed(state, account, self.clock())
             self._save_state(state)
             warmed += 1
             self._emit(
@@ -215,21 +228,24 @@ class WarmupEngine:
         usage = entry.last_good
         if not isinstance(usage, dict):
             return True
+        if self._stale_weekly_is_exhausted(usage, now):
+            return False
 
         weekly = usage.get("seven_day")
         if isinstance(weekly, dict) and isinstance(weekly.get("pct"), (int, float)):
             if float(weekly["pct"]) >= 100.0:
                 reset = parse_reset_ts(weekly.get("resets_at"))
-                return reset is not None and reset <= now
+                # A known future weekly reset makes a prompt pointless. Any
+                # less complete stale shape should still get a fresh probe.
+                return reset is None or reset <= now
 
         five_hour = usage.get("five_hour")
         if not isinstance(five_hour, dict):
             return True
-        resets_at = five_hour.get("resets_at")
-        if not resets_at:
-            return five_hour.get("pct") == 0
-        reset = parse_reset_ts(resets_at)
-        return reset is not None and reset <= now
+        reset = parse_reset_ts(five_hour.get("resets_at"))
+        # A stale percentage without an absolute deadline cannot prove that
+        # its five-hour window is still live.
+        return reset is None or reset <= now
 
     def _skip_reason(self, account: AccountSnapshot, state: dict, now: float) -> str | None:
         if account.disabled:
@@ -243,47 +259,90 @@ class WarmupEngine:
 
         entry = account.usage
         usage = entry.decision_value()
-        if (
-            not isinstance(usage, dict)
-            or entry.last_error is not None
-            or entry.age_s is None
-            or entry.age_s > STALE_OK_S
-        ):
-            return "usage-unavailable"
+        usage_is_fresh = (
+            isinstance(usage, dict)
+            and entry.last_error is None
+            and entry.age_s is not None
+            and entry.age_s <= STALE_OK_S
+        )
+        if not usage_is_fresh:
+            # A stale last-good row can still prove the window live when its
+            # absolute reset is in the future. Otherwise the user's opt-in
+            # favors one state-guarded attempt over leaving the window cold.
+            stale = entry.last_good
+            if isinstance(stale, dict):
+                if self._stale_weekly_is_exhausted(stale, now):
+                    return "weekly-exhausted"
+                if self._stale_five_hour_is_live(stale, now):
+                    return "live"
+            return None
 
         weekly = usage.get("seven_day")
-        if not isinstance(weekly, dict) or not isinstance(
-            weekly.get("pct"), (int, float)
-        ):
-            return "usage-unavailable"
-        if float(weekly["pct"]) >= 100.0 or self._model_weekly_exhausted(usage):
+        if (
+            isinstance(weekly, dict)
+            and isinstance(weekly.get("pct"), (int, float))
+            and float(weekly["pct"]) >= 100.0
+        ) or self._model_weekly_exhausted(usage):
             return "weekly-exhausted"
 
-        # The provider can return an all-zero/no-reset placeholder for an
-        # inactive credential. It is indistinguishable from a cold window by
-        # five-hour fields alone, so require evidence elsewhere in the payload
-        # and fail closed rather than spend quota on an uncertain account.
-        if not _usage_has_real_detail(usage):
-            return "usage-unavailable"
-
-        if "five_hour" not in usage:
-            return None
         five_hour = usage.get("five_hour")
-        if not isinstance(five_hour, dict) or not isinstance(
-            five_hour.get("pct"), (int, float)
-        ):
-            return "usage-unavailable"
+        if not isinstance(five_hour, dict):
+            return None
         resets_at = five_hour.get("resets_at")
-        if not resets_at:
-            # The live endpoint's cold shape is {pct: 0} with no reset.
-            # A non-zero window missing its deadline is ambiguous, so skip it.
-            return None if float(five_hour["pct"]) == 0.0 else "usage-unavailable"
-        reset_ts = parse_reset_ts(resets_at)
-        if reset_ts is None:
-            return "usage-unavailable"
-        if reset_ts > now:
+        if resets_at:
+            reset_ts = parse_reset_ts(resets_at)
+            if reset_ts is not None:
+                return "live" if reset_ts > now else None
+        pct = five_hour.get("pct")
+        if isinstance(pct, (int, float)) and float(pct) > 0.0:
+            # Non-zero utilization itself proves the window was started, even
+            # if a partial response omitted its reset timestamp.
             return "live"
         return None
+
+    @staticmethod
+    def _stale_five_hour_is_live(usage: dict, now: float) -> bool:
+        five_hour = usage.get("five_hour")
+        if not isinstance(five_hour, dict):
+            return False
+        reset_ts = parse_reset_ts(five_hour.get("resets_at"))
+        return reset_ts is not None and reset_ts > now
+
+    def _stale_weekly_is_exhausted(self, usage: dict, now: float) -> bool:
+        weekly = usage.get("seven_day")
+        if (
+            isinstance(weekly, dict)
+            and isinstance(weekly.get("pct"), (int, float))
+            and float(weekly["pct"]) >= 100.0
+        ):
+            reset_ts = parse_reset_ts(weekly.get("resets_at"))
+            if reset_ts is not None and reset_ts > now:
+                return True
+
+        scoped = usage.get("scoped")
+        if not isinstance(scoped, list):
+            return False
+        wanted = self.model.casefold()
+        family = next(
+            (name for name in ("haiku", "sonnet", "opus", "fable") if name in wanted),
+            wanted,
+        )
+        for window in scoped:
+            if not isinstance(window, dict):
+                continue
+            name = window.get("name")
+            pct = window.get("pct")
+            reset_ts = parse_reset_ts(window.get("resets_at"))
+            if (
+                isinstance(name, str)
+                and family in name.casefold()
+                and isinstance(pct, (int, float))
+                and float(pct) >= 100.0
+                and reset_ts is not None
+                and reset_ts > now
+            ):
+                return True
+        return False
 
     def _model_weekly_exhausted(self, usage: dict) -> bool:
         scoped = usage.get("scoped")
@@ -336,16 +395,44 @@ class WarmupEngine:
                 f"Could not read {self.state_path}; refusing to risk duplicate "
                 f"warm-up requests: {exc}"
             ) from exc
-        if (
-            not isinstance(data, dict)
-            or data.get("schemaVersion") != STATE_SCHEMA_VERSION
-            or not isinstance(data.get("accounts"), dict)
-        ):
+        if not isinstance(data, dict) or not isinstance(data.get("accounts"), dict):
+            raise WarmupError(
+                f"Invalid warm-up state in {self.state_path}; refusing to risk "
+                "duplicate requests."
+            )
+        if data.get("schemaVersion") == LEGACY_STATE_SCHEMA_VERSION:
+            return self._migrate_legacy_state(data)
+        if data.get("schemaVersion") != STATE_SCHEMA_VERSION:
             raise WarmupError(
                 f"Invalid warm-up state in {self.state_path}; refusing to risk "
                 "duplicate requests."
             )
         return data
+
+    @classmethod
+    def _migrate_legacy_state(cls, state: dict) -> dict:
+        """Convert slot-keyed v1 rows to stable identity keys in memory."""
+        migrated: dict[str, dict] = {}
+        for row in state["accounts"].values():
+            if not isinstance(row, dict):
+                continue
+            email = row.get("email")
+            org_uuid = row.get("orgUuid", "")
+            if not isinstance(email, str) or not isinstance(org_uuid, str):
+                continue
+            key = cls._identity_key(email, org_uuid)
+            existing = migrated.get(key)
+            if existing is None:
+                migrated[key] = dict(row)
+                continue
+            for field in ("lastWarmAt", "pendingAt"):
+                old = existing.get(field)
+                new = row.get(field)
+                if isinstance(new, (int, float)) and (
+                    not isinstance(old, (int, float)) or new > old
+                ):
+                    existing[field] = new
+        return {"schemaVersion": STATE_SCHEMA_VERSION, "accounts": migrated}
 
     def _save_state(self, state: dict) -> None:
         try:
@@ -356,8 +443,14 @@ class WarmupEngine:
             ) from exc
 
     @staticmethod
-    def _state_row(state: dict, account: AccountSnapshot) -> dict | None:
-        row = state["accounts"].get(account.number)
+    def _identity_key(email: str, org_uuid: str) -> str:
+        # Organization ids are shared by multiple members; the composite is
+        # the same exact identity pair SessionManager verifies before launch.
+        return f"org:{org_uuid}|email:{email.casefold()}"
+
+    @classmethod
+    def _state_row(cls, state: dict, account: AccountSnapshot) -> dict | None:
+        row = state["accounts"].get(cls._identity_key(account.email, account.org_uuid))
         if not isinstance(row, dict):
             return None
         if row.get("email") != account.email or row.get("orgUuid", "") != account.org_uuid:
@@ -381,7 +474,7 @@ class WarmupEngine:
     def _mark_pending(self, state: dict, account: AccountSnapshot, now: float) -> None:
         row = self._state_row(state, account) or self._row_for(account)
         row["pendingAt"] = now
-        state["accounts"][account.number] = row
+        state["accounts"][self._identity_key(account.email, account.org_uuid)] = row
 
     def _clear_pending(self, state: dict, account: AccountSnapshot) -> None:
         row = self._state_row(state, account)
@@ -392,7 +485,7 @@ class WarmupEngine:
         row = self._state_row(state, account) or self._row_for(account)
         row.pop("pendingAt", None)
         row["lastWarmAt"] = now
-        state["accounts"][account.number] = row
+        state["accounts"][self._identity_key(account.email, account.org_uuid)] = row
 
     @staticmethod
     def _clean_detail(detail: str) -> str:
@@ -407,7 +500,6 @@ class WarmupEngine:
             "not-oauth": "API-key accounts are not warmed",
             "unavailable": "account is not currently switchable",
             "recently-warmed": "a successful or in-progress warm is still protected",
-            "usage-unavailable": "fresh successful usage data is unavailable; skipped safely",
             "weekly-exhausted": "weekly quota is exhausted; no request sent",
             "live": "five-hour window is already active",
         }[reason]

--- a/src/claude_swap/warmup.py
+++ b/src/claude_swap/warmup.py
@@ -1,0 +1,416 @@
+"""Opt-in keeper for Claude subscription five-hour usage windows.
+
+The usage endpoint is checked first. A real, minimal Haiku request is sent only
+when a fresh, evidence-bearing snapshot says the five-hour window is absent (or
+its advertised reset is already past). Hollow, unknown, failed, disabled,
+non-OAuth, and weekly-exhausted accounts fail closed.
+
+Warm requests run through persistent per-account session profiles, never by
+switching the globally active login. A small state file prevents duplicate
+spend when a just-warmed usage snapshot remains briefly cached or the process
+is restarted.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+from claude_swap import oauth
+from claude_swap.exceptions import ClaudeSwitchError, PromptOutcomeUnknown, WarmupError
+from claude_swap.locking import FileLock
+from claude_swap.models import AccountSnapshot
+from claude_swap.poll_policy import parse_reset_ts
+from claude_swap.session import SessionManager
+from claude_swap.settings import atomic_write_json
+from claude_swap.usage_store import STALE_OK_S
+
+if TYPE_CHECKING:
+    from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+DEFAULT_INTERVAL_SECONDS = 600.0
+MIN_INTERVAL_SECONDS = 300.0
+DEFAULT_TIMEOUT_SECONDS = 120.0
+DEFAULT_MODEL = "claude-haiku-4-5"
+FIVE_HOUR_SECONDS = 5 * 60 * 60
+PENDING_GUARD_SECONDS = 10 * 60
+STATE_SCHEMA_VERSION = 1
+WARMUP_PROMPT = "Reply only: OK"
+
+
+def _usage_has_real_detail(usage: dict) -> bool:
+    """Whether a usage snapshot contains evidence beyond a hollow zero row."""
+    for _, pct, resets_at in oauth.relevant_windows(usage, models=("all",)):
+        if resets_at or pct > 0:
+            return True
+    return isinstance(usage.get("spend"), dict)
+
+
+@dataclass(frozen=True)
+class WarmupEvent:
+    """One account-level decision made during a warm-up tick."""
+
+    kind: str
+    account_number: str
+    email: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class WarmupSummary:
+    """Aggregate result of one warm-up tick."""
+
+    warmed: int = 0
+    would_warm: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+class WarmupEngine:
+    """Inspect all managed accounts and warm only confirmed-cold windows."""
+
+    def __init__(
+        self,
+        switcher: ClaudeAccountSwitcher,
+        *,
+        emit: Callable[[WarmupEvent], None],
+        session_manager: SessionManager | None = None,
+        interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        model: str = DEFAULT_MODEL,
+        dry_run: bool = False,
+        clock: Callable[[], float] = time.time,
+    ):
+        self.switcher = switcher
+        self.emit = emit
+        self.sessions = session_manager or SessionManager(switcher)
+        self.interval_seconds = interval_seconds
+        self.timeout_seconds = timeout_seconds
+        self.model = model
+        self.dry_run = dry_run
+        self.clock = clock
+        self.state_path = switcher.backup_dir / "warmup_state.json"
+        self.lock_path = switcher.backup_dir / ".warmup.lock"
+        self._stopped = threading.Event()
+
+    def stop(self) -> None:
+        """Request a foreground loop shutdown."""
+        self._stopped.set()
+
+    def run_loop(self) -> int:
+        """Run ticks until stopped; return nonzero if the final tick failed."""
+        exit_code = 0
+        while not self._stopped.is_set():
+            summary = self.tick()
+            exit_code = 1 if summary.failed else 0
+            if self._stopped.wait(self.interval_seconds):
+                break
+        return exit_code
+
+    def tick(self) -> WarmupSummary:
+        """Run one serialized usage-check and warm pass."""
+        with FileLock(self.lock_path, timeout=1.0):
+            return self._tick_locked()
+
+    def _tick_locked(self) -> WarmupSummary:
+        now = self.clock()
+        state = self._load_state()
+        snapshot = self.switcher.accounts_snapshot(fetch=None)
+        freshen = {
+            account.number
+            for account in snapshot.accounts
+            if self._needs_fresh_probe(account, state, now)
+        }
+        if freshen:
+            # An explicit fetch set may bypass an idle account's long poll plan,
+            # while UsageStore still enforces its serve TTL, claims, and backoff.
+            # Only stale accounts that look cold are escalated, and a persisted
+            # successful warm suppresses further probes for the whole window.
+            snapshot = self.switcher.accounts_snapshot(fetch=freshen)
+        warmed = would_warm = skipped = failed = 0
+
+        for account in snapshot.accounts:
+            reason = self._skip_reason(account, state, now)
+            if reason is not None:
+                skipped += 1
+                self._emit(account, reason, self._reason_detail(reason))
+                continue
+
+            if self.dry_run:
+                would_warm += 1
+                self._emit(
+                    account,
+                    "would-warm",
+                    f"would send one minimal {self.model} request",
+                )
+                continue
+
+            self._mark_pending(state, account, now)
+            self._save_state(state)
+            try:
+                result = self.sessions.run_prompt(
+                    account.number,
+                    self._claude_args(),
+                    timeout=self.timeout_seconds,
+                    expected_identity=(account.email, account.org_uuid),
+                )
+            except PromptOutcomeUnknown as exc:
+                # Anthropic may have accepted the request before the local
+                # timeout. Keep pendingAt so a stale cold snapshot cannot cause
+                # an immediate duplicate; its expiry forces a fresh usage probe.
+                failed += 1
+                self._emit(account, "failed", self._clean_detail(str(exc)))
+                continue
+            except (ClaudeSwitchError, OSError) as exc:
+                self._clear_pending(state, account)
+                self._save_state(state)
+                failed += 1
+                self._emit(account, "failed", self._clean_detail(str(exc)))
+                continue
+
+            if result.returncode != 0:
+                # A child can exit nonzero after the service accepted its
+                # message. Preserve pendingAt and require a later fresh probe.
+                failed += 1
+                self._emit(
+                    account,
+                    "failed",
+                    f"Claude exited with code {result.returncode}; retry protected",
+                )
+                continue
+
+            self._mark_warmed(state, account, now)
+            self._save_state(state)
+            warmed += 1
+            self._emit(
+                account,
+                "warmed",
+                f"started a five-hour window with one minimal {self.model} request",
+            )
+
+        return WarmupSummary(
+            warmed=warmed,
+            would_warm=would_warm,
+            skipped=skipped,
+            failed=failed,
+        )
+
+    def _needs_fresh_probe(
+        self, account: AccountSnapshot, state: dict, now: float
+    ) -> bool:
+        if (
+            account.disabled
+            or account.kind != "oauth"
+            or not account.switchable
+            or self._state_is_recent(state, account, now)
+        ):
+            return False
+        entry = account.usage
+        if entry.last_error is None and entry.age_s is not None and entry.age_s <= STALE_OK_S:
+            return False
+        usage = entry.last_good
+        if not isinstance(usage, dict):
+            return True
+
+        weekly = usage.get("seven_day")
+        if isinstance(weekly, dict) and isinstance(weekly.get("pct"), (int, float)):
+            if float(weekly["pct"]) >= 100.0:
+                reset = parse_reset_ts(weekly.get("resets_at"))
+                return reset is not None and reset <= now
+
+        five_hour = usage.get("five_hour")
+        if not isinstance(five_hour, dict):
+            return True
+        resets_at = five_hour.get("resets_at")
+        if not resets_at:
+            return five_hour.get("pct") == 0
+        reset = parse_reset_ts(resets_at)
+        return reset is not None and reset <= now
+
+    def _skip_reason(self, account: AccountSnapshot, state: dict, now: float) -> str | None:
+        if account.disabled:
+            return "disabled"
+        if account.kind != "oauth":
+            return "not-oauth"
+        if not account.switchable:
+            return "unavailable"
+        if self._state_is_recent(state, account, now):
+            return "recently-warmed"
+
+        entry = account.usage
+        usage = entry.decision_value()
+        if (
+            not isinstance(usage, dict)
+            or entry.last_error is not None
+            or entry.age_s is None
+            or entry.age_s > STALE_OK_S
+        ):
+            return "usage-unavailable"
+
+        weekly = usage.get("seven_day")
+        if not isinstance(weekly, dict) or not isinstance(
+            weekly.get("pct"), (int, float)
+        ):
+            return "usage-unavailable"
+        if float(weekly["pct"]) >= 100.0 or self._model_weekly_exhausted(usage):
+            return "weekly-exhausted"
+
+        # The provider can return an all-zero/no-reset placeholder for an
+        # inactive credential. It is indistinguishable from a cold window by
+        # five-hour fields alone, so require evidence elsewhere in the payload
+        # and fail closed rather than spend quota on an uncertain account.
+        if not _usage_has_real_detail(usage):
+            return "usage-unavailable"
+
+        if "five_hour" not in usage:
+            return None
+        five_hour = usage.get("five_hour")
+        if not isinstance(five_hour, dict) or not isinstance(
+            five_hour.get("pct"), (int, float)
+        ):
+            return "usage-unavailable"
+        resets_at = five_hour.get("resets_at")
+        if not resets_at:
+            # The live endpoint's cold shape is {pct: 0} with no reset.
+            # A non-zero window missing its deadline is ambiguous, so skip it.
+            return None if float(five_hour["pct"]) == 0.0 else "usage-unavailable"
+        reset_ts = parse_reset_ts(resets_at)
+        if reset_ts is None:
+            return "usage-unavailable"
+        if reset_ts > now:
+            return "live"
+        return None
+
+    def _model_weekly_exhausted(self, usage: dict) -> bool:
+        scoped = usage.get("scoped")
+        if not isinstance(scoped, list):
+            return False
+        wanted = self.model.casefold()
+        family = next(
+            (
+                name
+                for name in ("haiku", "sonnet", "opus", "fable")
+                if name in wanted
+            ),
+            wanted,
+        )
+        for window in scoped:
+            if not isinstance(window, dict):
+                continue
+            name = window.get("name")
+            pct = window.get("pct")
+            if (
+                isinstance(name, str)
+                and family in name.casefold()
+                and isinstance(pct, (int, float))
+                and float(pct) >= 100.0
+            ):
+                return True
+        return False
+
+    def _claude_args(self) -> list[str]:
+        return [
+            "--print",
+            "--model",
+            self.model,
+            "--effort",
+            "low",
+            "--safe-mode",
+            "--tools",
+            "",
+            "--no-session-persistence",
+            WARMUP_PROMPT,
+        ]
+
+    def _load_state(self) -> dict:
+        if not self.state_path.exists():
+            return {"schemaVersion": STATE_SCHEMA_VERSION, "accounts": {}}
+        try:
+            data = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise WarmupError(
+                f"Could not read {self.state_path}; refusing to risk duplicate "
+                f"warm-up requests: {exc}"
+            ) from exc
+        if (
+            not isinstance(data, dict)
+            or data.get("schemaVersion") != STATE_SCHEMA_VERSION
+            or not isinstance(data.get("accounts"), dict)
+        ):
+            raise WarmupError(
+                f"Invalid warm-up state in {self.state_path}; refusing to risk "
+                "duplicate requests."
+            )
+        return data
+
+    def _save_state(self, state: dict) -> None:
+        try:
+            atomic_write_json(self.state_path, state)
+        except (OSError, ValueError) as exc:
+            raise WarmupError(
+                f"Could not persist warm-up state to {self.state_path}: {exc}"
+            ) from exc
+
+    @staticmethod
+    def _state_row(state: dict, account: AccountSnapshot) -> dict | None:
+        row = state["accounts"].get(account.number)
+        if not isinstance(row, dict):
+            return None
+        if row.get("email") != account.email or row.get("orgUuid", "") != account.org_uuid:
+            return None
+        return row
+
+    def _state_is_recent(self, state: dict, account: AccountSnapshot, now: float) -> bool:
+        row = self._state_row(state, account)
+        if row is None:
+            return False
+        last_warm = row.get("lastWarmAt")
+        if isinstance(last_warm, (int, float)) and now < float(last_warm) + FIVE_HOUR_SECONDS:
+            return True
+        pending = row.get("pendingAt")
+        return isinstance(pending, (int, float)) and now < float(pending) + PENDING_GUARD_SECONDS
+
+    @staticmethod
+    def _row_for(account: AccountSnapshot) -> dict:
+        return {"email": account.email, "orgUuid": account.org_uuid}
+
+    def _mark_pending(self, state: dict, account: AccountSnapshot, now: float) -> None:
+        row = self._state_row(state, account) or self._row_for(account)
+        row["pendingAt"] = now
+        state["accounts"][account.number] = row
+
+    def _clear_pending(self, state: dict, account: AccountSnapshot) -> None:
+        row = self._state_row(state, account)
+        if row is not None:
+            row.pop("pendingAt", None)
+
+    def _mark_warmed(self, state: dict, account: AccountSnapshot, now: float) -> None:
+        row = self._state_row(state, account) or self._row_for(account)
+        row.pop("pendingAt", None)
+        row["lastWarmAt"] = now
+        state["accounts"][account.number] = row
+
+    @staticmethod
+    def _clean_detail(detail: str) -> str:
+        lines = [line.strip() for line in detail.splitlines() if line.strip()]
+        clean = lines[-1] if lines else "unknown error"
+        return clean if len(clean) <= 240 else clean[:237] + "..."
+
+    @staticmethod
+    def _reason_detail(reason: str) -> str:
+        return {
+            "disabled": "disabled accounts are not warmed",
+            "not-oauth": "API-key accounts are not warmed",
+            "unavailable": "account is not currently switchable",
+            "recently-warmed": "a successful or in-progress warm is still protected",
+            "usage-unavailable": "fresh successful usage data is unavailable; skipped safely",
+            "weekly-exhausted": "weekly quota is exhausted; no request sent",
+            "live": "five-hour window is already active",
+        }[reason]
+
+    def _emit(self, account: AccountSnapshot, kind: str, detail: str) -> None:
+        self.emit(WarmupEvent(kind, account.number, account.email, detail))

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -27,14 +27,17 @@ from claude_swap.autoswitch import (
     SwitchEvent,
     TickOutcome,
     UnquarantineEvent,
+    WarmupAutoEvent,
     _recovery_is_useful,
     pct_label,
 )
+from claude_swap.exceptions import WarmupError
 from claude_swap.json_output import USAGE_FOREIGN_CREDENTIAL, USAGE_TOKEN_EXPIRED
 from claude_swap.usage_store import FetchRecord, UsageEntry
 from claude_swap.models import Platform
 from claude_swap.settings import AutoSwitchSettings
 from claude_swap.switcher import ClaudeAccountSwitcher
+from claude_swap.warmup import WarmupEvent, WarmupSummary
 
 
 class FakeClock:
@@ -2053,6 +2056,176 @@ class TestEventsShape:
         assert poll.to_json()["windowsPct"]["2"] == {
             "5h": 3.0, "7d": 89.0, "Fable": 21.0,
         }
+
+
+class _FakeWarmupEngine:
+    instances: list["_FakeWarmupEngine"] = []
+    error: Exception | None = None
+    tick_duration = 0.0
+    on_tick = None
+
+    def __init__(self, switcher, *, emit, dry_run=False, clock=None, **_kwargs):
+        self.switcher = switcher
+        self.emit = emit
+        self.dry_run = dry_run
+        self.clock = clock
+        self.ticks = 0
+        self.stopped = False
+        type(self).instances.append(self)
+
+    def tick(self) -> WarmupSummary:
+        self.ticks += 1
+        if self.tick_duration:
+            self.clock.advance(self.tick_duration)
+        if self.error is not None:
+            raise self.error
+        callback = type(self).on_tick
+        if callback is not None:
+            callback()
+        self.emit(
+            WarmupEvent(
+                "would-warm" if self.dry_run else "warmed",
+                "2",
+                "b@example.com",
+                "simulated warm-up",
+            )
+        )
+        return WarmupSummary(would_warm=1) if self.dry_run else WarmupSummary(warmed=1)
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+class TestWarmupIntegration:
+    def setup_method(self):
+        _FakeWarmupEngine.instances = []
+        _FakeWarmupEngine.error = None
+        _FakeWarmupEngine.tick_duration = 0.0
+        _FakeWarmupEngine.on_tick = None
+
+    def test_disabled_by_default_does_not_construct_warmer(self, temp_home):
+        with patch("claude_swap.autoswitch.WarmupEngine") as warmer:
+            EngineHarness(temp_home)
+
+        warmer.assert_not_called()
+
+    def test_enabled_runs_now_then_at_ten_minute_cadence(self, temp_home):
+        with patch("claude_swap.autoswitch.WarmupEngine", _FakeWarmupEngine):
+            h = EngineHarness(temp_home, warmup_five_hour=True)
+            assert h.engine.tick() is TickOutcome.NO_ACTION
+            warmer = _FakeWarmupEngine.instances[0]
+            assert warmer.ticks == 1
+            event = next(e for e in h.events if isinstance(e, WarmupAutoEvent))
+            assert event.action == "warmed"
+            assert event.to_json()["account"] == {
+                "number": "2",
+                "email": "b@example.com",
+            }
+
+            h.engine.tick()
+            h.clock.advance(599)
+            h.engine.tick()
+            assert warmer.ticks == 1
+            h.clock.advance(1)
+            h.engine.tick()
+            assert warmer.ticks == 2
+
+    def test_cadence_starts_when_a_slow_pass_finishes(self, temp_home):
+        _FakeWarmupEngine.tick_duration = 700
+        with patch("claude_swap.autoswitch.WarmupEngine", _FakeWarmupEngine):
+            h = EngineHarness(temp_home, warmup_five_hour=True)
+            h.engine.tick()
+            warmer = _FakeWarmupEngine.instances[0]
+
+            h.clock.advance(599)
+            h.engine.tick()
+            assert warmer.ticks == 1
+            h.clock.advance(1)
+            h.engine.tick()
+            assert warmer.ticks == 2
+
+    def test_warmup_error_is_reported_and_retried_on_cadence(self, temp_home):
+        _FakeWarmupEngine.error = WarmupError("state is unreadable")
+        with patch("claude_swap.autoswitch.WarmupEngine", _FakeWarmupEngine):
+            h = EngineHarness(temp_home, warmup_five_hour=True)
+            assert h.engine.tick() is TickOutcome.ERROR
+            warmer = _FakeWarmupEngine.instances[0]
+            assert warmer.ticks == 1
+            error = next(e for e in h.events if isinstance(e, ErrorEvent))
+            assert error.message == "five-hour warm-up: state is unreadable"
+
+            _FakeWarmupEngine.error = None
+            h.engine.tick()
+            assert warmer.ticks == 1
+            h.clock.advance(600)
+            h.engine.tick()
+            assert warmer.ticks == 2
+
+    def test_auto_sleep_is_capped_at_the_warmup_deadline(self, temp_home):
+        with patch("claude_swap.autoswitch.WarmupEngine", _FakeWarmupEngine):
+            h = EngineHarness(
+                temp_home,
+                warmup_five_hour=True,
+                interval_seconds=3600,
+            )
+            h.engine.tick()
+
+            assert h.engine._next_delay(TickOutcome.NO_ACTION) == 600.0
+
+    def test_stopped_engine_does_not_start_a_due_warmup_pass(self, temp_home):
+        with patch("claude_swap.autoswitch.WarmupEngine", _FakeWarmupEngine):
+            h = EngineHarness(temp_home, warmup_five_hour=True)
+            warmer = _FakeWarmupEngine.instances[0]
+            h.engine.stop()
+
+            h.engine.tick()
+
+            assert warmer.ticks == 0
+
+    def test_reenable_during_old_pass_keeps_new_warmer_due_now(self, temp_home):
+        with patch("claude_swap.autoswitch.WarmupEngine", _FakeWarmupEngine):
+            h = EngineHarness(temp_home, warmup_five_hour=True)
+
+            def reenable():
+                _FakeWarmupEngine.on_tick = None
+                h.engine.apply_warmup_enabled(False)
+                h.engine.apply_warmup_enabled(True)
+
+            _FakeWarmupEngine.on_tick = reenable
+            h.engine.tick()
+
+            replacement = _FakeWarmupEngine.instances[-1]
+            assert h.engine._next_warmup_at == h.clock()
+            h.engine.tick()
+            assert replacement.ticks == 1
+
+    def test_auto_dry_run_makes_integrated_warmer_dry_run(self, temp_home):
+        with patch("claude_swap.autoswitch.WarmupEngine", _FakeWarmupEngine):
+            h = EngineHarness(temp_home, warmup_five_hour=True)
+            engine = h._make_engine(dry_run=True)
+            engine.tick()
+
+        warmer = _FakeWarmupEngine.instances[-1]
+        assert warmer.dry_run is True
+        event = next(e for e in h.events if isinstance(e, WarmupAutoEvent))
+        assert event.action == "would-warm"
+
+    def test_runtime_toggle_starts_immediately_and_can_disable(self, temp_home):
+        with patch("claude_swap.autoswitch.WarmupEngine", _FakeWarmupEngine):
+            h = EngineHarness(temp_home)
+            h.engine.apply_warmup_enabled(True)
+            assert h.engine.settings.warmup_five_hour is True
+            assert h.engine._wake.is_set()
+            h.engine.tick()
+            warmer = _FakeWarmupEngine.instances[0]
+            assert warmer.ticks == 1
+
+            h.engine.apply_warmup_enabled(False)
+            h.clock.advance(600)
+            h.engine.tick()
+            assert h.engine.settings.warmup_five_hour is False
+            assert warmer.stopped is True
+            assert warmer.ticks == 1
 
 
 class TestRunLoop:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1089,12 +1089,17 @@ class TestAutoCommand:
         backup.mkdir(parents=True, exist_ok=True)
         (backup / "settings.json").write_text(json.dumps({
             "schemaVersion": 1,
-            "autoswitch": {"threshold": 80.0, "cooldownSeconds": 42.0},
+            "autoswitch": {
+                "threshold": 80.0,
+                "cooldownSeconds": 42.0,
+                "warmupFiveHour": True,
+            },
         }))
         self._run(["--once", "--threshold", "60"], temp_home)
         engine = self.FakeEngine.instances[-1]
         assert engine.settings.threshold == 60.0     # CLI wins
         assert engine.settings.cooldown_seconds == 42.0  # settings.json kept
+        assert engine.settings.warmup_five_hour is True
 
     def test_dry_run_forwarded(self, temp_home):
         self._run(["--once", "--dry-run"], temp_home)

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,10 +48,11 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "autoswitch.warmupFiveHour",
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,10 +79,11 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False
+        assert by_key["autoswitch.warmupFiveHour"]["value"] is False
 
 
 class TestConfigSetGet:
@@ -109,6 +111,15 @@ class TestConfigSetGet:
         assert "= false" in out
         raw = json.loads(_settings_file(capsys).read_text())
         assert raw["autoswitch"]["includeApiKeyAccounts"] is False
+
+    def test_set_five_hour_warmup(self, temp_home, capsys):
+        code, out, _ = _run(
+            ["set", "autoswitch.warmupFiveHour", "yes"], capsys
+        )
+        assert code == 0
+        assert "= true" in out
+        raw = json.loads(_settings_file(capsys).read_text())
+        assert raw["autoswitch"]["warmupFiveHour"] is True
 
     def test_set_preserves_unknown_keys(self, temp_home, capsys):
         path = _settings_file(capsys)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -58,6 +58,22 @@ class TestLoadSettings:
         loaded = load_settings(tmp_path)
         assert loaded.threshold == 80.0
         assert loaded.interval_seconds == AutoSwitchSettings().interval_seconds
+        assert loaded.warmup_five_hour is False
+
+    def test_loads_five_hour_warmup_opt_in(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"autoswitch": {"warmupFiveHour": True}})
+        )
+
+        assert load_settings(tmp_path).warmup_five_hour is True
+
+    @pytest.mark.parametrize("value", ["true", "false", 1, 0, None])
+    def test_five_hour_warmup_requires_a_json_boolean(self, tmp_path: Path, value):
+        settings_path(tmp_path).write_text(
+            json.dumps({"autoswitch": {"warmupFiveHour": value}})
+        )
+
+        assert load_settings(tmp_path).warmup_five_hour is False
 
     def test_values_are_clamped(self, tmp_path: Path):
         settings_path(tmp_path).write_text(json.dumps({

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1635,6 +1635,55 @@ class TestEventText:
         assert "warm-up failed" in text.plain
         assert any(Palette.DARK.sev_warn in str(span.style) for span in text.spans)
 
+    def test_live_warmup_uses_muted_style(self):
+        from claude_swap.autoswitch import WarmupAutoEvent
+        from claude_swap.tui.autoview import event_text
+        from claude_swap.tui.theme import Palette
+
+        event = WarmupAutoEvent(
+            action="live",
+            number="2",
+            email="b@x.com",
+            detail="the five-hour window is already active",
+        )
+        text = event_text(event)
+
+        assert "five-hour window is already active" in text.plain
+        assert "5h warm-up sent" not in text.plain
+        assert Palette.DARK.muted in str(text.spans[-1].style)
+
+    def test_warmed_account_uses_accent_and_marks_warmup_sent(self):
+        from claude_swap.autoswitch import WarmupAutoEvent
+        from claude_swap.tui.autoview import event_text
+        from claude_swap.tui.theme import Palette
+
+        event = WarmupAutoEvent(
+            action="warmed",
+            number="2",
+            email="b@x.com",
+            detail="sent guarded warm-up prompt",
+        )
+        text = event_text(event)
+
+        assert text.plain.endswith("sent guarded warm-up prompt (5h warm-up sent)")
+        assert Palette.DARK.accent in str(text.spans[-1].style)
+
+    def test_dry_run_warmup_preview_uses_accent(self):
+        from claude_swap.autoswitch import WarmupAutoEvent
+        from claude_swap.tui.autoview import event_text
+        from claude_swap.tui.theme import Palette
+
+        event = WarmupAutoEvent(
+            action="would-warm",
+            number="2",
+            email="b@x.com",
+            detail="would send one minimal request",
+        )
+        text = event_text(event)
+
+        assert "5h warm-up sent" not in text.plain
+        assert Palette.DARK.accent in str(text.spans[-1].style)
+
 
 # ---------------------------------------------------------------------------
 # accounts_snapshot on the real switcher

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1294,6 +1294,7 @@ class _FakeEngine:
         self.dry_run = dry_run
         self.stopped = False
         self.applied_thresholds: list[float] = []
+        self.applied_warmups: list[bool] = []
         self.wakes = 0
         self._stop = threading.Event()
         _FakeEngine.instances.append(self)
@@ -1310,6 +1311,12 @@ class _FakeEngine:
     def apply_threshold(self, threshold: float) -> None:
         self.settings = dataclasses.replace(self.settings, threshold=threshold)
         self.applied_thresholds.append(threshold)
+
+    def apply_warmup_enabled(self, enabled: bool) -> None:
+        self.settings = dataclasses.replace(
+            self.settings, warmup_five_hour=enabled
+        )
+        self.applied_warmups.append(enabled)
 
     def wake(self) -> None:
         self.wakes += 1
@@ -1367,6 +1374,63 @@ class TestAutoScreen:
             assert len(fake_engine.instances) == 2
             assert fake_engine.instances[0].stopped is True
             assert fake_engine.instances[1].dry_run is False
+
+    async def test_five_hour_warmup_toggle_is_confirmed_and_persisted(
+        self, tmp_path, fake_engine
+    ):
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(pilot)
+            screen = app.screen
+
+            await pilot.press("w")
+            await pilot.pause()
+            from claude_swap.tui.modals import ConfirmModal
+
+            assert isinstance(app.screen, ConfirmModal)
+            await pilot.press("y")
+            await settle(pilot)
+
+            assert screen._settings.warmup_five_hour is True
+            assert fake_engine.instances[0].applied_warmups == [True]
+            raw = json.loads((tmp_path / "settings.json").read_text())
+            assert raw["autoswitch"]["warmupFiveHour"] is True
+            from textual.widgets import Static
+
+            summary = screen.query_one("#auto-summary", Static)
+            assert "5h warm-up on" in summary.render().plain
+
+            await pilot.press("w")
+            await pilot.pause()
+            assert screen._settings.warmup_five_hour is False
+            assert fake_engine.instances[0].applied_warmups == [True, False]
+            raw = json.loads((tmp_path / "settings.json").read_text())
+            assert raw["autoswitch"]["warmupFiveHour"] is False
+
+    async def test_live_warmup_confirmation_warns_requests_can_start_now(
+        self, tmp_path, fake_engine
+    ):
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(pilot)
+            await pilot.press("l")
+            await pilot.pause()
+            await pilot.press("y")
+            await settle(pilot)
+
+            await pilot.press("w")
+            await pilot.pause()
+
+            from claude_swap.tui.modals import ConfirmModal
+
+            assert isinstance(app.screen, ConfirmModal)
+            assert "Auto is LIVE" in app.screen._message
 
     async def test_back_stops_engine_and_restores_fetching(
         self, tmp_path, fake_engine
@@ -1554,6 +1618,22 @@ class TestEventText:
         )
         text = event_text(event, palette=Palette.from_theme(CSWAP_LIGHT))
         assert any(ACCENT_LIGHT in str(s.style) for s in text.spans)
+
+    def test_failed_warmup_uses_warning_style(self):
+        from claude_swap.autoswitch import WarmupAutoEvent
+        from claude_swap.tui.autoview import event_text
+        from claude_swap.tui.theme import Palette
+
+        event = WarmupAutoEvent(
+            action="failed",
+            number="2",
+            email="b@x.com",
+            detail="state is unreadable",
+        )
+        text = event_text(event)
+
+        assert "warm-up failed" in text.plain
+        assert any(Palette.DARK.sev_warn in str(span.style) for span in text.spans)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -23,6 +24,17 @@ from claude_swap.usage_store import UsageEntry
 NOW = 1_800_000_000.0
 
 
+class _MutableClock:
+    def __init__(self, now: float = NOW):
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
 def _iso(seconds_from_now: float) -> str:
     return datetime.fromtimestamp(NOW + seconds_from_now, timezone.utc).isoformat()
 
@@ -33,6 +45,7 @@ def _account(
     *,
     age_s: float = 0.0,
     last_error: str | None = None,
+    trust_extended: bool = False,
     kind: str = "oauth",
     switchable: bool = True,
     disabled: bool = False,
@@ -51,6 +64,7 @@ def _account(
             fetched_at=NOW - age_s,
             age_s=age_s,
             last_error=last_error,
+            trust_extended=trust_extended,
         ),
     )
 
@@ -90,6 +104,7 @@ def _engine(
     sessions=None,
     dry_run=False,
     model="claude-haiku-4-5",
+    clock=None,
 ):
     from claude_swap.warmup import WarmupEngine
 
@@ -102,7 +117,7 @@ def _engine(
         session_manager=sessions,
         dry_run=dry_run,
         model=model,
-        clock=lambda: NOW,
+        clock=clock or (lambda: NOW),
     )
     return engine, switcher, sessions, events
 
@@ -139,8 +154,10 @@ def test_tick_warms_cold_account_and_skips_live_window(tmp_path):
     ]
     assert [event.kind for event in events] == ["warmed", "live"]
     state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
-    assert state["accounts"]["1"]["email"] == "user1@example.com"
-    assert state["accounts"]["1"]["lastWarmAt"] == NOW
+    assert state["schemaVersion"] == 2
+    key = "org:org-1|email:user1@example.com"
+    assert state["accounts"][key]["email"] == "user1@example.com"
+    assert state["accounts"][key]["lastWarmAt"] == NOW
 
 
 def test_tick_forces_one_fresh_probe_for_stale_cold_account(tmp_path):
@@ -189,18 +206,74 @@ def test_tick_does_not_reprobe_stale_but_still_live_window(tmp_path):
 
     assert switcher.snapshot_calls == 1
     assert sessions.calls == []
-    assert events[0].kind == "usage-unavailable"
+    assert events[0].kind == "live"
+
+
+@pytest.mark.parametrize("trust_extended", [False, True])
+def test_stale_nonzero_window_without_reset_is_probed_then_warmed(
+    tmp_path, trust_extended
+):
+    stale = _account(
+        "1",
+        {"five_hour": {"pct": 1.0}, "seven_day": {"pct": 2}},
+        age_s=600,
+        last_error="http-429",
+        trust_extended=trust_extended,
+    )
+
+    class UnavailableSwitcher(_FakeSwitcher):
+        def __init__(self):
+            super().__init__(tmp_path, [stale])
+            self.fetches = []
+
+        def accounts_snapshot(self, fetch=None):
+            self.fetches.append(fetch)
+            return AccountsSnapshot("1", (stale,), NOW)
+
+    from claude_swap.warmup import WarmupEngine
+
+    switcher = UnavailableSwitcher()
+    sessions = _FakeSessions()
+    engine = WarmupEngine(
+        switcher,
+        emit=lambda _event: None,
+        session_manager=sessions,
+        clock=lambda: NOW,
+    )
+
+    assert engine.tick().warmed == 1
+    assert switcher.fetches == [None, {"1"}]
+    assert [call[0] for call in sessions.calls] == ["1"]
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        {
+            "seven_day": {"pct": 100.0, "resets_at": _iso(3600)},
+        },
+        {
+            "seven_day": {"pct": 20.0},
+            "scoped": [
+                {"name": "Haiku", "pct": 100.0, "resets_at": _iso(3600)}
+            ],
+        },
+    ],
+)
+def test_stale_known_weekly_exhaustion_still_skips(tmp_path, usage):
+    account = _account("1", usage, age_s=600, last_error="http-429")
+    engine, switcher, sessions, events = _engine(tmp_path, [account])
+
+    engine.tick()
+
+    assert switcher.snapshot_calls == 1
+    assert sessions.calls == []
+    assert events[0].kind == "weekly-exhausted"
 
 
 @pytest.mark.parametrize(
     ("account", "reason"),
     [
-        (_account("1", None), "usage-unavailable"),
-        (_account("1", {"seven_day": {"pct": 2}}, age_s=301), "usage-unavailable"),
-        (
-            _account("1", {"seven_day": {"pct": 2}}, last_error="http-429"),
-            "usage-unavailable",
-        ),
         (_account("1", {"seven_day": {"pct": 100}}), "weekly-exhausted"),
         (_account("1", {"seven_day": {"pct": 2}}, disabled=True), "disabled"),
         (
@@ -221,6 +294,24 @@ def test_tick_fails_closed_for_ineligible_accounts(tmp_path, account, reason):
     assert summary.warmed == 0
     assert sessions.calls == []
     assert events[0].kind == reason
+
+
+@pytest.mark.parametrize(
+    "account",
+    [
+        _account("1", None),
+        _account("1", {"seven_day": {"pct": 2}}, age_s=301),
+        _account("1", {"seven_day": {"pct": 2}}, last_error="http-429"),
+    ],
+)
+def test_tick_warms_when_usage_is_unavailable(tmp_path, account):
+    engine, _switcher, sessions, events = _engine(tmp_path, [account])
+
+    summary = engine.tick()
+
+    assert summary.warmed == 1
+    assert [call[0] for call in sessions.calls] == ["1"]
+    assert events[0].kind == "warmed"
 
 
 def test_tick_skips_exhausted_selected_model_window(tmp_path):
@@ -252,7 +343,7 @@ def test_zero_percent_five_hour_without_reset_is_warmed(tmp_path):
     assert events[0].kind == "warmed"
 
 
-def test_hollow_all_zero_usage_fails_closed(tmp_path):
+def test_hollow_all_zero_usage_is_warmed(tmp_path):
     account = _account(
         "1",
         {
@@ -265,12 +356,12 @@ def test_hollow_all_zero_usage_fails_closed(tmp_path):
 
     summary = engine.tick()
 
-    assert summary.warmed == 0
-    assert sessions.calls == []
-    assert events[0].kind == "usage-unavailable"
+    assert summary.warmed == 1
+    assert [call[0] for call in sessions.calls] == ["1"]
+    assert events[0].kind == "warmed"
 
 
-def test_nonzero_five_hour_without_reset_fails_closed(tmp_path):
+def test_nonzero_five_hour_without_reset_is_treated_as_live(tmp_path):
     account = _account(
         "1", {"five_hour": {"pct": 1.0}, "seven_day": {"pct": 1.0}}
     )
@@ -279,7 +370,34 @@ def test_nonzero_five_hour_without_reset_fails_closed(tmp_path):
     engine.tick()
 
     assert sessions.calls == []
-    assert events[0].kind == "usage-unavailable"
+    assert events[0].kind == "live"
+
+
+def test_unknown_usage_after_five_hour_guard_is_warmed_again(tmp_path):
+    (tmp_path / "warmup_state.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "accounts": {
+                    "1": {
+                        "email": "user1@example.com",
+                        "orgUuid": "org-1",
+                        "lastWarmAt": NOW - 6 * 3600,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    engine, _switcher, sessions, events = _engine(
+        tmp_path, [_account("1", None)]
+    )
+
+    summary = engine.tick()
+
+    assert summary.warmed == 1
+    assert [call[0] for call in sessions.calls] == ["1"]
+    assert events[0].kind == "warmed"
 
 
 def test_expired_five_hour_window_is_warmed(tmp_path):
@@ -347,6 +465,60 @@ def test_state_is_bound_to_identity_not_reused_slot(tmp_path):
     assert [call[0] for call in sessions.calls] == ["1"]
 
 
+def test_legacy_state_protection_follows_identities_after_slots_swap(tmp_path):
+    (tmp_path / "warmup_state.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "accounts": {
+                    "1": {
+                        "email": "user1@example.com",
+                        "orgUuid": "org-1",
+                        "lastWarmAt": NOW - 60,
+                    },
+                    "2": {
+                        "email": "user2@example.com",
+                        "orgUuid": "org-2",
+                        "lastWarmAt": NOW - 60,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    first = _account("1", None)
+    second = _account("2", None)
+    first = replace(first, email="user2@example.com", org_uuid="org-2")
+    second = replace(second, email="user1@example.com", org_uuid="org-1")
+    engine, _switcher, sessions, events = _engine(tmp_path, [first, second])
+
+    engine.tick()
+
+    assert sessions.calls == []
+    assert [event.kind for event in events] == ["recently-warmed", "recently-warmed"]
+
+
+def test_state_keeps_separate_guards_for_users_in_one_organization(tmp_path):
+    first = replace(_account("1", None), org_uuid="shared-org")
+    second = replace(_account("2", None), org_uuid="shared-org")
+    engine, _switcher, sessions, _events = _engine(tmp_path, [first, second])
+
+    assert engine.tick().warmed == 2
+    assert len(sessions.calls) == 2
+    state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
+    assert len(state["accounts"]) == 2
+
+    second_sessions = _FakeSessions()
+    engine, _switcher, _sessions, events = _engine(
+        tmp_path,
+        [first, second],
+        sessions=second_sessions,
+    )
+    assert engine.tick().skipped == 2
+    assert second_sessions.calls == []
+    assert [event.kind for event in events] == ["recently-warmed", "recently-warmed"]
+
+
 def test_dry_run_never_launches_or_writes_state(tmp_path):
     account = _account("1", {"seven_day": {"pct": 1.0}})
     engine, _switcher, sessions, events = _engine(tmp_path, [account], dry_run=True)
@@ -372,8 +544,9 @@ def test_failed_claude_request_is_not_recorded_as_warmed(tmp_path):
     assert events[0].kind == "failed"
     assert events[0].detail == "Claude exited with code 7; retry protected"
     state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
-    assert "lastWarmAt" not in state["accounts"]["1"]
-    assert state["accounts"]["1"]["pendingAt"] == NOW
+    key = "org:org-1|email:user1@example.com"
+    assert "lastWarmAt" not in state["accounts"][key]
+    assert state["accounts"][key]["pendingAt"] == NOW
 
 
 def test_ambiguous_timeout_keeps_duplicate_spend_guard(tmp_path):
@@ -392,7 +565,138 @@ def test_ambiguous_timeout_keeps_duplicate_spend_guard(tmp_path):
     assert summary.failed == 1
     assert events[0].kind == "failed"
     state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
-    assert state["accounts"]["1"]["pendingAt"] == NOW
+    key = "org:org-1|email:user1@example.com"
+    assert state["accounts"][key]["pendingAt"] == NOW
+
+
+def test_prelaunch_state_covers_the_full_request_timeout(tmp_path):
+    key = "org:org-1|email:user1@example.com"
+
+    class InspectingSessions(_FakeSessions):
+        def run_prompt(self, *_args, **_kwargs):
+            state = json.loads(
+                (tmp_path / "warmup_state.json").read_text(encoding="utf-8")
+            )
+            assert state["accounts"][key]["pendingAt"] == NOW + 120
+            raise PromptOutcomeUnknown("request outcome is unknown")
+
+    engine, _switcher, _sessions, _events = _engine(
+        tmp_path,
+        [_account("1", None)],
+        sessions=InspectingSessions(),
+    )
+
+    assert engine.tick().failed == 1
+
+
+@pytest.mark.parametrize("outcome", ["timeout", "nonzero"])
+def test_unavailable_usage_does_not_retry_ambiguous_attempt_each_poll(
+    tmp_path, outcome
+):
+    clock = _MutableClock()
+
+    class AmbiguousSessions(_FakeSessions):
+        def run_prompt(self, *args, **kwargs):
+            if outcome == "timeout":
+                self.calls.append((args[0], args[1], kwargs["timeout"]))
+                raise PromptOutcomeUnknown("request outcome is unknown")
+            return super().run_prompt(*args, **kwargs)
+
+    sessions = AmbiguousSessions({"1": 7} if outcome == "nonzero" else None)
+    engine, _switcher, _sessions, events = _engine(
+        tmp_path,
+        [_account("1", None)],
+        sessions=sessions,
+        clock=clock,
+    )
+
+    assert engine.tick().failed == 1
+    clock.advance(600)
+    assert engine.tick().skipped == 1
+
+    assert len(sessions.calls) == 1
+    assert events[-1].kind == "recently-warmed"
+
+
+@pytest.mark.parametrize("outcome", ["timeout", "nonzero"])
+def test_ambiguous_guard_starts_at_prompt_completion(tmp_path, outcome):
+    clock = _MutableClock()
+
+    class SlowAmbiguousSessions(_FakeSessions):
+        def run_prompt(self, *args, **kwargs):
+            if outcome == "timeout":
+                self.calls.append((args[0], args[1], kwargs["timeout"]))
+                clock.advance(700)
+                raise PromptOutcomeUnknown("request outcome is unknown")
+            result = super().run_prompt(*args, **kwargs)
+            clock.advance(700)
+            return result
+
+    sessions = SlowAmbiguousSessions({"1": 7} if outcome == "nonzero" else None)
+    engine, _switcher, _sessions, _events = _engine(
+        tmp_path,
+        [_account("1", None)],
+        sessions=sessions,
+        clock=clock,
+    )
+
+    assert engine.tick().failed == 1
+    key = "org:org-1|email:user1@example.com"
+    state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
+    assert state["accounts"][key]["pendingAt"] == NOW + 700
+
+    clock.advance(5 * 3600 - 1)
+    assert engine.tick().skipped == 1
+    assert len(sessions.calls) == 1
+    clock.advance(1)
+    assert engine.tick().failed == 1
+    assert len(sessions.calls) == 2
+
+
+def test_each_success_is_protected_from_its_actual_completion_time(tmp_path):
+    clock = _MutableClock()
+
+    class SlowSessions(_FakeSessions):
+        def run_prompt(self, *args, **kwargs):
+            result = super().run_prompt(*args, **kwargs)
+            clock.advance(700)
+            return result
+
+    engine, _switcher, _sessions, _events = _engine(
+        tmp_path,
+        [_account("1", None), _account("2", None)],
+        sessions=SlowSessions(),
+        clock=clock,
+    )
+
+    assert engine.tick().warmed == 2
+
+    state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
+    first_key = "org:org-1|email:user1@example.com"
+    second_key = "org:org-2|email:user2@example.com"
+    assert state["accounts"][first_key]["lastWarmAt"] == NOW + 700
+    assert state["accounts"][second_key]["lastWarmAt"] == NOW + 1400
+
+
+def test_stop_during_a_sweep_prevents_later_account_requests(tmp_path):
+    holder = {}
+
+    class StoppingSessions(_FakeSessions):
+        def run_prompt(self, *args, **kwargs):
+            result = super().run_prompt(*args, **kwargs)
+            holder["engine"].stop()
+            return result
+
+    sessions = StoppingSessions()
+    engine, _switcher, _sessions, _events = _engine(
+        tmp_path,
+        [_account("1", None), _account("2", None)],
+        sessions=sessions,
+    )
+    holder["engine"] = engine
+
+    assert engine.tick().warmed == 1
+    assert [call[0] for call in sessions.calls] == ["1"]
 
 
 def _session_switcher(tmp_path: Path, *, active: bool):
@@ -678,6 +982,14 @@ def test_main_dispatches_warmup_subcommand(monkeypatch):
     with patch("claude_swap.cli._warmup_command", side_effect=called.append):
         cli.main()
     assert called == [["--once"]]
+
+
+def test_warmup_help_describes_unavailable_usage_fallback(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli._warmup_command(["--help"])
+
+    assert exc.value.code == 0
+    assert "usage remains unavailable" in capsys.readouterr().out
 
 
 def test_warmup_command_builds_one_shot_dry_run_engine(tmp_path):

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -408,6 +408,23 @@ def _session_switcher(tmp_path: Path, *, active: bool):
     return switcher
 
 
+def _oauth_auth_status(argv=None):
+    return subprocess.CompletedProcess(
+        argv or [],
+        0,
+        json.dumps(
+            {
+                "loggedIn": True,
+                "authMethod": "claude.ai",
+                "apiProvider": "firstParty",
+                "email": "user2@example.com",
+                "orgId": "org-2",
+            }
+        ),
+        "",
+    )
+
+
 def test_run_prompt_uses_default_profile_for_active_account_and_scrubs_overrides(
     tmp_path, monkeypatch
 ):
@@ -430,6 +447,10 @@ def test_run_prompt_uses_default_profile_for_active_account_and_scrubs_overrides
     monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
 
     def fake_run(argv, **kwargs):
+        if argv[-3:] == ["auth", "status", "--json"]:
+            assert "--safe-mode" in argv
+            assert all(name not in kwargs["env"] for name in provider_routes)
+            return _oauth_auth_status(argv)
         seen.update(argv=argv, **kwargs)
         return subprocess.CompletedProcess(argv, 0, "OK\n", "")
 
@@ -459,6 +480,8 @@ def test_run_prompt_holds_account_lock_while_child_runs(tmp_path, monkeypatch):
     def fake_run(argv, **_kwargs):
         peer = FileLock(switcher.lock_file, timeout=0)
         assert peer.acquire() is False
+        if argv[-3:] == ["auth", "status", "--json"]:
+            return _oauth_auth_status(argv)
         return subprocess.CompletedProcess(argv, 0, "OK", "")
 
     with patch("claude_swap.session.shutil.which", return_value="claude"), patch(
@@ -481,7 +504,10 @@ def test_run_prompt_rechecks_active_account_after_profile_setup(tmp_path, monkey
         manager, "setup_session", return_value=(profile, "2", "user2@example.com")
     ), patch("claude_swap.session.shutil.which", return_value="claude"), patch(
         "claude_swap.session.subprocess.run",
-        return_value=subprocess.CompletedProcess([], 0, "OK", ""),
+        side_effect=[
+            _oauth_auth_status(),
+            subprocess.CompletedProcess([], 0, "OK", ""),
+        ],
     ) as run:
         manager.run_prompt(
             "2",
@@ -520,16 +546,121 @@ def test_run_prompt_uses_isolated_profile_for_inactive_account(tmp_path, monkeyp
         "setup_session",
         return_value=(profile, "2", "user2@example.com"),
     ) as setup, patch(
+        "claude_swap.session.read_session_identity",
+        return_value=("user2@example.com", "org-2"),
+    ), patch(
         "claude_swap.session.shutil.which", return_value="claude"
     ), patch(
         "claude_swap.session.subprocess.run",
-        return_value=subprocess.CompletedProcess([], 0, "OK", ""),
+        side_effect=[
+            _oauth_auth_status(),
+            subprocess.CompletedProcess([], 0, "OK", ""),
+        ],
     ) as run:
         manager.run_prompt("2", ["--print", "hi"], timeout=30)
 
     # Slot numbers remain unambiguous when two organizations share an email.
-    setup.assert_called_once_with("2", share=False, share_history=False)
+    setup.assert_called_once_with(
+        "2",
+        share=False,
+        share_history=False,
+        sync_sharing=False,
+        refresh_credentials=False,
+        expected_identity=("user2@example.com", "org-2"),
+    )
     assert run.call_args.kwargs["env"]["CLAUDE_CONFIG_DIR"] == str(profile)
+
+
+def test_run_prompt_rejects_aba_profile_identity_drift(tmp_path, monkeypatch):
+    switcher = _session_switcher(tmp_path, active=False)
+    manager = SessionManager(switcher)
+    profile = tmp_path / "sessions" / "2-user2"
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+
+    with patch.object(
+        manager,
+        "setup_session",
+        return_value=(profile, "2", "user2@example.com"),
+    ), patch(
+        "claude_swap.session.read_session_identity",
+        return_value=("user2@example.com", "org-other"),
+    ), patch("claude_swap.session.shutil.which", return_value="claude"), patch(
+        "claude_swap.session.subprocess.run",
+        return_value=subprocess.CompletedProcess([], 0, "OK", ""),
+    ) as run:
+        with pytest.raises(SessionError, match="prepared profile identity"):
+            manager.run_prompt(
+                "2",
+                ["--print", "hi"],
+                timeout=30,
+                expected_identity=("user2@example.com", "org-2"),
+            )
+
+    run.assert_not_called()
+
+
+def test_run_prompt_rejects_third_party_provider_preflight(tmp_path, monkeypatch):
+    switcher = _session_switcher(tmp_path, active=True)
+    manager = SessionManager(switcher)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+    third_party = subprocess.CompletedProcess(
+        [],
+        0,
+        json.dumps(
+            {
+                "loggedIn": True,
+                "authMethod": "third_party",
+                "apiProvider": "bedrock",
+            }
+        ),
+        "",
+    )
+
+    with patch("claude_swap.session.shutil.which", return_value="claude"), patch(
+        "claude_swap.session.subprocess.run", return_value=third_party
+    ) as run:
+        with pytest.raises(SessionError, match="first-party Claude OAuth"):
+            manager.run_prompt("2", ["--print", "hi"], timeout=30)
+
+    run.assert_called_once()
+
+
+def test_run_prompt_rejects_same_email_with_different_org(tmp_path, monkeypatch):
+    switcher = _session_switcher(tmp_path, active=True)
+    manager = SessionManager(switcher)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+    wrong_org = _oauth_auth_status()
+    status = json.loads(wrong_org.stdout)
+    status["orgId"] = ""
+    wrong_org = subprocess.CompletedProcess([], 0, json.dumps(status), "")
+
+    with patch("claude_swap.session.shutil.which", return_value="claude"), patch(
+        "claude_swap.session.subprocess.run", return_value=wrong_org
+    ) as run:
+        with pytest.raises(SessionError, match="authenticated identity changed"):
+            manager.run_prompt("2", ["--print", "hi"], timeout=30)
+
+    run.assert_called_once()
+
+
+def test_setup_prompt_session_rejects_changed_identity_before_credentials(tmp_path):
+    switcher = _session_switcher(tmp_path, active=False)
+    manager = SessionManager(switcher)
+
+    with pytest.raises(SessionError, match="refusing to touch"):
+        manager.setup_session(
+            "2",
+            share=False,
+            share_history=False,
+            sync_sharing=False,
+            refresh_credentials=False,
+            expected_identity=("user2@example.com", "org-other"),
+        )
+
+    switcher.read_account_credentials.assert_not_called()
 
 
 def test_run_prompt_rejects_nested_config_profile(tmp_path, monkeypatch):

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,613 @@
+"""Tests for the opt-in five-hour window warmer."""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_swap import cli
+from claude_swap.models import AccountSnapshot, AccountsSnapshot
+from claude_swap.exceptions import PromptOutcomeUnknown, SessionError
+from claude_swap.locking import FileLock
+from claude_swap.session import AUTH_OVERRIDE_ENV_VARS, SessionManager
+from claude_swap.usage_store import UsageEntry
+
+
+NOW = 1_800_000_000.0
+
+
+def _iso(seconds_from_now: float) -> str:
+    return datetime.fromtimestamp(NOW + seconds_from_now, timezone.utc).isoformat()
+
+
+def _account(
+    number: str,
+    usage: dict | None,
+    *,
+    age_s: float = 0.0,
+    last_error: str | None = None,
+    kind: str = "oauth",
+    switchable: bool = True,
+    disabled: bool = False,
+) -> AccountSnapshot:
+    return AccountSnapshot(
+        number=number,
+        email=f"user{number}@example.com",
+        org_name="",
+        org_uuid=f"org-{number}",
+        is_active=number == "1",
+        kind=kind,
+        switchable=switchable,
+        disabled=disabled,
+        usage=UsageEntry(
+            last_good=usage,
+            fetched_at=NOW - age_s,
+            age_s=age_s,
+            last_error=last_error,
+        ),
+    )
+
+
+class _FakeSwitcher:
+    def __init__(self, backup_dir: Path, accounts: list[AccountSnapshot]):
+        self.backup_dir = backup_dir
+        self._accounts = tuple(accounts)
+        self._logger = logging.getLogger("test-warmup")
+        self.snapshot_calls = 0
+
+    def accounts_snapshot(self, fetch=None):
+        self.snapshot_calls += 1
+        return AccountsSnapshot("1", self._accounts, NOW)
+
+
+class _FakeSessions:
+    def __init__(self, returncodes: dict[str, int] | None = None):
+        self.calls: list[tuple[str, list[str], float]] = []
+        self.returncodes = returncodes or {}
+
+    def run_prompt(
+        self, identifier, claude_args, *, timeout, expected_identity=None
+    ):
+        self.calls.append((identifier, claude_args, timeout))
+        return SimpleNamespace(
+            returncode=self.returncodes.get(identifier, 0),
+            stdout="OK\n",
+            stderr="simulated failure\n" if self.returncodes.get(identifier) else "",
+        )
+
+
+def _engine(
+    tmp_path,
+    accounts,
+    *,
+    sessions=None,
+    dry_run=False,
+    model="claude-haiku-4-5",
+):
+    from claude_swap.warmup import WarmupEngine
+
+    switcher = _FakeSwitcher(tmp_path, accounts)
+    sessions = sessions or _FakeSessions()
+    events = []
+    engine = WarmupEngine(
+        switcher,
+        emit=events.append,
+        session_manager=sessions,
+        dry_run=dry_run,
+        model=model,
+        clock=lambda: NOW,
+    )
+    return engine, switcher, sessions, events
+
+
+def test_tick_warms_cold_account_and_skips_live_window(tmp_path):
+    cold = _account("1", {"seven_day": {"pct": 12.0}})
+    live = _account(
+        "2",
+        {
+            "five_hour": {"pct": 1.0, "resets_at": _iso(4 * 3600)},
+            "seven_day": {"pct": 12.0},
+        },
+    )
+    engine, switcher, sessions, events = _engine(tmp_path, [cold, live])
+
+    summary = engine.tick()
+
+    assert summary.warmed == 1
+    assert summary.failed == 0
+    assert switcher.snapshot_calls == 1
+    assert [call[0] for call in sessions.calls] == ["1"]
+    args = sessions.calls[0][1]
+    assert args == [
+        "--print",
+        "--model",
+        "claude-haiku-4-5",
+        "--effort",
+        "low",
+        "--safe-mode",
+        "--tools",
+        "",
+        "--no-session-persistence",
+        "Reply only: OK",
+    ]
+    assert [event.kind for event in events] == ["warmed", "live"]
+    state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
+    assert state["accounts"]["1"]["email"] == "user1@example.com"
+    assert state["accounts"]["1"]["lastWarmAt"] == NOW
+
+
+def test_tick_forces_one_fresh_probe_for_stale_cold_account(tmp_path):
+    stale = _account("1", {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 2}}, age_s=600)
+    fresh = _account("1", {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 2}})
+
+    class RefreshingSwitcher(_FakeSwitcher):
+        def __init__(self):
+            super().__init__(tmp_path, [stale])
+            self.fetches = []
+
+        def accounts_snapshot(self, fetch=None):
+            self.fetches.append(fetch)
+            accounts = (stale,) if len(self.fetches) == 1 else (fresh,)
+            return AccountsSnapshot("1", accounts, NOW)
+
+    from claude_swap.warmup import WarmupEngine
+
+    switcher = RefreshingSwitcher()
+    sessions = _FakeSessions()
+    engine = WarmupEngine(
+        switcher,
+        emit=lambda _event: None,
+        session_manager=sessions,
+        clock=lambda: NOW,
+    )
+
+    summary = engine.tick()
+
+    assert switcher.fetches == [None, {"1"}]
+    assert summary.warmed == 1
+
+
+def test_tick_does_not_reprobe_stale_but_still_live_window(tmp_path):
+    live = _account(
+        "1",
+        {
+            "five_hour": {"pct": 1.0, "resets_at": _iso(3600)},
+            "seven_day": {"pct": 2},
+        },
+        age_s=600,
+    )
+    engine, switcher, sessions, events = _engine(tmp_path, [live])
+
+    engine.tick()
+
+    assert switcher.snapshot_calls == 1
+    assert sessions.calls == []
+    assert events[0].kind == "usage-unavailable"
+
+
+@pytest.mark.parametrize(
+    ("account", "reason"),
+    [
+        (_account("1", None), "usage-unavailable"),
+        (_account("1", {"seven_day": {"pct": 2}}, age_s=301), "usage-unavailable"),
+        (
+            _account("1", {"seven_day": {"pct": 2}}, last_error="http-429"),
+            "usage-unavailable",
+        ),
+        (_account("1", {"seven_day": {"pct": 100}}), "weekly-exhausted"),
+        (_account("1", {"seven_day": {"pct": 2}}, disabled=True), "disabled"),
+        (
+            _account("1", {"seven_day": {"pct": 2}}, kind="api_key"),
+            "not-oauth",
+        ),
+        (
+            _account("1", {"seven_day": {"pct": 2}}, switchable=False),
+            "unavailable",
+        ),
+    ],
+)
+def test_tick_fails_closed_for_ineligible_accounts(tmp_path, account, reason):
+    engine, _switcher, sessions, events = _engine(tmp_path, [account])
+
+    summary = engine.tick()
+
+    assert summary.warmed == 0
+    assert sessions.calls == []
+    assert events[0].kind == reason
+
+
+def test_tick_skips_exhausted_selected_model_window(tmp_path):
+    account = _account(
+        "1",
+        {
+            "seven_day": {"pct": 20},
+            "scoped": [{"name": "Haiku", "pct": 100}],
+        },
+    )
+    engine, _switcher, sessions, events = _engine(tmp_path, [account], model="haiku")
+
+    engine.tick()
+
+    assert sessions.calls == []
+    assert events[0].kind == "weekly-exhausted"
+
+
+def test_zero_percent_five_hour_without_reset_is_warmed(tmp_path):
+    account = _account(
+        "1", {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 1.0}}
+    )
+    engine, _switcher, sessions, events = _engine(tmp_path, [account])
+
+    summary = engine.tick()
+
+    assert summary.warmed == 1
+    assert [call[0] for call in sessions.calls] == ["1"]
+    assert events[0].kind == "warmed"
+
+
+def test_hollow_all_zero_usage_fails_closed(tmp_path):
+    account = _account(
+        "1",
+        {
+            "five_hour": {"pct": 0.0},
+            "seven_day": {"pct": 0.0},
+            "scoped": [{"name": "Haiku", "pct": 0.0}],
+        },
+    )
+    engine, _switcher, sessions, events = _engine(tmp_path, [account])
+
+    summary = engine.tick()
+
+    assert summary.warmed == 0
+    assert sessions.calls == []
+    assert events[0].kind == "usage-unavailable"
+
+
+def test_nonzero_five_hour_without_reset_fails_closed(tmp_path):
+    account = _account(
+        "1", {"five_hour": {"pct": 1.0}, "seven_day": {"pct": 1.0}}
+    )
+    engine, _switcher, sessions, events = _engine(tmp_path, [account])
+
+    engine.tick()
+
+    assert sessions.calls == []
+    assert events[0].kind == "usage-unavailable"
+
+
+def test_expired_five_hour_window_is_warmed(tmp_path):
+    account = _account(
+        "1",
+        {
+            "five_hour": {"pct": 3.0, "resets_at": _iso(-1)},
+            "seven_day": {"pct": 1.0},
+        },
+    )
+    engine, _switcher, sessions, _events = _engine(tmp_path, [account])
+
+    summary = engine.tick()
+
+    assert summary.warmed == 1
+    assert [call[0] for call in sessions.calls] == ["1"]
+
+
+def test_persisted_recent_warm_prevents_duplicate_spend(tmp_path):
+    (tmp_path / "warmup_state.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "accounts": {
+                    "1": {
+                        "email": "user1@example.com",
+                        "orgUuid": "org-1",
+                        "lastWarmAt": NOW - 60,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    account = _account("1", {"seven_day": {"pct": 1.0}})
+    engine, _switcher, sessions, events = _engine(tmp_path, [account])
+
+    engine.tick()
+
+    assert sessions.calls == []
+    assert events[0].kind == "recently-warmed"
+
+
+def test_state_is_bound_to_identity_not_reused_slot(tmp_path):
+    (tmp_path / "warmup_state.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "accounts": {
+                    "1": {
+                        "email": "old@example.com",
+                        "orgUuid": "old-org",
+                        "lastWarmAt": NOW - 60,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    account = _account("1", {"seven_day": {"pct": 1.0}})
+    engine, _switcher, sessions, _events = _engine(tmp_path, [account])
+
+    engine.tick()
+
+    assert [call[0] for call in sessions.calls] == ["1"]
+
+
+def test_dry_run_never_launches_or_writes_state(tmp_path):
+    account = _account("1", {"seven_day": {"pct": 1.0}})
+    engine, _switcher, sessions, events = _engine(tmp_path, [account], dry_run=True)
+
+    summary = engine.tick()
+
+    assert summary.would_warm == 1
+    assert sessions.calls == []
+    assert events[0].kind == "would-warm"
+    assert not (tmp_path / "warmup_state.json").exists()
+
+
+def test_failed_claude_request_is_not_recorded_as_warmed(tmp_path):
+    account = _account("1", {"seven_day": {"pct": 1.0}})
+    sessions = _FakeSessions({"1": 7})
+    engine, _switcher, _sessions, events = _engine(
+        tmp_path, [account], sessions=sessions
+    )
+
+    summary = engine.tick()
+
+    assert summary.failed == 1
+    assert events[0].kind == "failed"
+    assert events[0].detail == "Claude exited with code 7; retry protected"
+    state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
+    assert "lastWarmAt" not in state["accounts"]["1"]
+    assert state["accounts"]["1"]["pendingAt"] == NOW
+
+
+def test_ambiguous_timeout_keeps_duplicate_spend_guard(tmp_path):
+    account = _account("1", {"seven_day": {"pct": 1.0}})
+
+    class TimedOutSessions:
+        def run_prompt(self, *_args, **_kwargs):
+            raise PromptOutcomeUnknown("request outcome is unknown")
+
+    engine, _switcher, _sessions, events = _engine(
+        tmp_path, [account], sessions=TimedOutSessions()
+    )
+
+    summary = engine.tick()
+
+    assert summary.failed == 1
+    assert events[0].kind == "failed"
+    state = json.loads((tmp_path / "warmup_state.json").read_text(encoding="utf-8"))
+    assert state["accounts"]["1"]["pendingAt"] == NOW
+
+
+def _session_switcher(tmp_path: Path, *, active: bool):
+    switcher = MagicMock()
+    switcher.backup_dir = tmp_path
+    switcher.lock_file = tmp_path / ".lock"
+    switcher._logger = logging.getLogger("test-session-prompt")
+    switcher.resolve_account.return_value = ("2", "user2@example.com", "org-2")
+    switcher._account_kind.return_value = "oauth"
+    switcher._get_current_account.return_value = (
+        ("user2@example.com", "org-2") if active else ("other@example.com", "org-x")
+    )
+    return switcher
+
+
+def test_run_prompt_uses_default_profile_for_active_account_and_scrubs_overrides(
+    tmp_path, monkeypatch
+):
+    switcher = _session_switcher(tmp_path, active=True)
+    manager = SessionManager(switcher)
+    seen = {}
+    for name in AUTH_OVERRIDE_ENV_VARS:
+        monkeypatch.setenv(name, "must-not-leak")
+    provider_routes = {
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_USE_MANTLE",
+        "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+        "ANTHROPIC_BASE_URL",
+    }
+    for name in provider_routes:
+        monkeypatch.setenv(name, "1")
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+
+    def fake_run(argv, **kwargs):
+        seen.update(argv=argv, **kwargs)
+        return subprocess.CompletedProcess(argv, 0, "OK\n", "")
+
+    with patch("claude_swap.session.shutil.which", return_value="C:/bin/claude.exe"), patch(
+        "claude_swap.session.subprocess.run", side_effect=fake_run
+    ):
+        result = manager.run_prompt("2", ["--print", "hi"], timeout=30)
+
+    assert result.returncode == 0
+    assert seen["argv"] == ["C:/bin/claude.exe", "--print", "hi"]
+    assert seen["shell"] is False
+    assert seen["capture_output"] is True
+    assert seen["text"] is True
+    assert seen["timeout"] == 30
+    assert "CLAUDE_CONFIG_DIR" not in seen["env"]
+    assert "CLAUDE_SECURESTORAGE_CONFIG_DIR" not in seen["env"]
+    assert all(name not in seen["env"] for name in AUTH_OVERRIDE_ENV_VARS)
+    assert all(name not in seen["env"] for name in provider_routes)
+
+
+def test_run_prompt_holds_account_lock_while_child_runs(tmp_path, monkeypatch):
+    switcher = _session_switcher(tmp_path, active=True)
+    manager = SessionManager(switcher)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+
+    def fake_run(argv, **_kwargs):
+        peer = FileLock(switcher.lock_file, timeout=0)
+        assert peer.acquire() is False
+        return subprocess.CompletedProcess(argv, 0, "OK", "")
+
+    with patch("claude_swap.session.shutil.which", return_value="claude"), patch(
+        "claude_swap.session.subprocess.run", side_effect=fake_run
+    ):
+        manager.run_prompt("2", ["--print", "hi"], timeout=30)
+
+
+def test_run_prompt_rechecks_active_account_after_profile_setup(tmp_path, monkeypatch):
+    switcher = _session_switcher(tmp_path, active=False)
+    switcher._get_current_account.side_effect = [
+        ("other@example.com", "org-x"),
+        ("user2@example.com", "org-2"),
+    ]
+    manager = SessionManager(switcher)
+    profile = tmp_path / "sessions" / "2-user2"
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+    with patch.object(
+        manager, "setup_session", return_value=(profile, "2", "user2@example.com")
+    ), patch("claude_swap.session.shutil.which", return_value="claude"), patch(
+        "claude_swap.session.subprocess.run",
+        return_value=subprocess.CompletedProcess([], 0, "OK", ""),
+    ) as run:
+        manager.run_prompt(
+            "2",
+            ["--print", "hi"],
+            timeout=30,
+            expected_identity=("user2@example.com", "org-2"),
+        )
+
+    assert "CLAUDE_CONFIG_DIR" not in run.call_args.kwargs["env"]
+
+
+def test_run_prompt_rejects_changed_slot_identity(tmp_path, monkeypatch):
+    switcher = _session_switcher(tmp_path, active=True)
+    manager = SessionManager(switcher)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+
+    with patch("claude_swap.session.shutil.which", return_value="claude"):
+        with pytest.raises(SessionError, match="changed since the usage check"):
+            manager.run_prompt(
+                "2",
+                ["--print", "hi"],
+                timeout=30,
+                expected_identity=("someone-else@example.com", "org-else"),
+            )
+
+
+def test_run_prompt_uses_isolated_profile_for_inactive_account(tmp_path, monkeypatch):
+    switcher = _session_switcher(tmp_path, active=False)
+    manager = SessionManager(switcher)
+    profile = tmp_path / "sessions" / "2-user2"
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", raising=False)
+    with patch.object(
+        manager,
+        "setup_session",
+        return_value=(profile, "2", "user2@example.com"),
+    ) as setup, patch(
+        "claude_swap.session.shutil.which", return_value="claude"
+    ), patch(
+        "claude_swap.session.subprocess.run",
+        return_value=subprocess.CompletedProcess([], 0, "OK", ""),
+    ) as run:
+        manager.run_prompt("2", ["--print", "hi"], timeout=30)
+
+    # Slot numbers remain unambiguous when two organizations share an email.
+    setup.assert_called_once_with("2", share=False, share_history=False)
+    assert run.call_args.kwargs["env"]["CLAUDE_CONFIG_DIR"] == str(profile)
+
+
+def test_run_prompt_rejects_nested_config_profile(tmp_path, monkeypatch):
+    switcher = _session_switcher(tmp_path, active=True)
+    manager = SessionManager(switcher)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "already-isolated"))
+
+    with pytest.raises(Exception, match="outside a Claude session"):
+        manager.run_prompt("2", ["--print", "hi"], timeout=30)
+
+
+def test_main_dispatches_warmup_subcommand(monkeypatch):
+    called = []
+    monkeypatch.setattr("sys.argv", ["cswap", "warmup", "--once"])
+    with patch("claude_swap.cli._warmup_command", side_effect=called.append):
+        cli.main()
+    assert called == [["--once"]]
+
+
+def test_warmup_command_builds_one_shot_dry_run_engine(tmp_path):
+    from claude_swap.warmup import WarmupSummary
+
+    fake_switcher = SimpleNamespace(
+        backup_dir=tmp_path,
+        _logger=logging.getLogger("test-warmup-cli"),
+        _is_running_in_container=lambda: True,
+    )
+    fake_engine = MagicMock()
+    fake_engine.tick.return_value = WarmupSummary(would_warm=2)
+    with patch("claude_swap.cli.ClaudeAccountSwitcher", return_value=fake_switcher), patch(
+        "claude_swap.warmup.WarmupEngine", return_value=fake_engine
+    ) as engine_cls:
+        with pytest.raises(SystemExit) as exc:
+            cli._warmup_command(
+                [
+                    "--once",
+                    "--dry-run",
+                    "--interval",
+                    "900",
+                    "--timeout",
+                    "45",
+                ]
+            )
+
+    assert exc.value.code == 0
+    kwargs = engine_cls.call_args.kwargs
+    assert kwargs["dry_run"] is True
+    assert kwargs["interval_seconds"] == 900
+    assert kwargs["timeout_seconds"] == 45
+    assert kwargs["model"] == "claude-haiku-4-5"
+    fake_engine.tick.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--interval", "299"],
+        ["--interval", "nan"],
+        ["--interval", "inf"],
+        ["--timeout", "0"],
+    ],
+)
+def test_warmup_command_rejects_unsafe_values(argv, capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli._warmup_command(argv)
+    assert exc.value.code == 2
+
+
+def test_loop_exit_code_recovers_after_a_successful_tick(tmp_path):
+    from claude_swap.warmup import WarmupSummary
+
+    account = _account("1", {"seven_day": {"pct": 1.0}})
+    engine, _switcher, _sessions, _events = _engine(tmp_path, [account])
+    engine.tick = MagicMock(
+        side_effect=[WarmupSummary(failed=1), WarmupSummary(skipped=1)]
+    )
+    engine._stopped = MagicMock()
+    engine._stopped.is_set.return_value = False
+    engine._stopped.wait.side_effect = [False, True]
+
+    assert engine.run_loop() == 0


### PR DESCRIPTION
## Tracking

- Closes #263.
- Supersedes #273: this implements the same five-hour timer-starting goal while adding opt-in `cswap auto` and TUI integration, unknown-usage handling, identity isolation, duplicate-spend guards, and dry-run support.
- Related to #220, which documents that the usage endpoint can be unavailable under account load. This PR does not replace its proposed live-metrics fallback; it prevents unavailable usage from leaving a cold five-hour window unwarmed indefinitely.

## Summary

- Add an opt-in five-hour window warmer, available either as standalone `cswap warmup` or inside the existing `cswap auto` process through `autoswitch.warmupFiveHour`.
- Add a persisted TUI toggle on the Auto screen (`w`), with a spend warning that reflects whether Auto is dry-run or live.
- Warm only cold or unconfirmed OAuth accounts. A reliable live five-hour reset/usage signal still skips; known active weekly exhaustion, disabled/API-key/non-switchable accounts, and identity mismatches also skip.
- If usage remains missing, stale, errored, or hollow after a probe, make one guarded Haiku request instead of leaving the window cold indefinitely.
- Keep every prompt bound to the expected OAuth identity in an isolated account profile, without switching the global Claude login.
- In the Auto event feed, render already-live and other informational warm-up results in muted grey; render actual and dry-run warm actions with the existing orange accent, with successful sends labeled `(5h warm-up sent)`.

## Why both integration modes

The integrated mode lets the normal `cswap auto` process perform both jobs, including a ten-minute warm-up deadline even when the configured auto poll interval is longer. The standalone command remains useful for users who want warming without automatic switching.

Both modes use the same lock and persistent state. Users should run one mode, not both.

## Unknown-usage policy

The original revision failed closed when fresh successful usage was unavailable. In practice that can coincide with a fleet-wide reset and leave every five-hour window cold. The opt-in now treats unavailable usage as unconfirmed rather than permanently ineligible:

- A fresh positive percentage or a future reset proves the five-hour window is live.
- Stale data must have a future absolute reset; a stale percentage alone cannot suppress warming forever, including `trust_extended` rows.
- A known future account-wide or selected-model weekly reset at 100% still prevents a pointless request.
- Missing/errored/hollow data permits one request, protected by identity-bound persistent state for the full five-hour window.

## Safety details

- Successful, timed-out, nonzero-exit, crashed, and otherwise possibly accepted requests receive a full-window duplicate-spend guard. The pre-launch record conservatively covers the maximum timeout, then successful or ambiguous completions are timestamped at completion.
- State is keyed by the verified `(organization UUID, normalized email)` identity, migrates the previous slot-keyed schema, and continues to protect accounts after slot swaps.
- The account slot, stored identity, isolated profile, and launch identity are revalidated while holding cswap's account lock.
- The exact launch environment is preflighted with `claude --safe-mode auth status --json`; only the expected first-party Claude OAuth identity may proceed.
- API/provider override environment variables are scrubbed, and managed cloud-provider routing fails closed at the auth preflight.
- The warm-up uses fixed `claude-haiku-4-5`, low effort, safe mode, disabled tools, and no session persistence.
- Stopping or disabling the warmer prevents later accounts in an active sweep from launching, and rapid TUI toggles cannot overwrite a replacement scheduler deadline.
- `--dry-run` remains spend-free in standalone and integrated modes.

## Validation

- `uv run pytest -q -p no:cacheprovider` — 2,129 passed, 75 skipped
- Focused warmer/autoswitch/TUI tests after the event-style update — 411 passed
- Ruff on all changed source files and clean changed test lines — passed
- `python -m compileall -q src` — passed
- `git diff --check` — passed
- Graphify extraction, path, impact, and post-change queries confirm warm-up events reuse `event_text` and shared `Palette` roles
- Five independent correctness, compatibility, security, and test-quality review passes — no remaining blockers
