### PR TITLE
Add --warm-on-reset: prime an account's 5h window right when it resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ cswap auto --model Fable       # also switch when the Fable weekly limit is hit
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
 cswap auto --strategy consume-first   # burn the soonest-resetting account first
+cswap auto --warm-on-reset            # touch an idle account right when its 5h window resets
 ```
 
 <details>
@@ -103,6 +104,7 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you either log in with it and re-run `cswap add --slot N`, or replace its stored credentials from a known-good export — a plain `cswap import backup.cswap` replaces dead-token slots on its own (`--force` is still required to replace other existing accounts; note a stale export can carry an already-superseded token). API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
 - To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
+- **`--warm-on-reset`** (or `cswap config set autoswitch.warmOnReset true`): Anthropic's usage API reports no `five_hour` window at all for an account that hasn't been used since its last one reset — the 5h clock doesn't start until a request actually lands. Left alone, an idle account's fresh window starts at whatever moment `best`/`consume-first` eventually rotates onto it, which is fine for that account but means your fleet's 5h windows drift out of any predictable schedule. With this on, the moment cswap notices a non-active account's window has reset, it switches to it once — so the next message you send lands there and starts its clock right away — then hands back to your configured strategy as soon as that's confirmed (or after a bounded wait, if nothing was sent). Off by default: it costs one proactive switch per idle account per 5h cycle, worthwhile mainly if you keep a live session busy enough to pick the touch up immediately.
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
 
@@ -230,7 +232,7 @@ The original flag spellings (`cswap --switch`, `cswap --list`, ...) keep working
 | macOS | macOS Keychain | `~/.claude-swap-backup/` |
 | Linux / WSL | File-based (inside the backup directory, under `credentials/`) | `${XDG_DATA_HOME:-~/.local/share}/claude-swap/` |
 
-Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`. Tool preferences (`settings.json`) and auto-switch state (`autoswitch_state.json` — cooldown and quarantined accounts; delete it to reset) live in the backup directory root.
+Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`. Tool preferences (`settings.json`) and auto-switch state (`autoswitch_state.json` — cooldown, quarantined accounts, and `--warm-on-reset` bookkeeping; delete it to reset) live in the backup directory root.
 
 On Linux/WSL, set `XDG_DATA_HOME` to override the default location.
 
@@ -334,7 +336,7 @@ Weekly windows (`sevenDay` and per-model `scoped` entries — never `fiveHour`) 
 
 </details>
 
-`cswap auto --json` emits an event *stream* instead — one JSON object per line (`{"schemaVersion":1,"event":"switch","ts":…, …}` with kinds like `poll`, `switch`, `no-switch`, `account-quarantined`, `all-exhausted`, `error`). The contract is additive: new kinds and fields may appear, so scripts should ignore unknown ones.
+`cswap auto --json` emits an event *stream* instead — one JSON object per line (`{"schemaVersion":1,"event":"switch","ts":…, …}` with kinds like `poll`, `switch`, `no-switch`, `account-quarantined`, `all-exhausted`, `error`, and (with `--warm-on-reset`) `warm-hold-ended`). The contract is additive: new kinds and fields may appear, so scripts should ignore unknown ones.
 
 ### Add an account from a raw token or API key
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -104,8 +104,8 @@ NO_RESET_FALLBACK_S = 300.0
 IDLE_HOLD_MAX_S = 30 * 60.0
 
 # `warm_on_reset` hold cap: once the engine touches a freshly-reset account,
-# it waits for `five_hour` to reappear in that account's usage (proof a
-# request actually landed and the window is ticking) before handing control
+# it waits for `five_hour.resets_at` to reappear in that account's usage
+# (proof a request actually landed and the window is ticking) before handing control
 # back to `strategy`. Bounded because cswap cannot itself make Claude Code
 # send a message — an idle terminal would otherwise pin the engine off its
 # best account forever. Long enough for a live session's next turn to land
@@ -372,7 +372,7 @@ class PollEvent(AutoSwitchEvent):
 @dataclass(frozen=True)
 class SwitchEvent(AutoSwitchEvent):
     kind: ClassVar[str] = "switch"
-    trigger: str  # "proactive" | "at-limit" | "failover" | "consume-first" | "warm-reset"
+    trigger: str  # "proactive" | "at-limit" | "failover" | "consume-first" | "warm-reset" | "warm-return"
     from_ref: dict | None
     to_ref: dict | None
     warnings: list[str] = field(default_factory=list)
@@ -599,17 +599,22 @@ def _seven_day_reset_ts(usage: dict | str | None, now: float) -> float | None:
 
 
 def _five_hour_active(usage_value: dict | str | None) -> bool | None:
-    """Is this account's 5h window currently ticking (has accrued usage this
-    cycle)? ``None`` when unreadable this tick — never evidence of a reset.
+    """Is this account's 5h window currently ticking (has a live reset
+    timer)? ``None`` when unreadable this tick — never evidence of a reset.
 
-    ``oauth.build_usage_result`` omits the ``five_hour`` key entirely when
-    the API reports none — which it does until a request lands in the
-    current window — so the key's mere presence is the ground truth
+    ``oauth.build_usage_result`` keeps emitting a ``five_hour`` dict
+    (``pct`` only, no ``resets_at``) for an account that has just reset and
+    has not yet had a request land in the new window — so the key's mere
+    presence is NOT proof the window is ticking. ``resets_at`` (added once
+    the API starts reporting a real countdown) is the ground truth
     ``warm_on_reset`` watches for a transition on.
     """
     if not isinstance(usage_value, dict):
         return None
-    return isinstance(usage_value.get("five_hour"), dict)
+    fh = usage_value.get("five_hour")
+    if not isinstance(fh, dict):
+        return False
+    return "resets_at" in fh
 
 
 def _binding_recovery_ts(
@@ -2325,12 +2330,12 @@ class AutoSwitchEngine:
                 return None
             if _five_hour_active(usage.get(target)) is True:
                 self._end_warm_hold(warming, "started")
-                return None
+                return self._maybe_return_from_warm(warming, headroom, usage, quarantined, now)
             since = warming.get("since")
             elapsed = now - since if isinstance(since, (int, float)) else WARM_HOLD_MAX_S
             if elapsed >= WARM_HOLD_MAX_S:
                 self._end_warm_hold(warming, "timeout")
-                return None
+                return self._maybe_return_from_warm(warming, headroom, usage, quarantined, now)
             # Suppress the caller's own below-threshold strategy branch —
             # for `consume-first` that branch would otherwise proactively
             # move again (possibly right back off the account we just
@@ -2359,7 +2364,9 @@ class AutoSwitchEngine:
         if self.dry_run:
             outcome = self._perform(target, email, "warm-reset", left)
             if outcome is TickOutcome.SWITCHED:
-                self._dry_run_warming = {"number": target, "since": now}
+                self._dry_run_warming = {
+                    "number": target, "since": now, "returnTo": current
+                }
                 self._dry_run_five_hour_seen = {
                     **self._dry_run_five_hour_seen, target: False
                 }
@@ -2379,7 +2386,7 @@ class AutoSwitchEngine:
         outcome = self._perform(target, email, "warm-reset", left)
         if outcome is TickOutcome.SWITCHED:
             def commit(s: dict) -> None:
-                s["warming"] = {"number": target, "since": now}
+                s["warming"] = {"number": target, "since": now, "returnTo": current}
                 # Only NOW is the pending transition actually consumed — see
                 # the comment above `reset_candidates.append` for why it was
                 # deliberately left out of the earlier bookkeeping write.
@@ -2410,6 +2417,44 @@ class AutoSwitchEngine:
                 status=status,
             )
         )
+
+    def _maybe_return_from_warm(
+        self,
+        warming: dict,
+        headroom: dict[str, float | None],
+        usage: dict[str, dict | str | None],
+        quarantined: set[str],
+        now: float,
+    ) -> TickOutcome | None:
+        """A warm-reset hold just ended with the touch confirmed or given
+        up on — switch back to the account it borrowed the session from
+        (``warming["returnTo"]``), so priming an idle account never leaves
+        the fleet parked there. Returns ``None`` (fall through to the
+        caller's normal-strategy branch, which is a no-op change from
+        today's behavior) when there is nothing to return to or the
+        return account is not currently a safe landing spot — the target
+        just warmed is at least known-healthy, so staying put is fine.
+        """
+        return_to = warming.get("returnTo")
+        if return_to is None:
+            return None
+        return_to = str(return_to)
+        target = str(warming.get("number", ""))
+        if (
+            return_to == target
+            or return_to not in self.switcher.switchable_account_numbers()
+            or return_to in quarantined
+        ):
+            return None
+        util = headroom.get(return_to)
+        if util is None or (100.0 - util) >= self.settings.threshold:
+            return None  # no longer healthy — let normal strategy pick instead
+        email = self.switcher.account_email(return_to)
+        left = (
+            headroom.get(target),
+            _binding_recovery_ts(usage.get(target), self._models, now),
+        )
+        return self._perform(return_to, email, "warm-return", left)
 
     # -- helpers --------------------------------------------------------------
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -46,6 +46,7 @@ from claude_swap import oauth, poll_policy
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import SCHEMA_VERSION, USAGE_TOKEN_EXPIRED
 from claude_swap.locking import FileLock
+from claude_swap.paths import AUTOSWITCH_STATE_FILENAME
 from claude_swap.poll_policy import (
     ESCALATION_MARGIN_PCT,
     RESET_SLACK_S,
@@ -55,7 +56,11 @@ from claude_swap.settings import AutoSwitchSettings, atomic_write_json, parse_mo
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.usage_store import due_candidate, plan_oversleeps_interval
 
-STATE_FILENAME = "autoswitch_state.json"
+# Re-exported for callers that already spell it `autoswitch.STATE_FILENAME`;
+# `paths.AUTOSWITCH_STATE_FILENAME` is the source of truth so a reader
+# elsewhere in the package (e.g. `switcher.py`) can name it without an
+# `autoswitch` import, which would cycle (`autoswitch` imports `switcher`).
+STATE_FILENAME = AUTOSWITCH_STATE_FILENAME
 STATE_SCHEMA_VERSION = 1
 
 _logger = logging.getLogger("claude-swap")

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -103,6 +103,16 @@ NO_RESET_FALLBACK_S = 300.0
 # falls back to normal unhealthy counting.
 IDLE_HOLD_MAX_S = 30 * 60.0
 
+# `warm_on_reset` hold cap: once the engine touches a freshly-reset account,
+# it waits for `five_hour` to reappear in that account's usage (proof a
+# request actually landed and the window is ticking) before handing control
+# back to `strategy`. Bounded because cswap cannot itself make Claude Code
+# send a message — an idle terminal would otherwise pin the engine off its
+# best account forever. Long enough for a live session's next turn to land
+# under normal conversational pacing, short enough that giving up costs at
+# most one cycle of this constant before the configured strategy resumes.
+WARM_HOLD_MAX_S = 15 * 60.0
+
 # Anti-flap margin for the every-account-above-threshold escape, measured on
 # the axis that escape ranks by: a target must come back at least this much
 # sooner than the account we are leaving. Five minutes is comfortably longer
@@ -362,7 +372,7 @@ class PollEvent(AutoSwitchEvent):
 @dataclass(frozen=True)
 class SwitchEvent(AutoSwitchEvent):
     kind: ClassVar[str] = "switch"
-    trigger: str  # "proactive" | "at-limit" | "failover" | "consume-first"
+    trigger: str  # "proactive" | "at-limit" | "failover" | "consume-first" | "warm-reset"
     from_ref: dict | None
     to_ref: dict | None
     warnings: list[str] = field(default_factory=list)
@@ -433,6 +443,37 @@ class UnquarantineEvent(AutoSwitchEvent):
 
     def human(self) -> str:
         return f"Account-{self.number} ({self.email}) back in rotation ({self.reason})"
+
+
+@dataclass(frozen=True)
+class WarmResetHoldEndedEvent(AutoSwitchEvent):
+    """A `warm_on_reset` priming hold ended; control returns to `strategy`.
+
+    ``status``: ``"started"`` (the target's `five_hour` reappeared — the
+    touch worked), ``"timeout"`` (no confirmation within ``WARM_HOLD_MAX_S``
+    — nothing sent it a request), or ``"superseded"`` (something else moved
+    the active account off the target before either of those — a manual
+    switch, or another trigger).
+    """
+
+    kind: ClassVar[str] = "warm-hold-ended"
+    number: str
+    email: str
+    status: str
+
+    def _fields(self) -> dict:
+        return {"number": self.number, "email": self.email, "status": self.status}
+
+    def human(self) -> str:
+        verb = {
+            "started": "confirmed ticking",
+            "timeout": "no confirmation in time",
+            "superseded": "no longer the active account",
+        }.get(self.status, self.status)
+        return (
+            f"Account-{self.number} ({self.email}) warm-up ended ({verb}); "
+            "resuming normal auto-switch"
+        )
 
 
 @dataclass(frozen=True)
@@ -555,6 +596,20 @@ def _seven_day_reset_ts(usage: dict | str | None, now: float) -> float | None:
             if ts is not None and ts > now:
                 return ts
     return None
+
+
+def _five_hour_active(usage_value: dict | str | None) -> bool | None:
+    """Is this account's 5h window currently ticking (has accrued usage this
+    cycle)? ``None`` when unreadable this tick — never evidence of a reset.
+
+    ``oauth.build_usage_result`` omits the ``five_hour`` key entirely when
+    the API reports none — which it does until a request lands in the
+    current window — so the key's mere presence is the ground truth
+    ``warm_on_reset`` watches for a transition on.
+    """
+    if not isinstance(usage_value, dict):
+        return None
+    return isinstance(usage_value.get("five_hour"), dict)
 
 
 def _binding_recovery_ts(
@@ -684,6 +739,16 @@ class AutoSwitchEngine:
         # warned) on the first tick where every relevant account has readable
         # usage — adaptive polling legitimately leaves gaps before that.
         self._model_check_done = not self._models
+        # `warm_on_reset` bookkeeping mirrors `_unhealthy_ticks` above for
+        # dry-run: real ticks read/write it through the (locked, persisted)
+        # state file, but dry-run must never touch disk, so a `cswap auto
+        # --dry-run` LOOP still needs *some* place to remember the previous
+        # tick's `five_hour` presence and an in-flight hold across ticks of
+        # this one process. These two are that place, read/written only
+        # when `self.dry_run` is true; real runs use `state["fiveHourSeen"]`
+        # / `state["warming"]` exclusively (see `_maybe_warm_reset`).
+        self._dry_run_five_hour_seen: dict[str, bool] = {}
+        self._dry_run_warming: dict | None = None
 
     # -- state file ---------------------------------------------------------
 
@@ -978,6 +1043,12 @@ class AutoSwitchEngine:
             self._idle_hold_since = None
             utilization = 100.0 - active_headroom
             if utilization < settings.threshold:
+                if settings.warm_on_reset:
+                    warm_outcome = self._maybe_warm_reset(
+                        state, usage, headroom, current, quarantined
+                    )
+                    if warm_outcome is not None:
+                        return warm_outcome
                 if settings.strategy != "consume-first":
                     self._emit(
                         NoSwitchEvent(
@@ -2124,7 +2195,10 @@ class AutoSwitchEngine:
         # state lock.
         with self._state_lock():
             state = self._read_state()
-            if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+            if (
+                trigger in ("proactive", "consume-first", "warm-reset")
+                and self._in_cooldown(state)
+            ):
                 self._emit(NoSwitchEvent(reason="cooldown"))
                 return TickOutcome.NO_ACTION
 
@@ -2170,6 +2244,172 @@ class AutoSwitchEngine:
             )
         )
         return TickOutcome.SWITCHED
+
+    # -- warm-on-reset ----------------------------------------------------
+
+    def _maybe_warm_reset(
+        self,
+        state: dict,
+        usage: dict[str, dict | str | None],
+        headroom: dict[str, float | None],
+        current: str,
+        quarantined: set[str],
+    ) -> TickOutcome | None:
+        """``settings.warm_on_reset``: touch an account the moment its 5h
+        window resets, so its clock starts now rather than whenever
+        ``strategy`` would otherwise get around to it.
+
+        Called only while the active account is healthy (below threshold) —
+        an urgent trigger (at-limit/failover) must never be preempted by
+        this. Returns a :class:`TickOutcome` to make the caller return it
+        immediately (a warm switch happened, or a hold is in progress), or
+        ``None`` to fall through to the caller's own normal-strategy logic
+        unchanged (nothing to do, or a hold just ended and this same tick
+        should decide normally).
+
+        ``fiveHourSeen``/``warming`` live in the persisted state file for a
+        real run (so cron-driven ``cswap auto --once`` remembers across
+        processes, like the rest of this module's state), but dry-run must
+        never touch disk — it instead reads/writes the in-memory fallback
+        seeded in ``__init__``, which only ever survives for the life of
+        this one process (fine: a dry-run loop is a live preview, never a
+        cron invocation restarting cold).
+        """
+        now = self.clock()
+        oauth_candidates = [
+            n
+            for n in self.switcher.switchable_account_numbers()
+            if n != current
+            and n not in quarantined
+            and self.switcher.account_kind_for(n) != "api_key"
+        ]
+
+        seen_before = (
+            self._dry_run_five_hour_seen if self.dry_run else state.get("fiveHourSeen")
+        )
+        seen_before = dict(seen_before) if isinstance(seen_before, dict) else {}
+        seen_now = dict(seen_before)
+        reset_candidates: list[str] = []
+        for num in (*oauth_candidates, current):
+            active5h = _five_hour_active(usage.get(num))
+            if active5h is None:
+                continue  # unreadable this tick — not evidence either way
+            if seen_before.get(num) is True and active5h is False and num != current:
+                # A detected reset stays PENDING (baseline left at True) until
+                # it is actually acted on — committing it here regardless
+                # would drop the reset for good the moment cooldown or a
+                # freshen hiccup skips this tick: `prior is True` is what
+                # makes the transition visible at all, and once flipped to
+                # False here it can never re-arm on its own (5h resets are a
+                # one-way edge, not a level). Retried candidates the engine
+                # explicitly gave up on (quarantine) never reach this branch
+                # again anyway — they drop out of `oauth_candidates`.
+                reset_candidates.append(num)
+                continue
+            seen_now[num] = active5h
+        if seen_now != seen_before:
+            if self.dry_run:
+                self._dry_run_five_hour_seen = seen_now
+            else:
+                self._mutate_state(lambda s: s.__setitem__("fiveHourSeen", seen_now))
+
+        warming = self._dry_run_warming if self.dry_run else state.get("warming")
+        if isinstance(warming, dict) and warming.get("number") is not None:
+            target = str(warming["number"])
+            if target != current:
+                # Something else moved the active account off the target
+                # (a manual switch, or another engine instance) — the hold
+                # no longer applies to whatever is active now; let this
+                # tick's normal logic decide fresh.
+                self._end_warm_hold(warming, "superseded")
+                return None
+            if _five_hour_active(usage.get(target)) is True:
+                self._end_warm_hold(warming, "started")
+                return None
+            since = warming.get("since")
+            elapsed = now - since if isinstance(since, (int, float)) else WARM_HOLD_MAX_S
+            if elapsed >= WARM_HOLD_MAX_S:
+                self._end_warm_hold(warming, "timeout")
+                return None
+            # Suppress the caller's own below-threshold strategy branch —
+            # for `consume-first` that branch would otherwise proactively
+            # move again (possibly right back off the account we just
+            # touched) before it ever gets a chance to tick.
+            self._emit(
+                NoSwitchEvent(
+                    reason="warming",
+                    detail=(
+                        f"priming account {target}'s 5h window "
+                        f"({WARM_HOLD_MAX_S - elapsed:.0f}s left before "
+                        f"resuming '{self.settings.strategy}')"
+                    ),
+                )
+            )
+            return TickOutcome.NO_ACTION
+
+        if not reset_candidates or self._in_cooldown(state):
+            return None
+
+        target = reset_candidates[0]
+        email = self.switcher.account_email(target)
+        left = (
+            headroom.get(current),
+            _binding_recovery_ts(usage.get(current), self._models, now),
+        )
+        if self.dry_run:
+            outcome = self._perform(target, email, "warm-reset", left)
+            if outcome is TickOutcome.SWITCHED:
+                self._dry_run_warming = {"number": target, "since": now}
+                self._dry_run_five_hour_seen = {
+                    **self._dry_run_five_hour_seen, target: False
+                }
+            return outcome
+        status = self._freshen_target(target, email)
+        if status == "identity-conflict":
+            self._quarantine(target, email, "identity-conflict")
+            return None  # quarantined for next tick; active account is fine
+        if status == "invalid_grant":
+            self._quarantine(target, email, "invalid_grant")
+            return None
+        if status != "ok":
+            # transient / systemic / skip-live-session — leave it for the
+            # normal below-threshold path this tick, retry the warm touch
+            # next tick.
+            return None
+        outcome = self._perform(target, email, "warm-reset", left)
+        if outcome is TickOutcome.SWITCHED:
+            def commit(s: dict) -> None:
+                s["warming"] = {"number": target, "since": now}
+                # Only NOW is the pending transition actually consumed — see
+                # the comment above `reset_candidates.append` for why it was
+                # deliberately left out of the earlier bookkeeping write.
+                fh = s.get("fiveHourSeen")
+                fh = dict(fh) if isinstance(fh, dict) else {}
+                fh[target] = False
+                s["fiveHourSeen"] = fh
+
+            self._mutate_state(commit)
+        return outcome
+
+    def _end_warm_hold(self, warming: dict, status: str) -> None:
+        number = str(warming.get("number", ""))
+
+        def drop(s: dict) -> None:
+            w = s.get("warming")
+            if isinstance(w, dict) and str(w.get("number")) == number:
+                s.pop("warming", None)
+
+        if self.dry_run:
+            self._dry_run_warming = None
+        else:
+            self._mutate_state(drop)
+        self._emit(
+            WarmResetHoldEndedEvent(
+                number=number,
+                email=self.switcher.account_email(number) or "",
+                status=status,
+            )
+        )
 
     # -- helpers --------------------------------------------------------------
 
@@ -2282,6 +2522,16 @@ class AutoSwitchEngine:
         and each tick snapshots ``self.settings`` once, so no locking."""
         self.settings = replace(self.settings, threshold=threshold)
         self.switcher.set_poll_policy_inputs(threshold, self._models)
+
+    def apply_warm_on_reset(self, enabled: bool) -> None:
+        """Session override from the TUI, mirroring :meth:`apply_threshold`.
+
+        No poll-policy re-pin needed — unlike the threshold, this axis
+        doesn't feed the collector's cadence, only ``_tick_inner``'s own
+        below-threshold branch, which reads ``self.settings`` fresh every
+        tick.
+        """
+        self.settings = replace(self.settings, warm_on_reset=enabled)
 
     def _next_delay(self, outcome: TickOutcome) -> float:
         interval = self.settings.interval_seconds

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -608,6 +608,7 @@ Examples:
   cswap auto --json                # one JSON event per line (for scripts)
   cswap auto --once; echo $?       # single tick, outcome in exit code
   cswap auto --dry-run             # log decisions, never actually switch
+  cswap auto --warm-on-reset       # touch an idle account right when its 5h window resets
 
 Defaults live in settings.json in the backup root; flags override them.
         """,
@@ -670,6 +671,16 @@ Defaults live in settings.json in the backup root; flags override them.
             "Target selection: 'best' (most quota left; default) or "
             "'consume-first' (proactively use the account whose weekly window "
             "resets soonest)"
+        ),
+    )
+    parser.add_argument(
+        "--warm-on-reset",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Touch a non-active account once when its 5h window resets, so "
+            "its clock starts now instead of whenever it's next needed, "
+            "then resume the configured strategy (default: off)"
         ),
     )
     parser.add_argument(

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -159,6 +159,14 @@ class AccountsSnapshot:
     active_number: str | None
     accounts: tuple[AccountSnapshot, ...]
     taken_at: float
+    # `settings.warm_on_reset`'s in-flight priming hold, straight from
+    # `autoswitch_state.json`'s "warming" key (``{"number", "since",
+    # "returnTo"}``) if some `cswap auto` is mid-touch right now, else
+    # ``None``. Display-only: TUIs use ``number`` to tag that account
+    # "priming" alongside its (genuinely real) "active" badge, so a warm
+    # touch reads as a labeled automated event rather than an unexplained
+    # account change.
+    warming: dict | None = None
 
 
 @dataclass

--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -108,6 +108,14 @@ def get_backup_root() -> Path:
     return get_legacy_backup_root()
 
 
+# The auto-switch engine's cooldown/quarantine/warm-on-reset bookkeeping file,
+# under the backup root. Lives here (rather than in ``autoswitch.py``, its
+# only writer) so a *reader* elsewhere in the package — e.g. ``switcher.py``'s
+# display-only warm-on-reset lookup — can name it without importing
+# ``autoswitch``, which itself imports ``switcher`` and would cycle.
+AUTOSWITCH_STATE_FILENAME = "autoswitch_state.json"
+
+
 # Names that any prior cswap run may have created in the backup root without
 # user data being present (logger output, update-check + usage cache). The
 # migration treats a target containing only these as effectively empty, since

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -57,6 +57,14 @@ class AutoSwitchSettings:
     # 5h/7d windows still have headroom. None = account-wide 5h/7d only
     # (default).
     model: str | None = None
+    # When a non-active account's 5h window resets (its usage API stops
+    # reporting `five_hour` at all — Anthropic omits the key entirely until
+    # a request lands in the new window), touch it once so that window's
+    # clock starts now instead of whenever it is next needed, then resume
+    # `strategy` automatically. Off by default: it costs one proactive
+    # switch per idle account per 5h cycle, worthwhile only for a fleet kept
+    # busy enough that a live session can pick the touch up right away.
+    warm_on_reset: bool = False
 
 
 @dataclass(frozen=True)
@@ -134,6 +142,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         SettingSpec(
             "autoswitch", "model", "model", "string",
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
+        ),
+        SettingSpec(
+            "autoswitch", "warmOnReset", "warm_on_reset", "bool",
+            help="Touch an account once when its 5h window resets, then resume strategy",
         ),
         SettingSpec(
             "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
@@ -431,6 +443,7 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
         ("include_api_key_accounts", "include_api_key_accounts"),
         ("model", "model"),
         ("strategy", "strategy"),
+        ("warm_on_reset", "warm_on_reset"),
     ):
         value = getattr(args, attr, None)
         if value is not None:

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -57,13 +57,15 @@ class AutoSwitchSettings:
     # 5h/7d windows still have headroom. None = account-wide 5h/7d only
     # (default).
     model: str | None = None
-    # When a non-active account's 5h window resets (its usage API stops
-    # reporting `five_hour` at all — Anthropic omits the key entirely until
-    # a request lands in the new window), touch it once so that window's
-    # clock starts now instead of whenever it is next needed, then resume
-    # `strategy` automatically. Off by default: it costs one proactive
-    # switch per idle account per 5h cycle, worthwhile only for a fleet kept
-    # busy enough that a live session can pick the touch up right away.
+    # When a non-active account's 5h window resets (its usage API drops
+    # `resets_at` from `five_hour` until a request lands in the new
+    # window — the `pct` field alone stays present), touch it once so that
+    # window's clock starts now instead of whenever it is next needed, then
+    # switch back to whichever account it borrowed the session from, once
+    # the touch is confirmed (or given up on). Off by default: it costs one
+    # proactive switch per idle account per 5h cycle, worthwhile only for a
+    # fleet kept busy enough that a live session can pick the touch up
+    # right away.
     warm_on_reset: bool = False
 
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -75,6 +75,7 @@ from claude_swap.printer import (
     warning,
 )
 from claude_swap.paths import (
+    AUTOSWITCH_STATE_FILENAME,
     get_backup_root,
     get_credentials_path,
     get_default_claude_config_home,
@@ -1780,13 +1781,14 @@ class ClaudeAccountSwitcher:
         including no engine ever having run — is silently "nothing to
         show", never an error.
 
-        Duplicates ``autoswitch.STATE_FILENAME``'s value rather than
-        importing it: ``autoswitch`` imports this module for the
-        ``ClaudeAccountSwitcher`` type, so the reverse import would cycle.
+        ``AUTOSWITCH_STATE_FILENAME`` (also `autoswitch.STATE_FILENAME`)
+        lives in ``paths.py``, not ``autoswitch`` itself: ``autoswitch``
+        imports this module for the ``ClaudeAccountSwitcher`` type, so the
+        reverse import would cycle.
         """
         try:
             raw = json.loads(
-                (self.backup_dir / "autoswitch_state.json").read_text(encoding="utf-8")
+                (self.backup_dir / AUTOSWITCH_STATE_FILENAME).read_text(encoding="utf-8")
             )
         except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             return None

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1770,7 +1770,30 @@ class ClaudeAccountSwitcher:
             active_number=active_number,
             accounts=tuple(accounts),
             taken_at=self._usage_store.clock(),
+            warming=self._read_warming_state(),
         )
+
+    def _read_warming_state(self) -> dict | None:
+        """Best-effort read of `autoswitch_state.json`'s "warming" key (a
+        `settings.warm_on_reset` priming hold some `cswap auto` may be
+        mid-touch on right now). Display-only, so any read failure —
+        including no engine ever having run — is silently "nothing to
+        show", never an error.
+
+        Duplicates ``autoswitch.STATE_FILENAME``'s value rather than
+        importing it: ``autoswitch`` imports this module for the
+        ``ClaudeAccountSwitcher`` type, so the reverse import would cycle.
+        """
+        try:
+            raw = json.loads(
+                (self.backup_dir / "autoswitch_state.json").read_text(encoding="utf-8")
+            )
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if not isinstance(raw, dict):
+            return None
+        warming = raw.get("warming")
+        return warming if isinstance(warming, dict) else None
 
     def usage_fetch_stamps(self) -> dict[str, float | None]:
         """Per-slot ``fetchedAt`` snapshot from the usage store — a pure file

--- a/src/claude_swap/tui/autoview.py
+++ b/src/claude_swap/tui/autoview.py
@@ -46,7 +46,9 @@ _EVENT_ROLES = {
     "account-quarantined": "sev_warn",
     "all-exhausted": "sev_crit",
 }
-_QUIET_KINDS = {"poll", "no-switch", "sleep", "account-unquarantined"}
+_QUIET_KINDS = {
+    "poll", "no-switch", "sleep", "account-unquarantined", "warm-hold-ended",
+}
 
 
 def event_text(event: AutoSwitchEvent, *, palette: Palette = Palette.DARK) -> Text:
@@ -69,6 +71,7 @@ class AutoScreen(Screen):
         Binding("left", "threshold_step(-1)", "-1%"),
         Binding("right", "threshold_step(1)", "+1%"),
         Binding("enter", "adjust_done", "Done"),
+        Binding("w", "toggle_warm_on_reset", "Warm-on-reset"),
         Binding("escape,q", "back", "Back"),
     ]
 
@@ -86,6 +89,10 @@ class AutoScreen(Screen):
         self._adjusting = False
         self._configured_threshold: float | None = None
         self._entry_threshold: float | None = None
+        # Mount-time file value, so the summary can flag a session-only
+        # toggle the same way it flags a session-only threshold — neither
+        # is ever written to settings.json from here.
+        self._configured_warm_on_reset: bool | None = None
 
     def compose(self) -> ComposeResult:
         yield AccountsPanel(show_minis=False, id="auto-active-panel")
@@ -107,6 +114,7 @@ class AutoScreen(Screen):
         # and remember that value: unmount restores it (only the session
         # adjustment reverts, not this correction).
         self._configured_threshold = self._settings.threshold
+        self._configured_warm_on_reset = self._settings.warm_on_reset
         self.app.threshold_pct = self._settings.threshold
         self._update_summary()
         self.watch(self.app, "snapshot", self._on_snapshot)
@@ -189,6 +197,26 @@ class AutoScreen(Screen):
         self.query_one("#auto-active-panel", AccountsPanel).refresh()
         self._update_summary()
 
+    def action_toggle_warm_on_reset(self) -> None:
+        """Session-only flip, same precedent as the threshold override —
+        never written to settings.json. Only meaningful while auto-switch
+        itself is driving the active account, which is exactly this
+        screen's engine (an idle terminal, or a screen elsewhere in the
+        TUI, has no engine to hand the setting to)."""
+        if self._engine is None or self._settings is None:
+            return
+        enabled = not self._settings.warm_on_reset
+        self._settings = replace(self._settings, warm_on_reset=enabled)
+        self._engine.apply_warm_on_reset(enabled)
+        self._update_summary()
+        self.query_one("#event-log", RichLog).write(
+            Text(
+                f"— warm-on-reset {'enabled' if enabled else 'disabled'} "
+                "for this session —",
+                style=Palette.from_theme(self.app.current_theme).muted,
+            )
+        )
+
     def _update_summary(self) -> None:
         palette = Palette.from_theme(self.app.current_theme)
         text = Text()
@@ -200,6 +228,13 @@ class AutoScreen(Screen):
         if self._settings.threshold != self._configured_threshold:
             text.append(" (session)", style=palette.muted)
         text.append(f" · poll every {self._settings.interval_seconds:.0f}s")
+        warm_is_session = self._settings.warm_on_reset != self._configured_warm_on_reset
+        if self._settings.warm_on_reset:
+            text.append(" · warm-on-reset", style=palette.accent)
+            if warm_is_session:
+                text.append(" (session)", style=palette.muted)
+        elif warm_is_session:
+            text.append(" · warm-on-reset off (session)", style=palette.muted)
         if self._adjusting:
             text.append("   ← → adjust · enter done", style=palette.muted)
         self.query_one("#auto-summary", Static).update(text)

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -26,6 +26,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, ListView, Static
 
 from claude_swap.models import AccountsSnapshot
+from claude_swap.settings import load_settings
 from claude_swap.tui.widgets import AccountItem, AccountsPanel, MenuItem
 
 if TYPE_CHECKING:
@@ -352,8 +353,15 @@ class WatchScreen(AccountListScreen):
     def __init__(self) -> None:
         super().__init__()
         self._selecting = False
+        # Read once at mount, like the auto-switch view's own settings load:
+        # this screen runs no engine of its own, so this is the file's
+        # *configured* preference, honored whenever some `cswap auto` (this
+        # TUI's own auto view, the CLI, a cron `--once`, or the menu bar)
+        # is actually running — never a claim that priming is happening now.
+        self._warm_on_reset = False
 
     def on_mount(self) -> None:
+        self._warm_on_reset = load_settings(self.app.switcher.backup_dir).warm_on_reset
         self.watch(self.app, "refresh_status", self._on_refresh_status)
         self.query_one("#list-title", Static).update(self._title_text())
         super().on_mount()
@@ -361,8 +369,13 @@ class WatchScreen(AccountListScreen):
     def _title_text(self) -> str:
         if self._selecting:
             return self._SELECT_TITLE
+        base = (
+            f"{self._WATCH_TITLE} · warm-on-reset"
+            if self._warm_on_reset
+            else self._WATCH_TITLE
+        )
         status = self.app.refresh_status
-        return f"{self._WATCH_TITLE} · {status}" if status else self._WATCH_TITLE
+        return f"{base} · {status}" if status else base
 
     def _on_refresh_status(self, status: str) -> None:
         if not self._selecting:

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -244,7 +244,9 @@ class AccountListScreen(Screen):
             first_build = not self._numbers
             previous = listview.index
             await listview.clear()
-            await listview.extend(AccountItem(acc) for acc in snap.accounts)
+            await listview.extend(
+                AccountItem(acc, warming=snap.warming) for acc in snap.accounts
+            )
             self._numbers = numbers
             listview.index = (
                 self._index_after_build(snap, first_build, previous)
@@ -253,7 +255,7 @@ class AccountListScreen(Screen):
             )
         else:
             for item, acc in zip(listview.query(AccountItem), snap.accounts):
-                item.set_account(acc)
+                item.set_account(acc, snap.warming)
         self._flash_updated(snap, listview)
 
     def _index_after_build(

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -167,9 +167,20 @@ def account_card_text(
     threshold: float | None = None,
     now: float | None = None,
     palette: Palette = Palette.DARK,
+    warming: dict | None = None,
 ) -> Text:
-    """The full account card: header line + per-window bar rows."""
+    """The full account card: header line + per-window bar rows.
+
+    ``warming`` is the raw ``autoswitch_state.json`` "warming" entry
+    (``{"number", ...}``), when `settings.warm_on_reset` has some
+    `cswap auto` mid-touch right now. "active" always tracks the real live
+    credential (``acc.is_active``) — while a hold is open, the account it
+    landed on (``number``) additionally gets a "priming" tag alongside it,
+    since it genuinely is the live account for the moment, just briefly and
+    for an automated reason.
+    """
     now = now if now is not None else time.time()
+    warming_target = str(warming["number"]) if warming and "number" in warming else None
 
     text = Text()
     text.append(f"{acc.number:>2}  ", style=f"bold {palette.foreground}")
@@ -181,6 +192,8 @@ def account_card_text(
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.is_active:
         text.append("   ● active", style=f"bold {palette.accent}")
+    if acc.number == warming_target:
+        text.append("   ◐ priming", style=f"bold {palette.sev_warn}")
     if acc.disabled:
         text.append("   (disabled)", style=palette.muted)
     age = data.format_age(acc.usage.age_s)
@@ -340,7 +353,7 @@ class AccountsPanel(Static):
                 blocks.append(
                     account_card_text(
                         acc, width, threshold=app.threshold_pct, now=now,
-                        palette=palette,
+                        palette=palette, warming=snap.warming,
                     )
                 )
             elif self._show_minis:
@@ -362,34 +375,43 @@ class AccountsPanel(Static):
 class AccountCard(Static):
     """One account rendered full-size (used by the switch screen's list)."""
 
-    def __init__(self, acc: AccountSnapshot, *, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        acc: AccountSnapshot,
+        *,
+        threshold: float | None = None,
+        warming: dict | None = None,
+    ) -> None:
         super().__init__()
         self._acc = acc
         self._threshold = threshold
+        self._warming = warming
 
-    def set_account(self, acc: AccountSnapshot) -> None:
+    def set_account(self, acc: AccountSnapshot, warming: dict | None = None) -> None:
         self._acc = acc
+        self._warming = warming
         self.refresh(layout=True)
 
     def render(self) -> Text:
         return account_card_text(
             self._acc, self.size.width or 80, threshold=self._threshold,
             palette=Palette.from_theme(self.app.current_theme),
+            warming=self._warming,
         )
 
 
 class AccountItem(ListItem):
     """ListView row wrapping an :class:`AccountCard`; remembers its slot."""
 
-    def __init__(self, acc: AccountSnapshot) -> None:
-        super().__init__(AccountCard(acc))
+    def __init__(self, acc: AccountSnapshot, *, warming: dict | None = None) -> None:
+        super().__init__(AccountCard(acc, warming=warming))
         self.number = acc.number
         self.email = acc.email
 
-    def set_account(self, acc: AccountSnapshot) -> None:
+    def set_account(self, acc: AccountSnapshot, warming: dict | None = None) -> None:
         self.number = acc.number
         self.email = acc.email
-        self.query_one(AccountCard).set_account(acc)
+        self.query_one(AccountCard).set_account(acc, warming)
 
 
 class MenuItem(ListItem):

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -7043,6 +7043,50 @@ class TestWarmOnReset:
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
         assert reasons == ["below-threshold"]
 
+    def test_hold_ends_but_return_account_is_disabled_stays_put(self, temp_home):
+        """The account we'd return to was pulled out of rotation (`cswap
+        disable`) while we were away priming the target —
+        `switchable_account_numbers()` is the one gate every strategy
+        respects for that, and the return must honor it too rather than
+        reactivating a slot the user deliberately disabled."""
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})  # warm switch onto 2
+        h.switcher.set_account_disabled("1", True)
+        h.events.clear()
+
+        h.clock.advance(30.0)
+        outcome = h.tick_with_usage(
+            {"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(2.0, "2030-01-01T00:00:00Z")}
+        )
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 2
+        ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
+        assert ended.status == "started"
+        assert not any(isinstance(e, SwitchEvent) for e in h.events)
+
+    def test_hold_ends_but_return_account_is_quarantined_stays_put(self, temp_home):
+        """The account we'd return to got quarantined (e.g. a dead refresh
+        token found elsewhere) while we were away priming the target — the
+        return must never reactivate a quarantined slot."""
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})  # warm switch onto 2
+        h.engine._quarantine("1", "a@example.com", "invalid_grant")
+        h.events.clear()
+
+        h.clock.advance(30.0)
+        outcome = h.tick_with_usage(
+            {"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(2.0, "2030-01-01T00:00:00Z")}
+        )
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 2
+        ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
+        assert ended.status == "started"
+        assert not any(isinstance(e, SwitchEvent) for e in h.events)
+
     def test_manual_switch_away_supersedes_the_hold(self, temp_home):
         h = self._two_account_harness(temp_home)
         h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -6900,8 +6900,10 @@ class TestFreshenRoutesThroughGate:
 def _idle(seven_day_pct: float = 0.0) -> dict:
     """Usage shape for an account whose 5h window is not currently ticking.
 
-    ``oauth.build_usage_result`` omits the ``five_hour`` key entirely until a
-    request lands in the window following a reset — this is that shape.
+    Covers both real shapes ``oauth.build_usage_result`` can produce before a
+    request lands in the window following a reset: the ``five_hour`` key
+    omitted entirely, or present with ``pct`` but no ``resets_at`` — this
+    helper uses the former since ``_five_hour_active`` treats both alike.
     """
     return {"seven_day": {"pct": seven_day_pct}}
 
@@ -6923,10 +6925,10 @@ class TestWarmOnReset:
         h.seed(1, "a@example.com")
         h.seed(2, "b@example.com")
         h.make_live("a@example.com", 1)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})
         h.events.clear()
 
-        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle()})
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle()})
 
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
@@ -6936,7 +6938,7 @@ class TestWarmOnReset:
 
     def test_first_observation_only_seeds_the_baseline(self, temp_home):
         h = self._two_account_harness(temp_home)
-        outcome = h.tick_with_usage({"1": _usage(20), "2": _usage(30)})
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         assert not any(isinstance(e, SwitchEvent) for e in h.events)
@@ -6944,75 +6946,111 @@ class TestWarmOnReset:
 
     def test_reset_transition_triggers_one_shot_switch(self, temp_home):
         h = self._two_account_harness(temp_home)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
         h.events.clear()
 
-        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
 
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
         switch = next(e for e in h.events if isinstance(e, SwitchEvent))
         assert switch.trigger == "warm-reset"
-        assert h.state()["warming"] == {"number": "2", "since": h.clock.now}
+        assert h.state()["warming"] == {
+            "number": "2", "since": h.clock.now, "returnTo": "1"
+        }
         assert h.state()["fiveHourSeen"]["2"] is False
 
     def test_hold_suppresses_normal_strategy_while_unconfirmed(self, temp_home):
         h = self._two_account_harness(temp_home)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
-        h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})  # warm switch
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})  # warm switch
         assert h.active_number() == 2
         h.events.clear()
 
         h.clock.advance(60.0)
-        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
 
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 2
         reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
         assert reasons == ["warming"]
         assert not any(isinstance(e, WarmResetHoldEndedEvent) for e in h.events)
-        assert h.state()["warming"] == {"number": "2", "since": 1_000_000.0}
+        assert h.state()["warming"] == {
+            "number": "2", "since": 1_000_000.0, "returnTo": "1"
+        }
 
     def test_hold_ends_once_five_hour_reappears(self, temp_home):
         h = self._two_account_harness(temp_home)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
-        h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})  # warm switch
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})  # warm switch
         h.events.clear()
 
         h.clock.advance(30.0)
-        outcome = h.tick_with_usage({"1": _idle(3.0), "2": _usage(2.0)})
+        outcome = h.tick_with_usage({"1": _idle(3.0), "2": _usage(2.0, "2030-01-01T00:00:00Z")})
 
-        assert outcome is TickOutcome.NO_ACTION  # below-threshold once resumed
+        # Confirmed ticking -> hold ends -> auto-switch back to the account
+        # it borrowed the session from (account 1, still healthy).
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 1
         ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
         assert ended.status == "started"
         assert ended.number == "2"
+        switch = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "warm-return"
+        assert switch.to_ref["number"] == 1
         assert "warming" not in h.state()
         assert h.state()["fiveHourSeen"]["2"] is True
-        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
-        assert reasons == ["below-threshold"]
 
     def test_hold_times_out_without_confirmation(self, temp_home):
         h = self._two_account_harness(temp_home)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
-        h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})  # warm switch
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})  # warm switch
         h.events.clear()
 
         h.clock.advance(WARM_HOLD_MAX_S + 1.0)
         outcome = h.tick_with_usage({"1": _idle(3.0), "2": _idle(5.0)})
 
-        assert outcome is TickOutcome.NO_ACTION
+        # Timed out unconfirmed -> hold ends -> auto-switch back anyway; the
+        # account it borrowed from is idle but that means 0% used, not unhealthy.
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 1
         ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
         assert ended.status == "timeout"
+        switch = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "warm-return"
         assert "warming" not in h.state()
+
+    def test_hold_ends_but_return_account_no_longer_healthy_stays_put(self, temp_home):
+        """The account we'd return to crossed the threshold while we were
+        away priming the target — returning to it would just trade one
+        problem for another, so stay on the (confirmed-healthy) target and
+        let normal strategy sort it out next time account 1 is current."""
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})  # warm switch onto 2
+        h.events.clear()
+
+        h.clock.advance(30.0)
+        outcome = h.tick_with_usage(
+            {"1": _usage(95, "2030-01-01T00:00:00Z"), "2": _usage(2.0, "2030-01-01T00:00:00Z")}
+        )
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 2
+        ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
+        assert ended.status == "started"
+        assert not any(isinstance(e, SwitchEvent) for e in h.events)
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
 
     def test_manual_switch_away_supersedes_the_hold(self, temp_home):
         h = self._two_account_harness(temp_home)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
-        h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})  # warm switch onto 2
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})  # warm switch onto 2
         h.switcher.switch_to("1")  # user switches back by hand
         h.events.clear()
 
-        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
 
         assert outcome is TickOutcome.NO_ACTION
         ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
@@ -7021,12 +7059,12 @@ class TestWarmOnReset:
 
     def test_cooldown_blocks_the_touch_without_losing_the_transition(self, temp_home):
         h = self._two_account_harness(temp_home, cooldown_seconds=300.0)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
         # Prime a cooldown via an unrelated (already-active) switch report.
         h.engine._mutate_state(lambda s: s.__setitem__("lastSwitchAt", h.clock.now))
         h.events.clear()
 
-        blocked = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+        blocked = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
         assert blocked is TickOutcome.NO_ACTION
         assert h.active_number() == 1
         assert not any(isinstance(e, SwitchEvent) for e in h.events)
@@ -7035,7 +7073,7 @@ class TestWarmOnReset:
 
         h.clock.advance(301.0)
         h.events.clear()
-        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
 
         assert outcome is TickOutcome.SWITCHED
         assert h.active_number() == 2
@@ -7047,11 +7085,11 @@ class TestWarmOnReset:
         disabled slots — warm-reset must go through the same gate, not its
         own copy that could drift out of sync."""
         h = self._two_account_harness(temp_home)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
         h.switcher.set_account_disabled("2", True)
         h.events.clear()
 
-        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
 
         assert outcome is TickOutcome.NO_ACTION
         assert h.active_number() == 1
@@ -7063,10 +7101,10 @@ class TestWarmOnReset:
     def test_dry_run_never_persists_bookkeeping(self, temp_home):
         h = self._two_account_harness(temp_home)
         h.engine = h._make_engine(dry_run=True)
-        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
         assert h.state() == {}
 
-        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
 
         assert outcome is TickOutcome.SWITCHED
         switch = next(e for e in h.events if isinstance(e, SwitchEvent))

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -17,6 +17,7 @@ from claude_swap.autoswitch import (
     NO_RESET_FALLBACK_S,
     RECOVERY_HORIZON_S,
     SPENT_HEADROOM_PCT,
+    WARM_HOLD_MAX_S,
     AllExhaustedEvent,
     AutoSwitchEngine,
     ConfigWarningEvent,
@@ -27,6 +28,7 @@ from claude_swap.autoswitch import (
     SwitchEvent,
     TickOutcome,
     UnquarantineEvent,
+    WarmResetHoldEndedEvent,
     _recovery_is_useful,
     pct_label,
 )
@@ -6893,4 +6895,183 @@ class TestFreshenRoutesThroughGate:
         assert verdict == "ok"
         assert gate_calls["args"][0] == "2"
         assert "called" not in direct, "freshen must not POST outside the gate"
+
+
+def _idle(seven_day_pct: float = 0.0) -> dict:
+    """Usage shape for an account whose 5h window is not currently ticking.
+
+    ``oauth.build_usage_result`` omits the ``five_hour`` key entirely until a
+    request lands in the window following a reset — this is that shape.
+    """
+    return {"seven_day": {"pct": seven_day_pct}}
+
+
+class TestWarmOnReset:
+    """`settings.warm_on_reset`: touch a non-active account the moment its
+    5h window resets (its usage stops reporting `five_hour`), then hand
+    back to the configured strategy once that's confirmed or given up on."""
+
+    def _two_account_harness(self, temp_home: Path, **settings_kwargs) -> EngineHarness:
+        h = EngineHarness(temp_home, warm_on_reset=True, threshold=90.0, **settings_kwargs)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_off_by_default_ignores_a_reset_transition(self, temp_home):
+        h = EngineHarness(temp_home, threshold=90.0)  # warm_on_reset defaults False
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})
+        h.events.clear()
+
+        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle()})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert not any(isinstance(e, SwitchEvent) for e in h.events)
+        assert "fiveHourSeen" not in h.state()
+        assert "warming" not in h.state()
+
+    def test_first_observation_only_seeds_the_baseline(self, temp_home):
+        h = self._two_account_harness(temp_home)
+        outcome = h.tick_with_usage({"1": _usage(20), "2": _usage(30)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert not any(isinstance(e, SwitchEvent) for e in h.events)
+        assert h.state()["fiveHourSeen"] == {"1": True, "2": True}
+
+    def test_reset_transition_triggers_one_shot_switch(self, temp_home):
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.events.clear()
+
+        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        switch = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "warm-reset"
+        assert h.state()["warming"] == {"number": "2", "since": h.clock.now}
+        assert h.state()["fiveHourSeen"]["2"] is False
+
+    def test_hold_suppresses_normal_strategy_while_unconfirmed(self, temp_home):
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})  # warm switch
+        assert h.active_number() == 2
+        h.events.clear()
+
+        h.clock.advance(60.0)
+        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 2
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["warming"]
+        assert not any(isinstance(e, WarmResetHoldEndedEvent) for e in h.events)
+        assert h.state()["warming"] == {"number": "2", "since": 1_000_000.0}
+
+    def test_hold_ends_once_five_hour_reappears(self, temp_home):
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})  # warm switch
+        h.events.clear()
+
+        h.clock.advance(30.0)
+        outcome = h.tick_with_usage({"1": _idle(3.0), "2": _usage(2.0)})
+
+        assert outcome is TickOutcome.NO_ACTION  # below-threshold once resumed
+        ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
+        assert ended.status == "started"
+        assert ended.number == "2"
+        assert "warming" not in h.state()
+        assert h.state()["fiveHourSeen"]["2"] is True
+        reasons = [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+        assert reasons == ["below-threshold"]
+
+    def test_hold_times_out_without_confirmation(self, temp_home):
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})  # warm switch
+        h.events.clear()
+
+        h.clock.advance(WARM_HOLD_MAX_S + 1.0)
+        outcome = h.tick_with_usage({"1": _idle(3.0), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
+        assert ended.status == "timeout"
+        assert "warming" not in h.state()
+
+    def test_manual_switch_away_supersedes_the_hold(self, temp_home):
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})  # warm switch onto 2
+        h.switcher.switch_to("1")  # user switches back by hand
+        h.events.clear()
+
+        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        ended = next(e for e in h.events if isinstance(e, WarmResetHoldEndedEvent))
+        assert ended.status == "superseded"
+        assert "warming" not in h.state()
+
+    def test_cooldown_blocks_the_touch_without_losing_the_transition(self, temp_home):
+        h = self._two_account_harness(temp_home, cooldown_seconds=300.0)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        # Prime a cooldown via an unrelated (already-active) switch report.
+        h.engine._mutate_state(lambda s: s.__setitem__("lastSwitchAt", h.clock.now))
+        h.events.clear()
+
+        blocked = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+        assert blocked is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert not any(isinstance(e, SwitchEvent) for e in h.events)
+        # Still pending — not silently dropped by the cooldown miss.
+        assert h.state()["fiveHourSeen"]["2"] is True
+
+        h.clock.advance(301.0)
+        h.events.clear()
+        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        switch = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "warm-reset"
+
+    def test_never_touches_a_disabled_account(self, temp_home):
+        """`switchable_account_numbers()` is where every strategy excludes
+        disabled slots — warm-reset must go through the same gate, not its
+        own copy that could drift out of sync."""
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        h.switcher.set_account_disabled("2", True)
+        h.events.clear()
+
+        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert not any(isinstance(e, SwitchEvent) for e in h.events)
+        # Excluded from the loop entirely — its stale baseline carries
+        # forward untouched rather than being read as a (fake) reset.
+        assert h.state()["fiveHourSeen"]["2"] is True
+
+    def test_dry_run_never_persists_bookkeeping(self, temp_home):
+        h = self._two_account_harness(temp_home)
+        h.engine = h._make_engine(dry_run=True)
+        h.tick_with_usage({"1": _usage(20), "2": _usage(30)})  # baseline
+        assert h.state() == {}
+
+        outcome = h.tick_with_usage({"1": _usage(20), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.SWITCHED
+        switch = next(e for e in h.events if isinstance(e, SwitchEvent))
+        assert switch.trigger == "warm-reset"
+        assert switch.dry_run is True
+        assert h.active_number() == 1  # never actually switched
+        assert h.state() == {}
 

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,10 +48,11 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "autoswitch.warmOnReset",
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,7 +79,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -343,6 +343,32 @@ class TestFormatting:
         ).plain
         assert "last seen" not in api_key
 
+    def test_warming_badge_tags_the_genuinely_active_touched_account(self):
+        # A `warm_on_reset` hold means the live credential really is on the
+        # touched account (here #2) for the moment — "active" must keep
+        # tracking that ground truth, with "priming" added alongside it as
+        # context for why the active account just changed automatically.
+        from claude_swap.tui.widgets import account_card_text
+
+        warming = {"number": "2", "since": 0.0, "returnTo": "1"}
+
+        untouched = account_card_text(
+            make_account(1, active=False), 80, warming=warming
+        ).plain
+        assert "active" not in untouched
+        assert "priming" not in untouched
+
+        touched = account_card_text(
+            make_account(2, active=True), 80, warming=warming
+        ).plain
+        assert "● active" in touched
+        assert "◐ priming" in touched
+
+        # No hold in flight: no priming tag, badge is just the real slot.
+        no_hold = account_card_text(make_account(2, active=True), 80).plain
+        assert "● active" in no_hold
+        assert "priming" not in no_hold
+
     def test_account_card_uses_light_palette_when_passed(self):
         from claude_swap.tui.theme import ACCENT_LIGHT, CSWAP_LIGHT, Palette
         from claude_swap.tui.widgets import account_card_text

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1164,6 +1164,34 @@ class TestWatchScreen:
             assert isinstance(app.screen, DashboardScreen)
             assert not any(call[0] == "switch_to" for call in fake.calls)
 
+    async def test_warm_on_reset_indicator_shown_when_configured(self, tmp_path):
+        import json as _json
+
+        (tmp_path / "settings.json").write_text(_json.dumps({
+            "schemaVersion": 1, "autoswitch": {"warmOnReset": True},
+        }))
+        app = make_app(self._fake(tmp_path))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from textual.widgets import Static
+
+            title = app.screen.query_one("#list-title", Static).render().plain
+            assert "warm-on-reset" in title
+            assert "watching all accounts" in title
+
+    async def test_warm_on_reset_indicator_absent_by_default(self, tmp_path):
+        app = make_app(self._fake(tmp_path))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from textual.widgets import Static
+
+            title = app.screen.query_one("#list-title", Static).render().plain
+            assert "warm-on-reset" not in title
+
     async def test_menu_watch_entry_opens_it(self, tmp_path):
         app = make_app(self._fake(tmp_path))
         async with app.run_test(size=(100, 40)) as pilot:
@@ -1294,6 +1322,7 @@ class _FakeEngine:
         self.dry_run = dry_run
         self.stopped = False
         self.applied_thresholds: list[float] = []
+        self.applied_warm_on_reset: list[bool] = []
         self.wakes = 0
         self._stop = threading.Event()
         _FakeEngine.instances.append(self)
@@ -1310,6 +1339,10 @@ class _FakeEngine:
     def apply_threshold(self, threshold: float) -> None:
         self.settings = dataclasses.replace(self.settings, threshold=threshold)
         self.applied_thresholds.append(threshold)
+
+    def apply_warm_on_reset(self, enabled: bool) -> None:
+        self.settings = dataclasses.replace(self.settings, warm_on_reset=enabled)
+        self.applied_warm_on_reset.append(enabled)
 
     def wake(self) -> None:
         self.wakes += 1
@@ -1474,6 +1507,72 @@ class TestAutoScreen:
             screen.action_threshold_step(-60.0)
             await pilot.pause()
             assert screen._settings.threshold == 50.0  # spec's lower bound
+
+    async def test_warm_on_reset_toggle_is_session_only(self, tmp_path, fake_engine):
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(pilot)
+            screen = app.screen
+            assert screen._settings.warm_on_reset is False  # file default
+            from textual.widgets import Static
+
+            summary = screen.query_one("#auto-summary", Static)
+            assert "warm-on-reset" not in summary.render().plain
+
+            await pilot.press("w")
+            await pilot.pause()
+            assert screen._settings.warm_on_reset is True
+            engine = fake_engine.instances[0]
+            assert engine.applied_warm_on_reset == [True]
+            assert "warm-on-reset (session)" in summary.render().plain
+            assert not (tmp_path / "settings.json").exists()  # never persisted
+
+            await pilot.press("w")  # back off — matches the file default again
+            await pilot.pause()
+            assert screen._settings.warm_on_reset is False
+            assert engine.applied_warm_on_reset == [True, False]
+            # Round-tripped back to the configured value: indistinguishable
+            # from never having touched it, same as the threshold's marker.
+            assert "warm-on-reset" not in summary.render().plain
+
+            # a dry↔live restart rebuilds the engine from the adjusted copy
+            await pilot.press("w")  # on again, then go live
+            await pilot.pause()
+            await pilot.press("l")
+            await pilot.pause()
+            await pilot.press("y")
+            await settle(pilot)
+            assert fake_engine.instances[1].settings.warm_on_reset is True
+
+    async def test_warm_on_reset_session_off_marks_deviation_from_file(
+        self, tmp_path, fake_engine
+    ):
+        import json as _json
+
+        (tmp_path / "settings.json").write_text(_json.dumps({
+            "schemaVersion": 1, "autoswitch": {"warmOnReset": True},
+        }))
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(pilot)
+            screen = app.screen
+            assert screen._settings.warm_on_reset is True  # file default
+            from textual.widgets import Static
+
+            summary = screen.query_one("#auto-summary", Static)
+            assert "warm-on-reset" in summary.render().plain
+            assert "(session)" not in summary.render().plain
+
+            await pilot.press("w")  # turn it off for this session
+            await pilot.pause()
+            assert screen._settings.warm_on_reset is False
+            assert "warm-on-reset off (session)" in summary.render().plain
 
     async def test_candidates_ranked_by_headroom(self, tmp_path, fake_engine):
         fake = FakeSwitcher(


### PR DESCRIPTION
## Why

Anthropic's usage API omits `five_hour` entirely for an account that hasn't been used since its last window rolled over — the 5h clock only starts once a request actually lands. Left alone, an idle account's fresh window starts at whatever moment `best`/`consume-first` next rotates onto it, which is fine for that account alone but leaves the fleet's 5h windows drifting with no predictable schedule.

## What

`autoswitch.warm_on_reset` (CLI: `--warm-on-reset`, config: `autoswitch.warmOnReset`, default off) watches every candidate for that transition (`five_hour` present → absent) and, the moment it's seen, switches to the account once so the next request starts its clock right away. It then holds there until either `five_hour` reappears (confirmed) or a bounded timeout elapses with no confirmation, and hands back to the configured strategy either way.

Design notes:
- Only engages while the active account is healthy (below threshold) — never preempts an at-limit/failover escape.
- A detected reset stays "pending" (not committed to `fiveHourSeen`) until it's actually acted on, so a cooldown miss or a freshen hiccup retries next tick instead of losing the reset for good.
- Dry-run tracks its own in-memory baseline/hold (mirroring `_unhealthy_ticks`) so `cswap auto --dry-run --warm-on-reset` previews the feature across ticks without ever touching the state file.
- Targets go through the same `switchable_account_numbers()` every other strategy uses, so a disabled account is never touched.
- New `warm-reset` switch trigger and `warm-hold-ended` event, both additive to the existing `--json` event stream.

## TUI

- Auto-switch view (`g`): `w` toggles it for the session — same memory-only precedent as the existing threshold override, never written to `settings.json`.
- Watch screen ("watching all accounts"): shows a `· warm-on-reset` note in the title when the setting is on in `settings.json` (this screen runs no engine of its own, so it's the *configured* preference, honored whenever some `cswap auto` is actually running).

## Testing

- 10 new cases in `TestWarmOnReset` (transition detection, the priming hold's confirm/timeout/superseded exits, cooldown-preserves-the-pending-transition, disabled-account exclusion, dry-run isolation).
- 4 new TUI cases (session-only toggle + its summary marker, Watch screen indicator).
- Full suite: `2190 passed, 3 skipped` locally, no regressions.

Happy to adjust naming/scope/defaults if you'd rather this ship differently — opened as a real PR rather than an issue first since I wanted to validate the idea against the actual engine invariants (anti-flap, cooldown, quarantine) before proposing it in the abstract.