### PR TITLE
Add --warm-on-reset: prime an idle account's 5h window via an isolated ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ cswap auto --model Fable       # also switch when the Fable weekly limit is hit
 cswap auto --once              # single check-and-switch, for cron/scripts
 cswap auto --dry-run           # log what it would do, never switch
 cswap auto --strategy consume-first   # burn the soonest-resetting account first
+cswap auto --warm-on-reset            # ping an idle account right when its 5h window resets
 ```
 
 <details>
@@ -103,6 +104,7 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you either log in with it and re-run `cswap add --slot N`, or replace its stored credentials from a known-good export — a plain `cswap import backup.cswap` replaces dead-token slots on its own (`--force` is still required to replace other existing accounts; note a stale export can carry an already-superseded token). API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
 - To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
+- **`--warm-on-reset`** (or `cswap config set autoswitch.warmOnReset true`): Anthropic's usage API reports no `five_hour` window at all for an account that hasn't been used since its last one reset — the 5h clock doesn't start until a request actually lands. Left alone, an idle account's fresh window starts at whatever moment `best`/`consume-first` eventually rotates onto it, which is fine for that account but means your fleet's 5h windows drift out of any predictable schedule. With this on, the moment cswap notices a non-active account's window has reset, it sends one throwaway Haiku message through that account's own isolated session profile — the same isolation `cswap run` uses — so its clock starts right away. It never touches your active credential, so it can't redirect a real Claude Code session you have open elsewhere onto a different account mid-conversation (prompt cache is scoped per Anthropic org; a redirected session would silently reprocess its whole history at full price on its next message). Off by default; the ping itself costs a fraction of a cent.
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
 
@@ -230,7 +232,7 @@ The original flag spellings (`cswap --switch`, `cswap --list`, ...) keep working
 | macOS | macOS Keychain | `~/.claude-swap-backup/` |
 | Linux / WSL | File-based (inside the backup directory, under `credentials/`) | `${XDG_DATA_HOME:-~/.local/share}/claude-swap/` |
 
-Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`. Tool preferences (`settings.json`) and auto-switch state (`autoswitch_state.json` — cooldown and quarantined accounts; delete it to reset) live in the backup directory root.
+Session-mode profiles (`cswap run`) live under the backup directory in `sessions/`. Tool preferences (`settings.json`) and auto-switch state (`autoswitch_state.json` — cooldown, quarantined accounts, and `--warm-on-reset` bookkeeping; delete it to reset) live in the backup directory root.
 
 On Linux/WSL, set `XDG_DATA_HOME` to override the default location.
 
@@ -334,7 +336,7 @@ Weekly windows (`sevenDay` and per-model `scoped` entries — never `fiveHour`) 
 
 </details>
 
-`cswap auto --json` emits an event *stream* instead — one JSON object per line (`{"schemaVersion":1,"event":"switch","ts":…, …}` with kinds like `poll`, `switch`, `no-switch`, `account-quarantined`, `all-exhausted`, `error`). The contract is additive: new kinds and fields may appear, so scripts should ignore unknown ones.
+`cswap auto --json` emits an event *stream* instead — one JSON object per line (`{"schemaVersion":1,"event":"switch","ts":…, …}` with kinds like `poll`, `switch`, `no-switch`, `account-quarantined`, `all-exhausted`, `error`, and (with `--warm-on-reset`) `warm-ping`). The contract is additive: new kinds and fields may appear, so scripts should ignore unknown ones.
 
 ### Add an account from a raw token or API key
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -46,16 +46,22 @@ from claude_swap import oauth, poll_policy
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import SCHEMA_VERSION, USAGE_TOKEN_EXPIRED
 from claude_swap.locking import FileLock
+from claude_swap.paths import AUTOSWITCH_STATE_FILENAME
 from claude_swap.poll_policy import (
     ESCALATION_MARGIN_PCT,
     RESET_SLACK_S,
     binding_pct,
 )
+from claude_swap.session import SessionManager
 from claude_swap.settings import AutoSwitchSettings, atomic_write_json, parse_model_names
 from claude_swap.switcher import ClaudeAccountSwitcher
 from claude_swap.usage_store import due_candidate, plan_oversleeps_interval
 
-STATE_FILENAME = "autoswitch_state.json"
+# Re-exported for callers that already spell it `autoswitch.STATE_FILENAME`;
+# `paths.AUTOSWITCH_STATE_FILENAME` is the source of truth so a reader
+# elsewhere in the package (e.g. `switcher.py`) can name it without an
+# `autoswitch` import, which would cycle (`autoswitch` imports `switcher`).
+STATE_FILENAME = AUTOSWITCH_STATE_FILENAME
 STATE_SCHEMA_VERSION = 1
 
 _logger = logging.getLogger("claude-swap")
@@ -102,6 +108,7 @@ NO_RESET_FALLBACK_S = 300.0
 # active user would look identical forever, so after this long the engine
 # falls back to normal unhealthy counting.
 IDLE_HOLD_MAX_S = 30 * 60.0
+
 
 # Anti-flap margin for the every-account-above-threshold escape, measured on
 # the axis that escape ranks by: a target must come back at least this much
@@ -436,6 +443,42 @@ class UnquarantineEvent(AutoSwitchEvent):
 
 
 @dataclass(frozen=True)
+class WarmPingEvent(AutoSwitchEvent):
+    """A `warm_on_reset` priming touch: one throwaway message sent through a
+    reset account's own isolated session profile (`SessionManager.
+    ping_to_warm`), never the active credential — see the module docstring.
+
+    ``status``: ``"sent"`` (the ping ran and exited cleanly — the account's
+    5h window should start once Anthropic's side reflects it) or
+    ``"failed"`` (bootstrap, spawn, or the ping itself failed; the reset
+    stays pending and is retried next cycle).
+    """
+
+    kind: ClassVar[str] = "warm-ping"
+    number: str
+    email: str
+    status: str
+    dry_run: bool = False
+
+    def _fields(self) -> dict:
+        return {
+            "number": self.number,
+            "email": self.email,
+            "status": self.status,
+            "dryRun": self.dry_run,
+        }
+
+    def human(self) -> str:
+        if self.status == "failed":
+            return (
+                f"Account-{self.number} ({self.email}) priming failed, "
+                "will retry (warm-on-reset)"
+            )
+        prefix = "[dry-run] would prime" if self.dry_run else "Primed"
+        return f"{prefix} Account-{self.number} ({self.email}) (warm-on-reset)"
+
+
+@dataclass(frozen=True)
 class AllExhaustedEvent(AutoSwitchEvent):
     kind: ClassVar[str] = "all-exhausted"
     earliest_reset_at: str | None
@@ -557,6 +600,25 @@ def _seven_day_reset_ts(usage: dict | str | None, now: float) -> float | None:
     return None
 
 
+def _five_hour_active(usage_value: dict | str | None) -> bool | None:
+    """Is this account's 5h window currently ticking (has a live reset
+    timer)? ``None`` when unreadable this tick — never evidence of a reset.
+
+    ``oauth.build_usage_result`` keeps emitting a ``five_hour`` dict
+    (``pct`` only, no ``resets_at``) for an account that has just reset and
+    has not yet had a request land in the new window — so the key's mere
+    presence is NOT proof the window is ticking. ``resets_at`` (added once
+    the API starts reporting a real countdown) is the ground truth
+    ``warm_on_reset`` watches for a transition on.
+    """
+    if not isinstance(usage_value, dict):
+        return None
+    fh = usage_value.get("five_hour")
+    if not isinstance(fh, dict):
+        return False
+    return "resets_at" in fh
+
+
 def _binding_recovery_ts(
     usage: dict | str | None, models: Sequence[str], now: float
 ) -> float:
@@ -649,6 +711,9 @@ class AutoSwitchEngine:
         clock: Callable[[], float] = time.time,
     ):
         self.switcher = switcher
+        # `warm_on_reset`'s isolated ping reuses the same per-account session
+        # profile `cswap run` bootstraps — never the active credential.
+        self._session_manager = SessionManager(switcher)
         self.settings = settings
         # Model(s) whose per-model weekly limit also binds the switch decision
         # (empty = account-wide 5h/7d only). ``settings.model`` is a comma-
@@ -684,6 +749,16 @@ class AutoSwitchEngine:
         # warned) on the first tick where every relevant account has readable
         # usage — adaptive polling legitimately leaves gaps before that.
         self._model_check_done = not self._models
+        # `warm_on_reset` bookkeeping mirrors `_unhealthy_ticks` above for
+        # dry-run: real ticks read/write it through the (locked, persisted)
+        # state file, but dry-run must never touch disk, so a `cswap auto
+        # --dry-run` LOOP still needs *some* place to remember the previous
+        # tick's `five_hour` presence across ticks of this one process. This
+        # is that place, read/written only when `self.dry_run` is true; real
+        # runs use `state["fiveHourSeen"]` exclusively (see
+        # `_maybe_warm_reset`). No hold to track in memory either way — the
+        # ping is a one-shot action, never a multi-tick borrow.
+        self._dry_run_five_hour_seen: dict[str, bool] = {}
 
     # -- state file ---------------------------------------------------------
 
@@ -978,6 +1053,12 @@ class AutoSwitchEngine:
             self._idle_hold_since = None
             utilization = 100.0 - active_headroom
             if utilization < settings.threshold:
+                if settings.warm_on_reset:
+                    warm_outcome = self._maybe_warm_reset(
+                        state, usage, current, quarantined
+                    )
+                    if warm_outcome is not None:
+                        return warm_outcome
                 if settings.strategy != "consume-first":
                     self._emit(
                         NoSwitchEvent(
@@ -2124,7 +2205,10 @@ class AutoSwitchEngine:
         # state lock.
         with self._state_lock():
             state = self._read_state()
-            if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+            if (
+                trigger in ("proactive", "consume-first")
+                and self._in_cooldown(state)
+            ):
                 self._emit(NoSwitchEvent(reason="cooldown"))
                 return TickOutcome.NO_ACTION
 
@@ -2170,6 +2254,132 @@ class AutoSwitchEngine:
             )
         )
         return TickOutcome.SWITCHED
+
+    # -- warm-on-reset ----------------------------------------------------
+
+    def _maybe_warm_reset(
+        self,
+        state: dict,
+        usage: dict[str, dict | str | None],
+        current: str,
+        quarantined: set[str],
+    ) -> TickOutcome | None:
+        """``settings.warm_on_reset``: the moment a non-active account's 5h
+        window resets, send it one throwaway message through its own
+        isolated session profile (``SessionManager.ping_to_warm`` — the
+        same isolation ``cswap run`` uses), so its clock starts now rather
+        than whenever ``strategy`` would otherwise get around to it. Never
+        touches the active credential, so no other running Claude Code
+        session is ever redirected mid-conversation or loses its prompt
+        cache (cache is scoped per Anthropic org and switching accounts
+        means switching orgs — a redirected session would reprocess its
+        whole history at full price on its next message).
+
+        Called only while the active account is healthy (below threshold) —
+        an urgent trigger (at-limit/failover) must never be preempted by
+        this. Returns a :class:`TickOutcome` to make the caller return it
+        immediately (a ping was attempted this tick), or ``None`` to fall
+        through to the caller's own normal-strategy logic unchanged
+        (nothing to do this tick).
+
+        ``fiveHourSeen`` lives in the persisted state file for a real run
+        (so cron-driven ``cswap auto --once`` remembers across processes,
+        like the rest of this module's state), but dry-run must never
+        touch disk — it instead reads/writes the in-memory fallback seeded
+        in ``__init__``. The ping is a one-shot action: unlike the old
+        switch-based touch, there is no multi-tick hold to persist either
+        way, since nothing is ever borrowed from the active session.
+        """
+        oauth_candidates = [
+            n
+            for n in self.switcher.switchable_account_numbers()
+            if n != current
+            and n not in quarantined
+            and self.switcher.account_kind_for(n) != "api_key"
+        ]
+
+        seen_before = (
+            self._dry_run_five_hour_seen if self.dry_run else state.get("fiveHourSeen")
+        )
+        seen_before = dict(seen_before) if isinstance(seen_before, dict) else {}
+        seen_now = dict(seen_before)
+        reset_candidates: list[str] = []
+        for num in (*oauth_candidates, current):
+            active5h = _five_hour_active(usage.get(num))
+            if active5h is None:
+                continue  # unreadable this tick — not evidence either way
+            if seen_before.get(num) is True and active5h is False and num != current:
+                # A detected reset stays PENDING (baseline left at True) until
+                # it is actually acted on — committing it here regardless
+                # would drop the reset for good the moment a ping hiccup
+                # skips this tick: `prior is True` is what makes the
+                # transition visible at all, and once flipped to False here
+                # it can never re-arm on its own (5h resets are a one-way
+                # edge, not a level). Retried candidates the engine
+                # explicitly gave up on (quarantine) never reach this branch
+                # again anyway — they drop out of `oauth_candidates`.
+                reset_candidates.append(num)
+                continue
+            seen_now[num] = active5h
+        if seen_now != seen_before:
+            if self.dry_run:
+                self._dry_run_five_hour_seen = seen_now
+            else:
+                self._mutate_state(lambda s: s.__setitem__("fiveHourSeen", seen_now))
+
+        if not reset_candidates:
+            return None
+
+        target = reset_candidates[0]
+        email = self.switcher.account_email(target)
+        if self.dry_run:
+            self._emit(
+                WarmPingEvent(number=target, email=email, status="sent", dry_run=True)
+            )
+            self._dry_run_five_hour_seen = {
+                **self._dry_run_five_hour_seen, target: False
+            }
+            return TickOutcome.NO_ACTION
+        # `_freshen_target`'s pre-flight: dead/conflicting credential ->
+        # quarantine same as any other candidate; a live manual `cswap run`
+        # already owning this slot -> "skip-live-session", never interfered
+        # with; either way `ping_to_warm` (below) is never reached.
+        status = self._freshen_target(target, email)
+        if status == "identity-conflict":
+            self._quarantine(target, email, "identity-conflict")
+            return None  # quarantined for next tick; active account is fine
+        if status == "invalid_grant":
+            self._quarantine(target, email, "invalid_grant")
+            return None
+        if status != "ok":
+            # transient / systemic / skip-live-session — leave it for the
+            # normal below-threshold path this tick, retry the warm touch
+            # next tick.
+            return None
+        # `pinging` is display-only and lives only for the duration of the
+        # blocking call below — set right before, cleared right after,
+        # regardless of outcome — so a TUI reading the state file mid-call
+        # can badge the account "priming" while it's actually happening.
+        now = self.clock()
+        self._mutate_state(
+            lambda s: s.__setitem__("pinging", {"number": target, "since": now})
+        )
+        try:
+            sent = self._session_manager.ping_to_warm(target)
+        finally:
+            self._mutate_state(lambda s: s.pop("pinging", None))
+        self._emit(
+            WarmPingEvent(
+                number=target, email=email, status="sent" if sent else "failed"
+            )
+        )
+        if sent:
+            self._mutate_state(
+                lambda s: s.__setitem__(
+                    "fiveHourSeen", {**(s.get("fiveHourSeen") or {}), target: False}
+                )
+            )
+        return TickOutcome.NO_ACTION
 
     # -- helpers --------------------------------------------------------------
 
@@ -2282,6 +2492,16 @@ class AutoSwitchEngine:
         and each tick snapshots ``self.settings`` once, so no locking."""
         self.settings = replace(self.settings, threshold=threshold)
         self.switcher.set_poll_policy_inputs(threshold, self._models)
+
+    def apply_warm_on_reset(self, enabled: bool) -> None:
+        """Session override from the TUI, mirroring :meth:`apply_threshold`.
+
+        No poll-policy re-pin needed — unlike the threshold, this axis
+        doesn't feed the collector's cadence, only ``_tick_inner``'s own
+        below-threshold branch, which reads ``self.settings`` fresh every
+        tick.
+        """
+        self.settings = replace(self.settings, warm_on_reset=enabled)
 
     def _next_delay(self, outcome: TickOutcome) -> float:
         interval = self.settings.interval_seconds

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -2289,6 +2289,11 @@ class AutoSwitchEngine:
         in ``__init__``. The ping is a one-shot action: unlike the old
         switch-based touch, there is no multi-tick hold to persist either
         way, since nothing is ever borrowed from the active session.
+
+        A 5h reset alone doesn't mean the account is usable: its 7-day
+        window can still be ≥100%, which would reject the ping at the API
+        level. The binding-window check below skips those candidates
+        without spawning anything — retried next tick, no wasted request.
         """
         oauth_candidates = [
             n
@@ -2331,6 +2336,13 @@ class AutoSwitchEngine:
             return None
 
         target = reset_candidates[0]
+        if (binding_pct(usage.get(target), self._models) or 0.0) >= 100.0:
+            # 5h just reset but another window (typically 7d) is still
+            # ≥100% — the account is still hard-capped at the API level, so
+            # a ping would just fail and burn a real request for nothing.
+            # Leave the reset pending (`fiveHourSeen` untouched) and retry
+            # next tick once every relevant window is actually clear.
+            return None
         email = self.switcher.account_email(target)
         if self.dry_run:
             self._emit(

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -608,6 +608,7 @@ Examples:
   cswap auto --json                # one JSON event per line (for scripts)
   cswap auto --once; echo $?       # single tick, outcome in exit code
   cswap auto --dry-run             # log decisions, never actually switch
+  cswap auto --warm-on-reset       # ping an idle account right when its 5h window resets
 
 Defaults live in settings.json in the backup root; flags override them.
         """,
@@ -670,6 +671,17 @@ Defaults live in settings.json in the backup root; flags override them.
             "Target selection: 'best' (most quota left; default) or "
             "'consume-first' (proactively use the account whose weekly window "
             "resets soonest)"
+        ),
+    )
+    parser.add_argument(
+        "--warm-on-reset",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Ping a non-active account once when its 5h window resets, via "
+            "its own isolated session profile (never the active credential), "
+            "so its clock starts now instead of whenever it's next needed "
+            "(default: off)"
         ),
     )
     parser.add_argument(

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -159,6 +159,13 @@ class AccountsSnapshot:
     active_number: str | None
     accounts: tuple[AccountSnapshot, ...]
     taken_at: float
+    # `settings.warm_on_reset`'s in-flight isolated ping, straight from
+    # `autoswitch_state.json`'s "pinging" key (``{"number", "since"}``) if
+    # some `cswap auto` is mid-touch right now, else ``None``. Display-only:
+    # TUIs use ``number`` to tag that account "priming" — the ping never
+    # touches the active credential, so ``active_number`` above is never
+    # affected by it.
+    pinging: dict | None = None
 
 
 @dataclass

--- a/src/claude_swap/paths.py
+++ b/src/claude_swap/paths.py
@@ -108,6 +108,14 @@ def get_backup_root() -> Path:
     return get_legacy_backup_root()
 
 
+# The auto-switch engine's cooldown/quarantine/warm-on-reset bookkeeping file,
+# under the backup root. Lives here (rather than in ``autoswitch.py``, its
+# only writer) so a *reader* elsewhere in the package — e.g. ``switcher.py``'s
+# display-only warm-on-reset lookup — can name it without importing
+# ``autoswitch``, which itself imports ``switcher`` and would cycle.
+AUTOSWITCH_STATE_FILENAME = "autoswitch_state.json"
+
+
 # Names that any prior cswap run may have created in the backup root without
 # user data being present (logger output, update-check + usage cache). The
 # migration treats a target containing only these as effectively empty, since

--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -200,6 +200,11 @@ AUTH_OVERRIDE_ENV_VARS = (
 # `claude auth status` is a local check (no API call) but spawns the full CLI.
 _AUTH_STATUS_TIMEOUT = 10.0
 
+# `ping_to_warm`'s headless generation is a real API round trip (unlike the
+# local auth-status probe above), so it needs real headroom past a network
+# call plus a short Haiku completion.
+_WARM_PING_TIMEOUT = 60.0
+
 # Bootstrap holds the backup-dir lock across one token refresh (10s network
 # timeout) plus auth-status probes, so it needs more headroom than the
 # default 10s acquire used by the switch paths.
@@ -798,6 +803,38 @@ class SessionManager:
         # Lock released here, before any exec.
 
         return session_dir, account_num, email
+
+    def ping_to_warm(self, identifier: str) -> bool:
+        """Send one throwaway message through ``identifier``'s own isolated
+        session profile, so its 5h window starts now.
+
+        Never touches the global active credential (``~/.claude/``) or any
+        other running Claude Code session — same isolation ``run`` gives a
+        manual ``cswap run``, just a one-shot headless call instead of an
+        interactive `exec`. Returns ``True`` on success, ``False`` on any
+        failure (bootstrap, spawn, timeout, non-zero exit); callers retry
+        next cycle either way, so failures aren't classified further here —
+        credential health (a dead token, an identity conflict, a live
+        manual session already owning the slot) is the caller's job
+        *before* this is ever invoked, via the same `_freshen_target`
+        pre-flight the old switch-based touch used.
+        """
+        try:
+            session_dir, _num, _email = self.setup_session(identifier, share=False)
+        except SessionError:
+            return False
+        claude_bin = shutil.which("claude") or "claude"
+        try:
+            result = subprocess.run(
+                [claude_bin, "-p", "hi", "--model", "haiku"],
+                env=_probe_env(session_dir),
+                capture_output=True,
+                text=True,
+                timeout=_WARM_PING_TIMEOUT,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+        return result.returncode == 0
 
     def _profile_matches_backup(
         self, session_dir: Path, account_num: str, email: str

--- a/src/claude_swap/settings.py
+++ b/src/claude_swap/settings.py
@@ -57,6 +57,18 @@ class AutoSwitchSettings:
     # 5h/7d windows still have headroom. None = account-wide 5h/7d only
     # (default).
     model: str | None = None
+    # When a non-active account's 5h window resets (its usage API drops
+    # `resets_at` from `five_hour` until a request lands in the new
+    # window — the `pct` field alone stays present), send it one throwaway
+    # Haiku message through its own isolated session profile (the same
+    # isolation `cswap run` uses) so that window's clock starts now instead
+    # of whenever it is next needed. Never touches the active credential,
+    # so it can never redirect another live Claude Code session onto a
+    # different account mid-conversation and break its prompt cache (cache
+    # is scoped per Anthropic org; a redirected session would reprocess its
+    # whole history at full price on its next message). Off by default;
+    # the ping itself costs a fraction of a cent (Haiku, ~2 tokens in).
+    warm_on_reset: bool = False
 
 
 @dataclass(frozen=True)
@@ -134,6 +146,10 @@ SETTING_SPECS: dict[str, SettingSpec] = {
         SettingSpec(
             "autoswitch", "model", "model", "string",
             help="Also switch on these models' weekly limits (e.g. Fable, Fable,Opus, or all)",
+        ),
+        SettingSpec(
+            "autoswitch", "warmOnReset", "warm_on_reset", "bool",
+            help="Touch an account once when its 5h window resets, then resume strategy",
         ),
         SettingSpec(
             "ui", "theme", "theme", "choice", choices=("dark", "light", "auto"),
@@ -431,6 +447,7 @@ def merged_with_cli(settings: AutoSwitchSettings, args) -> AutoSwitchSettings:
         ("include_api_key_accounts", "include_api_key_accounts"),
         ("model", "model"),
         ("strategy", "strategy"),
+        ("warm_on_reset", "warm_on_reset"),
     ):
         value = getattr(args, attr, None)
         if value is not None:

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -75,6 +75,7 @@ from claude_swap.printer import (
     warning,
 )
 from claude_swap.paths import (
+    AUTOSWITCH_STATE_FILENAME,
     get_backup_root,
     get_credentials_path,
     get_default_claude_config_home,
@@ -1770,7 +1771,31 @@ class ClaudeAccountSwitcher:
             active_number=active_number,
             accounts=tuple(accounts),
             taken_at=self._usage_store.clock(),
+            pinging=self._read_pinging_state(),
         )
+
+    def _read_pinging_state(self) -> dict | None:
+        """Best-effort read of `autoswitch_state.json`'s "pinging" key (a
+        `settings.warm_on_reset` isolated priming ping some `cswap auto` may
+        be mid-touch on right now). Display-only, so any read failure —
+        including no engine ever having run — is silently "nothing to
+        show", never an error.
+
+        ``AUTOSWITCH_STATE_FILENAME`` (also `autoswitch.STATE_FILENAME`)
+        lives in ``paths.py``, not ``autoswitch`` itself: ``autoswitch``
+        imports this module for the ``ClaudeAccountSwitcher`` type, so the
+        reverse import would cycle.
+        """
+        try:
+            raw = json.loads(
+                (self.backup_dir / AUTOSWITCH_STATE_FILENAME).read_text(encoding="utf-8")
+            )
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if not isinstance(raw, dict):
+            return None
+        pinging = raw.get("pinging")
+        return pinging if isinstance(pinging, dict) else None
 
     def usage_fetch_stamps(self) -> dict[str, float | None]:
         """Per-slot ``fetchedAt`` snapshot from the usage store — a pure file

--- a/src/claude_swap/tui/autoview.py
+++ b/src/claude_swap/tui/autoview.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 _EVENT_ROLES = {
     "switch": "accent",
+    "warm-ping": "accent",
     "error": "sev_warn",
     "account-quarantined": "sev_warn",
     "all-exhausted": "sev_crit",
@@ -69,6 +70,7 @@ class AutoScreen(Screen):
         Binding("left", "threshold_step(-1)", "-1%"),
         Binding("right", "threshold_step(1)", "+1%"),
         Binding("enter", "adjust_done", "Done"),
+        Binding("w", "toggle_warm_on_reset", "Warm-on-reset"),
         Binding("escape,q", "back", "Back"),
     ]
 
@@ -86,6 +88,10 @@ class AutoScreen(Screen):
         self._adjusting = False
         self._configured_threshold: float | None = None
         self._entry_threshold: float | None = None
+        # Mount-time file value, so the summary can flag a session-only
+        # toggle the same way it flags a session-only threshold — neither
+        # is ever written to settings.json from here.
+        self._configured_warm_on_reset: bool | None = None
 
     def compose(self) -> ComposeResult:
         yield AccountsPanel(show_minis=False, id="auto-active-panel")
@@ -107,6 +113,7 @@ class AutoScreen(Screen):
         # and remember that value: unmount restores it (only the session
         # adjustment reverts, not this correction).
         self._configured_threshold = self._settings.threshold
+        self._configured_warm_on_reset = self._settings.warm_on_reset
         self.app.threshold_pct = self._settings.threshold
         self._update_summary()
         self.watch(self.app, "snapshot", self._on_snapshot)
@@ -189,6 +196,27 @@ class AutoScreen(Screen):
         self.query_one("#auto-active-panel", AccountsPanel).refresh()
         self._update_summary()
 
+    def action_toggle_warm_on_reset(self) -> None:
+        """Session-only flip, same precedent as the threshold override —
+        never written to settings.json. Only meaningful for this screen's
+        own running engine (an idle terminal, or a screen elsewhere in the
+        TUI, has no engine to hand the setting to) — the ping it enables
+        never touches the active credential either way, so toggling it has
+        no effect on what account this or any other screen shows active."""
+        if self._engine is None or self._settings is None:
+            return
+        enabled = not self._settings.warm_on_reset
+        self._settings = replace(self._settings, warm_on_reset=enabled)
+        self._engine.apply_warm_on_reset(enabled)
+        self._update_summary()
+        self.query_one("#event-log", RichLog).write(
+            Text(
+                f"— warm-on-reset {'enabled' if enabled else 'disabled'} "
+                "for this session —",
+                style=Palette.from_theme(self.app.current_theme).muted,
+            )
+        )
+
     def _update_summary(self) -> None:
         palette = Palette.from_theme(self.app.current_theme)
         text = Text()
@@ -200,6 +228,13 @@ class AutoScreen(Screen):
         if self._settings.threshold != self._configured_threshold:
             text.append(" (session)", style=palette.muted)
         text.append(f" · poll every {self._settings.interval_seconds:.0f}s")
+        warm_is_session = self._settings.warm_on_reset != self._configured_warm_on_reset
+        if self._settings.warm_on_reset:
+            text.append(" · warm-on-reset", style=palette.accent)
+            if warm_is_session:
+                text.append(" (session)", style=palette.muted)
+        elif warm_is_session:
+            text.append(" · warm-on-reset off (session)", style=palette.muted)
         if self._adjusting:
             text.append("   ← → adjust · enter done", style=palette.muted)
         self.query_one("#auto-summary", Static).update(text)

--- a/src/claude_swap/tui/dashboard.py
+++ b/src/claude_swap/tui/dashboard.py
@@ -26,6 +26,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, ListView, Static
 
 from claude_swap.models import AccountsSnapshot
+from claude_swap.settings import load_settings
 from claude_swap.tui.widgets import AccountItem, AccountsPanel, MenuItem
 
 if TYPE_CHECKING:
@@ -243,7 +244,9 @@ class AccountListScreen(Screen):
             first_build = not self._numbers
             previous = listview.index
             await listview.clear()
-            await listview.extend(AccountItem(acc) for acc in snap.accounts)
+            await listview.extend(
+                AccountItem(acc, pinging=snap.pinging) for acc in snap.accounts
+            )
             self._numbers = numbers
             listview.index = (
                 self._index_after_build(snap, first_build, previous)
@@ -252,7 +255,7 @@ class AccountListScreen(Screen):
             )
         else:
             for item, acc in zip(listview.query(AccountItem), snap.accounts):
-                item.set_account(acc)
+                item.set_account(acc, snap.pinging)
         self._flash_updated(snap, listview)
 
     def _index_after_build(
@@ -352,8 +355,15 @@ class WatchScreen(AccountListScreen):
     def __init__(self) -> None:
         super().__init__()
         self._selecting = False
+        # Read once at mount, like the auto-switch view's own settings load:
+        # this screen runs no engine of its own, so this is the file's
+        # *configured* preference, honored whenever some `cswap auto` (this
+        # TUI's own auto view, the CLI, a cron `--once`, or the menu bar)
+        # is actually running — never a claim that priming is happening now.
+        self._warm_on_reset = False
 
     def on_mount(self) -> None:
+        self._warm_on_reset = load_settings(self.app.switcher.backup_dir).warm_on_reset
         self.watch(self.app, "refresh_status", self._on_refresh_status)
         self.query_one("#list-title", Static).update(self._title_text())
         super().on_mount()
@@ -361,8 +371,13 @@ class WatchScreen(AccountListScreen):
     def _title_text(self) -> str:
         if self._selecting:
             return self._SELECT_TITLE
+        base = (
+            f"{self._WATCH_TITLE} · warm-on-reset"
+            if self._warm_on_reset
+            else self._WATCH_TITLE
+        )
         status = self.app.refresh_status
-        return f"{self._WATCH_TITLE} · {status}" if status else self._WATCH_TITLE
+        return f"{base} · {status}" if status else base
 
     def _on_refresh_status(self, status: str) -> None:
         if not self._selecting:

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -167,9 +167,19 @@ def account_card_text(
     threshold: float | None = None,
     now: float | None = None,
     palette: Palette = Palette.DARK,
+    pinging: dict | None = None,
 ) -> Text:
-    """The full account card: header line + per-window bar rows."""
+    """The full account card: header line + per-window bar rows.
+
+    ``pinging`` is the raw ``autoswitch_state.json`` "pinging" entry
+    (``{"number", "since"}``), when `settings.warm_on_reset` has some
+    `cswap auto` mid-touch right now — a brief, isolated ping that never
+    touches the active credential. "active" always tracks the real live
+    credential (``acc.is_active``), completely unaffected by this; the
+    account being pinged (``number``) additionally gets a "priming" tag.
+    """
     now = now if now is not None else time.time()
+    pinging_target = str(pinging["number"]) if pinging and "number" in pinging else None
 
     text = Text()
     text.append(f"{acc.number:>2}  ", style=f"bold {palette.foreground}")
@@ -181,6 +191,8 @@ def account_card_text(
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.is_active:
         text.append("   ● active", style=f"bold {palette.accent}")
+    if acc.number == pinging_target:
+        text.append("   ◐ priming", style=f"bold {palette.sev_warn}")
     if acc.disabled:
         text.append("   (disabled)", style=palette.muted)
     age = data.format_age(acc.usage.age_s)
@@ -340,7 +352,7 @@ class AccountsPanel(Static):
                 blocks.append(
                     account_card_text(
                         acc, width, threshold=app.threshold_pct, now=now,
-                        palette=palette,
+                        palette=palette, pinging=snap.pinging,
                     )
                 )
             elif self._show_minis:
@@ -362,34 +374,43 @@ class AccountsPanel(Static):
 class AccountCard(Static):
     """One account rendered full-size (used by the switch screen's list)."""
 
-    def __init__(self, acc: AccountSnapshot, *, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        acc: AccountSnapshot,
+        *,
+        threshold: float | None = None,
+        pinging: dict | None = None,
+    ) -> None:
         super().__init__()
         self._acc = acc
         self._threshold = threshold
+        self._pinging = pinging
 
-    def set_account(self, acc: AccountSnapshot) -> None:
+    def set_account(self, acc: AccountSnapshot, pinging: dict | None = None) -> None:
         self._acc = acc
+        self._pinging = pinging
         self.refresh(layout=True)
 
     def render(self) -> Text:
         return account_card_text(
             self._acc, self.size.width or 80, threshold=self._threshold,
             palette=Palette.from_theme(self.app.current_theme),
+            pinging=self._pinging,
         )
 
 
 class AccountItem(ListItem):
     """ListView row wrapping an :class:`AccountCard`; remembers its slot."""
 
-    def __init__(self, acc: AccountSnapshot) -> None:
-        super().__init__(AccountCard(acc))
+    def __init__(self, acc: AccountSnapshot, *, pinging: dict | None = None) -> None:
+        super().__init__(AccountCard(acc, pinging=pinging))
         self.number = acc.number
         self.email = acc.email
 
-    def set_account(self, acc: AccountSnapshot) -> None:
+    def set_account(self, acc: AccountSnapshot, pinging: dict | None = None) -> None:
         self.number = acc.number
         self.email = acc.email
-        self.query_one(AccountCard).set_account(acc)
+        self.query_one(AccountCard).set_account(acc, pinging)
 
 
 class MenuItem(ListItem):

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -27,6 +27,7 @@ from claude_swap.autoswitch import (
     SwitchEvent,
     TickOutcome,
     UnquarantineEvent,
+    WarmPingEvent,
     _recovery_is_useful,
     pct_label,
 )
@@ -6894,3 +6895,189 @@ class TestFreshenRoutesThroughGate:
         assert gate_calls["args"][0] == "2"
         assert "called" not in direct, "freshen must not POST outside the gate"
 
+
+def _idle(seven_day_pct: float = 0.0) -> dict:
+    """Usage shape for an account whose 5h window is not currently ticking.
+
+    Covers both real shapes ``oauth.build_usage_result`` can produce before a
+    request lands in the window following a reset: the ``five_hour`` key
+    omitted entirely, or present with ``pct`` but no ``resets_at`` — this
+    helper uses the former since ``_five_hour_active`` treats both alike.
+    """
+    return {"seven_day": {"pct": seven_day_pct}}
+
+
+
+class TestWarmOnReset:
+    """`settings.warm_on_reset`: the moment a non-active account's 5h window
+    resets, ping it once through its own isolated session profile (never
+    the active credential — see `_maybe_warm_reset`'s docstring) so its
+    clock starts now rather than whenever `strategy` gets around to it."""
+
+    def _two_account_harness(self, temp_home: Path, **settings_kwargs) -> EngineHarness:
+        h = EngineHarness(temp_home, warm_on_reset=True, threshold=90.0, **settings_kwargs)
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        return h
+
+    def test_off_by_default_ignores_a_reset_transition(self, temp_home):
+        h = EngineHarness(temp_home, threshold=90.0)  # warm_on_reset defaults False
+        h.seed(1, "a@example.com")
+        h.seed(2, "b@example.com")
+        h.make_live("a@example.com", 1)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})
+        h.events.clear()
+
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle()})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert not any(isinstance(e, WarmPingEvent) for e in h.events)
+        assert "fiveHourSeen" not in h.state()
+
+    def test_first_observation_only_seeds_the_baseline(self, temp_home):
+        h = self._two_account_harness(temp_home)
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert not any(isinstance(e, WarmPingEvent) for e in h.events)
+        assert h.state()["fiveHourSeen"] == {"1": True, "2": True}
+
+    def test_reset_transition_pings_without_touching_the_active_account(
+        self, temp_home, monkeypatch
+    ):
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.events.clear()
+        monkeypatch.setattr(
+            h.engine._session_manager, "ping_to_warm", lambda identifier: True
+        )
+
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1  # never touched — the ping is isolated
+        assert not any(isinstance(e, SwitchEvent) for e in h.events)
+        ping = next(e for e in h.events if isinstance(e, WarmPingEvent))
+        assert ping.number == "2"
+        assert ping.status == "sent"
+        assert ping.dry_run is False
+        assert h.state()["fiveHourSeen"]["2"] is False
+        # `pinging` only ever exists for the blocking call's duration —
+        # cleared again before the tick returns.
+        assert "pinging" not in h.state()
+
+    def test_ping_failure_leaves_the_reset_pending_for_next_tick(
+        self, temp_home, monkeypatch
+    ):
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.events.clear()
+        monkeypatch.setattr(
+            h.engine._session_manager, "ping_to_warm", lambda identifier: False
+        )
+
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        ping = next(e for e in h.events if isinstance(e, WarmPingEvent))
+        assert ping.number == "2"
+        assert ping.status == "failed"
+        # Not consumed — a later tick with the same idle usage detects the
+        # same reset again and retries the ping.
+        assert h.state()["fiveHourSeen"]["2"] is True
+
+    def test_dead_credential_is_quarantined_before_any_ping_is_attempted(
+        self, temp_home, monkeypatch
+    ):
+        """`_freshen_target`'s pre-flight (the same one every other trigger
+        uses) catches a dead/conflicting credential — the isolated profile
+        must never be bootstrapped from a token already known bad."""
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.events.clear()
+        calls: list[str] = []
+        monkeypatch.setattr(
+            h.engine._session_manager,
+            "ping_to_warm",
+            lambda identifier: calls.append(identifier) or True,
+        )
+        monkeypatch.setattr(
+            h.engine, "_freshen_target", lambda number, email: "invalid_grant"
+        )
+
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert calls == []  # ping_to_warm never reached
+        assert any(
+            isinstance(e, QuarantineEvent) and e.number == "2" for e in h.events
+        )
+        assert not any(isinstance(e, WarmPingEvent) for e in h.events)
+
+    def test_live_manual_session_is_never_interrupted(self, temp_home, monkeypatch):
+        """A live manual `cswap run` on the target already owns its token —
+        `_freshen_target` already reports this as "skip-live-session", and
+        warm-reset must never bootstrap or ping over it."""
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.events.clear()
+        calls: list[str] = []
+        monkeypatch.setattr(
+            h.engine._session_manager,
+            "ping_to_warm",
+            lambda identifier: calls.append(identifier) or True,
+        )
+        monkeypatch.setattr(
+            h.engine, "_freshen_target", lambda number, email: "skip-live-session"
+        )
+
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert calls == []
+        assert not any(isinstance(e, WarmPingEvent) for e in h.events)
+        # Retried later — the reset stays pending, not dropped.
+        assert h.state()["fiveHourSeen"]["2"] is True
+
+    def test_never_touches_a_disabled_account(self, temp_home):
+        """`switchable_account_numbers()` is where every strategy excludes
+        disabled slots — warm-reset must go through the same gate, not its
+        own copy that could drift out of sync."""
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.switcher.set_account_disabled("2", True)
+        h.events.clear()
+
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert not any(isinstance(e, WarmPingEvent) for e in h.events)
+        # Excluded from the loop entirely — its stale baseline carries
+        # forward untouched rather than being read as a (fake) reset.
+        assert h.state()["fiveHourSeen"]["2"] is True
+
+    def test_dry_run_never_pings_or_persists(self, temp_home, monkeypatch):
+        h = self._two_account_harness(temp_home)
+        h.engine = h._make_engine(dry_run=True)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        assert h.state() == {}
+        calls: list[str] = []
+        monkeypatch.setattr(
+            h.engine._session_manager,
+            "ping_to_warm",
+            lambda identifier: calls.append(identifier) or True,
+        )
+
+        outcome = h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(5.0)})
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert calls == []  # dry-run never calls the real (or mocked) ping
+        ping = next(e for e in h.events if isinstance(e, WarmPingEvent))
+        assert ping.dry_run is True
+        assert ping.status == "sent"
+        assert h.active_number() == 1  # never touched
+        assert h.state() == {}

--- a/tests/test_autoswitch.py
+++ b/tests/test_autoswitch.py
@@ -6989,6 +6989,33 @@ class TestWarmOnReset:
         # same reset again and retries the ping.
         assert h.state()["fiveHourSeen"]["2"] is True
 
+    def test_still_capped_by_weekly_window_is_never_pinged(
+        self, temp_home, monkeypatch
+    ):
+        """5h resetting doesn't mean the account is usable — a still-100%
+        7d window would reject the ping at the API level. Must not spawn a
+        session/ping for it at all, and the reset stays pending so it's
+        retried once the weekly window actually clears."""
+        h = self._two_account_harness(temp_home)
+        h.tick_with_usage({"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _usage(30, "2030-01-01T00:00:00Z")})  # baseline
+        h.events.clear()
+        calls: list[str] = []
+        monkeypatch.setattr(
+            h.engine._session_manager,
+            "ping_to_warm",
+            lambda identifier: calls.append(identifier) or True,
+        )
+
+        outcome = h.tick_with_usage(
+            {"1": _usage(20, "2030-01-01T00:00:00Z"), "2": _idle(100.0)}
+        )
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert calls == []  # ping_to_warm never reached
+        assert not any(isinstance(e, WarmPingEvent) for e in h.events)
+        # Retried later — the reset stays pending, not dropped.
+        assert h.state()["fiveHourSeen"]["2"] is True
+
     def test_dead_credential_is_quarantined_before_any_ping_is_attempted(
         self, temp_home, monkeypatch
     ):

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -48,10 +48,11 @@ class TestConfigList:
             "autoswitch.includeApiKeyAccounts",
             "autoswitch.unhealthyTicks",
             "autoswitch.model",
+            "autoswitch.warmOnReset",
             "ui.theme",
         ):
             assert key in out
-        assert out.count("(default)") == 9
+        assert out.count("(default)") == 10
 
     def test_set_key_not_marked_default(self, temp_home, capsys):
         _run(["set", "autoswitch.cooldownSeconds", "600"], capsys)
@@ -78,7 +79,7 @@ class TestConfigList:
         assert payload["schemaVersion"] == 1
         assert payload["path"].endswith("settings.json")
         by_key = {entry["key"]: entry for entry in payload["settings"]}
-        assert len(by_key) == 9
+        assert len(by_key) == 10
         assert by_key["autoswitch.threshold"]["value"] == 90.0
         assert by_key["autoswitch.threshold"]["isSet"] is False
         assert by_key["autoswitch.includeApiKeyAccounts"]["value"] is False

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -784,6 +784,91 @@ class TestIsSessionValid:
         assert seen_argv["argv"][0] == resolved
 
 
+class TestPingToWarm:
+    """`SessionManager.ping_to_warm`: `warm_on_reset`'s isolated priming
+    touch — one throwaway headless message through the account's own
+    session profile, never the active credential."""
+
+    def _mock_setup_session(self, manager, monkeypatch, session_dir):
+        monkeypatch.setattr(
+            manager,
+            "setup_session",
+            lambda identifier, share=False, share_history=False: (
+                session_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
+            ),
+        )
+
+    def test_ok(self, manager, tmp_path, monkeypatch):
+        self._mock_setup_session(manager, monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            session_mod.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        assert manager.ping_to_warm(ACCOUNT_NUM) is True
+
+    def test_setup_session_failure_never_spawns(self, manager, monkeypatch):
+        def boom(identifier, share=False, share_history=False):
+            raise SessionError("profile could not be bootstrapped")
+
+        monkeypatch.setattr(manager, "setup_session", boom)
+        spawned = []
+        monkeypatch.setattr(
+            session_mod.subprocess,
+            "run",
+            lambda *a, **k: spawned.append(a) or SimpleNamespace(returncode=0),
+        )
+        assert manager.ping_to_warm(ACCOUNT_NUM) is False
+        assert spawned == []
+
+    def test_nonzero_exit_is_a_failure(self, manager, tmp_path, monkeypatch):
+        self._mock_setup_session(manager, monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            session_mod.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="oops"),
+        )
+        assert manager.ping_to_warm(ACCOUNT_NUM) is False
+
+    def test_timeout_is_a_failure(self, manager, tmp_path, monkeypatch):
+        self._mock_setup_session(manager, monkeypatch, tmp_path)
+
+        def raise_timeout(*a, **k):
+            raise session_mod.subprocess.TimeoutExpired(cmd="claude", timeout=60)
+
+        monkeypatch.setattr(session_mod.subprocess, "run", raise_timeout)
+        assert manager.ping_to_warm(ACCOUNT_NUM) is False
+
+    def test_missing_binary_is_a_failure(self, manager, tmp_path, monkeypatch):
+        self._mock_setup_session(manager, monkeypatch, tmp_path)
+
+        def raise_oserror(*a, **k):
+            raise OSError("claude not found")
+
+        monkeypatch.setattr(session_mod.subprocess, "run", raise_oserror)
+        assert manager.ping_to_warm(ACCOUNT_NUM) is False
+
+    def test_uses_the_isolated_profile_and_a_cheap_headless_call(
+        self, manager, tmp_path, monkeypatch
+    ):
+        """The ping must run in the account's own `CLAUDE_CONFIG_DIR`
+        (never the global default) with Haiku and a throwaway message —
+        the whole point is never touching the active credential and never
+        spending more than a fraction of a cent."""
+        self._mock_setup_session(manager, monkeypatch, tmp_path)
+        seen: dict = {}
+
+        def capture_run(argv, env=None, **kwargs):
+            seen["argv"] = argv
+            seen["env"] = env
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(session_mod.subprocess, "run", capture_run)
+        assert manager.ping_to_warm(ACCOUNT_NUM) is True
+        assert seen["argv"][1:] == ["-p", "hi", "--model", "haiku"]
+        assert seen["env"]["CLAUDE_CONFIG_DIR"] == str(tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # sharing
 # ---------------------------------------------------------------------------

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -343,6 +343,32 @@ class TestFormatting:
         ).plain
         assert "last seen" not in api_key
 
+    def test_pinging_badge_tags_the_account_being_pinged(self):
+        # `warm_on_reset`'s isolated ping never touches the active
+        # credential — "active" tracks ground truth exactly as always;
+        # the account being pinged (here #2) additionally gets "priming",
+        # independent of which account is active.
+        from claude_swap.tui.widgets import account_card_text
+
+        pinging = {"number": "2", "since": 0.0}
+
+        untouched = account_card_text(
+            make_account(1, active=True), 80, pinging=pinging
+        ).plain
+        assert "● active" in untouched
+        assert "priming" not in untouched
+
+        touched = account_card_text(
+            make_account(2, active=False), 80, pinging=pinging
+        ).plain
+        assert "active" not in touched
+        assert "◐ priming" in touched
+
+        # No ping in flight: no priming tag, badge is just the real slot.
+        no_ping = account_card_text(make_account(2, active=True), 80).plain
+        assert "● active" in no_ping
+        assert "priming" not in no_ping
+
     def test_account_card_uses_light_palette_when_passed(self):
         from claude_swap.tui.theme import ACCENT_LIGHT, CSWAP_LIGHT, Palette
         from claude_swap.tui.widgets import account_card_text
@@ -1164,6 +1190,34 @@ class TestWatchScreen:
             assert isinstance(app.screen, DashboardScreen)
             assert not any(call[0] == "switch_to" for call in fake.calls)
 
+    async def test_warm_on_reset_indicator_shown_when_configured(self, tmp_path):
+        import json as _json
+
+        (tmp_path / "settings.json").write_text(_json.dumps({
+            "schemaVersion": 1, "autoswitch": {"warmOnReset": True},
+        }))
+        app = make_app(self._fake(tmp_path))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from textual.widgets import Static
+
+            title = app.screen.query_one("#list-title", Static).render().plain
+            assert "warm-on-reset" in title
+            assert "watching all accounts" in title
+
+    async def test_warm_on_reset_indicator_absent_by_default(self, tmp_path):
+        app = make_app(self._fake(tmp_path))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("w")
+            await pilot.pause()
+            from textual.widgets import Static
+
+            title = app.screen.query_one("#list-title", Static).render().plain
+            assert "warm-on-reset" not in title
+
     async def test_menu_watch_entry_opens_it(self, tmp_path):
         app = make_app(self._fake(tmp_path))
         async with app.run_test(size=(100, 40)) as pilot:
@@ -1294,6 +1348,7 @@ class _FakeEngine:
         self.dry_run = dry_run
         self.stopped = False
         self.applied_thresholds: list[float] = []
+        self.applied_warm_on_reset: list[bool] = []
         self.wakes = 0
         self._stop = threading.Event()
         _FakeEngine.instances.append(self)
@@ -1310,6 +1365,10 @@ class _FakeEngine:
     def apply_threshold(self, threshold: float) -> None:
         self.settings = dataclasses.replace(self.settings, threshold=threshold)
         self.applied_thresholds.append(threshold)
+
+    def apply_warm_on_reset(self, enabled: bool) -> None:
+        self.settings = dataclasses.replace(self.settings, warm_on_reset=enabled)
+        self.applied_warm_on_reset.append(enabled)
 
     def wake(self) -> None:
         self.wakes += 1
@@ -1474,6 +1533,72 @@ class TestAutoScreen:
             screen.action_threshold_step(-60.0)
             await pilot.pause()
             assert screen._settings.threshold == 50.0  # spec's lower bound
+
+    async def test_warm_on_reset_toggle_is_session_only(self, tmp_path, fake_engine):
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(pilot)
+            screen = app.screen
+            assert screen._settings.warm_on_reset is False  # file default
+            from textual.widgets import Static
+
+            summary = screen.query_one("#auto-summary", Static)
+            assert "warm-on-reset" not in summary.render().plain
+
+            await pilot.press("w")
+            await pilot.pause()
+            assert screen._settings.warm_on_reset is True
+            engine = fake_engine.instances[0]
+            assert engine.applied_warm_on_reset == [True]
+            assert "warm-on-reset (session)" in summary.render().plain
+            assert not (tmp_path / "settings.json").exists()  # never persisted
+
+            await pilot.press("w")  # back off — matches the file default again
+            await pilot.pause()
+            assert screen._settings.warm_on_reset is False
+            assert engine.applied_warm_on_reset == [True, False]
+            # Round-tripped back to the configured value: indistinguishable
+            # from never having touched it, same as the threshold's marker.
+            assert "warm-on-reset" not in summary.render().plain
+
+            # a dry↔live restart rebuilds the engine from the adjusted copy
+            await pilot.press("w")  # on again, then go live
+            await pilot.pause()
+            await pilot.press("l")
+            await pilot.pause()
+            await pilot.press("y")
+            await settle(pilot)
+            assert fake_engine.instances[1].settings.warm_on_reset is True
+
+    async def test_warm_on_reset_session_off_marks_deviation_from_file(
+        self, tmp_path, fake_engine
+    ):
+        import json as _json
+
+        (tmp_path / "settings.json").write_text(_json.dumps({
+            "schemaVersion": 1, "autoswitch": {"warmOnReset": True},
+        }))
+        fake = FakeSwitcher(
+            [make_account(1, active=True), make_account(2)], tmp_path
+        )
+        app = make_app(fake)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await self._open(pilot)
+            screen = app.screen
+            assert screen._settings.warm_on_reset is True  # file default
+            from textual.widgets import Static
+
+            summary = screen.query_one("#auto-summary", Static)
+            assert "warm-on-reset" in summary.render().plain
+            assert "(session)" not in summary.render().plain
+
+            await pilot.press("w")  # turn it off for this session
+            await pilot.pause()
+            assert screen._settings.warm_on_reset is False
+            assert "warm-on-reset off (session)" in summary.render().plain
 
     async def test_candidates_ranked_by_headroom(self, tmp_path, fake_engine):
         fake = FakeSwitcher(


### PR DESCRIPTION
## Why

Anthropic's usage API drops `resets_at` from an account's `five_hour` window until a request actually lands in it after a reset — the clock doesn't start on its own. Left alone, an idle account's fresh window starts at whatever moment `best`/`consume-first` eventually rotates onto it, leaving a fleet's 5h windows drifting with no predictable schedule.

## What

`autoswitch.warm_on_reset` (CLI: `--warm-on-reset`, config: `autoswitch.warmOnReset`) watches every non-active oauth candidate for that transition and, the moment it's seen, sends one throwaway Haiku message through that account's own **isolated session profile** — the same per-account isolation `cswap run` already provides (`<backup_dir>/sessions/<num>-<email>/`, its own `CLAUDE_CONFIG_DIR`) — so the window's clock starts right away.

This never touches the active credential. That matters: prompt cache is scoped per Anthropic organization and never shared across orgs, so redirecting a live Claude Code session (running in another terminal or project) onto a different account mid-conversation would make its next message reprocess the entire history at full price instead of the usual cached rate — a large, unexpected one-time hit to that session's own 5h quota. The isolated ping can't cause that: nothing about the account you were actually working from ever changes, and the ping itself (Haiku, ~2 tokens) costs a fraction of a cent. Off by default.

## Implementation

- `SessionManager.ping_to_warm` (session.py): bootstraps (or reuses) the target's isolated profile via the existing `setup_session`, then runs `claude -p "hi" --model haiku` as a bounded, one-shot subprocess (never `execvpe` — this must return, not replace the engine process) with that profile's env. Returns success/failure only; credential health (a dead token, an identity conflict, a live manual `cswap run` already owning the slot) is screened out by the engine's existing `_freshen_target` pre-flight before this is ever called.
- `AutoSwitchEngine._maybe_warm_reset` (autoswitch.py): reset-transition detection (`fiveHourSeen`, one-way edge) is unchanged in shape from a normal switch-based design; the action taken on a detected reset is now the isolated ping instead of a real account switch, so there is no multi-tick "hold" to track and no "give the session back" step. A `WarmPingEvent` reports each attempt (`cswap auto --json` kind `warm-ping`).
- TUI (Watch screen, auto-switch view): `AccountsSnapshot.pinging` tags whichever account a ping is currently in flight for with "priming", entirely independent of which account is genuinely active.

## Tests

`TestPingToWarm` (session.py mechanics, mocked), `TestWarmOnReset` (transition detection, ping success/failure, the `_freshen_target` pre-flight, disabled-account exclusion, dry-run isolation), plus a TUI test for the "priming" badge. Full suite green (2195 passed).