### PR TITLE
feat(menubar): warn when the interpreter cannot draw the status item

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ On Linux/WSL, set `XDG_DATA_HOME` to override the default location.
 
 Needs the `menubar` extra (macOS only):
 
+> [!IMPORTANT]
+> Install it on **Python 3.13**. On Python 3.14 the menu bar starts, runs and logs nothing, but no status item is ever drawn ([#310](https://github.com/realiti4/claude-swap/issues/310)). `uv` picks the newest interpreter by default, so ask for 3.13 explicitly:
+>
+> ```bash
+> uv tool install --python 3.13 'claude-swap[menubar]'
+> ```
+
 ```bash
 uv tool install 'claude-swap[menubar]'   # or: pipx install 'claude-swap[menubar]'
 cswap menubar

--- a/README.md
+++ b/README.md
@@ -241,16 +241,8 @@ On Linux/WSL, set `XDG_DATA_HOME` to override the default location.
 
 Needs the `menubar` extra (macOS only):
 
-> [!IMPORTANT]
-> Install it against a **non-framework** interpreter. On macOS 26 a framework build of Python — which is what Homebrew and python.org ship — draws no menu bar icon at all: the process runs, logs nothing, and the menu bar stays empty ([#310](https://github.com/realiti4/claude-swap/issues/310)). uv-managed interpreters are not framework builds, so ask for one explicitly. Check with `python -c "import sys; print(repr(sys._framework))"` — an empty string is what you want.
-
 ```bash
-uv tool install --managed-python 'claude-swap[menubar]'   # or: pipx install --python <a non-framework python> 'claude-swap[menubar]'
-```
-
-The rest of the CLI is unaffected on any interpreter; this is about the status item only.
-
-```bash
+uv tool install 'claude-swap[menubar]'   # or: pipx install 'claude-swap[menubar]'
 cswap menubar
 ```
 

--- a/README.md
+++ b/README.md
@@ -242,14 +242,15 @@ On Linux/WSL, set `XDG_DATA_HOME` to override the default location.
 Needs the `menubar` extra (macOS only):
 
 > [!IMPORTANT]
-> Install it on **Python 3.13**. On Python 3.14 the menu bar starts, runs and logs nothing, but no status item is ever drawn ([#310](https://github.com/realiti4/claude-swap/issues/310)). `uv` picks the newest interpreter by default, so ask for 3.13 explicitly:
->
-> ```bash
-> uv tool install --python 3.13 'claude-swap[menubar]'
-> ```
+> Install it against a **non-framework** interpreter. On macOS 26 a framework build of Python — which is what Homebrew and python.org ship — draws no menu bar icon at all: the process runs, logs nothing, and the menu bar stays empty ([#310](https://github.com/realiti4/claude-swap/issues/310)). uv-managed interpreters are not framework builds, so ask for one explicitly. Check with `python -c "import sys; print(repr(sys._framework))"` — an empty string is what you want.
 
 ```bash
-uv tool install 'claude-swap[menubar]'   # or: pipx install 'claude-swap[menubar]'
+uv tool install --managed-python 'claude-swap[menubar]'   # or: pipx install --python <a non-framework python> 'claude-swap[menubar]'
+```
+
+The rest of the CLI is unaffected on any interpreter; this is about the status item only.
+
+```bash
 cswap menubar
 ```
 

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -926,6 +926,12 @@ def _menubar_service(args) -> int:
     from claude_swap import launch_agent
 
     if args.install_service:
+        # Installing a service for a menu bar that this interpreter cannot draw
+        # is the worst version of the bug: it survives reboots and shows
+        # nothing. Say so here too, not only when the menu bar is launched.
+        from claude_swap.menubar import python_support_warning
+
+        unsupported = python_support_warning()
         result = launch_agent.install()
         print(f"Menu bar service installed ({result['label']}).")
         print(f"  plist: {result['plist']}")
@@ -936,6 +942,8 @@ def _menubar_service(args) -> int:
                 "upgrade to point launchd at the new build."
             )
         )
+        if unsupported:
+            warning(unsupported)
         return 0
 
     if args.uninstall_service:

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -929,9 +929,9 @@ def _menubar_service(args) -> int:
         # Installing a service for a menu bar that this interpreter cannot draw
         # is the worst version of the bug: it survives reboots and shows
         # nothing. Say so here too, not only when the menu bar is launched.
-        from claude_swap.menubar import python_support_warning
+        from claude_swap.menubar import framework_build_warning
 
-        unsupported = python_support_warning()
+        unsupported = framework_build_warning()
         result = launch_agent.install()
         print(f"Menu bar service installed ({result['label']}).")
         print(f"  plist: {result['plist']}")
@@ -943,7 +943,12 @@ def _menubar_service(args) -> int:
             )
         )
         if unsupported:
-            warning(unsupported)
+            # The hint printed above is about upgrades. A reinstall does not
+            # restart the service that is already running, so say that here.
+            warning(
+                unsupported + "\n  Then run: cswap menubar --install-service",
+                file=sys.stderr,
+            )
         return 0
 
     if args.uninstall_service:

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from claude_swap import pace
 from claude_swap.exceptions import ClaudeSwitchError, CredentialReadError
+from claude_swap.printer import warning
 from claude_swap.switcher import SENTINEL_NOTES
 
 ICON = "⇄"
@@ -438,9 +439,40 @@ def _adapt_snapshot(snap) -> dict:
     }
 
 
+# Interpreters where rumps draws no status item. Measured on macOS 26.6.2 with
+# rumps 0.4.0: under Python 3.14 the app starts, the event loop runs, nothing is
+# logged and no icon appears; the same app on 3.13 draws it with pyobjc held
+# constant, so the interpreter is the variable. 3.15+ is included because it is
+# untested, not because it is known broken — the point is to stop claiming a
+# working menu bar on interpreters where nobody has seen one.
+STATUS_ITEM_UNTESTED_PYTHON = (3, 14)
+
+
+def python_support_warning(version_info=None) -> str | None:
+    """Text to show when this interpreter is not known to draw a status item.
+
+    Returns None on interpreters where the menu bar is known to work. Nothing
+    here can fix the incompatibility; the silence is what makes it expensive,
+    so the point is only to say it out loud instead of starting a process that
+    will look healthy and show nothing.
+    """
+    info = tuple((version_info or sys.version_info)[:2])
+    if info < STATUS_ITEM_UNTESTED_PYTHON:
+        return None
+    return (
+        f"Python {info[0]}.{info[1]} is not known to draw the menu bar icon "
+        "on macOS: the process runs and logs nothing, but no status item "
+        "appears. Reinstall on 3.13 to get it back:\n"
+        "  uv tool install --python 3.13 --force 'claude-swap[menubar]'"
+    )
+
+
 def run(switcher) -> int:
     """Entry point for ``cswap --menubar``. Blocks until the user quits."""
     ensure_notification_identity()
+    _warn = python_support_warning()
+    if _warn:
+        warning(_warn)
     try:
         import rumps  # lazy: optional dependency, imported only when launching
         import AppKit  # ships with rumps (pyobjc-framework-Cocoa), never fails alone

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -473,6 +473,10 @@ def run(switcher) -> int:
     _warn = python_support_warning()
     if _warn:
         warning(_warn)
+        # Under launchd stdout is a log file, not a tty, so this would sit in
+        # a block buffer for as long as the process lives — which for a menu
+        # bar is days. Flush it now or it never reaches the log at all.
+        sys.stdout.flush()
     try:
         import rumps  # lazy: optional dependency, imported only when launching
         import AppKit  # ships with rumps (pyobjc-framework-Cocoa), never fails alone

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -439,44 +439,71 @@ def _adapt_snapshot(snap) -> dict:
     }
 
 
-# Interpreters where rumps draws no status item. Measured on macOS 26.6.2 with
-# rumps 0.4.0: under Python 3.14 the app starts, the event loop runs, nothing is
-# logged and no icon appears; the same app on 3.13 draws it with pyobjc held
-# constant, so the interpreter is the variable. 3.15+ is included because it is
-# untested, not because it is known broken — the point is to stop claiming a
-# working menu bar on interpreters where nobody has seen one.
-STATUS_ITEM_UNTESTED_PYTHON = (3, 14)
+# macOS 26 stopped drawing status items for processes launched through an
+# exec trampoline, and a CPython *framework* build is exactly that: its
+# ``bin/python3.x`` is a stub that posix_spawns into ``Python.app``
+# (Mac/Tools/pythonw.c). Homebrew and python.org ship framework builds;
+# uv-managed and most other interpreters do not.
+#
+# Measured on macOS 26.6.2 with rumps 0.4.0, same bare rumps app throughout:
+#
+#   Homebrew 3.14.6   sys._framework 'Python'   no status item
+#   Homebrew 3.10.21  sys._framework 'Python'   no status item
+#   uv 3.14.7         sys._framework ''         status item drawn
+#   uv 3.13.15        sys._framework ''         status item drawn
+#
+# The interpreter version is not the variable; the build is.
 
 
-def python_support_warning(version_info=None) -> str | None:
-    """Text to show when this interpreter is not known to draw a status item.
+def framework_build_warning(framework=None, install_method=None) -> str | None:
+    """Text to show when this interpreter cannot draw a status item.
 
-    Returns None on interpreters where the menu bar is known to work. Nothing
-    here can fix the incompatibility; the silence is what makes it expensive,
-    so the point is only to say it out loud instead of starting a process that
-    will look healthy and show nothing.
+    Returns None on builds where the menu bar is known to work. Nothing here
+    can fix the incompatibility — the point is that it fails silently, with a
+    healthy process and empty logs, so it is worth one line up front.
     """
-    info = tuple((version_info or sys.version_info)[:2])
-    if info < STATUS_ITEM_UNTESTED_PYTHON:
+    fw = getattr(sys, "_framework", "") if framework is None else framework
+    if not fw:
         return None
+
+    if install_method is None:
+        from claude_swap.update_check import _detect_install_method
+
+        install_method = _detect_install_method()
+
+    if install_method == "uv":
+        remedy = (
+            "  uv tool install --managed-python --force 'claude-swap[menubar]'"
+        )
+    elif install_method == "pipx":
+        remedy = (
+            "  Reinstall against a non-framework interpreter, e.g. one from "
+            "`uv python install 3.13`:\n"
+            "  pipx install --force --python <that python> 'claude-swap[menubar]'"
+        )
+    else:
+        remedy = (
+            "  Reinstall against a non-framework interpreter "
+            "(uv-managed ones are; Homebrew and python.org are not)."
+        )
+
     return (
-        f"Python {info[0]}.{info[1]} is not known to draw the menu bar icon "
-        "on macOS: the process runs and logs nothing, but no status item "
-        "appears. Reinstall on 3.13 to get it back:\n"
-        "  uv tool install --python 3.13 --force 'claude-swap[menubar]'"
+        "This is a framework build of Python, which on macOS 26 does not draw "
+        "the menu bar icon: the process runs and logs nothing, but no status "
+        "item appears.\n" + remedy
     )
 
 
 def run(switcher) -> int:
     """Entry point for ``cswap --menubar``. Blocks until the user quits."""
     ensure_notification_identity()
-    _warn = python_support_warning()
+    _warn = framework_build_warning()
     if _warn:
-        warning(_warn)
-        # Under launchd stdout is a log file, not a tty, so this would sit in
-        # a block buffer for as long as the process lives — which for a menu
-        # bar is days. Flush it now or it never reaches the log at all.
-        sys.stdout.flush()
+        # stderr, not stdout: launchd sends stdout to the .log file where it
+        # would sit in a block buffer for the life of the process, and the
+        # install output points the user at the .err file anyway. stderr stays
+        # line-buffered even when redirected, so it lands immediately.
+        warning(_warn, file=sys.stderr)
     try:
         import rumps  # lazy: optional dependency, imported only when launching
         import AppKit  # ships with rumps (pyobjc-framework-Cocoa), never fails alone

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import platform
 import plistlib
 import re
 import sys
@@ -455,15 +456,36 @@ def _adapt_snapshot(snap) -> dict:
 # The interpreter version is not the variable; the build is.
 
 
-def framework_build_warning(framework=None, install_method=None) -> str | None:
+MIN_AFFECTED_MACOS = 26
+
+
+def _macos_major(mac_ver: str | None = None) -> int | None:
+    """Major version of the running macOS, or None if it cannot be read."""
+    raw = platform.mac_ver()[0] if mac_ver is None else mac_ver
+    head = raw.split(".")[0]
+    return int(head) if head.isdigit() else None
+
+
+def framework_build_warning(
+    framework=None, install_method=None, mac_ver: str | None = None
+) -> str | None:
     """Text to show when this interpreter cannot draw a status item.
 
-    Returns None on builds where the menu bar is known to work. Nothing here
-    can fix the incompatibility — the point is that it fails silently, with a
-    healthy process and empty logs, so it is worth one line up front.
+    Returns None wherever the menu bar is known to work. Both halves of the
+    condition matter: the evidence is a framework build *on macOS 26*, and
+    framework builds draw fine on earlier releases — gating on the build alone
+    would nag every Homebrew user on macOS 14 or 15, on every launch and in
+    the service log on every restart.
+
+    Nothing here can fix the incompatibility. The point is that it fails
+    silently, with a healthy process and empty logs, so it is worth one line.
     """
     fw = getattr(sys, "_framework", "") if framework is None else framework
     if not fw:
+        return None
+
+    major = _macos_major(mac_ver)
+    if major is None or major < MIN_AFFECTED_MACOS:
         return None
 
     if install_method is None:
@@ -488,9 +510,9 @@ def framework_build_warning(framework=None, install_method=None) -> str | None:
         )
 
     return (
-        "This is a framework build of Python, which on macOS 26 does not draw "
-        "the menu bar icon: the process runs and logs nothing, but no status "
-        "item appears.\n" + remedy
+        "This is a framework build of Python, which on macOS 26 has been "
+        "observed not to draw the menu bar icon: the process runs and logs "
+        "nothing, but no status item appears.\n" + remedy
     )
 
 

--- a/src/claude_swap/printer.py
+++ b/src/claude_swap/printer.py
@@ -173,9 +173,14 @@ def error(msg: str) -> None:
     print(_style(msg, _pal("red")), file=sys.stderr)
 
 
-def warning(msg: str) -> None:
-    """Print a warning message (yellow)."""
-    print(_style(msg, _pal("yellow")))
+def warning(msg: str, *, file=None) -> None:
+    """Print a warning message (yellow).
+
+    ``file`` routes it elsewhere than stdout — stderr for anything a
+    long-running process emits, since stderr stays line-buffered when it is
+    redirected to a file and stdout does not.
+    """
+    print(_style(msg, _pal("yellow")), file=file)
 
 
 # --- Display helpers for process detection ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -550,6 +550,36 @@ class TestCLI:
         assert seen["menubar_ran"] is False
         assert "installed" in capsys.readouterr().out
 
+    def test_install_service_warns_when_the_interpreter_draws_nothing(
+        self, monkeypatch, capsys
+    ):
+        # Installing a login service for a menu bar that cannot draw is the
+        # worst case: it survives reboots and shows nothing. See issue #310.
+        self._service_harness(monkeypatch, ["cswap", "menubar", "--install-service"])
+        monkeypatch.setattr(
+            "claude_swap.menubar.python_support_warning", lambda *a: "3.14 draws nothing"
+        )
+
+        with pytest.raises(SystemExit):
+            cli.main()
+
+        captured = capsys.readouterr()
+        assert "3.14 draws nothing" in (captured.out + captured.err)
+
+    def test_install_service_stays_quiet_on_a_supported_interpreter(
+        self, monkeypatch, capsys
+    ):
+        self._service_harness(monkeypatch, ["cswap", "menubar", "--install-service"])
+        monkeypatch.setattr(
+            "claude_swap.menubar.python_support_warning", lambda *a: None
+        )
+
+        with pytest.raises(SystemExit):
+            cli.main()
+
+        captured = capsys.readouterr()
+        assert "draws nothing" not in (captured.out + captured.err)
+
     def test_menubar_uninstall_service_routes_to_launch_agent(self, monkeypatch, capsys):
         seen = self._service_harness(monkeypatch, ["cswap", "menubar", "--uninstall-service"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -557,7 +557,7 @@ class TestCLI:
         # worst case: it survives reboots and shows nothing. See issue #310.
         self._service_harness(monkeypatch, ["cswap", "menubar", "--install-service"])
         monkeypatch.setattr(
-            "claude_swap.menubar.python_support_warning", lambda *a: "3.14 draws nothing"
+            "claude_swap.menubar.framework_build_warning", lambda *a: "3.14 draws nothing"
         )
 
         with pytest.raises(SystemExit):
@@ -571,7 +571,7 @@ class TestCLI:
     ):
         self._service_harness(monkeypatch, ["cswap", "menubar", "--install-service"])
         monkeypatch.setattr(
-            "claude_swap.menubar.python_support_warning", lambda *a: None
+            "claude_swap.menubar.framework_build_warning", lambda *a: None
         )
 
         with pytest.raises(SystemExit):

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -556,3 +556,32 @@ def test_run_without_rumps_raises_clean_error(monkeypatch):
     monkeypatch.setitem(sys.modules, "rumps", None)
     with pytest.raises(ClaudeSwitchError, match=r"claude-swap\[menubar\]"):
         menubar.run(switcher=None)
+
+
+class TestPythonSupportWarning:
+    """The menu bar draws nothing on Python 3.14; say so instead of pretending.
+
+    See issue #310. Nothing in this project can fix the incompatibility, so the
+    tests here are about the warning existing and being accurate, not about the
+    status item.
+    """
+
+    def test_no_warning_on_an_interpreter_that_works(self):
+        assert menubar.python_support_warning((3, 13, 15)) is None
+
+    def test_warns_on_314(self):
+        msg = menubar.python_support_warning((3, 14, 6))
+        assert msg is not None
+        assert "3.14" in msg
+
+    def test_warns_on_untested_newer_interpreters_too(self):
+        # Not known broken, but nobody has seen a status item there either.
+        assert menubar.python_support_warning((3, 15, 0)) is not None
+
+    def test_the_warning_carries_the_remedy_not_just_the_diagnosis(self):
+        msg = menubar.python_support_warning((3, 14, 0))
+        assert "--python 3.13" in msg
+
+    def test_older_interpreters_are_never_warned_about(self):
+        for minor in (10, 11, 12, 13):
+            assert menubar.python_support_warning((3, minor, 0)) is None

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -558,30 +558,42 @@ def test_run_without_rumps_raises_clean_error(monkeypatch):
         menubar.run(switcher=None)
 
 
-class TestPythonSupportWarning:
-    """The menu bar draws nothing on Python 3.14; say so instead of pretending.
+class TestFrameworkBuildWarning:
+    """The menu bar draws nothing from a framework build on macOS 26.
 
-    See issue #310. Nothing in this project can fix the incompatibility, so the
-    tests here are about the warning existing and being accurate, not about the
-    status item.
+    See #310. The interpreter *version* is not the variable — measured with the
+    same bare rumps app, Homebrew 3.14.6 and 3.10.21 (both framework) draw
+    nothing while uv-managed 3.14.7 and 3.13.15 (neither framework) draw.
+    Nothing here can fix that; these tests are about the warning, not the icon.
     """
 
-    def test_no_warning_on_an_interpreter_that_works(self):
-        assert menubar.python_support_warning((3, 13, 15)) is None
+    def test_silent_on_a_build_that_draws(self):
+        assert menubar.framework_build_warning("", "uv") is None
 
-    def test_warns_on_314(self):
-        msg = menubar.python_support_warning((3, 14, 6))
-        assert msg is not None
-        assert "3.14" in msg
+    def test_warns_on_a_framework_build(self):
+        assert menubar.framework_build_warning("Python", "uv") is not None
 
-    def test_warns_on_untested_newer_interpreters_too(self):
-        # Not known broken, but nobody has seen a status item there either.
-        assert menubar.python_support_warning((3, 15, 0)) is not None
+    def test_the_version_is_not_the_gate(self):
+        # A framework build warns whatever the version; a non-framework one
+        # never does. Keying on version_info was the original mistake here.
+        assert menubar.framework_build_warning("Python", None) is not None
+        assert menubar.framework_build_warning("", None) is None
 
-    def test_the_warning_carries_the_remedy_not_just_the_diagnosis(self):
-        msg = menubar.python_support_warning((3, 14, 0))
-        assert "--python 3.13" in msg
+    def test_uv_gets_a_uv_remedy(self):
+        msg = menubar.framework_build_warning("Python", "uv")
+        assert "--managed-python" in msg
 
-    def test_older_interpreters_are_never_warned_about(self):
-        for minor in (10, 11, 12, 13):
-            assert menubar.python_support_warning((3, minor, 0)) is None
+    def test_pipx_is_not_handed_a_uv_command(self):
+        # `uv tool install --force` would overwrite pipx's own executable.
+        msg = menubar.framework_build_warning("Python", "pipx")
+        assert "uv tool install" not in msg
+        assert "pipx install" in msg
+
+    def test_unknown_install_method_still_says_what_to_aim_for(self):
+        msg = menubar.framework_build_warning("Python", None)
+        assert "non-framework" in msg
+
+    def test_the_warning_names_the_silence(self):
+        # The symptom is that everything looks healthy, so say so.
+        msg = menubar.framework_build_warning("Python", "uv")
+        assert "logs nothing" in msg

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -568,32 +568,52 @@ class TestFrameworkBuildWarning:
     """
 
     def test_silent_on_a_build_that_draws(self):
-        assert menubar.framework_build_warning("", "uv") is None
+        assert menubar.framework_build_warning("", "uv", "26.6.2") is None
+
+    def test_silent_on_macos_where_framework_builds_still_draw(self):
+        # The evidence is a framework build *on macOS 26*. Warning on 14 or 15
+        # would nag every Homebrew user on every launch, and in the service log
+        # on every restart, about something that works there.
+        assert menubar.framework_build_warning("Python", "uv", "15.7") is None
+        assert menubar.framework_build_warning("Python", "uv", "14.2") is None
+
+    def test_warns_from_macos_26_onwards(self):
+        assert menubar.framework_build_warning("Python", "uv", "26.0") is not None
+        assert menubar.framework_build_warning("Python", "uv", "27.1") is not None
+
+    def test_unreadable_macos_version_stays_quiet(self):
+        assert menubar.framework_build_warning("Python", "uv", "") is None
+
+    def test_the_wording_does_not_overclaim(self):
+        # An observation on one machine that has also been seen to behave
+        # otherwise; "observed" is what the evidence supports.
+        msg = menubar.framework_build_warning("Python", "uv", "26.6.2")
+        assert "observed" in msg
 
     def test_warns_on_a_framework_build(self):
-        assert menubar.framework_build_warning("Python", "uv") is not None
+        assert menubar.framework_build_warning("Python", "uv", "26.6.2") is not None
 
     def test_the_version_is_not_the_gate(self):
         # A framework build warns whatever the version; a non-framework one
         # never does. Keying on version_info was the original mistake here.
-        assert menubar.framework_build_warning("Python", None) is not None
-        assert menubar.framework_build_warning("", None) is None
+        assert menubar.framework_build_warning("Python", None, "26.6.2") is not None
+        assert menubar.framework_build_warning("", None, "26.6.2") is None
 
     def test_uv_gets_a_uv_remedy(self):
-        msg = menubar.framework_build_warning("Python", "uv")
+        msg = menubar.framework_build_warning("Python", "uv", "26.6.2")
         assert "--managed-python" in msg
 
     def test_pipx_is_not_handed_a_uv_command(self):
         # `uv tool install --force` would overwrite pipx's own executable.
-        msg = menubar.framework_build_warning("Python", "pipx")
+        msg = menubar.framework_build_warning("Python", "pipx", "26.6.2")
         assert "uv tool install" not in msg
         assert "pipx install" in msg
 
     def test_unknown_install_method_still_says_what_to_aim_for(self):
-        msg = menubar.framework_build_warning("Python", None)
+        msg = menubar.framework_build_warning("Python", None, "26.6.2")
         assert "non-framework" in msg
 
     def test_the_warning_names_the_silence(self):
         # The symptom is that everything looks healthy, so say so.
-        msg = menubar.framework_build_warning("Python", "uv")
+        msg = menubar.framework_build_warning("Python", "uv", "26.6.2")
         assert "logs nothing" in msg


### PR DESCRIPTION
## Why

Closes #310.

On macOS 26 a **framework build** of CPython draws no menu bar status item. The process runs, the event loop is live, the logs stay empty, `--service-status` says `running`, and the menu bar is simply empty. The incompatibility is not this project's to fix — a bare `rumps.App("TEST").run()` reproduces it — but the silence is, because every signal says the app is healthy.

## The diagnosis in the first version of this branch was wrong

@realiti4 caught it on #310: my bisect held rumps, pyobjc and macOS constant but not the build type. The failing 3.14 was Homebrew (a framework build, `bin/python3.x` a stub that `posix_spawn`s into `Python.app`) and the working 3.13 was uv-managed (not one), so it moved two variables and blamed the version.

Filling in the missing cells, same bare rumps app throughout, macOS 26.6.2:

| interpreter | `sys._framework` | status item |
|---|---|---|
| Homebrew 3.14.6 | `'Python'` | not drawn |
| Homebrew 3.10.21 | `'Python'` | not drawn |
| uv-managed 3.14.7 | `''` | drawn |
| uv-managed 3.13.15 | `''` | drawn |

A framework build fails on 3.10 as readily as on 3.14, and 3.14 draws fine when it is not one. The build is the variable; the version is not.

## What this adds

`menubar.framework_build_warning()`, gated on `sys._framework`, emitted at the two points a user starts down that path: `cswap menubar`, and `cswap menubar --install-service` where the failure would otherwise survive reboots.

The remedy is install-method aware via `update_check._detect_install_method()` — handing a pipx user `uv tool install --force` would overwrite pipx's own executable. uv gets `--managed-python`, pipx gets a `pipx install --python` form, unknown gets the constraint stated plainly.

Plus the README note, with the pinned command as the primary one rather than a callout above an unpinned copyable line.

## Your four smaller points

1. **stderr.** Done — `printer.warning` takes an optional `file`, and both call sites pass `sys.stderr`. You were right that this also removes the need for the explicit flush I had added, since stderr stays line-buffered when redirected.
2. **Hard-coded `uv`.** Done, as above.
3. **"run `--install-service` again".** Done, appended in the service path only, since the hint above it is about upgrades.
4. **README.** Done.

## One thing I cannot explain

On 18 Aug this same machine drew the icon under Homebrew 3.14.6. That Cellar build was installed 17 Jun and has not changed since, and macOS 26.6.2 (25G83) was installed 13 Aug — so neither the interpreter nor the OS moved between it working and it not working two weeks later. Everything above reproduces reliably today, but "framework builds never draw on macOS 26" does not account for that observation, so there may be a third factor I have not found. Flagging it in case it argues for a softer wording than the unconditional one I have used.

## Validation

- `uv run pytest` — 2185 passed, 3 skipped, 0 failed.
- 7 tests on the gate: both directions, that version is not the gate, the uv and pipx remedies, and that pipx is never handed a uv command.
- Negative controls: the gate inverted (7 failures) and the pipx branch replaced with the uv command (1 failure), each observed failing for the right reason, then restored.
- The shipped remedy run for real on the machine from #310: `uv tool install --managed-python --force 'claude-swap[menubar]'` moved it to uv-managed 3.14.7 with `sys._framework == ''`, and the status item is drawn — the same 3.14 that showed nothing as a Homebrew build.
