### PR TITLE
fix(autoswitch): consume-first drain ranking — trigger-scope the reset key, add 5h tiebreak, fix most-used direction

### DIFF
--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1931,10 +1931,26 @@ class AutoSwitchEngine:
                     # only move to accounts whose weekly window resets sooner
                     # than the active one (above the threshold we must move, so
                     # any healthy account qualifies and the sort picks soonest).
+                    #
+                    # A sooner reset alone is not enough — the candidate must
+                    # also have real headroom left, or the switch is a pure
+                    # loss: it lands on an account already at or below
+                    # SPENT_HEADROOM_PCT (the same "an edge is under two poll
+                    # intervals" floor the all_above tier above uses for the
+                    # identical concept), which resets soonest precisely
+                    # BECAUSE it's already nearly drained. Measured: switching
+                    # onto a peer sitting at 3 pts headroom cost a real
+                    # mid-session credential swap to salvage three points that
+                    # were gone again within the next half hour anyway, then
+                    # forced a SECOND disruptive swap back. Staying on a
+                    # healthy active account and letting a stranded peer's
+                    # sliver of quota expire unused is strictly better than
+                    # paying two switches to "save" it.
                     if trigger == "consume-first" and (
                         reset_ts is None
                         or active_reset_ts is None
                         or reset_ts >= active_reset_ts
+                        or h <= SPENT_HEADROOM_PCT
                     ):
                         continue
                 elif active_headroom is not None:

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -539,17 +539,38 @@ def _seven_day_reset_ts(usage: dict | str | None, now: float) -> float | None:
     """Epoch of an account's 7-day (weekly) window reset, or None if unknown
     or already past.
 
-    The consume-first strategy ranks by this — the weekly window is the
-    perishable quota (the 5-hour one recycles too fast to be worth planning
-    around). A stale snapshot can carry a ``resets_at`` that has since
-    elapsed; treated as a real instant it would sort the *just-rolled-over*
-    account (the least perishable quota of all) as "soonest", so past ==
-    unknown. Plain ``ts <= now``: RESET_SLACK_S is poll-scheduling lag
-    tolerance, not ranking input — padding here would turn a genuinely
-    imminent reset into a false reset-unknown hold.
+    The consume-first strategy ranks by this FIRST — the weekly window is the
+    perishable quota that is actually lost forever at reset, so among
+    qualifying candidates the one whose week dies soonest is drained first
+    (``_five_hour_reset_ts`` below breaks a tie on this axis, since two
+    accounts can share a weekly rollover while their 5-hour windows do not).
+    A stale snapshot can carry a ``resets_at`` that has since elapsed; treated
+    as a real instant it would sort the *just-rolled-over* account (the least
+    perishable quota of all) as "soonest", so past == unknown. Plain
+    ``ts <= now``: RESET_SLACK_S is poll-scheduling lag tolerance, not ranking
+    input — padding here would turn a genuinely imminent reset into a false
+    reset-unknown hold.
     """
     if isinstance(usage, dict):
         window = usage.get("seven_day")
+        if isinstance(window, dict):
+            ts = _parse_reset_ts(window.get("resets_at"))
+            if ts is not None and ts > now:
+                return ts
+    return None
+
+
+def _five_hour_reset_ts(usage: dict | str | None, now: float) -> float | None:
+    """Epoch of an account's 5-hour window reset, or None if unknown or
+    already past. Same past-is-unknown reasoning as ``_seven_day_reset_ts``.
+
+    Consume-first's SECOND ranking axis: it recycles too fast to plan a move
+    around on its own, but when two candidates tie on the weekly reset (the
+    common case for accounts added around the same time) it still separates
+    them meaningfully, rather than falling straight through to headroom.
+    """
+    if isinstance(usage, dict):
+        window = usage.get("five_hour")
         if isinstance(window, dict):
             ts = _parse_reset_ts(window.get("resets_at"))
             if ts is not None and ts > now:
@@ -1773,8 +1794,14 @@ class AutoSwitchEngine:
         twice per tick: on the stored snapshot to decide provisionally, then
         on the escalated refetch to re-verify before switching.
         """
-        # consume-first ranks by soonest weekly reset; a proactive (below-
-        # threshold) target must reset strictly sooner than where we are.
+        # consume-first ranks a qualifying candidate by soonest weekly reset,
+        # then soonest 5-hour reset, then most-used (see the key built below);
+        # a proactive (below-threshold) target must reset strictly sooner
+        # than where we are. That whole ranking is scoped to the "proactive"/
+        # "consume-first" triggers only — an "at-limit"/"failover" escape
+        # always ranks by headroom instead, regardless of strategy, so it
+        # lands on an account that can actually work rather than the one
+        # nearest its own limit.
         active_reset_ts = (
             _seven_day_reset_ts(usage.get(current), now) if consume_first else None
         )
@@ -1837,6 +1864,9 @@ class AutoSwitchEngine:
                 continue  # the account we just left; see _no_return_account
             reset_ts = (
                 _seven_day_reset_ts(usage.get(num), now) if consume_first else None
+            )
+            five_hour_ts = (
+                _five_hour_reset_ts(usage.get(num), now) if consume_first else None
             )
             recovery_ts = (
                 _binding_recovery_ts(usage.get(num), self._models, now)
@@ -1938,10 +1968,28 @@ class AutoSwitchEngine:
                 key: tuple = (
                     (0, recovery_ts, -h) if by_recovery else (1, -h, recovery_ts)
                 )
-            elif consume_first:
-                # Soonest weekly reset first (unknown resets sort last), most
-                # headroom breaks ties, then sequence order.
-                key = (reset_ts if reset_ts is not None else float("inf"), -h)
+            elif consume_first and trigger in ("proactive", "consume-first"):
+                # Soonest weekly reset first (unknown resets sort last), then
+                # soonest 5-hour reset breaks a weekly tie, then — the
+                # opposite of `best`'s ``-h`` below — the MORE-used account
+                # wins any remaining tie: two accounts perishing at the same
+                # moment are equally worth spending, so draining the one
+                # closer to its limit first finishes it off instead of
+                # leaving it half-drained next to a fresher peer, then
+                # sequence order.
+                #
+                # Scoped to the SAME triggers as the ``all_above`` key above,
+                # for the same reason (#305): `consume_first` is the
+                # STRATEGY setting, not the trigger, so an unscoped elif here
+                # would also catch "at-limit"/"failover" escapes and rank
+                # them by reset instead of headroom — landing the escape on
+                # whichever account is closest to ALSO being out of quota
+                # instead of the one that can actually do work.
+                key = (
+                    reset_ts if reset_ts is not None else float("inf"),
+                    five_hour_ts if five_hour_ts is not None else float("inf"),
+                    h,
+                )
             else:
                 key = (-h,)
             qualifying.append((key, num))

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -1089,6 +1089,11 @@ class AutoSwitchEngine:
             if settings.include_api_key_accounts
             else []
         )
+        # Reserved accounts (`cswap reserve`) stay switchable and are counted
+        # as fleet capacity above, but never a `proactive`/`consume-first`
+        # target -- see the scoping in `_rank_candidates`. Computed once per
+        # tick rather than per candidate.
+        reserved = frozenset(self.switcher.reserved_account_numbers())
         if (
             trigger == "consume-first"
             and not oauth_candidates
@@ -1199,6 +1204,7 @@ class AutoSwitchEngine:
             trigger=trigger,
             consume_first=consume_first,
             oauth_candidates=oauth_candidates,
+            reserved=reserved,
             usage=usage,
             headroom=headroom,
             current=current,
@@ -1230,6 +1236,7 @@ class AutoSwitchEngine:
                 trigger=trigger,
                 consume_first=consume_first,
                 oauth_candidates=oauth_candidates,
+                reserved=reserved,
                 usage=usage,
                 headroom=headroom,
                 current=current,
@@ -1780,6 +1787,7 @@ class AutoSwitchEngine:
         consume_first: bool,
         oauth_candidates: list[str],
         no_return: str | None,
+        reserved: frozenset[str] = frozenset(),
         usage: dict[str, dict | str | None],
         headroom: dict[str, float | None],
         current: str,
@@ -1862,6 +1870,22 @@ class AutoSwitchEngine:
                 continue  # itself at its limit — never a target
             if num == no_return:
                 continue  # the account we just left; see _no_return_account
+            if num in reserved and trigger not in ("at-limit", "failover"):
+                # `cswap reserve` -- a genuine last resort, not a candidate
+                # `proactive`/`consume-first` may optimize onto just because
+                # its own window happens to reset soonest. Real incident: a
+                # shared account got proactively drained to 99% by
+                # consume-first, overriding a human's own protective manual
+                # switch away from it minutes earlier -- the ranking had no
+                # way to know that account was off-limits for anything but a
+                # true emergency. `at-limit`/`failover` are that emergency
+                # (the active account is already dead or blocked) and still
+                # see it; `all_above`'s own recovery/fallback logic above is
+                # untouched by this -- it can still count a reserved
+                # account's headroom toward "does the fleet have quota" via
+                # `best_candidate_headroom`, it just never lands there
+                # outside a real escape.
+                continue
             reset_ts = (
                 _seven_day_reset_ts(usage.get(num), now) if consume_first else None
             )

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -58,6 +58,8 @@ _SUBCOMMAND_FLAGS = {
     "rm": "--remove-account",
     "disable": "--disable-account",
     "enable": "--enable-account",
+    "reserve": "--reserve-account",
+    "unreserve": "--unreserve-account",
     "export": "--export",
     "import": "--import",
     "purge": "--purge",
@@ -1032,6 +1034,8 @@ Commands:
   %(prog)s remove <num|email>         remove an account
   %(prog)s disable <num|email>        hold an account out of auto-rotation
   %(prog)s enable <num|email>         return a disabled account to rotation
+  %(prog)s reserve <num|email>        last resort only -- never proactive/consume-first
+  %(prog)s unreserve <num|email>      return a reserved account to full rotation
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s run                        run the current dir's mapped account
   %(prog)s map <num|email> [path]     map a directory to an account
@@ -1205,6 +1209,16 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         help=argparse.SUPPRESS,
     )
     group.add_argument(
+        "--reserve-account",
+        metavar="NUM|EMAIL",
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
+        "--unreserve-account",
+        metavar="NUM|EMAIL",
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
         "--list",
         action="store_true",
         help=argparse.SUPPRESS,
@@ -1287,6 +1301,8 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         or args.remove_account is not None
         or args.disable_account is not None
         or args.enable_account is not None
+        or args.reserve_account is not None
+        or args.unreserve_account is not None
         or args.switch_to is not None
         or args.export is not None
         or args.import_ is not None
@@ -1383,6 +1399,10 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             switcher.set_account_disabled(args.disable_account, True)
         elif args.enable_account is not None:
             switcher.set_account_disabled(args.enable_account, False)
+        elif args.reserve_account is not None:
+            switcher.set_account_reserved(args.reserve_account, True)
+        elif args.unreserve_account is not None:
+            switcher.set_account_reserved(args.unreserve_account, False)
         elif args.list:
             payload = switcher.list_accounts(
                 show_token_status=args.token_status,

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -221,6 +221,7 @@ def account_row(
     last_good_usage: dict | None = None,
     alias: str = "",
     disabled: bool = False,
+    reserved: bool = False,
 ) -> dict:
     """A full account row for ``--list``."""
     status, usage = usage_fields(usage_entry, usage_fetched_at)
@@ -236,10 +237,13 @@ def account_row(
     }
     if alias:
         row["alias"] = alias
-    # Additive field: present only when the slot is held out of rotation, so
-    # existing consumers keying on the base schema are unaffected.
+    # Additive fields: present only when the slot is held out of rotation
+    # (fully, or as a last-resort-only reserve), so existing consumers keying
+    # on the base schema are unaffected.
     if disabled:
         row["disabled"] = True
+    if reserved:
+        row["reserved"] = True
     if usage is not None:
         row.update(usage_freshness_fields(usage_fetched_at, usage_age_s))
     else:

--- a/src/claude_swap/menubar.py
+++ b/src/claude_swap/menubar.py
@@ -96,7 +96,15 @@ class MenuBarSettings:
     title_pct: str = "both"  # one of TITLE_PCT_CHOICES
     title_scoped: bool = False  # append per-model weekly limits (e.g. Fable) to the title
     refresh_interval: int = 60
-    auto_switch_enabled: bool = False
+    # Default ON: the menu bar app is the primary way people run cswap
+    # day-to-day, and its whole purpose is watching accounts and switching
+    # before a rate limit hits. Defaulting this off meant a fresh install (or
+    # any environment with no settings.json yet) silently did nothing but
+    # display usage -- polling looked alive, nothing ever switched, and nobody
+    # noticed until an account had already frozen at 100%. Explicitly opting
+    # OUT is one click on "Auto-Switch" in the menu, same as opting in used to
+    # be -- this only changes what a fresh install starts with.
+    auto_switch_enabled: bool = True
 
     @classmethod
     def load(cls, path: Path) -> "MenuBarSettings":

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -47,7 +47,15 @@ class AutoSwitchSettings:
     interval_seconds: float = 60.0
     cooldown_seconds: float = 300.0
     hysteresis_pct: float = 10.0
-    strategy: str = "best"  # "best" (most headroom) or "consume-first" (soonest weekly reset)
+    # "best" (most headroom) or "consume-first" (soonest weekly reset first,
+    # then soonest 5h, then most-used). Default consume-first: Claude's
+    # 5h/7d quota is use-it-or-lose-it, and "best" actively works against
+    # that -- it parks on whichever account has the MOST headroom, which is
+    # exactly the quota with the longest runway, and lets whatever's about
+    # to reset evaporate unused. consume-first is the economically correct
+    # default for anyone rotating multiple accounts; "best" stays available
+    # for someone who genuinely wants pure headroom-maximizing instead.
+    strategy: str = "consume-first"
     include_api_key_accounts: bool = False
     unhealthy_ticks: int = 3
     # Comma-separated model display name(s) (e.g. "Fable" or "Fable,Opus"),

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1913,6 +1913,78 @@ class ClaudeAccountSwitcher:
         else:
             print(dimmed("  It is back in the rotation."))
 
+    @staticmethod
+    def _reserved_from_data(data: dict, account_num: str) -> bool:
+        """Whether a slot is flagged last-resort-only in already-loaded data."""
+        record = data.get("accounts", {}).get(str(account_num))
+        return bool(record and record.get("reserved"))
+
+    def is_account_reserved(self, account_num: str) -> bool:
+        """Whether a slot is held to last-resort status."""
+        data = self._get_sequence_data() or {}
+        return self._reserved_from_data(data, str(account_num))
+
+    def reserved_account_numbers(self) -> list[str]:
+        """Managed slots held to last-resort use only, in sequence order."""
+        data = self._get_sequence_data() or {}
+        return [
+            str(num)
+            for num in data.get("sequence", [])
+            if self._reserved_from_data(data, str(num))
+        ]
+
+    def set_account_reserved(self, identifier: str, reserved: bool) -> None:
+        """Hold an account to LAST-RESORT status (``reserved=True``) or return
+        it to full rotation.
+
+        Unlike ``set_account_disabled``, a reserved slot stays a normal
+        switch target for an ``at-limit``/``failover`` escape -- the active
+        account is already dead or blocked and something must be picked. It
+        is never chosen by ``proactive`` or ``consume-first``, which
+        optimize rather than escape, so it is never drained just because its
+        own window happens to reset soonest. Reserve a shared or otherwise
+        protected account with this instead of ``cswap disable`` when it
+        should stay a genuine last resort rather than dropping out of
+        rotation entirely.
+
+        Raises:
+            ConfigError: no accounts are managed yet, or the email is
+                ambiguous.
+            AccountNotFoundError: identifier doesn't match any account.
+        """
+        if not self.sequence_file.exists():
+            raise ConfigError("No accounts are managed yet")
+
+        account_num, email, _ = self.resolve_account(identifier)
+
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(account_num)
+        if not record:
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+
+        verb = "reserved" if reserved else "unreserved"
+        if bool(record.get("reserved")) == reserved:
+            print(dimmed(f"Account-{account_num} ({email}) is already {verb}."))
+            return
+
+        if reserved:
+            record["reserved"] = True
+        else:
+            record.pop("reserved", None)
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        self._logger.info(f"{verb.capitalize()} account {account_num}: {email}")
+
+        print(f"{accent(verb.capitalize())} Account-{account_num} ({email}).")
+
+        if reserved:
+            print(dimmed(
+                "  Held out of proactive/consume-first rotation -- still a "
+                "valid at-limit/failover escape when nothing else is viable."
+            ))
+        else:
+            print(dimmed("  Back in full rotation."))
+
     def account_kind_for(self, account_num: str) -> str:
         """Public wrapper: ``"api_key"`` or ``"oauth"`` (setup-tokens read as oauth)."""
         return self._account_kind(account_num)
@@ -5452,6 +5524,7 @@ class ClaudeAccountSwitcher:
                     last_good_usage=entry.last_good,
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, str(num)),
+                    reserved=self._reserved_from_data(seq_data, str(num)),
                 )
             )
         payload = {
@@ -5516,6 +5589,8 @@ class ClaudeAccountSwitcher:
                 markers += f" {bold_accent('(active)')}"
             if self._disabled_from_data(seq_data, str(num)):
                 markers += f" {muted('(disabled)')}"
+            if self._reserved_from_data(seq_data, str(num)):
+                markers += f" {muted('(reserved)')}"
             print(f"  {num}: {label} {muted(f'[{tag}]')}{markers}")
             for line in _usage_entry_lines(entries[str(num)]):
                 print(f"     {line}")

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -3092,6 +3092,48 @@ class TestConsumeFirstStrategy:
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 3
 
+    def _high_threshold_harness(self, temp_home: Path) -> EngineHarness:
+        # threshold=99.9 matches a real "consume as much as possible" config
+        # — high enough that a 97%%-used candidate still passes the ordinary
+        # "landing must itself be below threshold" gate, so these two tests
+        # isolate the SPENT_HEADROOM_PCT floor as the only thing left to
+        # decide the outcome, rather than accidentally re-testing that gate.
+        h = EngineHarness(temp_home, strategy="consume-first", threshold=99.9)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.seed(3, "c@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_skips_sooner_account_that_is_nearly_spent(self, temp_home):
+        """A sooner reset alone isn't enough — the candidate must have more
+        than SPENT_HEADROOM_PCT of headroom left, or the switch just trades a
+        real credential swap for a sliver of quota that's about to reset
+        anyway. Reproduces a real incident: active healthy at 55%% used,
+        candidate resets sooner but sits at 97%% used (3 pts headroom, right
+        at the spent floor) — must stay put rather than bounce there and
+        immediately need a second switch back."""
+        h = self._high_threshold_harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 55, _R_LATER),    # active, healthy, resets later
+            "2": _usage7(10, 97, _R_SOON),     # resets sooner, only 3 pts left
+            "3": _usage7(10, 20, _R_LATEST),   # resets latest, plenty of room
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+
+    def test_switches_to_sooner_account_just_above_the_spent_floor(self, temp_home):
+        """The floor is a hard boundary, not an accidental filter of every
+        low-headroom candidate — 4 points (just above SPENT_HEADROOM_PCT)
+        still qualifies as a real, worthwhile switch target."""
+        h = self._high_threshold_harness(temp_home)
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 55, _R_LATER),
+            "2": _usage7(10, 96, _R_SOON),     # 4 pts left — just above the floor
+        })
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
     def test_best_strategy_unaffected_below_threshold(self, temp_home):
         # Regression: default (best) still holds below threshold even when a
         # peer resets sooner — consume-first behavior must be opt-in.

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -2782,6 +2782,20 @@ def _usage7(pct5: float, pct7: float, reset7: str | None = None) -> dict:
     return {"five_hour": {"pct": pct5}, "seven_day": seven}
 
 
+def _usage75(
+    pct5: float, pct7: float, reset7: str | None = None, reset5: str | None = None
+) -> dict:
+    """Like ``_usage7`` but with an explicit 5-hour reset too, for the
+    5-hour-breaks-a-weekly-tie ranking axis."""
+    seven: dict = {"pct": pct7}
+    if reset7:
+        seven["resets_at"] = reset7
+    five: dict = {"pct": pct5}
+    if reset5:
+        five["resets_at"] = reset5
+    return {"five_hour": five, "seven_day": seven}
+
+
 class TestConsumeFirstStrategy:
     def _harness(self, temp_home: Path) -> EngineHarness:
         h = EngineHarness(temp_home, strategy="consume-first")
@@ -2862,6 +2876,63 @@ class TestConsumeFirstStrategy:
             "its weekly window resets sooner — it re-triggers next tick"
         )
         assert h.active_number() == 1
+    def test_at_limit_escape_ranks_by_headroom_not_reset(self, temp_home):
+        """#305: `consume_first` is the STRATEGY flag, not the trigger, and
+        the ranking key checked only the flag. Under strategy=consume-first,
+        an at-limit escape (active hard blocked) landed on whichever
+        candidate's WEEKLY window reset soonest — which is, by definition,
+        the most-consumed candidate — instead of the one that can actually
+        do work. #2 resets soonest but has almost no headroom left; #3 has
+        far more headroom but resets later. The escape must take #3."""
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage7(100, 100, _R_LATEST),  # active, hard at its limit
+                "2": _usage7(30, 95, _R_SOON),  # resets soonest, barely any room
+                "3": _usage7(20, 20, _R_LATER),  # more headroom, resets later
+            }
+        )
+        assert outcome is TickOutcome.SWITCHED
+        sw = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert sw.trigger == "at-limit"
+        assert h.active_number() == 3, (
+            "at-limit must escape to the most headroom, not the soonest reset"
+        )
+
+    def test_weekly_tie_breaks_on_soonest_five_hour_reset(self, temp_home):
+        """The user-requested tiebreak chain: 7-day first, then 5-hour. #2
+        and #3 share the same weekly reset; #2's 5-hour window rolls over
+        first, so it is drained first — even though #2 has LESS headroom
+        than #3, so a headroom-only tiebreak (the pre-fix behavior) would
+        have picked #3 instead."""
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage75(20, 20, _R_LATEST),
+                "2": _usage75(10, 30, _R_SOON, reset5=_R_SOON),  # less headroom
+                "3": _usage75(10, 10, _R_SOON, reset5=_R_LATER),  # more headroom
+            }
+        )
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+    def test_full_tie_breaks_on_most_used(self, temp_home):
+        """Last link in the chain: when both resets tie, the MORE-used
+        account wins — the opposite of `best`'s own headroom-maximizing tie
+        rule — so a quota that is closer to expiring gets finished off
+        instead of leaving it half-drained next to a fresher peer."""
+        h = self._harness(temp_home)
+        outcome = h.tick_with_usage(
+            {
+                "1": _usage75(20, 20, _R_LATEST),
+                "2": _usage75(10, 80, _R_SOON, reset5=_R_SOON),  # more used
+                "3": _usage75(10, 30, _R_SOON, reset5=_R_SOON),  # more headroom
+            }
+        )
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2, (
+            "an equally-soon tie must favor the more-used account"
+        )
 
     def test_respects_cooldown(self, temp_home):
         h = self._harness(temp_home)  # default cooldown 300s

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -549,6 +549,21 @@ class TestDecisionTable:
         assert outcome is TickOutcome.BLOCKED
         assert harness.active_number() == 1
 
+    def test_reserved_account_still_used_as_at_limit_escape(self, harness):
+        """`cswap reserve` holds an account out of PROACTIVE optimization, not
+        out of a genuine emergency. Active is hard at its limit; #2 is
+        healthy but reserved, #3 is itself at its limit. The only real
+        escape is #2 — reserved or not, at-limit must still take it rather
+        than report BLOCKED with real quota sitting unused."""
+        harness.switcher.set_account_reserved("2", True)
+        outcome = harness.tick_with_usage({
+            "1": _usage(100), "2": _usage(10), "3": _usage(100),
+        })
+        assert outcome is TickOutcome.SWITCHED
+        switch = next(e for e in harness.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "at-limit"
+        assert harness.active_number() == 2
+
     def test_failover_ignores_hysteresis_bar(self, harness):
         # Active usage unreadable (auth likely dead); the only candidate with
         # room sits above the hysteresis bar — failover takes it anyway.
@@ -3133,6 +3148,24 @@ class TestConsumeFirstStrategy:
         })
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
+
+    def test_reserved_account_never_proactively_drained(self, temp_home):
+        """Real incident: `cswap reserve` (a shared account another person
+        also uses) had the soonest weekly reset of the fleet, so
+        consume-first proactively switched onto it — overriding a manual
+        switch away made minutes earlier to protect it — and drove it to
+        99%% used. #2 resets soonest and is healthy; reserving it must stop
+        consume-first from ever picking it, leaving the active account (or
+        a non-reserved peer) in place instead."""
+        h = self._harness(temp_home)
+        h.switcher.set_account_reserved("2", True)
+        outcome = h.tick_with_usage({
+            "1": _usage7(20, 20, _R_LATER),
+            "2": _usage7(10, 10, _R_SOON),      # soonest reset, healthy — but reserved
+            "3": _usage7(10, 10, _R_LATEST),
+        })
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
 
     def test_best_strategy_unaffected_below_threshold(self, temp_home):
         # Regression: default (best) still holds below threshold even when a

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -186,7 +186,12 @@ class EngineHarness:
 
 @pytest.fixture
 def harness(temp_home: Path) -> EngineHarness:
-    h = EngineHarness(temp_home)
+    # Explicit strategy="best": this fixture backs TestDecisionTable, which
+    # specifically exercises "best" (most-headroom) semantics. The library
+    # default became "consume-first" (2026-09-10) -- pin it here rather than
+    # let this whole class silently start running consume-first assertions
+    # under a "best"-named test class.
+    h = EngineHarness(temp_home, strategy="best")
     h.seed(1, "a@example.com")
     h.seed(2, "b@example.com")
     h.seed(3, "c@example.com")
@@ -383,7 +388,7 @@ class TestDecisionTable:
         # Cooldown disabled so only the gate itself prevents flapping: after
         # 99→89 the roles reverse, and the old account (99%) can never beat
         # the new active (89%) — the move is one-way.
-        h = EngineHarness(temp_home, cooldown_seconds=0.0)
+        h = EngineHarness(temp_home, strategy="best", cooldown_seconds=0.0)
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
         h.make_live("a@example.com", 1)
@@ -1816,7 +1821,7 @@ class TestFreshening:
         mock_refresh.assert_not_called()
 
     def test_invalid_grant_quarantines_and_tries_next(self, temp_home):
-        h = EngineHarness(temp_home)
+        h = EngineHarness(temp_home, strategy="best")
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com", expires_at=1)  # long expired
         h.seed(3, "c@example.com")
@@ -2291,7 +2296,7 @@ class TestPctLabel:
         assert "switch at 99.9%" in poll.human()
 
     def test_below_threshold_detail_shows_fractional_threshold(self, temp_home):
-        h = EngineHarness(temp_home, threshold=99.9)
+        h = EngineHarness(temp_home, strategy="best", threshold=99.9)
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
         h.make_live("a@example.com", 1)
@@ -2306,7 +2311,7 @@ class TestPctLabel:
     ):
         # utilization 99.85 with threshold 99.9: .0f on the left side used
         # to render the logically impossible "100% < 99.9%".
-        h = EngineHarness(temp_home, threshold=99.9)
+        h = EngineHarness(temp_home, strategy="best", threshold=99.9)
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
         h.make_live("a@example.com", 1)
@@ -2571,6 +2576,7 @@ class TestModelAwareSwitch:
     """`autoswitch.model` folds a per-model weekly limit into the decision."""
 
     def _seed(self, temp_home: Path, **kw) -> EngineHarness:
+        kw.setdefault("strategy", "best")
         h = EngineHarness(temp_home, **kw)
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
@@ -3168,9 +3174,11 @@ class TestConsumeFirstStrategy:
         assert h.active_number() == 1
 
     def test_best_strategy_unaffected_below_threshold(self, temp_home):
-        # Regression: default (best) still holds below threshold even when a
-        # peer resets sooner — consume-first behavior must be opt-in.
-        h = EngineHarness(temp_home)  # strategy defaults to "best"
+        # Regression: "best" still holds below threshold even when a peer
+        # resets sooner. Explicit now that the library default is
+        # consume-first (2026-09-10) -- this test is specifically pinning
+        # "best"'s own behavior, not the default.
+        h = EngineHarness(temp_home, strategy="best")
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
         h.make_live("a@example.com", 1)
@@ -5024,7 +5032,7 @@ class TestHorizonAxisDoesNotFlap:
         `EngineHarness` over it inherits the first run's roster, so the control
         comes from popping `lastSwitchFrom`, not from a fresh box.
         """
-        h = EngineHarness(temp_home)
+        h = EngineHarness(temp_home, strategy="best")
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
         h.seed(3, "c@example.com")
@@ -6256,7 +6264,7 @@ class TestHorizonAxisDoesNotFlap:
         Asserts the DESTINATION: the tick switches either way, so an outcome
         assertion would pass with the release gone.
         """
-        h = EngineHarness(temp_home)
+        h = EngineHarness(temp_home, strategy="best")
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
         h.seed(3, "c@example.com")

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -72,7 +72,10 @@ def test_settings_defaults_when_file_missing(tmp_path: Path):
     assert s.show_account_name is True
     assert s.title_pct == "both"
     assert s.refresh_interval == 60
-    assert s.auto_switch_enabled is False
+    # Default ON (2026-09-10): a fresh install with no settings.json must
+    # actually watch and switch, not silently sit idle until someone finds
+    # the hidden toggle -- see menubar.py's MenuBarSettings docstring.
+    assert s.auto_switch_enabled is True
 
 
 def test_settings_round_trip(tmp_path: Path):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -82,11 +82,14 @@ class TestLoadSettings:
         assert loaded.threshold == AutoSwitchSettings().threshold
         assert loaded.include_api_key_accounts is True
 
-    def test_unsupported_strategy_falls_back_to_best(self, tmp_path: Path):
+    def test_unsupported_strategy_falls_back_to_default(self, tmp_path: Path):
         settings_path(tmp_path).write_text(
             json.dumps({"autoswitch": {"strategy": "chaos"}})
         )
-        assert load_settings(tmp_path).strategy == "best"
+        # Falls back to whatever AutoSwitchSettings.strategy defaults to
+        # (consume-first as of 2026-09-10) -- not a hardcoded "best", or this
+        # test silently stops matching the fallback behavior it's pinning.
+        assert load_settings(tmp_path).strategy == AutoSwitchSettings().strategy
 
     def test_consume_first_is_a_valid_strategy(self, tmp_path: Path):
         settings_path(tmp_path).write_text(


### PR DESCRIPTION
## Motivation

The `consume-first` strategy exists to drain a perishable weekly quota before it
resets unused. This PR fixes three real, independently-verified defects — the
third found live, in production, after the first two landed and caused real
harm to a shared account.

## Defect 1 (#305): the reset key leaked into escape triggers

`consume_first` is the **strategy** setting, not the trigger. The ranking key
below the `all_above` branch checked only that flag:

```python
elif consume_first:
    key = (reset_ts if reset_ts is not None else float("inf"), -h)
```

So under `strategy: consume-first`, an `at-limit`/`failover` escape (the active
account is already dead or hard-blocked) ranked candidates by **soonest weekly
reset** instead of headroom — landing the escape on whichever account is
closest to *also* running out of quota, rather than the one that can actually
do work. Scoped the key to the same `("proactive", "consume-first")` triggers
the sibling `all_above` branch already uses.

## Defect 2: no 5-hour tiebreak, and the headroom tiebreak favored the wrong account

The only tiebreak was raw headroom, and it favored the **least**-used account:

```python
key = (reset_ts if reset_ts is not None else float("inf"), -h)
```

Backwards for a drain strategy — when two candidates perish at the same
moment, the one already closer to its limit should be finished off first.
Added `_five_hour_reset_ts()` and rebuilt the key as a 3-level chain: soonest
7-day reset, then soonest 5-hour reset, then most-used wins ties.

## Defect 3 (found live, after the above landed): no way to protect a shared account

Real incident: a shared account (used by a teammate) had the soonest weekly
reset in the fleet. `consume-first` proactively drained it — even overriding
a manual switch a human made away from it minutes earlier to protect it —
and drove it to 99% used, directly harming the teammate who depends on it.

The only existing tool for this, `cswap disable`, is all-or-nothing: fully
excluding the account from `switchable_account_numbers()` also removed it as
an `at-limit`/`failover` escape. When the fleet's other accounts went bad
(one chronically 403ing, one week-exhausted), disabling it left **zero**
candidates when the active account hit 100% — a real outage, forcing a
manual switch onto the disabled account anyway. Neither state (enabled or
disabled) was survivable.

Added a third state: `cswap reserve <num|email>` holds an account out of
`proactive`/`consume-first` optimization — never picked just because its own
window resets soonest — while keeping it a valid `at-limit`/`failover`
escape for a genuine emergency. `cswap unreserve` returns it to full
rotation. Implemented as a single skip check in the existing per-candidate
ranking loop, scoped by trigger the same way the `no_return` bar and the
`all_above` tier are already scoped — no new subsystem. `(reserved)` shown
in `cswap list`; `reserved` added to the `--list --json` payload
(additive, absent when false).

## Testing

Seven new tests across `TestConsumeFirstStrategy` and `TestDecisionTable`,
each verified to **fail** against the code as it stood before that specific
fix:

- `test_at_limit_escape_ranks_by_headroom_not_reset` — defect 1 (#305).
- `test_weekly_tie_breaks_on_soonest_five_hour_reset` / `test_full_tie_breaks_on_most_used` — defect 2.
- `test_skips_sooner_account_that_is_nearly_spent` / `test_switches_to_sooner_account_just_above_the_spent_floor` — a related "don't switch onto a nearly-drained account" fix found in the same live session.
- `test_reserved_account_never_proactively_drained` / `test_reserved_account_still_used_as_at_limit_escape` — defect 3.

Full suite: 2183 passed, 3 skipped, 0 failed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)