### PR TITLE
Read a symlinked profile's keychain entry under its target path

### DIFF
--- a/src/claude_swap/session.py
+++ b/src/claude_swap/session.py
@@ -305,13 +305,14 @@ def _may_have_credential_material(session_dir: Path) -> bool:
         pass  # no readable seed — the keychain may still hold the material
     if Platform.detect() != Platform.MACOS:
         return False
-    try:
-        material = macos_keychain.get_password(
-            keychain_service_name(session_dir), _keychain_account_name()
-        )
-    except macos_keychain.KEYCHAIN_ERRORS:
-        return True  # unreadable is not absent: preserve the profile
-    return material is not None
+    for service in _keychain_services(str(session_dir)):
+        try:
+            material = macos_keychain.get_password(service, _keychain_account_name())
+        except macos_keychain.KEYCHAIN_ERRORS:
+            return True  # unreadable is not absent: preserve the profile
+        if material is not None:
+            return True
+    return False
 
 
 def _artifacts_say_usable(session_dir: Path, email: str, org_uuid: str) -> bool:
@@ -334,6 +335,47 @@ def _artifacts_say_usable(session_dir: Path, email: str, org_uuid: str) -> bool:
 # (credentials._ACTIVE_READ_ATTEMPTS / _ACTIVE_READ_RETRY_DELAY).
 _STRICT_KEYCHAIN_ATTEMPTS = 2
 _STRICT_KEYCHAIN_RETRY_DELAY = 0.3  # seconds between attempts
+
+
+def _keychain_services(config_dir: str, override: str | None = None) -> list[str]:
+    """Keychain service names that may hold a profile's credential, in
+    lookup order.
+
+    Claude hashes the exported ``CLAUDE_CONFIG_DIR`` verbatim, so a profile
+    that is a symlink was launched under one of two names: its own path, or
+    the target's, when a tool launches claude at the target directly and
+    keeps the per-account symlink as its bookkeeping (a lease). Reading only
+    the link's name would miss every rotation claude wrote under the
+    target's and serve the plaintext seed left behind, which is how a leased
+    profile's usage silently froze at the last pre-rotation measurement. The
+    profile's own name is tried first, then the target's. ``override`` names
+    the unsuffixed default-profile item and stands alone.
+    """
+    if override is not None:
+        return [override]
+    services = [keychain_service_name(config_dir)]
+    try:
+        target = os.readlink(config_dir)
+    except OSError:
+        return services
+    if not os.path.isabs(target):
+        target = os.path.join(os.path.dirname(config_dir), target)
+    services.append(keychain_service_name(target))
+    return services
+
+
+def _keychain_entry(service: str, strict: bool) -> str | None:
+    """One service's item, or ``None`` when absent (rc 44). An unreadable
+    keychain is retried once under ``strict`` and then raised as it stands."""
+    attempts = _STRICT_KEYCHAIN_ATTEMPTS if strict else 1
+    while True:
+        try:
+            return macos_keychain.get_password(service, _keychain_account_name())
+        except macos_keychain.KEYCHAIN_ERRORS:
+            attempts -= 1
+            if not attempts:
+                raise
+            time.sleep(_STRICT_KEYCHAIN_RETRY_DELAY)
 
 
 def read_config_dir_credentials(
@@ -366,17 +408,10 @@ def read_config_dir_credentials(
     if not directory.is_dir():
         return None
     if Platform.detect() == Platform.MACOS:
-        attempts = _STRICT_KEYCHAIN_ATTEMPTS if strict_keychain else 1
-        for attempt in range(attempts):
+        for service in _keychain_services(config_dir, keychain_service):
             try:
-                creds = macos_keychain.get_password(
-                    keychain_service or keychain_service_name(config_dir),
-                    _keychain_account_name(),
-                )
+                creds = _keychain_entry(service, strict_keychain)
             except macos_keychain.KEYCHAIN_ERRORS as e:
-                if attempt + 1 < attempts:
-                    time.sleep(_STRICT_KEYCHAIN_RETRY_DELAY)
-                    continue
                 if strict_keychain:
                     raise CredentialReadError(
                         f"Keychain entry for profile {config_dir} is unreadable "
@@ -385,7 +420,7 @@ def read_config_dir_credentials(
                 break  # best-effort read: the plaintext seed is the next-best truth
             if creds:
                 return creds
-            break  # entry absent (rc 44) — claude's own signal to read the file
+            # entry absent (rc 44) — claude's own signal to look further
     try:
         return (directory / ".credentials.json").read_text(encoding="utf-8")
     except (OSError, ValueError):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2092,6 +2092,50 @@ class TestReadSessionCredentials:
         creds = session_mod.read_session_credentials(session_dir)
         assert creds is not None and "sk-seed" in creds
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlinks are POSIX-only")
+    def test_symlinked_profile_reads_the_target_keychain_entry(
+        self, tmp_path, macos_platform, block_real_keychain
+    ):
+        """A tool that launches claude at a shared directory and leases it to
+        an account through a profile symlink leaves every rotation under the
+        target's hashed name, with the seed at the link's path behind it."""
+        target = tmp_path / "space"
+        target.mkdir()
+        (target / ".credentials.json").write_text(
+            '{"claudeAiOauth": {"accessToken": "sk-stale-seed"}}'
+        )
+        session_dir = tmp_path / "sess"
+        session_dir.symlink_to(target)
+        block_real_keychain.set_password(
+            keychain_service_name(target),
+            session_mod._keychain_account_name(),
+            '{"claudeAiOauth": {"accessToken": "sk-rotated"}}',
+        )
+        creds = session_mod.read_session_credentials(session_dir)
+        assert creds is not None and "sk-rotated" in creds
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlinks are POSIX-only")
+    def test_symlinked_profile_prefers_its_own_keychain_entry(
+        self, tmp_path, macos_platform, block_real_keychain
+    ):
+        target = tmp_path / "space"
+        target.mkdir()
+        session_dir = tmp_path / "sess"
+        session_dir.symlink_to(target)
+        account = session_mod._keychain_account_name()
+        block_real_keychain.set_password(
+            keychain_service_name(target),
+            account,
+            '{"claudeAiOauth": {"accessToken": "sk-target"}}',
+        )
+        block_real_keychain.set_password(
+            keychain_service_name(session_dir),
+            account,
+            '{"claudeAiOauth": {"accessToken": "sk-own"}}',
+        )
+        creds = session_mod.read_session_credentials(session_dir)
+        assert creds is not None and "sk-own" in creds
+
 
 ACTIVE_TOKEN = "active-store-token"
 CONFIG_DIR_TOKEN = "config-dir-token"


### PR DESCRIPTION
Claude derives its keychain service name from the exported CLAUDE_CONFIG_DIR string, so a session profile that is a symlink can hold its credential under two names: the link's own path, when claude was launched through the link, or the target's path, when a tool launches claude at the target directly and keeps the per-account symlink for cswap's bookkeeping. Every read of a session profile hashed only the link's path, so on macOS a profile of the second kind always missed the keychain entry and fell back to the plaintext seed at the target, which claude stops updating the moment it first writes the keychain. The usage collector then fetched with that stale seed until it expired and, with the session still live, deferred every pass as a token-expired sentinel, so the account's usage silently froze at the last pre-rotation measurement while the credential in the keychain was perfectly fresh. The same lookup fed the reuse check and the credential adoption on exit, which saw the seed rather than the head.

This makes the read try the link's own service name first and, when the profile is a symlink, the target's next, before falling back to the plaintext file, and applies the same order to the existence test the validation-timeout fallback uses. Deletion keeps hashing only the profile's own path, since removing an entry under a target that another tool manages is not cswap's to do. Absence under one name still means looking further, and an unreadable keychain keeps its existing strict and best-effort behaviour.