### PR TITLE
auto: autoswitch.preferred — land on chosen accounts first when switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
+- To land on particular accounts first whenever a switch happens — your main account, the ones on the bigger plan — set `cswap config set autoswitch.preferred you@example.com,2` (emails and/or slot numbers, comma-separated; emails are the stable choice since `cswap reorder` moves slot numbers). A preferred account still has to qualify under the strategy's own rules (below the threshold, clear of the hysteresis margin), so the preference only orders the candidates that do — it never lands somewhere that re-triggers next tick. When every account is spent, soonest-reset still wins regardless.
 
 For cron/systemd timers, `--once` reports the outcome in its exit code (`0` switched, `1` error, `2` nothing to do, `3` blocked — no viable target), and `--json` emits one JSON event per line:
 
@@ -274,6 +275,7 @@ cswap config                              # list effective settings ("(default)"
 cswap config get autoswitch.threshold
 cswap config set autoswitch.threshold 80  # validated: rejects out-of-range values loudly
 cswap config set autoswitch.model Fable   # per-model switching (see "auto"); Fable,Opus for several
+cswap config set autoswitch.preferred you@example.com,2  # land on these first when switching (see "auto")
 cswap config unset autoswitch.threshold   # back to the default
 cswap config path                         # where settings.json lives
 ```

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -51,7 +51,12 @@ from claude_swap.poll_policy import (
     RESET_SLACK_S,
     binding_pct,
 )
-from claude_swap.settings import AutoSwitchSettings, atomic_write_json, parse_model_names
+from claude_swap.settings import (
+    AutoSwitchSettings,
+    atomic_write_json,
+    parse_model_names,
+    parse_preferred,
+)
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.usage_store import due_candidate, plan_oversleeps_interval
 
@@ -656,6 +661,9 @@ class AutoSwitchEngine:
         # pass everywhere usage windows are read — decisions, cadence, and
         # reset scheduling must all see the same axes.
         self._models = parse_model_names(settings.model)
+        # Accounts to land on first when a switch happens (emails and/or slot
+        # numbers, lowercased); resolved against the candidates per tick.
+        self._preferred = parse_preferred(settings.preferred)
         # Poll plans written by the collector must key on the same threshold/
         # models the engine decides with (CLI overrides included), not on
         # whatever the settings file happens to say.
@@ -1823,6 +1831,8 @@ class AutoSwitchEngine:
             else 0.0  # unread unless all_above; never a live sentinel
         )
 
+        preferred = self._preferred_numbers(oauth_candidates)
+
         qualifying: list[tuple[tuple, str]] = []
         fallback: list[tuple[tuple, str]] = []
         any_known = False
@@ -1944,11 +1954,33 @@ class AutoSwitchEngine:
                 key = (reset_ts if reset_ts is not None else float("inf"), -h)
             else:
                 key = (-h,)
+            # autoswitch.preferred: a listed account beats an unlisted one
+            # among the candidates that qualified above. The gates decide
+            # WHETHER a move is sound; the preference only picks which sound
+            # target to take, so it can never land somewhere that re-triggers.
+            # The recovery-tier keys are left alone on purpose: when every
+            # account is spent, soonest-back is the whole point, listed or not.
+            if preferred and not (
+                all_above and trigger in ("proactive", "consume-first")
+            ):
+                key = (0 if num in preferred else 1, *key)
             qualifying.append((key, num))
         # Ascending by the strategy's key; list order (sequence order) breaks ties.
         qualifying = qualifying or fallback
         qualifying.sort(key=lambda t: t[0])
         return [num for _, num in qualifying], any_known, active_reset_ts
+
+    def _preferred_numbers(self, candidates: list[str]) -> frozenset[str]:
+        """Candidates named by ``autoswitch.preferred``, by slot number or
+        email (case-insensitive). Names matching nothing are ignored."""
+        if not self._preferred:
+            return frozenset()
+        return frozenset(
+            n
+            for n in candidates
+            if n in self._preferred
+            or self.switcher.account_email(n).lower() in self._preferred
+        )
 
     # -- adaptive usage scheduling ---------------------------------------------
 

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -57,6 +57,12 @@ class AutoSwitchSettings:
     # 5h/7d windows still have headroom. None = account-wide 5h/7d only
     # (default).
     model: str | None = None
+    # Comma-separated account emails and/or slot numbers to land on first
+    # whenever a switch happens. A listed account beats an unlisted one only
+    # among the candidates that already qualify under the strategy's own
+    # gates (threshold, hysteresis, no-return); the strategy's key orders the
+    # rest. None = strategy order only (default).
+    preferred: str | None = None
 
 
 @dataclass(frozen=True)
@@ -136,6 +142,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
         ),
         SettingSpec(
+            "autoswitch", "preferred", "preferred", "string",
+            help="Land on these accounts first when switching (emails and/or slot numbers, comma-separated)",
+        ),
+        SettingSpec(
             "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
             help="Color theme; auto follows the terminal background",
         ),
@@ -165,6 +175,15 @@ def parse_model_names(value: str | None) -> tuple[str, ...]:
         if name and name.lower() not in seen:
             seen[name.lower()] = name
     return tuple(seen.values())
+
+
+def parse_preferred(value: str | None) -> frozenset[str]:
+    """Split ``autoswitch.preferred`` into trimmed, lowercased tokens — emails
+    or slot numbers. Emails are the stable identity (slot numbers move under
+    ``cswap reorder``) and match case-insensitively."""
+    if not value:
+        return frozenset()
+    return frozenset(t.strip().lower() for t in value.split(",") if t.strip())
 
 
 def _clamped(settings: AutoSwitchSettings) -> AutoSwitchSettings:

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -6894,3 +6894,74 @@ class TestFreshenRoutesThroughGate:
         assert gate_calls["args"][0] == "2"
         assert "called" not in direct, "freshen must not POST outside the gate"
 
+
+
+class TestPreferredAccounts:
+    """``autoswitch.preferred`` orders qualifying targets, never the gates."""
+
+    def _harness(self, temp_home: Path, **kw) -> EngineHarness:
+        h = EngineHarness(temp_home, **kw)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_preferred_beats_more_headroom_when_it_qualifies(self, temp_home):
+        h = self._harness(temp_home, preferred="C@Example.com")
+        outcome = h.tick_with_usage({
+            "1": _usage(95),   # over the threshold: must move
+            "2": _usage(10),   # most headroom
+            "3": _usage(40),   # preferred, qualifies -> wins
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+
+    def test_preferred_by_slot_number(self, temp_home):
+        h = self._harness(temp_home, preferred="3")
+        outcome = h.tick_with_usage({
+            "1": _usage(95), "2": _usage(10), "3": _usage(40),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+
+    def test_preferred_must_still_clear_the_gates(self, temp_home):
+        """A preferred account over the threshold is not landed on."""
+        h = self._harness(temp_home, preferred="c@example.com")
+        outcome = h.tick_with_usage({
+            "1": _usage(95), "2": _usage(10), "3": _usage(92),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_unknown_preferred_names_are_ignored(self, temp_home):
+        h = self._harness(temp_home, preferred="nobody@example.com,9")
+        outcome = h.tick_with_usage({
+            "1": _usage(95), "2": _usage(10), "3": _usage(40),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_preferred_orders_consume_first_targets_too(self, temp_home):
+        """Among sooner-resetting accounts, the preferred one wins even when
+        another resets sooner still; the strictly-sooner gate is untouched."""
+        h = self._harness(temp_home, strategy="consume-first", preferred="c@example.com")
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATEST),   # active resets last
+            "2": _usage7(10, 10, _R_SOON),     # soonest
+            "3": _usage7(10, 10, _R_LATER),    # preferred, still sooner than active
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+        assert next(e for e in h.events if isinstance(e, SwitchEvent)).trigger == "consume-first"
+
+    def test_preferred_does_not_override_all_spent_recovery_order(self, temp_home):
+        """Everything at/over the threshold: soonest-back still wins."""
+        h = self._harness(temp_home, preferred="c@example.com")
+        outcome = h.tick_with_usage({
+            "1": _usage(99, _iso_at(h.clock.now + 3600 * 2)),
+            "2": _usage(97, _iso_at(h.clock.now + 300)),     # soonest back
+            "3": _usage(95, _iso_at(h.clock.now + 3600)),    # preferred, later back
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,10 +48,11 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "autoswitch.preferred",
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,7 +79,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -20,6 +20,7 @@ from claude_swap.settings import (
     load_settings,
     load_ui_settings,
     merged_with_cli,
+    parse_preferred,
     save_settings,
     set_setting,
     settings_path,
@@ -201,6 +202,22 @@ class TestSetUnsetSetting:
         with pytest.raises(ConfigError, match="unset"):
             set_setting(tmp_path, "autoswitch.model", "   ")
         assert not settings_path(tmp_path).exists()
+
+    def test_set_preferred_round_trips(self, tmp_path: Path):
+        assert set_setting(tmp_path, "autoswitch.preferred", "A@x.io, 2") == "A@x.io, 2"
+        assert load_settings(tmp_path).preferred == "A@x.io, 2"
+        assert parse_preferred(load_settings(tmp_path).preferred) == {"a@x.io", "2"}
+
+    def test_parse_preferred_trims_lowercases_and_skips_blanks(self):
+        assert parse_preferred(" B@X.io ,,3, ") == {"b@x.io", "3"}
+        assert parse_preferred(None) == frozenset()
+        assert parse_preferred("") == frozenset()
+
+    def test_garbage_preferred_value_falls_back_to_none(self, tmp_path: Path):
+        settings_path(tmp_path).write_text(
+            json.dumps({"autoswitch": {"preferred": ["a@x.io"]}})
+        )
+        assert load_settings(tmp_path).preferred is None
 
     def test_garbage_model_value_falls_back_to_none(self, tmp_path: Path):
         settings_path(tmp_path).write_text(


### PR DESCRIPTION
## What

A new `autoswitch.preferred` setting: comma-separated account emails and/or slot numbers to land on first whenever `cswap auto` switches.

```
cswap config set autoswitch.preferred you@example.com,2
```

## How it ranks

In `_rank_candidates`, a listed account gets a leading tier in its sort key, so it beats an unlisted one **among the candidates that already qualified** under the strategy's own gates: the threshold landing gate, the hysteresis margin, the no-return bar, and consume-first's strictly-sooner reset. The gates decide *whether* a move is sound; the preference only picks *which* sound target to take, so it can never land on an account that re-triggers next tick.

Deliberately untouched:
- The all-spent recovery tier (`all_above` on proactive/consume-first): when every account is at or over the threshold, soonest-back still wins, listed or not.
- Nothing proactive: on `best`, a preferred account is chosen when a switch happens; the engine does not move back to it early. That could be a follow-up if wanted.

Emails match case-insensitively and are the stable identity (`cswap reorder` moves slot numbers); names that match nothing are ignored.

## Files

Same shape as #93: `settings.py` (field, spec, `parse_preferred`), `autoswitch.py` (tier + `_preferred_numbers`), README, tests in `test_autoswitch.py` (6: beats more headroom, by slot number, must still clear the gates, unknown names ignored, consume-first ordering, all-spent order unchanged), `test_settings.py`, `test_config_cli.py` (key count).

Full suite: 2185 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
