### PR TITLE
fix: carry the weekly reset slot forward when a 0% sample omits it

### DIFF
--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -52,6 +52,8 @@ def _window_to_json(entry: dict) -> dict:
     out: dict = {"pct": entry["pct"]}
     if "resets_at" in entry:
         out["resetsAt"] = entry["resets_at"]
+    if entry.get("resets_at_inferred"):
+        out["resetsAtInferred"] = True
     cell = oauth.fresh_reset_strings(entry)
     if cell:
         out["countdown"], out["clock"] = cell

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -33,6 +33,7 @@ import time
 import uuid
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from pathlib import Path
 
 from claude_swap.locking import FileLock
@@ -61,6 +62,8 @@ STALE_OK_S = 300.0  # trusted for switch decisions; older → headroom unknown
 # polling interval.
 CLAIM_TTL_S = 90.0  # in-flight claim window: skip just-claimed accounts
 LEGACY_CLAIM_TTL_S = 10.0  # additive-schema overlap with older collectors
+
+WEEK_S = 7 * 24 * 3600
 
 
 def _live_claim(
@@ -479,6 +482,32 @@ def _earliest_reset(last_good: dict | None, models: tuple[str, ...] = ()) -> flo
         if (ts := parse_reset_ts(resets_at)) is not None
     ]
     return min(resets) if resets else None
+
+
+def _carry_weekly_reset(new, previous, now: float) -> None:
+    """Anthropic's weekly window resets at a fixed per-account slot, but the
+    usage endpoint omits ``resets_at`` for some tokens while utilization is
+    0. A window measured before pins the slot: step the last reset forward
+    by whole weeks to the first instant after ``now``. Mutates ``new`` in
+    place; no-op unless both sides qualify. seven_day only — the 5-hour
+    window is rolling from first use, nothing to infer."""
+    if not isinstance(new, dict) or not isinstance(previous, dict):
+        return
+    d7 = new.get("seven_day")
+    if not isinstance(d7, dict) or d7.get("resets_at"):
+        return
+    prev_d7 = previous.get("seven_day")
+    if not isinstance(prev_d7, dict):
+        return
+    ts = parse_reset_ts(prev_d7.get("resets_at"))
+    if ts is None:
+        return
+    while ts <= now:
+        ts += WEEK_S
+    resets_at = datetime.fromtimestamp(ts, timezone.utc).isoformat()
+    d7["resets_at"] = resets_at
+    d7["resets_at_inferred"] = True
+    d7["countdown"], d7["clock"] = oauth.format_reset(resets_at)
 
 
 def _rate_limited_trust_ok(
@@ -1070,6 +1099,7 @@ class UsageStore:
                 return
             row["lastAttemptAt"] = now
             if rec.error is None:
+                _carry_weekly_reset(rec.usage, row.get("lastGood"), now)
                 row["lastGood"] = rec.usage
                 row["fetchedAt"] = now
                 # Replace the old, possibly due plan in the outcome transaction

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -2804,6 +2804,24 @@ class TestConsumeFirstStrategy:
         assert sw.trigger == "consume-first"
         assert sw.to_ref == {"number": 2, "email": "b@example.com"}
 
+    def test_carried_reset_on_a_zero_pct_account_still_ranks_soonest(self, temp_home):
+        # usage_store._carry_weekly_reset pins a carried-forward resets_at
+        # onto a 0%-utilization weekly window (Anthropic omits resets_at for
+        # some tokens while utilization is 0). Once carried it is an
+        # ordinary resets_at value by the time it reaches the ranking, so
+        # this only pins that consume-first picks the SOONEST reset even
+        # when that account reports 0% usage — not "reset unknown -> last".
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATER),   # active resets later
+            "2": _usage7(0, 0, _R_SOON),      # 0% but carried reset is soonest
+            "3": _usage7(10, 10, _R_LATEST),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "consume-first"
+
     def test_stays_when_active_already_resets_soonest(self, temp_home):
         h = self._harness(temp_home)
         outcome = h.tick_with_usage({

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -47,6 +47,24 @@ class TestJsonHelpers:
         assert out["spend"]["used"] == 12.5
         assert out["spend"]["resetsAt"] == resets_at
 
+    def test_usage_to_json_emits_resets_at_inferred_for_carried_reset(self):
+        # usage_store._carry_weekly_reset marks a carried-forward weekly
+        # reset with resets_at_inferred=True; the JSON projection must
+        # surface that so clients can distinguish it from a real reset.
+        resets_at = (datetime.now(timezone.utc) + timedelta(days=3)).isoformat()
+        usage = {
+            "seven_day": {"pct": 0.0, "resets_at": resets_at,
+                          "resets_at_inferred": True},
+        }
+        out = usage_to_json(usage)
+        assert out["sevenDay"]["resetsAtInferred"] is True
+
+    def test_usage_to_json_omits_resets_at_inferred_for_a_real_reset(self):
+        resets_at = (datetime.now(timezone.utc) + timedelta(days=3)).isoformat()
+        usage = {"seven_day": {"pct": 16.0, "resets_at": resets_at}}
+        out = usage_to_json(usage)
+        assert "resetsAtInferred" not in out["sevenDay"]
+
     def test_usage_to_json_projects_scoped_windows(self):
         resets_at = (datetime.now(timezone.utc) + timedelta(hours=3, seconds=30)).isoformat()
         countdown, clock = oauth.format_reset(resets_at)

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -1682,3 +1682,111 @@ class TestStruckFingerprintHygiene:
         )
         store.clear_dead_token(["1"], ident)
         assert store.entries(ident)["1"].struck_fingerprint is None
+
+
+class TestWeeklyResetCarry:
+    """The weekly (7-day) window resets at a fixed per-account slot, but the
+    usage endpoint omits ``resets_at`` for some tokens while utilization is 0
+    (live evidence: the same account, two tokens, one response carrying a
+    real ``resets_at`` and the other not). Losing the slot there would rank
+    the account "reset unknown -> last" for consume-first even though its
+    real reset is the soonest. ``_carry_weekly_reset`` pins the slot from a
+    previously-measured ``resets_at``, stepped forward by whole weeks to the
+    next future occurrence.
+    """
+
+    def _iso(self, ts: float) -> str:
+        from datetime import datetime, timezone
+
+        return datetime.fromtimestamp(ts, timezone.utc).isoformat()
+
+    def _ts(self, resets_at: str) -> float:
+        from claude_swap import poll_policy
+
+        return poll_policy.parse_reset_ts(resets_at)
+
+    def test_zero_pct_after_measured_reset_is_carried_forward(self):
+        now = 1_000_000.0
+        previous = {"seven_day": {"pct": 80.0, "resets_at": self._iso(now - 10.0)}}
+        new = {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 0.0}}
+        usage_store._carry_weekly_reset(new, previous, now)
+        d7 = new["seven_day"]
+        assert d7["resets_at_inferred"] is True
+        assert self._ts(d7["resets_at"]) == pytest.approx(now - 10.0 + usage_store.WEEK_S)
+        assert "countdown" in d7 and "clock" in d7
+
+    def test_real_resets_at_in_new_sample_is_untouched(self):
+        now = 1_000_000.0
+        previous = {"seven_day": {"pct": 80.0, "resets_at": self._iso(now - 10.0)}}
+        real_reset = self._iso(now + 500.0)
+        new = {"seven_day": {"pct": 5.0, "resets_at": real_reset}}
+        usage_store._carry_weekly_reset(new, previous, now)
+        assert new["seven_day"]["resets_at"] == real_reset
+        assert "resets_at_inferred" not in new["seven_day"]
+
+    def test_previous_reset_ten_days_old_steps_by_whole_weeks(self):
+        now = 1_000_000.0
+        ten_days_ago = now - 10 * 24 * 3600
+        previous = {"seven_day": {"pct": 80.0, "resets_at": self._iso(ten_days_ago)}}
+        new = {"seven_day": {"pct": 0.0}}
+        usage_store._carry_weekly_reset(new, previous, now)
+        # 10 days old steps by 2 whole weeks (+14d) landing 4 days in the
+        # future, not a single +7d step (which would still be in the past).
+        assert self._ts(new["seven_day"]["resets_at"]) == pytest.approx(
+            now + 4 * 24 * 3600
+        )
+
+    def test_no_previous_last_good_is_a_noop(self):
+        new = {"seven_day": {"pct": 0.0}}
+        usage_store._carry_weekly_reset(new, None, 1_000_000.0)
+        assert "resets_at" not in new["seven_day"]
+
+    def test_previous_without_resets_at_is_a_noop(self):
+        now = 1_000_000.0
+        previous = {"seven_day": {"pct": 50.0}}  # no resets_at
+        new = {"seven_day": {"pct": 0.0}}
+        usage_store._carry_weekly_reset(new, previous, now)
+        assert "resets_at" not in new["seven_day"]
+
+    def test_five_hour_is_never_touched(self):
+        now = 1_000_000.0
+        previous = {
+            "five_hour": {"pct": 50.0, "resets_at": self._iso(now - 5.0)},
+            "seven_day": {"pct": 80.0, "resets_at": self._iso(now - 10.0)},
+        }
+        new = {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 0.0}}
+        usage_store._carry_weekly_reset(new, previous, now)
+        assert new["five_hour"] == {"pct": 0.0}
+        assert "resets_at" in new["seven_day"]
+
+    def test_chaining_two_successive_zero_pct_samples_keep_the_slot(self):
+        now1 = 1_000_000.0
+        previous1 = {"seven_day": {"pct": 80.0, "resets_at": self._iso(now1 - 10.0)}}
+        new1 = {"seven_day": {"pct": 0.0}}
+        usage_store._carry_weekly_reset(new1, previous1, now1)
+        ts1 = self._ts(new1["seven_day"]["resets_at"])
+
+        now2 = ts1 + 1.0  # just past the first carried reset
+        new2 = {"seven_day": {"pct": 0.0}}
+        usage_store._carry_weekly_reset(new2, new1, now2)
+        assert new2["seven_day"]["resets_at_inferred"] is True
+        assert self._ts(new2["seven_day"]["resets_at"]) == pytest.approx(
+            ts1 + usage_store.WEEK_S
+        )
+
+    def test_record_carries_weekly_reset_on_zero_pct_sample(self, store, clock):
+        """Integration through ``UsageStore.record`` (not just the helper):
+        exercises the wiring at the ``lastGood`` transition point."""
+        measured = {
+            "five_hour": {"pct": 10.0},
+            "seven_day": {"pct": 80.0, "resets_at": self._iso(clock.now + 3600.0)},
+        }
+        store.record({"1": FetchRecord(usage=measured)}, IDENT)
+        clock.advance(3601.0)  # past that reset
+        zero = {"five_hour": {"pct": 0.0}, "seven_day": {"pct": 0.0}}
+        store.record({"1": FetchRecord(usage=zero)}, IDENT)
+        d7 = store.entries(IDENT)["1"].last_good["seven_day"]
+        assert d7["resets_at_inferred"] is True
+        assert self._ts(d7["resets_at"]) == pytest.approx(
+            clock.now + 3600.0 - 3601.0 + usage_store.WEEK_S
+        )


### PR DESCRIPTION
## Problem

Anthropic's weekly (7-day) usage window resets at a fixed per-account
slot (support.claude.com "How do usage and length limits work"), but
the usage endpoint omits `seven_day.resets_at` for some tokens while
utilization is 0.

Verified live (2026-09-03): the same account, queried through two
different tokens, returned two different shapes for the same window —
one token answered `{"utilization":0.0,"resets_at":"2026-09-04T01:00:00Z"}`,
the other came back with utilization 0 and no `resets_at` at all.
Observed on two real accounts.

`UsageStore` persists whatever it got, so when the response omits
`resets_at` the stored window becomes bare `{"pct": 0}`. Downstream,
`autoswitch._seven_day_reset_ts` returns `None` for that account, and
consume-first's ranking key (`autoswitch.py`, around line 2132)

```python
key = (reset_ts if reset_ts is not None else float("inf"), -h)
```

treats an unknown reset as "sorts last". The practical consequence: an
account with the **soonest** real reset and full headroom is never
picked by consume-first, while accounts that reset days later keep
getting consumed instead — purely because one particular token's
response happened to omit a field the account's own recent history
already answered.

## Fix

The fix lives in `usage_store.py`, not in `autoswitch.py`, so every
consumer benefits (ranking, `list --json`'s `resetsAt`, the human
list) without touching ranking logic at all.

`UsageStore.record()` now calls a new `_carry_weekly_reset(new_usage,
previous_lastGood, now)` right before committing the new measurement
to `lastGood`. It only acts when:

- the new sample's `seven_day` is a dict with no truthy `resets_at`
  (a real value from the API always wins, untouched), and
- the previous `lastGood.seven_day.resets_at` parses to a real
  timestamp.

When both hold, the previous reset is stepped forward by whole
`WEEK_S` (7×24×3600s) increments to the first instant after `now` —
Anthropic's reset slot is a fixed time-of-week, so a reset seen before
pins where the next one falls, it's just simple modular arithmetic
from there. The carried window is written with `resets_at_inferred:
True` and gets fresh `countdown`/`clock` via `oauth.format_reset`,
exactly as `oauth.build_usage_result` does for a real measurement — so
it behaves identically everywhere downstream.

`json_output._window_to_json` now also emits `resetsAtInferred: true`
when the entry carries the flag, so JSON API consumers can tell a
carried reset from a directly-measured one. The human-facing list
renderer needed no changes — it already renders any entry with
`countdown`/`clock` the same way, and there is no existing
inferred-value marker convention in that surface to follow.

**Autoswitch ranking code is completely untouched.** The carried
`resets_at` simply becomes an ordinary value by the time
`_seven_day_reset_ts` reads it.

## Tests

`tests/test_usage_store.py` — new `TestWeeklyResetCarry`:
- 0% sample after a measured reset is carried forward, stepped to the
  first future occurrence, `resets_at_inferred` True, countdown/clock
  present
- a real `resets_at` in the new sample is left untouched, no inferred
  flag
- a previous reset 10 days old steps by whole weeks (+14d → +4 days in
  the future, not a single +7d step which would still be past)
- no previous `lastGood`, and previous `lastGood` without
  `resets_at`, are both no-ops
- `five_hour` is never touched
- chaining: two successive 0% samples keep the same pinned slot
- one integration test exercising the actual `UsageStore.record()`
  wiring, not just the helper

`tests/test_autoswitch.py` — new consume-first test: a 0%-utilization
account whose (carried) reset is soonest still ranks first over an
account with more headroom but a later reset.

`tests/test_json_output.py` — two new tests for `resetsAtInferred`
presence on a carried reset and absence on a real one.

Full suite: `uv run pytest -q` → 2139 passed, 3 skipped (pre-existing,
unrelated), 3 warnings (pre-existing, unrelated).