### PR TITLE
auto: per-account order — an explicit switch chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,35 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you either log in with it and re-run `cswap add --slot N`, or replace its stored credentials from a known-good export — a plain `cswap import backup.cswap` replaces dead-token slots on its own (`--force` is still required to replace other existing accounts; note a stale export can carry an already-superseded token). API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
 - To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
+- **Per-account policy.** Two knobs let one account be spent differently from the rest. `cswap threshold <num|email> <pct>` gives that account its own switch-away line, used in place of the global one on both sides of a switch — the engine leaves an account when *its own* line is reached, and refuses to land on a candidate already past *its own*. `cswap backup <num|email>` holds an account back as a reserve: it is skipped while any other account can still be used, and taken only when none can — after which auto-switch returns to a primary as soon as one recovers. Both are per-account overrides, not global settings, so an account you never touch keeps behaving exactly as it does today. `cswap threshold` with no arguments lists the global default and every override; the [TUI](#interactive-dashboard-tui) shows `th 85%` and `(backup)` badges beside the account. Clear either with `cswap threshold <num|email> --unset` or `cswap unbackup <num|email>`.
+
+  A three-account fleet where account 1 is spent early, account 2 runs a little longer, and
+  account 3 is the reserve:
+
+  ```console
+  $ cswap threshold 1 75
+  Set Account-1 (a@example.com) threshold to 75%.
+
+  $ cswap threshold 2 85
+  Set Account-2 (b@example.com) threshold to 85%.
+
+  $ cswap backup 3
+  Account-3 (c@example.com) marked as backup.
+    It will be skipped by auto-switch while any other account can still be used, and taken only when none can.
+
+  $ cswap threshold
+  Switch-away thresholds:
+    global default  90%
+    Account-1  75%
+    Account-2  85%
+  ```
+
+  `cswap auto` now leaves account 1 at 75% and account 2 at 85%, and only reaches for account 3
+  once neither of the others can be landed on. Only the keys you set are written — account 2's
+  record gains `"threshold": 85.0` and account 3's gains `"backup": true`, and clearing them
+  removes the keys again, leaving `sequence.json` byte-identical to a store that never used the
+  feature. A rejected value (out of the 50–99.9 range, or not a number) is refused before the
+  file is opened, so a bad command changes nothing.
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
 
@@ -192,6 +221,11 @@ cswap add --alias dev           # Add account and give it a short alias
 cswap remove 2                  # Remove an account
 cswap disable 2                 # Hold an account out of auto-rotation (keeps its login)
 cswap enable 2                  # Return a disabled account to rotation
+cswap threshold 2 85            # Switch away from account 2 at 85%, not the global default
+cswap threshold 2 --unset       # Return account 2 to the global default
+cswap threshold                 # Show the global default and every per-account override
+cswap backup 3                  # Hold account 3 back as a last resort ("last man standing")
+cswap unbackup 3                # Return it to normal rotation
 cswap alias 2 dev               # Give an account a short alias (usable anywhere NUM|EMAIL is)
 cswap alias 2 --unset           # Remove an account's alias
 cswap alias                     # List all aliases
@@ -326,7 +360,7 @@ cswap switch 2 --json
 
 Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
 
-Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise).
+Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise). Per-account policy follows the same convention: a row carries `"threshold": 85.0` once one is set with `cswap threshold`, and `"backup": true` once the account is marked with `cswap backup` — both absent otherwise, so a fleet that never sets a policy emits rows identical to before.
 
 An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
 - It fails safe: if a usage check errors it keeps trusting the last-known numbers while retries back off, and an expired token on an idle machine makes it hold rather than fail over (Claude Code refreshes the token on your next message).
 - An account whose refresh token has died is quarantined and reported until you either log in with it and re-run `cswap add --slot N`, or replace its stored credentials from a known-good export — a plain `cswap import backup.cswap` replaces dead-token slots on its own (`--force` is still required to replace other existing accounts; note a stale export can carry an already-superseded token). API-key accounts are never rotated onto unless you pass `--include-api-key-accounts`.
 - To hold an account out of rotation yourself — a work account you don't want touched, one you're resting — run `cswap disable <num|email>`; `cswap enable <num|email>` puts it back. Disabled accounts are skipped by auto-switch, bare `cswap switch`, and the `best` / `next-available` strategies, but stay fully managed and remain a valid explicit `cswap switch <num|email>` target. They show a `(disabled)` marker in `cswap list`, in the [TUI](#interactive-dashboard-tui), and in the [menu bar](#menu-bar-macos) — both of which also let you toggle the state in place (TUI: menu → *Disable / enable account…*; menu bar: *Disable / enable account*).
-- **Per-account policy.** Two knobs let one account be spent differently from the rest. `cswap threshold <num|email> <pct>` gives that account its own switch-away line, used in place of the global one on both sides of a switch — the engine leaves an account when *its own* line is reached, and refuses to land on a candidate already past *its own*. `cswap backup <num|email>` holds an account back as a reserve: it is skipped while any other account can still be used, and taken only when none can — after which auto-switch returns to a primary as soon as one recovers. Both are per-account overrides, not global settings, so an account you never touch keeps behaving exactly as it does today. `cswap threshold` with no arguments lists the global default and every override; the [TUI](#interactive-dashboard-tui) shows `th 85%` and `(backup)` badges beside the account. Clear either with `cswap threshold <num|email> --unset` or `cswap unbackup <num|email>`.
+- **Per-account policy.** Three knobs let one account be spent differently from the rest. `cswap threshold <num|email> <pct>` gives that account its own switch-away line, used in place of the global one on both sides of a switch — the engine leaves an account when *its own* line is reached, and refuses to land on a candidate already past *its own*. `cswap backup <num|email>` holds an account back as a reserve: it is skipped while any other account can still be used, and taken only when none can — after which auto-switch returns to a primary as soon as one recovers. `cswap order <num|email> <rank>` pins that account's position in the switch chain: a lower rank is spent first, and every pinned account sorts ahead of every unpinned one. A pin is a leading tier on the ranking, not a tie-break — *within* a tier the active strategy still decides, so pins compose with `consume-first` rather than replacing it, and unpinned accounts go on being ranked by strategy alone. All three are per-account overrides rather than global settings, so an account you never touch keeps behaving exactly as it does today. `cswap threshold` and `cswap order` with no arguments print the global default with every override, and the resolved chain; the [TUI](#interactive-dashboard-tui) shows `th 85%`, `(backup)` and `ord 1` badges beside the account. Clear any of them with `cswap threshold <num|email> --unset`, `cswap order <num|email> --unset`, or `cswap unbackup <num|email>`.
 
-  A three-account fleet where account 1 is spent early, account 2 runs a little longer, and
-  account 3 is the reserve:
+  A three-account fleet where account 2 is spent first and to 85%, account 1 follows and leaves
+  earlier at 75%, and account 3 is the reserve nobody touches until the other two are done:
 
   ```console
   $ cswap threshold 1 75
@@ -124,14 +124,37 @@ cswap auto --strategy consume-first   # burn the soonest-resetting account first
     global default  90%
     Account-1  75%
     Account-2  85%
+
+  $ cswap order 2 1
+  Set Account-2 (b@example.com) chain order to 1.
+
+  $ cswap order 1 2
+  Set Account-1 (a@example.com) chain order to 2.
+
+  $ cswap order
+  Switch chain order:
+    Account-2  order 1
+    Account-1  order 2
+    Then, by the active ranking strategy:
+      Account-3
   ```
 
-  `cswap auto` now leaves account 1 at 75% and account 2 at 85%, and only reaches for account 3
-  once neither of the others can be landed on. Only the keys you set are written — account 2's
-  record gains `"threshold": 85.0` and account 3's gains `"backup": true`, and clearing them
-  removes the keys again, leaving `sequence.json` byte-identical to a store that never used the
-  feature. A rejected value (out of the 50–99.9 range, or not a number) is refused before the
-  file is opened, so a bad command changes nothing.
+  `cswap auto` now works down the chain — account 2 to 85%, then account 1 to 75% — and only
+  reaches for account 3 once neither of the others can be landed on. Account 3 is listed under
+  *by the active ranking strategy* because it carries no pin; being a reserve is what keeps it
+  out of the running, not its position. Only the keys you set are written — account 2's record
+  gains `"threshold": 85.0` and `"order": 1`, account 3's gains `"backup": true` — and
+  clearing them removes the keys again, leaving `sequence.json` byte-identical to a store that
+  never used the feature. A rejected value (a threshold outside 50–99.9, a rank outside 1–999,
+  or anything non-numeric) is refused before the file is opened, so a bad command changes
+  nothing.
+
+  One thing to know before you pin: a pin is a hard preference, and it overrides the strategy's
+  own judgement about what to spend. Under `consume-first`, an account whose weekly window has
+  just rolled over stops being urgent and the strategy demotes it on its own — a pin keeps it at
+  the front anyway, which can cost you the perishable quota on a different account. Pin when you
+  genuinely want a fixed chain; if you only mean *prefer this one, but not at any cost*, leave it
+  unpinned and let the strategy rank it.
 - By default only the account-wide 5h/7d windows drive switching. If you work on one model and hit its **weekly per-model limit** first (e.g. Fable), add `--model Fable` (or `cswap config set autoswitch.model Fable`) to fold that model's window into the decision, so it switches off an account whose model quota is spent even while its 5h/7d windows still have room.
   - **Model names** are Anthropic's own per-model `display_name`s, matched case-insensitively. The exact strings for your accounts are the per-model rows in `cswap list` (e.g. a line reading `Fable: 100%`).
 
@@ -226,6 +249,9 @@ cswap threshold 2 --unset       # Return account 2 to the global default
 cswap threshold                 # Show the global default and every per-account override
 cswap backup 3                  # Hold account 3 back as a last resort ("last man standing")
 cswap unbackup 3                # Return it to normal rotation
+cswap order 2 1                 # Spend account 2 first in the switch chain
+cswap order 2 --unset           # Drop the pin (rank account 2 by strategy again)
+cswap order                     # Show the resolved chain: pins first, then the rest
 cswap alias 2 dev               # Give an account a short alias (usable anywhere NUM|EMAIL is)
 cswap alias 2 --unset           # Remove an account's alias
 cswap alias                     # List all aliases
@@ -360,7 +386,7 @@ cswap switch 2 --json
 
 Every payload carries a `schemaVersion` (currently `1`); on a handled error stdout is `{"schemaVersion":1,"error":{...}}` with a non-zero exit code. `--switch`/`--switch-to` report `{"switched": true|false, "from": …, "to": …, "reason": …}`.
 
-Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise). Per-account policy follows the same convention: a row carries `"threshold": 85.0` once one is set with `cswap threshold`, and `"backup": true` once the account is marked with `cswap backup` — both absent otherwise, so a fleet that never sets a policy emits rows identical to before.
+Usage is served from a per-account cache: when the usage API is briefly unreachable, the last-known numbers are shown instead of nothing (the human view marks them with their age, e.g. `· 2m ago`). Rows with decision-trusted usage carry additive `usageFetchedAt`/`usageAgeSeconds` fields telling you how old the measurement is. Whenever `usage` is null but a last-known measurement exists — data too old to drive a decision (`usageStatus` stays `unavailable`), or a row in a non-`ok` state such as `token_expired` — additive `lastGoodUsage`/`lastGoodFetchedAt`/`lastGoodAgeSeconds` fields preserve the human display without making the account actionable. These fields apply to list rows and the managed active row from `status --json`. An account held out of rotation with `cswap disable` carries an additive `"disabled": true` on its row (absent otherwise). Per-account policy follows the same convention: a row carries `"threshold": 85.0` once one is set with `cswap threshold`, `"backup": true` once the account is marked with `cswap backup`, and `"order": 1` once it is pinned with `cswap order` — all three absent otherwise, so a fleet that never sets a policy emits rows identical to before.
 
 An account row also carries an additive `alias` field once one is set with `cswap alias` (e.g. `"alias": "dev"`); accounts without one simply omit the key.
 

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -47,6 +47,7 @@ from claude_swap import oauth, poll_policy
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import SCHEMA_VERSION, USAGE_TOKEN_EXPIRED
 from claude_swap.locking import FileLock
+from claude_swap.models import ORDER_UNSET_RANK
 from claude_swap.poll_policy import (
     ESCALATION_MARGIN_PCT,
     RESET_SLACK_S,
@@ -395,6 +396,23 @@ class SwitchEvent(AutoSwitchEvent):
 @dataclass(frozen=True)
 class NoSwitchEvent(AutoSwitchEvent):
     kind: ClassVar[str] = "no-switch"
+    # Enumerated for the same reason `SwitchEvent.trigger` above carries its
+    # own list: `reason` is what the TUI and `--json` consumers switch on, so
+    # an undocumented value is invisible to the next person extending this
+    # event.
+    #
+    #   active-account census:
+    #     "no-active-account" | "unmanaged-active-account" | "active-api-key"
+    #     | "active-idle" | "active-usage-unknown"
+    #   departure gate:
+    #     "below-threshold" | "cooldown" | "reset-unknown"
+    #   candidate census:
+    #     "no-candidates" | "no-comparison" | "no-qualifying-candidate"
+    #     | "no-viable-target" | "already-active" | "stale-usage"
+    #   strategy holds:
+    #     "already-consuming-soonest"
+    #     | "failback-hold" — a backup account is active and no primary has
+    #       recovered yet; detail "primaries still exhausted"
     reason: str
     detail: str = ""
 
@@ -610,6 +628,25 @@ class ThresholdMap(dict):
 
     def __missing__(self, key: str) -> float:
         return self.default
+
+
+class OrderMap(dict):
+    """Chain rank per account number - total by construction.
+
+    Mirrors :class:`ThresholdMap` for the same reason: ranking subscripts it
+    directly while building sort keys, so a partial map would raise mid-tick
+    in an unattended loop. An account with no ``order`` pin reads
+    ``ORDER_UNSET_RANK``, which is ``ACCOUNT_ORDER_MAX + 1`` and therefore
+    sorts *after* every legal rank - the sentinel must not be
+    ``ACCOUNT_ORDER_MIN``, or an unpinned fleet would outrank every pin and
+    the feature would be inverted.
+
+    ``__missing__`` deliberately does not memoise: the map is rebuilt per tick
+    and a caching sentinel would make it grow with every key ever asked for.
+    """
+
+    def __missing__(self, key: str) -> int:
+        return ORDER_UNSET_RANK
 
 
 def _every_account_above_threshold(
@@ -946,6 +983,20 @@ class AutoSwitchEngine:
             effective.threshold,
         )
 
+    def _resolve_orders(self) -> OrderMap:
+        """Every pinned account's chain rank, resolved once per tick.
+
+        Threaded DOWN into ``_rank_candidates`` as a parameter for the same
+        reason thresholds are: ranking is documented pure and runs twice per
+        tick under the consume-first two-phase commit, so a store read inside
+        it could rank phase 1 and phase 2 against different pins.
+
+        Unlike thresholds there is no global default to fall back to - "no
+        pin" is its own tier - so the map carries only the accounts that set
+        one and ``OrderMap.__missing__`` supplies the sentinel for the rest.
+        """
+        return OrderMap(self.switcher.account_orders())
+
     def _min_effective_threshold(
         self, thresholds: ThresholdMap | None = None
     ) -> float:
@@ -1045,6 +1096,13 @@ class AutoSwitchEngine:
         # account absent from it (never sequenced, just removed) reads the
         # global rather than raising mid-tick.
         thresholds = self._resolve_thresholds(settings)
+        # Same discipline, one resolution per tick: `_rank_candidates` runs
+        # twice under the consume-first two-phase commit and once more per
+        # backup pass, and all of them must rank against the same pins.
+        # Deliberately NOT passed to `_refresh_poll_policy_inputs` below:
+        # cadence is threshold-driven, and a pin says where to go, never how
+        # often to look.
+        orders = self._resolve_orders()
         # Cadence follows the same snapshot, and does so BEFORE collection is
         # planned below — see `_refresh_poll_policy_inputs`.
         self._refresh_poll_policy_inputs(thresholds)
@@ -1357,6 +1415,7 @@ class AutoSwitchEngine:
             settings=settings,
             now=decided_now,
             thresholds=thresholds,
+            orders=orders,
         )
 
         if trigger in ("consume-first", "failback") and ordered:
@@ -1389,6 +1448,7 @@ class AutoSwitchEngine:
                 settings=settings,
                 now=decided_now,
                 thresholds=thresholds,
+                orders=orders,
             )
 
         if trigger == "consume-first" and current not in backups and ordered:
@@ -1428,18 +1488,24 @@ class AutoSwitchEngine:
             because the departure gate stops at `below-threshold` before any
             ranking happens. The whole contract of this trigger is that a
             fleet which merely *configures* a reserve never starts seeing
-            `BLOCKED` or `ERROR` where it used to see a quiet hold — so the
-            hold reuses the gate's own event verbatim rather than inventing a
-            reason string. A diagnostic reason ("primaries still exhausted")
-            is a new observable and ships with its TUI surfacing in PR 2.
+            `BLOCKED` or `ERROR` where it used to see a quiet hold, and that is
+            still true: only the reason STRING changes here.
+
+            PR 1 held that string back on purpose and named PR 2 as its owner.
+            It borrowed the departure gate's `below-threshold` event verbatim,
+            which is a true statement about the active account and a useless
+            one about the tick: on a failback tick the active account IS the
+            reserve, and a reserve sitting under its own line is the normal
+            state rather than a reason. `failback-hold` says the one thing an
+            operator reading a stuck fleet needs — the primaries have not come
+            back yet.
+
+            Both hold sites call this closure, so the wording lives here once.
             """
             self._emit(
                 NoSwitchEvent(
-                    reason="below-threshold",
-                    detail=(
-                        f"{pct_label(100.0 - (active_headroom or 0.0))}% < "
-                        f"{pct_label(thresholds[current])}%"
-                    ),
+                    reason="failback-hold",
+                    detail="primaries still exhausted",
                 )
             )
             return TickOutcome.NO_ACTION
@@ -1456,8 +1522,18 @@ class AutoSwitchEngine:
             # expensive thing in the fleet. The same two-pass filter applies
             # here, so a reserve that happens to be an API-key account is the
             # last thing reached rather than the first.
+            # Here order really is a list pre-sort. Metered API-key accounts
+            # have no measurable headroom and no weekly window, so there is no
+            # strategy key to prepend a tier to - the list itself is the
+            # ranking. `sorted` is stable, so an unpinned fleet keeps today's
+            # sequence order exactly. Each pass is sorted separately so the
+            # two-pass reserve filter still wins: a pinned API-key reserve is
+            # ordered among the reserves, never promoted past a primary.
+            def _by_rank(pool: list[str]) -> list[str]:
+                return sorted(pool, key=lambda n: orders[n])
+
             primary_api_keys = [n for n in api_key_candidates if n not in backups]
-            ordered = primary_api_keys or api_key_candidates
+            ordered = _by_rank(primary_api_keys) or _by_rank(api_key_candidates)
 
         if not ordered:
             if trigger == "failback":
@@ -2061,6 +2137,12 @@ class AutoSwitchEngine:
         # for every account, so a caller without per-account context behaves
         # exactly as this function did before per-account thresholds existed.
         thresholds: Mapping[str, float] | None = None,
+        # Chain ranks, same contract as `thresholds`: optional, and absent it
+        # behaves exactly as this function did before per-account order
+        # existed. `OrderMap()` (empty) maps every account to the sentinel, so
+        # every key gains an identical leading element and the sort is
+        # unchanged - identity by construction, not by luck.
+        orders: Mapping[str, int] | None = None,
     ) -> tuple[list[str], bool, float | None]:
         """Filter and rank OAuth candidates for this tick's trigger.
 
@@ -2119,6 +2201,13 @@ class AutoSwitchEngine:
             _binding_recovery_ts(usage.get(current), self._models, now)
             if all_above
             else 0.0  # unread unless all_above; never a live sentinel
+        )
+
+        # Total by construction, so the key builders below can subscript it
+        # unguarded. An absent `orders` yields the sentinel for EVERY account,
+        # which is a constant leading element and therefore no reordering.
+        rank: Mapping[str, int] = (
+            orders if orders is not None else OrderMap()
         )
 
         qualifying: list[tuple[tuple, str]] = []
@@ -2201,7 +2290,15 @@ class AutoSwitchEngine:
                                 and recovery_ts
                                 < active_recovery_ts - RECOVERY_HYSTERESIS_S
                             ):
-                                fallback.append(((0, recovery_ts, -h), num))
+                                # Tiered like `qualifying` below, and for a
+                                # reason that is easy to miss: the two lists
+                                # are SELECTED between (`qualifying or
+                                # fallback`), never merged, so a tier applied
+                                # to only one of them silently drops order on
+                                # every tick that takes the other path.
+                                fallback.append(
+                                    ((rank[num], 0, recovery_ts, -h), num)
+                                )
                             continue
                 elif consume_first:
                     # Purely proactive on reset ordering: below the threshold,
@@ -2262,7 +2359,12 @@ class AutoSwitchEngine:
                 key = (reset_ts if reset_ts is not None else float("inf"), -h)
             else:
                 key = (-h,)
-            qualifying.append((key, num))
+            # Order is a PRIMARY selector, not a tie-break: it is prepended to
+            # the strategy key rather than appended to it. Appended, it would
+            # decide only exact ties, and neither strategy key ties in practice
+            # (headroom and reset timestamps are floats), so the feature would
+            # be inert. Within a tier the strategy still decides everything.
+            qualifying.append(((rank[num], *key), num))
         # Ascending by the strategy's key; list order (sequence order) breaks ties.
         qualifying = qualifying or fallback
         qualifying.sort(key=lambda t: t[0])

--- a/src/claude_swap/autoswitch.py
+++ b/src/claude_swap/autoswitch.py
@@ -8,8 +8,9 @@ human lines or JSONL, and any future frontend (TUI dashboard, menubar) can
 consume the same stream.
 
 Policy in one paragraph: when the active account's *binding window* (the
-higher of its 5h/7d utilization) crosses ``settings.threshold``, switch to
-the candidate with the most headroom — proactively, so the old account is
+higher of its 5h/7d utilization) crosses that account's **effective
+threshold** — its own per-account override where one is set, otherwise
+``settings.threshold`` — switch to the candidate with the most headroom — proactively, so the old account is
 still valid while a running Claude Code picks the new one up (this is what
 makes the macOS ~30s Keychain cache latency harmless). Candidates must sit
 ``hysteresis_pct`` below the threshold so two accounts hovering at the line
@@ -36,7 +37,7 @@ import math
 import random
 import threading
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -363,6 +364,7 @@ class PollEvent(AutoSwitchEvent):
 class SwitchEvent(AutoSwitchEvent):
     kind: ClassVar[str] = "switch"
     trigger: str  # "proactive" | "at-limit" | "failover" | "consume-first"
+    #                | "failback" — a backup account handing back to a primary
     from_ref: dict | None
     to_ref: dict | None
     warnings: list[str] = field(default_factory=list)
@@ -591,11 +593,31 @@ def _binding_recovery_ts(
     return ts if ts is not None and ts > now else float("inf")
 
 
+class ThresholdMap(dict):
+    """Effective switch threshold per account number — total by construction.
+
+    Every account with a per-account override maps to that override; every
+    other account, including one that is not in the fleet at all, reads the
+    global ``autoswitch.threshold``. Totality lives here rather than at each
+    of the ten call sites: they subscript directly (``thresholds[num]``), and
+    a ``.get(num, default)`` convention would be one forgotten default away
+    from a ``KeyError`` mid-tick, in a code path that runs unattended.
+    """
+
+    def __init__(self, overrides: Mapping[str, float], default: float) -> None:
+        super().__init__(overrides)
+        self.default = default
+
+    def __missing__(self, key: str) -> float:
+        return self.default
+
+
 def _every_account_above_threshold(
     candidates: Sequence[str],
     headroom: dict[str, float | None],
     active_headroom: float | None,
-    threshold: float,
+    thresholds: Mapping[str, float],
+    current: str,
 ) -> bool:
     """Whether the active account AND every measured candidate are at or over
     the threshold — the state where "land somewhere healthy" has no answer.
@@ -606,12 +628,18 @@ def _every_account_above_threshold(
     verdict (it may be healthy, but it cannot be *chosen* either — the caller
     skips ``None`` headroom) as long as at least one candidate was measured.
     """
-    if active_headroom is None or (100.0 - active_headroom) < threshold:
+    if active_headroom is None or (100.0 - active_headroom) < thresholds[current]:
         return False
-    measured = [headroom.get(n) for n in candidates if headroom.get(n) is not None]
+    # Each candidate is compared against ITS OWN line, so a fleet is only
+    # "all above" when no account has room under the rule it is actually
+    # governed by. One account with a higher line still sitting under it is a
+    # real landing spot, and the all-above regime must not swallow it.
+    measured = [
+        (n, headroom.get(n)) for n in candidates if headroom.get(n) is not None
+    ]
     if not measured:
         return False
-    return all((100.0 - h) >= threshold for h in measured)
+    return all((100.0 - h) >= thresholds[n] for n, h in measured)
 
 
 def _ref(number: str, email: str) -> dict:
@@ -659,7 +687,12 @@ class AutoSwitchEngine:
         # Poll plans written by the collector must key on the same threshold/
         # models the engine decides with (CLI overrides included), not on
         # whatever the settings file happens to say.
-        switcher.set_poll_policy_inputs(settings.threshold, self._models)
+        # The fleet MINIMUM, not the global: poll_policy's urgent mode fires
+        # at `new_pct >= threshold - 15`, so the lowest line in the fleet is
+        # the one that decides when collection must already be tight. Taking
+        # the minimum can only make collection earlier, never lazier — the
+        # safe direction when accounts disagree about where their line is.
+        switcher.set_poll_policy_inputs(self._min_effective_threshold(), self._models)
         self.on_event = on_event
         self.dry_run = dry_run
         self.state_path = state_path or (switcher.backup_dir / STATE_FILENAME)
@@ -889,6 +922,79 @@ class AutoSwitchEngine:
             )
             return TickOutcome.ERROR
 
+    def _resolve_thresholds(
+        self, settings: AutoSwitchSettings | None = None
+    ) -> ThresholdMap:
+        """The effective threshold for every account, resolved once per tick.
+
+        Resolution is ``policy(n).threshold if set else settings.threshold``.
+        The result is passed DOWN as a parameter rather than looked up where
+        it is needed: ``_rank_candidates`` is documented pure and runs twice
+        per tick under the consume-first two-phase commit, so a store read
+        inside it could decide phase 1 and phase 2 on different lines.
+
+        The ``settings`` argument exists so a tick resolves against the same
+        snapshot it gates with, even if ``apply_threshold()`` lands mid-tick.
+        """
+        effective = settings or self.settings
+        return ThresholdMap(
+            {
+                num: policy.threshold
+                for num, policy in self.switcher.account_policies().items()
+                if policy.threshold is not None
+            },
+            effective.threshold,
+        )
+
+    def _min_effective_threshold(
+        self, thresholds: ThresholdMap | None = None
+    ) -> float:
+        """The lowest effective threshold across switchable accounts.
+
+        Used only for poll cadence (``set_poll_policy_inputs``), never for a
+        switch decision — cadence is fleet-wide, so it has to be tight enough
+        for whichever account crosses its own line first. With no overrides
+        this is exactly ``settings.threshold``.
+
+        ``thresholds`` lets a tick reuse the map it already resolved, so the
+        cadence it pins and the lines it gates on come from one store read of
+        one snapshot. Callers outside a tick (construction, ``apply_threshold``)
+        omit it and resolve their own.
+        """
+        thresholds = thresholds if thresholds is not None else self._resolve_thresholds()
+        values = [
+            thresholds[num]
+            for num in self.switcher.switchable_account_numbers()
+        ]
+        return min(values) if values else self.settings.threshold
+
+    def _refresh_poll_policy_inputs(self, thresholds: ThresholdMap) -> None:
+        """Re-pin poll cadence from this tick's threshold map.
+
+        ``set_poll_policy_inputs`` used to be called in exactly two places,
+        ``__init__`` and ``apply_threshold()``. Neither is on the path a
+        *persisted* policy write takes: ``cswap threshold 1 50`` runs in a
+        separate process from ``cswap auto``, so a running engine re-read the
+        new line for its DECISION every tick (``_resolve_thresholds``) while
+        its CADENCE stayed pinned to the minimum as it stood at boot.
+
+        That inverts AC-20's rationale. The minimum is chosen because
+        ``poll_policy``'s urgent mode fires at ``new_pct >= threshold - 15``,
+        so the fleet minimum can only make collection *earlier* — never
+        lazier, and no crossing is missed. A stale 90 against a live 50 goes
+        urgent at 75% instead of 35%, which is lazier in exactly the direction
+        the rationale rules out, on every tick until the process restarts.
+
+        Called before ``_collect_scheduled_usage`` so the tick that discovers
+        the change also plans on it. The pin itself is a bare attribute write
+        (``switcher.py:1800``); the only added per-tick cost is one
+        ``switchable_account_numbers()`` read, which ``_tick_inner`` already
+        performs for candidate construction.
+        """
+        self.switcher.set_poll_policy_inputs(
+            self._min_effective_threshold(thresholds), self._models
+        )
+
     def _tick_inner(self) -> TickOutcome:
         self._sleep_until_ts = None
         self._blocked_wait_long = False
@@ -934,14 +1040,25 @@ class AutoSwitchEngine:
             "email": "",
         }
 
+        # One resolution per tick, threaded down as a parameter from here on.
+        # Every gate below reads `thresholds[...]`; the map is total, so an
+        # account absent from it (never sequenced, just removed) reads the
+        # global rather than raising mid-tick.
+        thresholds = self._resolve_thresholds(settings)
+        # Cadence follows the same snapshot, and does so BEFORE collection is
+        # planned below — see `_refresh_poll_policy_inputs`.
+        self._refresh_poll_policy_inputs(thresholds)
         entries, usage, headroom = self._collect_scheduled_usage(
-            current, quarantined, threshold=settings.threshold
+            current, quarantined, threshold=thresholds[current]
         )
         self._emit(
             PollEvent(
                 active=active_ref,
                 headroom=headroom,
-                threshold=settings.threshold,
+                # The active account's own line: the number the CLI and TUI
+                # render as "the threshold" must be the one the departure
+                # gate below actually used, or the UI contradicts the engine.
+                threshold=thresholds[current],
                 fetch_errors={
                     num: entry.last_error
                     for num, entry in entries.items()
@@ -977,8 +1094,29 @@ class AutoSwitchEngine:
             self._unhealthy_ticks = 0
             self._idle_hold_since = None
             utilization = 100.0 - active_headroom
-            if utilization < settings.threshold:
-                if settings.strategy != "consume-first":
+            if utilization < thresholds[current]:
+                if self._failback_available(current, quarantined):
+                    # A backup ("last man standing") account is only supposed
+                    # to carry the fleet while nothing else can. It was taken
+                    # BECAUSE every primary was out, so waiting for it to
+                    # cross its own threshold before handing back is the
+                    # wrong test entirely — the reserve may sit at 20% for a
+                    # week while a primary's window rolls over on the hour.
+                    #
+                    # The predicate is deliberately store-only (backup flag,
+                    # disabled, kind, quarantine) so it is decidable HERE,
+                    # before any usage ranking: it answers "should we be
+                    # looking to leave?", never "where should we go?". The
+                    # OAuth clause is load-bearing — a fleet whose only peer
+                    # is an API-key account must keep today's quiet hold
+                    # rather than fall through to a `no-candidates` BLOCKED.
+                    #
+                    # Fall through; never switch from inside the gate. Every
+                    # landing gate, cooldown and freshness check downstream
+                    # still applies, and if none of them yields a target the
+                    # tick holds exactly as it does today.
+                    trigger = "failback"
+                elif settings.strategy != "consume-first":
                     self._emit(
                         NoSwitchEvent(
                             reason="below-threshold",
@@ -986,16 +1124,18 @@ class AutoSwitchEngine:
                             # display an impossible "100% < 99.9%".
                             detail=(
                                 f"{pct_label(utilization)}% < "
-                                f"{pct_label(settings.threshold)}%"
+                                f"{pct_label(thresholds[current])}%"
                             ),
                         )
                     )
                     return TickOutcome.NO_ACTION
-                # consume-first: below the threshold we still proactively move to
-                # whichever account's weekly window resets soonest, to burn the
-                # most-perishable quota first. Candidate selection decides whether
-                # a sooner-resetting account with room actually exists.
-                trigger = "consume-first"
+                else:
+                    # consume-first: below the threshold we still proactively
+                    # move to whichever account's weekly window resets soonest,
+                    # to burn the most-perishable quota first. Candidate
+                    # selection decides whether a sooner-resetting account with
+                    # room actually exists.
+                    trigger = "consume-first"
             else:
                 trigger = "at-limit" if active_headroom <= 0 else "proactive"
         else:
@@ -1046,7 +1186,10 @@ class AutoSwitchEngine:
                 return TickOutcome.NO_ACTION
             trigger = "failover"
 
-        if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+        if (
+            trigger in ("proactive", "consume-first", "failback")
+            and self._in_cooldown(state)
+        ):
             self._emit(NoSwitchEvent(reason="cooldown"))
             return TickOutcome.NO_ACTION
 
@@ -1059,6 +1202,12 @@ class AutoSwitchEngine:
         oauth_candidates = [
             n for n in candidates if self.switcher.account_kind_for(n) != "api_key"
         ]
+        # `oauth_candidates` keeps its FULL-SET meaning on purpose: the
+        # "everything is exhausted" census below is a statement about the
+        # whole fleet, and a reserve holding quota means the fleet is not
+        # exhausted. The reserve is filtered out of the *ranking* instead —
+        # inside `_rank`, so both consume-first commit phases inherit it.
+        backups = set(self.switcher.backup_account_numbers())
         # The no-return bar itself lives in `_rank` below: it is a statement
         # about the CHOICE, so it belongs where the choice is made rather than
         # in this census of what exists. See `_no_return_account` for the
@@ -1086,7 +1235,7 @@ class AutoSwitchEngine:
                     reason="below-threshold",
                     detail=(
                         f"{pct_label(100.0 - active_headroom)}% < "
-                        f"{pct_label(settings.threshold)}%"
+                        f"{pct_label(thresholds[current])}%"
                     ),
                 )
             )
@@ -1148,30 +1297,53 @@ class AutoSwitchEngine:
             # values. Computed once, the bar answered from a snapshot the
             # ranking had already thrown away — `left=20 active=30` bars,
             # `left=90 active=10` releases, and phase 2 is where that flips.
-            recovered = self._left_account_recovered(
-                state,
-                kw["usage"],
-                kw["headroom"],
-                kw["active_headroom"],
-                kw["settings"],
-                kw["now"],
-                kw["current"],
-            )
-            no_return = self._no_return_account(
-                trigger,
-                state,
-                kw["headroom"],
-                kw["active_headroom"],
-                recovered,
-                kw["settings"],
-                kw["current"],
-            )
-            ranked = self._rank_candidates(no_return=no_return, **kw)
-            if no_return is not None and not ranked[0] and recovered:
-                unbarred = self._rank_candidates(no_return=None, **kw)
-                if unbarred[0]:
-                    return unbarred
-            return ranked
+            def _one_pass(pool):
+                pass_kw = {**kw, "oauth_candidates": pool}
+                recovered = self._left_account_recovered(
+                    state,
+                    pass_kw["usage"],
+                    pass_kw["headroom"],
+                    pass_kw["active_headroom"],
+                    pass_kw["settings"],
+                    pass_kw["now"],
+                    pass_kw["current"],
+                    thresholds=pass_kw["thresholds"],
+                )
+                no_return = self._no_return_account(
+                    trigger,
+                    state,
+                    pass_kw["headroom"],
+                    pass_kw["active_headroom"],
+                    recovered,
+                    pass_kw["settings"],
+                    pass_kw["current"],
+                    thresholds=pass_kw["thresholds"],
+                )
+                ranked = self._rank_candidates(no_return=no_return, **pass_kw)
+                if no_return is not None and not ranked[0] and recovered:
+                    unbarred = self._rank_candidates(no_return=None, **pass_kw)
+                    if unbarred[0]:
+                        return unbarred
+                return ranked
+
+            # Pass 1 over the primaries only. A reserve must lose to a WORSE
+            # primary, so this cannot be a sort key — an `order: 999` tie-break
+            # still promotes the reserve the moment it holds more headroom,
+            # which is precisely when it looks most attractive and is most
+            # wrong. Two passes make the exclusion absolute, and `all_above`
+            # (computed inside `_rank_candidates` from the pool it is given)
+            # correctly ignores the reserve's untouched quota.
+            #
+            # Pass 2 restores the reserve when the primaries yield nothing —
+            # the "last man standing" contract. It is skipped entirely when no
+            # account is marked backup, so an unconfigured fleet ranks exactly
+            # once, on exactly today's list.
+            primaries = [n for n in kw["oauth_candidates"] if n not in backups]
+            if len(primaries) != len(kw["oauth_candidates"]):
+                first = _one_pass(primaries)
+                if first[0]:
+                    return first
+            return _one_pass(kw["oauth_candidates"])
 
         decided_now = self.clock()
         ordered, any_known, active_reset_ts = _rank(
@@ -1184,9 +1356,10 @@ class AutoSwitchEngine:
             active_headroom=active_headroom,
             settings=settings,
             now=decided_now,
+            thresholds=thresholds,
         )
 
-        if trigger == "consume-first" and ordered:
+        if trigger in ("consume-first", "failback") and ordered:
             # Two-phase commit: the provisional pick may have ridden a
             # snapshot up to CANDIDATE_MAX_INTERVAL_S stale — consume-first
             # decides below the threshold, where the collector only escalates
@@ -1215,15 +1388,84 @@ class AutoSwitchEngine:
                 active_headroom=active_headroom,
                 settings=settings,
                 now=decided_now,
+                thresholds=thresholds,
             )
 
-        if not ordered and api_key_candidates and trigger != "consume-first":
+        if trigger == "consume-first" and current not in backups and ordered:
+            # The active account is a non-backup too — and it is the ONE
+            # non-backup `_rank`'s pass 1 can never see, because the candidate
+            # list is built with `num != current`. On a fleet whose only other
+            # OAuth account is the reserve, pass 1 therefore ranks an empty
+            # pool, falls through to pass 2, and burns the reserve while a
+            # perfectly healthy primary is active — the exact inverse of the
+            # "only used once all the others are at their limit" contract, and
+            # a fleet that then ping-pongs back on the next `failback` tick.
+            #
+            # Scoped to `consume-first` because that is the only trigger that
+            # departs a still-usable account: under `proactive`/`at-limit`/
+            # `failover` the active primary is by definition NOT usable, which
+            # is precisely when promoting the reserve is right. `current not in
+            # backups` excludes `failback`, whose active account IS the reserve.
+            #
+            # Applied HERE rather than inside `_rank` on purpose. The reserve's
+            # provisional rank is what arms the two-phase commit's forced
+            # refetch, and that refetch is how a spent primary is discovered to
+            # have recovered (AC-29). Filtering earlier would suppress the
+            # escalation and lose a legitimate primary→primary move; filtering
+            # after phase 2 keeps the escalation and rejects only the commit.
+            #
+            # `any_known` is deliberately left as `_rank` reported it: a
+            # `backups` entry in `ordered` can only have come from the
+            # full-pool pass, so the census still sees the reserve and the
+            # empty list below lands on the quiet `already-consuming-soonest`
+            # hold rather than a `no-comparison` BLOCK.
+            ordered = [num for num in ordered if num not in backups]
+
+        def _failback_hold() -> TickOutcome:
+            """The failback tick found nowhere better; hold exactly as today.
+
+            Every one of these ticks returns `NO_ACTION` on unmodified source,
+            because the departure gate stops at `below-threshold` before any
+            ranking happens. The whole contract of this trigger is that a
+            fleet which merely *configures* a reserve never starts seeing
+            `BLOCKED` or `ERROR` where it used to see a quiet hold — so the
+            hold reuses the gate's own event verbatim rather than inventing a
+            reason string. A diagnostic reason ("primaries still exhausted")
+            is a new observable and ships with its TUI surfacing in PR 2.
+            """
+            self._emit(
+                NoSwitchEvent(
+                    reason="below-threshold",
+                    detail=(
+                        f"{pct_label(100.0 - (active_headroom or 0.0))}% < "
+                        f"{pct_label(thresholds[current])}%"
+                    ),
+                )
+            )
+            return TickOutcome.NO_ACTION
+
+        if not ordered and api_key_candidates and trigger not in (
+            "consume-first",
+            "failback",
+        ):
             # Last resort when we must move: metered API-key accounts
             # (unmeasurable headroom). Never for a below-threshold consume-first
             # nudge — those API-key accounts have no weekly window to consume.
-            ordered = api_key_candidates
+            # Never for a failback either: the reserve is quiet by definition,
+            # so there is nothing to escape and metered credit is the most
+            # expensive thing in the fleet. The same two-pass filter applies
+            # here, so a reserve that happens to be an API-key account is the
+            # last thing reached rather than the first.
+            primary_api_keys = [n for n in api_key_candidates if n not in backups]
+            ordered = primary_api_keys or api_key_candidates
 
         if not ordered:
+            if trigger == "failback":
+                # ABOVE `if not any_known:` deliberately. The predicate is
+                # store-only, so it fires even when no primary has readable
+                # usage this tick — and that tick returns a quiet NO_ACTION
+                # today, not `no-comparison`/BLOCKED.
+                return _failback_hold()
             if not any_known:
                 # No candidate readable this tick — true for every strategy,
                 # and must not be dressed up as a consume-first hold.
@@ -1313,7 +1555,7 @@ class AutoSwitchEngine:
         systemic = ""
         for num in ordered:
             email = self.switcher.account_email(num)
-            if trigger == "consume-first":
+            if trigger in ("consume-first", "failback"):
                 # The phase-2 refetch is best-effort: the collector refuses
                 # accounts in failure backoff or claimed by a concurrent
                 # poller, which then serve their stored entries. Consume-first
@@ -1368,6 +1610,15 @@ class AutoSwitchEngine:
                 continue
             return self._perform(num, email, trigger, left_snapshot)
 
+        if trigger == "failback":
+            # AFTER the loop, never in place of it: the `identity-conflict`
+            # and `invalid_grant` quarantines written above are durable
+            # findings about a credential and are correct regardless of why
+            # the engine was looking. An early return would silently drop
+            # them. Only the terminal outcome changes — and on the error leg
+            # no `ErrorEvent` is emitted, because today's tick emits none and
+            # "indistinguishable from today" is the contract.
+            return _failback_hold()
         if systemic or transient_failure:
             self._emit(
                 ErrorEvent(
@@ -1381,6 +1632,33 @@ class AutoSwitchEngine:
         self._emit(NoSwitchEvent(reason="no-viable-target"))
         return TickOutcome.BLOCKED
 
+    def _failback_available(self, current: str, quarantined: set[str]) -> bool:
+        """Is the active account a reserve with a usable primary to hand back to?
+
+        Store-only by design — backup flag, disabled, kind, quarantine — so it
+        is decidable at the departure gate, before any usage is ranked. It
+        answers "should we be looking to leave?"; the ranking answers "where
+        to?", and every landing gate downstream still applies.
+
+        The OAuth clause is load-bearing rather than tidy. Without it, a fleet
+        whose only non-backup peer is an API-key account classifies as
+        `failback`, both candidate lists come back empty, and the tick reaches
+        the generic `no-candidates` exit and returns BLOCKED — where today it
+        returns a quiet NO_ACTION. `include_api_key_accounts` widens the
+        candidate list, never this predicate: metered credit is not somewhere
+        a quiet reserve should hand back to.
+        """
+        backups = set(self.switcher.backup_account_numbers())
+        if current not in backups:
+            return False
+        return any(
+            num != current
+            and num not in backups
+            and num not in quarantined
+            and self.switcher.account_kind_for(num) != "api_key"
+            for num in self.switcher.switchable_account_numbers()
+        )
+
     def _no_return_account(
         self,
         trigger: str,
@@ -1390,6 +1668,12 @@ class AutoSwitchEngine:
         recovered: bool,
         settings: AutoSwitchSettings,
         current: str | None = None,
+        *,
+        # Optional so a caller with no per-account context (and every
+        # pre-existing test that exercises this helper directly) keeps
+        # today's exact semantics: one global line for every account. The
+        # engine's own tick always passes the resolved map explicitly.
+        thresholds: Mapping[str, float] | None = None,
     ) -> str | None:
         """The account this engine most recently left, while it is still barred.
 
@@ -1466,6 +1750,8 @@ class AutoSwitchEngine:
         ranking cannot answer: is this a different account from the one we
         left, or only a different active?
         """
+        if thresholds is None:
+            thresholds = ThresholdMap({}, settings.threshold)
         came_from = state.get("lastSwitchFrom")
         if trigger not in ("proactive", "consume-first") or came_from is None:
             return None
@@ -1491,10 +1777,7 @@ class AutoSwitchEngine:
             if active_headroom is not None:
                 if left_headroom >= active_headroom * HORIZON_HEADROOM_RATIO:
                     return None               # beats us outright; not a flip
-            elif (
-                settings is not None
-                and left_headroom > 100.0 - settings.threshold
-            ):
+            elif left_headroom > 100.0 - thresholds[barred]:
                 # An unreadable active must not be silently scored as "the
                 # peer does not beat it" -- same landing-eligible fallback
                 # `_left_account_recovered` uses when it, too, has no active
@@ -1511,6 +1794,12 @@ class AutoSwitchEngine:
         settings: AutoSwitchSettings,
         now: float,
         current: str | None = None,
+        *,
+        # Optional so a caller with no per-account context (and every
+        # pre-existing test that exercises this helper directly) keeps
+        # today's exact semantics: one global line for every account. The
+        # engine's own tick always passes the resolved map explicitly.
+        thresholds: Mapping[str, float] | None = None,
     ) -> bool:
         """Is the account we left a better proposition than when we left it?
 
@@ -1537,7 +1826,7 @@ class AutoSwitchEngine:
         departure — there is no `leftHeadroom` to diff against and never was
         — so the two signals that do not depend on the active's LIVE state
         are (1) whether the peer, right now, would itself be a healthy place
-        to land: `h > 100 - settings.threshold`, the same "would the ranking
+        to land: `h > 100 - thresholds[peer]`, the same "would the ranking
         accept this as a landing spot" test `_rank_candidates` already runs
         (`:1617`) on every candidate, reused rather than inventing a fresh
         constant; and (2), when the landing floor cannot answer, whether the
@@ -1552,7 +1841,8 @@ class AutoSwitchEngine:
         floor should land on: sweeping mutations of this same leg for the
         ordinary path showed an absolute floor is silently reintroducible
         with a green suite, so this is not free of that risk either — the
-        difference is this constant is `settings.threshold`, not a
+        difference is this constant is the peer's own effective threshold
+        (its per-account override, else `settings.threshold`), not a
         hardcoded number, so a
         user's OWN policy decides how conservative the hold is, and it moves
         when they change it (pinned directly, below). Deliberately MORE
@@ -1609,6 +1899,8 @@ class AutoSwitchEngine:
         escapes the account untouched, and the next successful switch
         overwrites the snapshot outright.
         """
+        if thresholds is None:
+            thresholds = ThresholdMap({}, settings.threshold)
         came_from = state.get("lastSwitchFrom")
         if came_from is None:
             # Unreachable through `_no_return_account`, the only caller: it
@@ -1651,7 +1943,7 @@ class AutoSwitchEngine:
             # that proved it. Two legs, both read-only against CURRENT state
             # (no departure baseline exists to diff against):
             #
-            #   landing   `h > 100 - settings.threshold` -- would the
+            #   landing   `h > 100 - thresholds[peer]` -- would the
             #             ranking accept this peer as a landing spot right
             #             now (`_rank_candidates`, :1636)?
             #   recovery  the peer's binding reset is meaningfully sooner
@@ -1669,7 +1961,7 @@ class AutoSwitchEngine:
             # when a nearer window starts binding, never as a side effect
             # of the active spending down -- the failure mode a bare
             # dominance leg has, guarded directly in the mutation table.
-            if h is not None and h > 100.0 - settings.threshold:
+            if h is not None and h > 100.0 - thresholds[barred]:
                 return True
             peer_recovery_ts = _binding_recovery_ts(usage.get(barred), self._models, now)
             active_recovery_ts = _binding_recovery_ts(usage.get(current), self._models, now)
@@ -1735,7 +2027,7 @@ class AutoSwitchEngine:
             if active_headroom is not None:
                 if h > active_headroom * HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT:
                     return True
-            elif h > 100.0 - settings.threshold:
+            elif h > 100.0 - thresholds[barred]:
                 return True
         if (
             isinstance(left_headroom, (int, float))
@@ -1765,6 +2057,10 @@ class AutoSwitchEngine:
         active_headroom: float | None,
         settings: AutoSwitchSettings,
         now: float,
+        # See `_no_return_account`: optional, defaulting to the global line
+        # for every account, so a caller without per-account context behaves
+        # exactly as this function did before per-account thresholds existed.
+        thresholds: Mapping[str, float] | None = None,
     ) -> tuple[list[str], bool, float | None]:
         """Filter and rank OAuth candidates for this tick's trigger.
 
@@ -1773,6 +2069,8 @@ class AutoSwitchEngine:
         twice per tick: on the stored snapshot to decide provisionally, then
         on the escalated refetch to re-verify before switching.
         """
+        if thresholds is None:
+            thresholds = ThresholdMap({}, settings.threshold)
         # consume-first ranks by soonest weekly reset; a proactive (below-
         # threshold) target must reset strictly sooner than where we are.
         active_reset_ts = (
@@ -1791,7 +2089,7 @@ class AutoSwitchEngine:
         # wins the normal way, and RECOVERY_HYSTERESIS_S below replaces the
         # percentage-point margin so two accounts in the 90s cannot ping-pong.
         all_above = _every_account_above_threshold(
-            oauth_candidates, headroom, active_headroom, settings.threshold
+            oauth_candidates, headroom, active_headroom, thresholds, current
         )
         # "Is anything worth having?" — the most headroom any candidate with a
         # READABLE row offers. Two exclusions and no others:
@@ -1843,14 +2141,23 @@ class AutoSwitchEngine:
                 if all_above
                 else 0.0
             )
-            if trigger in ("proactive", "consume-first"):
+            if trigger in ("proactive", "consume-first", "failback"):
                 # Landing must be healthy: an account at/over the threshold
                 # would re-trigger on the very next tick. At-limit and failover
                 # are escapes that skip this whole block — any account with real
                 # headroom beats a blocked or dead one.
-                if (100.0 - h) >= settings.threshold and not all_above:
+                #
+                # `all_above` relaxes the gate so a fleet with nothing below
+                # the line still rotates instead of freezing. Failback must
+                # NOT borrow that: the reserve is quiet, so "everyone is over
+                # their line" is a reason to stay, not to move. Note the
+                # phase-2 refetch can flip `all_above` to True on a failback
+                # tick, so this is a live interaction, not a theoretical one.
+                if (100.0 - h) >= thresholds[num] and (
+                    not all_above or trigger == "failback"
+                ):
                     continue
-                if all_above:
+                if all_above and trigger != "failback":
                     # Checked before the strategies, because with nothing below
                     # the threshold the strategy question is moot: consume-first
                     # exists to spend perishable WEEKLY quota, and every account
@@ -1911,7 +2218,18 @@ class AutoSwitchEngine:
                     # best: the candidate must beat the active account by the
                     # full hysteresis margin (a one-way move like 99%→89%
                     # qualifies; near-line pairs can't flap back).
-                    if h - active_headroom < settings.hysteresis_pct:
+                    #
+                    # Not for failback. That bar compares the reserve against
+                    # the primary on headroom, and the reserve almost always
+                    # wins it — it has been idle. Applying it would make the
+                    # trigger inert in the exact fleet it exists for. The
+                    # anti-flap property is supplied instead by the landing
+                    # gate above (the primary must be under its OWN line) plus
+                    # the no-return bar on the following tick.
+                    if (
+                        h - active_headroom < settings.hysteresis_pct
+                        and trigger != "failback"
+                    ):
                         continue
             if all_above and trigger in ("proactive", "consume-first"):
                 # Ranked on the axis its own gate decided, and TIERED so the two
@@ -2124,7 +2442,11 @@ class AutoSwitchEngine:
         # state lock.
         with self._state_lock():
             state = self._read_state()
-            if trigger in ("proactive", "consume-first") and self._in_cooldown(state):
+            if trigger in (
+                "proactive",
+                "consume-first",
+                "failback",
+            ) and self._in_cooldown(state):
                 self._emit(NoSwitchEvent(reason="cooldown"))
                 return TickOutcome.NO_ACTION
 
@@ -2281,7 +2603,11 @@ class AutoSwitchEngine:
         state) are fixed at construction. The frozen-settings swap is atomic
         and each tick snapshots ``self.settings`` once, so no locking."""
         self.settings = replace(self.settings, threshold=threshold)
-        self.switcher.set_poll_policy_inputs(threshold, self._models)
+        # Recomputed, not passed through: a per-account override may still be
+        # lower than the new session global, and cadence follows the minimum.
+        self.switcher.set_poll_policy_inputs(
+            self._min_effective_threshold(), self._models
+        )
 
     def _next_delay(self, outcome: TickOutcome) -> float:
         interval = self.settings.interval_seconds

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -10,7 +10,12 @@ import sys
 from claude_swap import __version__, paths, printer
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
-from claude_swap.models import ACCOUNT_THRESHOLD_MAX, ACCOUNT_THRESHOLD_MIN
+from claude_swap.models import (
+    ACCOUNT_ORDER_MAX,
+    ACCOUNT_ORDER_MIN,
+    ACCOUNT_THRESHOLD_MAX,
+    ACCOUNT_THRESHOLD_MIN,
+)
 from claude_swap.printer import (
     accent,
     bolded,
@@ -685,6 +690,154 @@ def _print_threshold_table(switcher: ClaudeAccountSwitcher) -> None:
         print(f"  Account-{num}  {value:g}%")
 
 
+def _order_command(argv: list[str]) -> None:
+    """Handle `cswap order [NUM|EMAIL|ALIAS] [RANK] [--unset]`.
+
+    With no arguments, prints the resolved switch chain. Otherwise pins (or,
+    with --unset, unpins) one account's position in it. Pre-dispatched before
+    the main parser for the same reason as `threshold` and `alias`: the main
+    parser's required mutually-exclusive group cannot hold a positional
+    subcommand.
+
+    The rank is validated inside `set_account_order`, before any file is
+    touched, so a rejected value leaves `sequence.json` byte-identical.
+
+    Deliberately absent from `_SUBCOMMAND_FLAGS`: pre-dispatch above runs
+    before `_translate_subcommand`, so an entry would be unreachable. The long
+    flags exist on the main parser instead, the same way `--backup-account`
+    does, and both spellings write the same bytes.
+    """
+    parser = argparse.ArgumentParser(
+        prog="cswap order",
+        description=(
+            "Pin, unpin, or list an account's position in the switch chain. A "
+            "pinned account is preferred over every unpinned one, and a lower "
+            "rank over a higher one, BEFORE the ranking strategy is consulted."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Examples:
+  cswap order 2 1
+  cswap order user@example.com 2
+  cswap order 2 --unset               # back to strategy-only ranking
+  cswap order                         # show the resolved chain
+
+Valid range: {ACCOUNT_ORDER_MIN}-{ACCOUNT_ORDER_MAX} (lower goes first).
+
+A pin costs throughput. Unpinned, an account whose window rolls over is
+demoted automatically, so the fleet spends whatever resets soonest. A pin
+overrides that demotion permanently - pin for a hard requirement (a billing
+account, an org that must carry the work), not for a preference.
+        """,
+    )
+    parser.add_argument(
+        "account",
+        nargs="?",
+        metavar="NUM|EMAIL",
+        help="Account to pin (number, email, or alias). Omit to list.",
+    )
+    parser.add_argument(
+        "order",
+        nargs="?",
+        metavar="RANK",
+        help=(
+            f"Position in the switch chain "
+            f"({ACCOUNT_ORDER_MIN}-{ACCOUNT_ORDER_MAX}, lower goes first)."
+        ),
+    )
+    parser.add_argument(
+        "--unset", action="store_true", help="Remove the account's pin"
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    if args.unset and args.order:
+        parser.error("--unset does not take a RANK argument")
+    if args.unset and args.account is None:
+        parser.error("NUM|EMAIL is required with --unset")
+    if args.account is not None and not args.unset and args.order is None:
+        parser.error("RANK is required (or pass --unset to remove the pin)")
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+
+        if args.account is None:
+            _print_order_chain(switcher)
+            return
+
+        switcher.set_account_order(args.account, None if args.unset else args.order)
+    except ValueError as e:
+        # normalize_account_order's message; it always names the range.
+        error(f"Error: {e}")
+        sys.exit(1)
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
+def _set_order_or_exit(
+    switcher: ClaudeAccountSwitcher, identifier: str, order: object
+) -> None:
+    """Flag-path wrapper around `set_account_order`.
+
+    `normalize_account_order` raises `ValueError`, but `main()`'s dispatch
+    handler catches `ClaudeSwitchError` only, so `--order-account 2 0` would
+    answer bad input with a traceback while `cswap order 2 0` answers with one
+    red line. The two spellings are meant to be one command, so they must fail
+    the same way too. `SystemExit` passes straight through that handler.
+    """
+    try:
+        switcher.set_account_order(identifier, order)
+    except ValueError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+
+
+def _print_order_chain(switcher: ClaudeAccountSwitcher) -> None:
+    """Print the resolved switch chain: pins in rank order, then the rest.
+
+    The unpinned accounts are listed rather than merely counted, because the
+    question this command answers is "what happens next", and an operator
+    reading only the pins cannot tell whether the fleet has two unpinned
+    accounts or twenty. The trailing line is suppressed when nothing is left,
+    so a fully pinned fleet does not print an empty heading.
+    """
+    policies = switcher.account_policies()
+    pinned = sorted(
+        ((num, p.order) for num, p in policies.items() if p.order is not None),
+        key=lambda row: (row[1], _slot_key(row[0])),
+    )
+    print(bolded("Switch chain order:"))
+    if not pinned:
+        print(dimmed("  No per-account order set"))
+        return
+    for num, rank in pinned:
+        print(f"  Account-{num}  order {rank}")
+
+    rest = sorted(
+        (num for num, p in policies.items() if p.order is None), key=_slot_key
+    )
+    if not rest:
+        return
+    print(dimmed("  Then, by the active ranking strategy:"))
+    for num in rest:
+        print(dimmed(f"    Account-{num}"))
+
+
+def _slot_key(num: str) -> tuple[bool, int, str]:
+    """Sort slot numbers numerically, tolerating a non-numeric key.
+
+    `account_policies()` is keyed by whatever is in `sequence.json`, and this
+    command must not raise on a hand-edited store. Mirrors the sort key
+    `_print_threshold_table` uses for the same reason.
+    """
+    return (not num.isdigit(), int(num) if num.isdigit() else 0, num)
+
+
 def _auto_command(argv: list[str]) -> None:
     """Handle `cswap auto [--once] [--json] [...]`.
 
@@ -1113,6 +1266,9 @@ def main() -> None:
     if argv and argv[0] == "threshold":
         _threshold_command(argv[1:])
         return
+    if argv and argv[0] == "order":
+        _order_command(argv[1:])
+        return
     if argv and argv[0] == "swap":
         _swap_command(argv[1:])
         return
@@ -1152,6 +1308,9 @@ Commands:
   %(prog)s threshold <num|email> <pct>  set one account's switch-away point
   %(prog)s threshold <num|email> --unset  clear it (use the global default)
   %(prog)s threshold                  list the global default and overrides
+  %(prog)s order <num|email> <rank>   pin an account's place in the chain
+  %(prog)s order <num|email> --unset  unpin it (strategy ranking only)
+  %(prog)s order                      show the resolved switch chain
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s run                        run the current dir's mapped account
   %(prog)s map <num|email> [path]     map a directory to an account
@@ -1334,6 +1493,21 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         metavar="NUM|EMAIL",
         help=argparse.SUPPRESS,
     )
+    # Two-argument, unlike every other account flag, because a pin is a
+    # (who, where) pair. The verb form `cswap order` is the documented
+    # spelling; these exist so the long-flag interface stays complete,
+    # the way `--backup-account` mirrors `cswap backup`.
+    group.add_argument(
+        "--order-account",
+        nargs=2,
+        metavar=("NUM|EMAIL", "RANK"),
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
+        "--unorder-account",
+        metavar="NUM|EMAIL",
+        help=argparse.SUPPRESS,
+    )
     group.add_argument(
         "--list",
         action="store_true",
@@ -1419,6 +1593,8 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         or args.enable_account is not None
         or args.backup_account is not None
         or args.unbackup_account is not None
+        or args.order_account is not None
+        or args.unorder_account is not None
         or args.switch_to is not None
         or args.export is not None
         or args.import_ is not None
@@ -1519,6 +1695,10 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             switcher.set_account_backup(args.backup_account, True)
         elif args.unbackup_account is not None:
             switcher.set_account_backup(args.unbackup_account, False)
+        elif args.order_account is not None:
+            _set_order_or_exit(switcher, *args.order_account)
+        elif args.unorder_account is not None:
+            _set_order_or_exit(switcher, args.unorder_account, None)
         elif args.list:
             payload = switcher.list_accounts(
                 show_token_status=args.token_status,

--- a/src/claude_swap/cli.py
+++ b/src/claude_swap/cli.py
@@ -10,6 +10,7 @@ import sys
 from claude_swap import __version__, paths, printer
 from claude_swap.exceptions import ClaudeSwitchError
 from claude_swap.json_output import error_envelope
+from claude_swap.models import ACCOUNT_THRESHOLD_MAX, ACCOUNT_THRESHOLD_MIN
 from claude_swap.printer import (
     accent,
     bolded,
@@ -58,6 +59,8 @@ _SUBCOMMAND_FLAGS = {
     "rm": "--remove-account",
     "disable": "--disable-account",
     "enable": "--enable-account",
+    "backup": "--backup-account",
+    "unbackup": "--unbackup-account",
     "export": "--export",
     "import": "--import",
     "purge": "--purge",
@@ -573,6 +576,115 @@ Examples:
         sys.exit(130)
 
 
+def _threshold_command(argv: list[str]) -> None:
+    """Handle `cswap threshold [NUM|EMAIL|ALIAS] [PCT] [--unset]`.
+
+    With no arguments, prints the global `autoswitch.threshold` and every
+    per-account override. Otherwise sets (or, with --unset, removes) one
+    account's own switch-away threshold. Pre-dispatched before the main parser
+    for the same reason as `alias`: the main parser's required
+    mutually-exclusive group cannot hold a positional subcommand.
+
+    The value is validated inside `set_account_threshold`, before any file is
+    touched, so a rejected value leaves `sequence.json` byte-identical.
+    """
+    parser = argparse.ArgumentParser(
+        prog="cswap threshold",
+        description=(
+            "Set, remove, or list a per-account switch-away threshold. The "
+            "per-account value replaces autoswitch.threshold for that account "
+            "only, so one shared account can reserve headroom without capping "
+            "the whole fleet."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Examples:
+  cswap threshold 2 85
+  cswap threshold user@example.com 99.9
+  cswap threshold 2 --unset           # back to the global default
+  cswap threshold                     # list the global default and overrides
+
+Valid range: {ACCOUNT_THRESHOLD_MIN:g}-{ACCOUNT_THRESHOLD_MAX:g} (percent used).
+        """,
+    )
+    parser.add_argument(
+        "account",
+        nargs="?",
+        metavar="NUM|EMAIL",
+        help="Account to set (number, email, or alias). Omit to list.",
+    )
+    parser.add_argument(
+        "threshold",
+        nargs="?",
+        metavar="PCT",
+        help=(
+            f"Percent used at which to switch away "
+            f"({ACCOUNT_THRESHOLD_MIN:g}-{ACCOUNT_THRESHOLD_MAX:g})."
+        ),
+    )
+    parser.add_argument(
+        "--unset", action="store_true", help="Remove the account's override"
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    if args.unset and args.threshold:
+        parser.error("--unset does not take a PCT argument")
+    if args.unset and args.account is None:
+        parser.error("NUM|EMAIL is required with --unset")
+    if args.account is not None and not args.unset and args.threshold is None:
+        parser.error("PCT is required (or pass --unset to remove the override)")
+
+    try:
+        switcher = ClaudeAccountSwitcher(debug=args.debug)
+        _guard_root(switcher)
+
+        if args.account is None:
+            _print_threshold_table(switcher)
+            return
+
+        switcher.set_account_threshold(
+            args.account, None if args.unset else args.threshold
+        )
+    except ValueError as e:
+        # normalize_account_threshold's message; it always names the range.
+        error(f"Error: {e}")
+        sys.exit(1)
+    except ClaudeSwitchError as e:
+        error(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print(f"\n{dimmed('Operation cancelled')}")
+        sys.exit(130)
+
+
+def _print_threshold_table(switcher: ClaudeAccountSwitcher) -> None:
+    """Print the global switch-away threshold and every per-account override.
+
+    The global line is printed unconditionally: an operator reading a list of
+    overrides needs to know what the accounts *without* one are using.
+    """
+    from claude_swap.settings import load_settings
+
+    default = load_settings(switcher.backup_dir).threshold
+    print(bolded("Switch-away thresholds:"))
+    print(f"  {dimmed('global default')}  {default:g}%")
+
+    rows = sorted(
+        (
+            (num, policy.threshold)
+            for num, policy in switcher.account_policies().items()
+            if policy.threshold is not None
+        ),
+        key=lambda row: (not row[0].isdigit(), int(row[0]) if row[0].isdigit() else 0),
+    )
+    if not rows:
+        print(dimmed("  No per-account overrides set"))
+        return
+    for num, value in rows:
+        print(f"  Account-{num}  {value:g}%")
+
+
 def _auto_command(argv: list[str]) -> None:
     """Handle `cswap auto [--once] [--json] [...]`.
 
@@ -998,6 +1110,9 @@ def main() -> None:
     if argv and argv[0] == "alias":
         _alias_command(argv[1:])
         return
+    if argv and argv[0] == "threshold":
+        _threshold_command(argv[1:])
+        return
     if argv and argv[0] == "swap":
         _swap_command(argv[1:])
         return
@@ -1032,6 +1147,11 @@ Commands:
   %(prog)s remove <num|email>         remove an account
   %(prog)s disable <num|email>        hold an account out of auto-rotation
   %(prog)s enable <num|email>         return a disabled account to rotation
+  %(prog)s backup <num|email>         hold an account back as a last resort
+  %(prog)s unbackup <num|email>       return a backup account to rotation
+  %(prog)s threshold <num|email> <pct>  set one account's switch-away point
+  %(prog)s threshold <num|email> --unset  clear it (use the global default)
+  %(prog)s threshold                  list the global default and overrides
   %(prog)s run <num|email> [-- ...]   run as an account, this terminal only
   %(prog)s run                        run the current dir's mapped account
   %(prog)s map <num|email> [path]     map a directory to an account
@@ -1205,6 +1325,16 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         help=argparse.SUPPRESS,
     )
     group.add_argument(
+        "--backup-account",
+        metavar="NUM|EMAIL",
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
+        "--unbackup-account",
+        metavar="NUM|EMAIL",
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
         "--list",
         action="store_true",
         help=argparse.SUPPRESS,
@@ -1287,6 +1417,8 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
         or args.remove_account is not None
         or args.disable_account is not None
         or args.enable_account is not None
+        or args.backup_account is not None
+        or args.unbackup_account is not None
         or args.switch_to is not None
         or args.export is not None
         or args.import_ is not None
@@ -1383,6 +1515,10 @@ The original flag spellings (%(prog)s --switch, %(prog)s --list, ...) keep worki
             switcher.set_account_disabled(args.disable_account, True)
         elif args.enable_account is not None:
             switcher.set_account_disabled(args.enable_account, False)
+        elif args.backup_account is not None:
+            switcher.set_account_backup(args.backup_account, True)
+        elif args.unbackup_account is not None:
+            switcher.set_account_backup(args.unbackup_account, False)
         elif args.list:
             payload = switcher.list_accounts(
                 show_token_status=args.token_status,

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -249,6 +249,8 @@ def account_row(
         row["threshold"] = policy.threshold
     if policy.backup:
         row["backup"] = True
+    if policy.order is not None:
+        row["order"] = policy.order
     if usage is not None:
         row.update(usage_freshness_fields(usage_fetched_at, usage_age_s))
     else:

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from claude_swap import oauth, pace
+from claude_swap.models import AccountPolicy
 
 # Bump only on a breaking change to any payload shape. Scripts key off this.
 SCHEMA_VERSION = 1
@@ -221,6 +222,7 @@ def account_row(
     last_good_usage: dict | None = None,
     alias: str = "",
     disabled: bool = False,
+    policy: AccountPolicy = AccountPolicy(),
 ) -> dict:
     """A full account row for ``--list``."""
     status, usage = usage_fields(usage_entry, usage_fetched_at)
@@ -240,6 +242,13 @@ def account_row(
     # existing consumers keying on the base schema are unaffected.
     if disabled:
         row["disabled"] = True
+    # Same convention for the per-account policy: a slot on the global default
+    # emits neither key, so a fleet that never sets a policy produces rows
+    # byte-identical to those from before this feature existed.
+    if policy.threshold is not None:
+        row["threshold"] = policy.threshold
+    if policy.backup:
+        row["backup"] = True
     if usage is not None:
         row.update(usage_freshness_fields(usage_fetched_at, usage_age_s))
     else:

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import sys
@@ -45,6 +46,89 @@ def normalize_alias(name: str) -> str:
             f"alias '{name}' may only contain letters, digits, '-', '_', and '.'"
         )
     return normalized
+
+
+#: Per-account switch-away threshold bounds, in binding-window utilization
+#: percent. Mirrors ``SETTING_SPECS["autoswitch.threshold"]``, written as
+#: literals rather than imported: ``models`` is a leaf and must not import
+#: ``settings`` (AGENTS.md §Architecture). The two are asserted equal in
+#: ``tests/test_account_policy_values.py`` so they cannot drift apart.
+ACCOUNT_THRESHOLD_MIN = 50.0
+ACCOUNT_THRESHOLD_MAX = 99.9
+
+
+def normalize_account_threshold(value: object) -> float:
+    """Validate a per-account switch-away threshold; raise ValueError if invalid.
+
+    Strict, in the manner of ``settings.parse_setting_value`` and unlike the
+    forgiving clamp applied when *reading* a record: a user who types 150 learns
+    about it at set time rather than by watching the account never switch away.
+    This is the single write-boundary validator for the value — the CLI verb,
+    the store setter, and any future UI all route through it.
+
+    Accepts ``int``, ``float``, and numeric ``str`` (the CLI hands over argv
+    strings). Rejects ``bool`` explicitly: ``True`` is an ``int`` in Python and
+    would otherwise normalize to 1.0, failing the range test for the wrong
+    reason.
+
+    Args:
+        value: The proposed threshold.
+
+    Returns:
+        The threshold as a ``float`` in ``[ACCOUNT_THRESHOLD_MIN,
+        ACCOUNT_THRESHOLD_MAX]``.
+
+    Raises:
+        ValueError: If the value is not numeric, is NaN or infinite, or falls
+            outside the valid range. The message always names the range.
+    """
+    range_text = (
+        f"must be between {ACCOUNT_THRESHOLD_MIN:g} and {ACCOUNT_THRESHOLD_MAX:g}"
+    )
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise ValueError(f"threshold {range_text}, got {value!r}")
+    if isinstance(value, str):
+        try:
+            pct = float(value.strip())
+        except ValueError:
+            raise ValueError(f"threshold {range_text}, got {value!r}") from None
+    else:
+        pct = float(value)
+    # NaN fails every comparison and infinity passes the lower bound, so both
+    # are rejected by name rather than left to the range test to catch by luck.
+    if math.isnan(pct) or math.isinf(pct):
+        raise ValueError(f"threshold {range_text}, got {value!r}")
+    if not ACCOUNT_THRESHOLD_MIN <= pct <= ACCOUNT_THRESHOLD_MAX:
+        raise ValueError(f"threshold {range_text}, got {pct:g}")
+    return pct
+
+
+@dataclass(frozen=True)
+class AccountPolicy:
+    """Per-account auto-switch overrides, stored in the sequence record.
+
+    Both knobs are unset by default, so a fleet with no policy set behaves
+    exactly as it did before this existed — the default-identity property
+    the acceptance criteria assert throughout.
+
+    ``threshold``
+        This account's own switch-away cap, in binding-window utilization
+        percent. ``None`` inherits ``autoswitch.threshold``. Reserving headroom
+        on one shared account no longer means taxing the whole fleet with a
+        global cap set to the strictest member's.
+
+    ``backup``
+        "Last man standing": held out of candidate selection while any
+        non-backup account can still be landed on, and offered only when none
+        can. Orthogonal to ``disabled``, which removes an account from
+        auto-rotation entirely; ``disabled`` is applied first and wins.
+
+    Frozen because ``AccountSnapshot`` is frozen — a mutable member would
+    silently break that guarantee for the whole row.
+    """
+
+    threshold: float | None = None
+    backup: bool = False
 
 
 class Platform(Enum):
@@ -140,6 +224,9 @@ class AccountSnapshot:
     usage: UsageEntry
     alias: str = ""
     disabled: bool = False  # held out of auto-rotation (still a valid explicit target)
+    #: Per-account auto-switch overrides. Appended last and defaulted, so every
+    #: pre-existing construction site keeps working and yields the default.
+    policy: AccountPolicy = AccountPolicy()
 
     @property
     def display_tag(self) -> str:

--- a/src/claude_swap/models.py
+++ b/src/claude_swap/models.py
@@ -103,6 +103,80 @@ def normalize_account_threshold(value: object) -> float:
     return pct
 
 
+#: Per-account chain-order bounds. ``order`` is an **ordinal** that indexes the
+#: switch chain, not a measurement of it, so unlike ``threshold`` it is an
+#: ``int``. The lower bound is 1 rather than 0 so that 0 stays available as a
+#: future "always first" sentinel; the upper bound exists so the rejection
+#: message can name a range, and three digits is wide enough that no real fleet
+#: reaches it while still catching a 99999 typo.
+ACCOUNT_ORDER_MIN = 1
+ACCOUNT_ORDER_MAX = 999
+
+#: The rank an *unpinned* account sorts at. Strictly greater than every legal
+#: pin, because the order tier is the leading element of an ascending sort key:
+#: if this were not greater, an account with no pin could outrank one with a
+#: pin and the feature would be unsound. Defined here — once — because both the
+#: ranking map in ``autoswitch`` and the CLI listing refer to it.
+ORDER_UNSET_RANK = ACCOUNT_ORDER_MAX + 1
+
+
+def normalize_account_order(value: object) -> int:
+    """Validate a per-account chain order; raise ValueError if invalid.
+
+    The single write-boundary validator for the value, in the manner of
+    :func:`normalize_account_threshold`: strict here, forgiving when *reading* a
+    record, so a user who types 0 learns at set time rather than by watching the
+    account never come up.
+
+    Accepts ``int``, integral ``float``, and integral numeric ``str`` — ``2``,
+    ``2.0`` and ``"2"`` all yield the ``int`` ``2``. The CLI hands over argv
+    strings, and a JSON round-trip can widen a whole number to a float, so both
+    are legitimate spellings of the same ordinal. Fractional values are refused:
+    there is no position 1.5 in a chain.
+
+    Rejects ``bool`` explicitly. ``True`` is an ``int`` in Python and would
+    otherwise normalize to 1 — a *legal* order — and be stored silently, which
+    is a worse failure than an error message.
+
+    Args:
+        value: The proposed order.
+
+    Returns:
+        The order as an ``int`` in ``[ACCOUNT_ORDER_MIN, ACCOUNT_ORDER_MAX]``.
+
+    Raises:
+        ValueError: If the value is not numeric, is NaN or infinite, is
+            fractional, or falls outside the valid range. The message always
+            names the range.
+    """
+    range_text = (
+        f"must be a whole number between {ACCOUNT_ORDER_MIN} and {ACCOUNT_ORDER_MAX}"
+    )
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise ValueError(f"order {range_text}, got {value!r}")
+    if isinstance(value, int):
+        rank = value
+    else:
+        if isinstance(value, str):
+            try:
+                number = float(value.strip())
+            except ValueError:
+                raise ValueError(f"order {range_text}, got {value!r}") from None
+        else:
+            number = value
+        # NaN fails every comparison, so the range test below would pass it by
+        # luck rather than by design; int(inf) raises OverflowError rather than
+        # ValueError. Both are rejected by name before either can happen.
+        if math.isnan(number) or math.isinf(number):
+            raise ValueError(f"order {range_text}, got {value!r}")
+        rank = int(number)
+        if rank != number:
+            raise ValueError(f"order {range_text}, got {value!r}")
+    if not ACCOUNT_ORDER_MIN <= rank <= ACCOUNT_ORDER_MAX:
+        raise ValueError(f"order {range_text}, got {rank}")
+    return rank
+
+
 @dataclass(frozen=True)
 class AccountPolicy:
     """Per-account auto-switch overrides, stored in the sequence record.
@@ -123,12 +197,34 @@ class AccountPolicy:
         can. Orthogonal to ``disabled``, which removes an account from
         auto-rotation entirely; ``disabled`` is applied first and wins.
 
+    ``order``
+        This account's position in the switch chain. Pinned accounts are
+        preferred over unpinned ones, and lower pins over higher, before the
+        ranking strategy is consulted at all — the pin is a primary selector,
+        not a tie-break. ``None`` leaves the account unpinned, sorting by
+        strategy alone behind every pinned account. Equal pins are a group, not
+        an error: they tie on the leading key element and fall through to the
+        strategy, which is the intended load-balancing semantics.
+
+        **A pin costs throughput.** Unpinned, an account whose 7-day window
+        rolls over is demoted to the back of the queue automatically, so the
+        fleet spends whatever resets soonest. A pin overrides that demotion
+        permanently - that is what pinning means - so an account pinned as a
+        soft "prefer this one" will be chosen even when spending a peer first
+        would have banked more total quota. Pin for a hard requirement (a
+        billing account, an org that must carry the work), not for a
+        preference.
+
     Frozen because ``AccountSnapshot`` is frozen — a mutable member would
     silently break that guarantee for the whole row.
+
+    ``order`` is appended rather than inserted so that the positional
+    construction sites written against the two-field version stay correct.
     """
 
     threshold: float | None = None
     backup: bool = False
+    order: int | None = None
 
 
 class Platform(Enum):

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -54,11 +54,13 @@ from claude_swap.fsutil import read_text_with_retry
 from claude_swap.locking import FileLock
 from claude_swap.logging_config import setup_logging
 from claude_swap.models import (
+    AccountPolicy,
     AccountSnapshot,
     AccountsSnapshot,
     Platform,
     SwitchTransaction,
     get_timestamp,
+    normalize_account_threshold,
     normalize_alias,
 )
 from claude_swap.printer import (
@@ -1764,6 +1766,7 @@ class ClaudeAccountSwitcher:
                     usage=entries[n],
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, n),
+                    policy=self._policy_from_data(seq_data, n),
                 )
             )
         return AccountsSnapshot(
@@ -1843,6 +1846,76 @@ class ClaudeAccountSwitcher:
         record = data.get("accounts", {}).get(str(account_num))
         return bool(record and record.get("disabled"))
 
+    @staticmethod
+    def _policy_from_data(data: dict, account_num: str) -> AccountPolicy:
+        """Per-account auto-switch overrides from already-loaded data.
+
+        A staticmethod for the same reason ``_disabled_from_data`` is one: the
+        engine reads every slot's policy inside a single pass over one
+        ``_get_sequence_data()`` result, and a method that re-entered the store
+        per slot would turn one file read into N.
+
+        **Degrades, never raises.** The strict validator runs at the write
+        boundary (``set_account_threshold``); by the time a value is in the
+        file it may have been hand-edited, and a corrupt record must leave the
+        account on the global default rather than crash the auto-switch loop.
+        An unusable threshold reads as ``None``, which is exactly "inherit".
+
+        Args:
+            data: An already-loaded ``sequence.json`` mapping.
+            account_num: Slot number, as ``str`` or ``int``.
+
+        Returns:
+            The slot's :class:`AccountPolicy`, or the default if the record or
+            its keys are missing or unusable.
+        """
+        record = data.get("accounts", {}).get(str(account_num))
+        if not record:
+            return AccountPolicy()
+        raw = record.get("threshold")
+        threshold: float | None
+        if raw is None:
+            threshold = None
+        else:
+            try:
+                threshold = normalize_account_threshold(raw)
+            except ValueError:
+                # Hand-edited garbage, out-of-range, NaN/inf: inherit the
+                # global default rather than propagate an unusable number.
+                threshold = None
+        return AccountPolicy(threshold=threshold, backup=bool(record.get("backup")))
+
+    def account_policies(self) -> dict[str, AccountPolicy]:
+        """Every managed slot's auto-switch policy, from one sequence read.
+
+        Keyed by slot number in sequence order. The auto-switch engine calls
+        this once per tick and resolves effective thresholds from the result,
+        so it must not re-enter the store per account.
+        """
+        data = self._get_sequence_data() or {}
+        return {
+            str(num): self._policy_from_data(data, str(num))
+            for num in data.get("sequence", [])
+        }
+
+    def backup_account_numbers(self) -> list[str]:
+        """Managed slots marked as backup ("last man standing"), in sequence order.
+
+        Mirrors :meth:`disabled_account_numbers`, with the same two exclusions
+        as :meth:`switchable_account_numbers`: a slot without usable stored
+        backups is not a candidate for anything, and ``disabled`` is applied
+        first and wins — an account that is both disabled and backup appears in
+        neither pass of the engine's two-pass candidate filter.
+        """
+        data = self._get_sequence_data() or {}
+        return [
+            str(num)
+            for num in data.get("sequence", [])
+            if self._policy_from_data(data, str(num)).backup
+            and self._account_is_switchable(str(num))
+            and not self._disabled_from_data(data, str(num))
+        ]
+
     def is_account_disabled(self, account_num: str) -> bool:
         """Whether a slot is currently held out of rotation."""
         data = self._get_sequence_data() or {}
@@ -1856,6 +1929,140 @@ class ClaudeAccountSwitcher:
             for num in data.get("sequence", [])
             if self._disabled_from_data(data, str(num))
         ]
+
+    def _resolve_for_policy_write(self, identifier: str) -> tuple[str, str, dict, dict]:
+        """Resolve an identifier and fetch its record, ready for a policy write.
+
+        Shared by :meth:`set_account_threshold` and :meth:`set_account_backup`
+        so the two cannot drift in how they resolve, validate, or fail. Every
+        raising path here happens **before** any write, so a rejected call
+        leaves ``sequence.json`` byte-identical.
+
+        Returns:
+            ``(account_num, email, data, record)``.
+
+        Raises:
+            ConfigError: No accounts are managed yet, or the email is ambiguous.
+            AccountNotFoundError: The identifier matches no managed account.
+        """
+        if not self.sequence_file.exists():
+            raise ConfigError("No accounts are managed yet")
+
+        # resolve_account migrates org fields and hard-errors on ambiguity.
+        account_num, email, _ = self.resolve_account(identifier)
+
+        data = self._get_sequence_data() or {}
+        record = data.get("accounts", {}).get(account_num)
+        if not record:
+            raise AccountNotFoundError(f"Account-{account_num} does not exist")
+        return account_num, email, data, record
+
+    def set_account_threshold(self, identifier: str, threshold: object | None) -> None:
+        """Set or clear one account's own switch-away threshold.
+
+        The per-account value replaces ``autoswitch.threshold`` for this
+        account only, in both directions: the departure gate uses the *active*
+        account's value to decide when to leave, and the landing gate uses each
+        *candidate's* own value to decide whether it is an acceptable target.
+        Reserving headroom on one shared account therefore no longer means
+        taxing the whole fleet with a global cap set to the strictest member's.
+
+        ``threshold=None`` removes the override and returns the account to the
+        global default. The key is popped rather than written as ``null``, so a
+        fleet that has never set a policy keeps a ``sequence.json`` byte-identical
+        to one from before this feature existed.
+
+        Args:
+            identifier: Slot number, email, or alias.
+            threshold: Percentage in ``[ACCOUNT_THRESHOLD_MIN,
+                ACCOUNT_THRESHOLD_MAX]``, or ``None`` to clear.
+
+        Raises:
+            ConfigError: No accounts are managed yet, or the email is ambiguous.
+            AccountNotFoundError: The identifier matches no managed account.
+            ValueError: The value is not a number in range. Raised *before* any
+                write, so a rejected value leaves the store untouched.
+        """
+        # Validate first: a bad value must never reach the file. Resolution
+        # order matters only in that both checks precede the single write.
+        normalized = None if threshold is None else normalize_account_threshold(threshold)
+
+        account_num, email, data, record = self._resolve_for_policy_write(identifier)
+
+        current = record.get("threshold")
+        if normalized is None and "threshold" not in record:
+            print(dimmed(
+                f"Account-{account_num} ({email}) has no threshold override "
+                f"— already using the global default."
+            ))
+            return
+        if normalized is not None and current == normalized:
+            print(dimmed(
+                f"Account-{account_num} ({email}) is already at {normalized:g}%."
+            ))
+            return
+
+        if normalized is None:
+            record.pop("threshold", None)
+        else:
+            record["threshold"] = normalized
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+
+        if normalized is None:
+            self._logger.info(f"Cleared threshold for account {account_num}: {email}")
+            print(f"{accent('Cleared')} threshold for Account-{account_num} ({email}) "
+                  f"— now using the global default.")
+        else:
+            self._logger.info(
+                f"Set threshold {normalized:g} for account {account_num}: {email}"
+            )
+            print(f"{accent('Set')} Account-{account_num} ({email}) "
+                  f"threshold to {normalized:g}%.")
+
+    def set_account_backup(self, identifier: str, backup: bool) -> None:
+        """Mark an account as backup ("last man standing") or clear the mark.
+
+        A backup account is held out of automatic selection while any
+        non-backup account can still be landed on, and is offered only when
+        none can. It stays a valid explicit ``cswap switch <num|email>``
+        target, exactly like a disabled slot.
+
+        Orthogonal to ``disabled``: an account that is both is excluded
+        entirely, because ``disabled`` is applied first in
+        :meth:`switchable_account_numbers`.
+
+        Args:
+            identifier: Slot number, email, or alias.
+            backup: ``True`` to mark, ``False`` to clear.
+
+        Raises:
+            ConfigError: No accounts are managed yet, or the email is ambiguous.
+            AccountNotFoundError: The identifier matches no managed account.
+        """
+        account_num, email, data, record = self._resolve_for_policy_write(identifier)
+
+        verb = "marked as backup" if backup else "cleared as backup"
+        if bool(record.get("backup")) == backup:
+            state = "already a backup" if backup else "not a backup"
+            print(dimmed(f"Account-{account_num} ({email}) is {state}."))
+            return
+
+        if backup:
+            record["backup"] = True
+        else:
+            record.pop("backup", None)
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+        self._logger.info(f"Account {account_num} {verb}: {email}")
+
+        print(f"{accent('Account-' + account_num)} ({email}) {verb}.")
+
+        if backup:
+            print(dimmed(
+                "  It will be skipped by auto-switch while any other account "
+                "can still be used, and taken only when none can."
+            ))
 
     def set_account_disabled(self, identifier: str, disabled: bool) -> None:
         """Hold an account out of rotation (``disabled=True``) or return it.
@@ -5452,6 +5659,7 @@ class ClaudeAccountSwitcher:
                     last_good_usage=entry.last_good,
                     alias=alias,
                     disabled=self._disabled_from_data(seq_data, str(num)),
+                    policy=self._policy_from_data(seq_data, str(num)),
                 )
             )
         payload = {

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -60,6 +60,7 @@ from claude_swap.models import (
     Platform,
     SwitchTransaction,
     get_timestamp,
+    normalize_account_order,
     normalize_account_threshold,
     normalize_alias,
 )
@@ -1883,7 +1884,23 @@ class ClaudeAccountSwitcher:
                 # Hand-edited garbage, out-of-range, NaN/inf: inherit the
                 # global default rather than propagate an unusable number.
                 threshold = None
-        return AccountPolicy(threshold=threshold, backup=bool(record.get("backup")))
+        raw_order = record.get("order")
+        order: int | None
+        if raw_order is None:
+            order = None
+        else:
+            try:
+                order = normalize_account_order(raw_order)
+            except ValueError:
+                # Same degradation as ``threshold`` above, and the same reason:
+                # an unusable pin reads as "unpinned", which is precisely how
+                # this account behaved before the feature existed.
+                order = None
+        return AccountPolicy(
+            threshold=threshold,
+            backup=bool(record.get("backup")),
+            order=order,
+        )
 
     def account_policies(self) -> dict[str, AccountPolicy]:
         """Every managed slot's auto-switch policy, from one sequence read.
@@ -1897,6 +1914,23 @@ class ClaudeAccountSwitcher:
             str(num): self._policy_from_data(data, str(num))
             for num in data.get("sequence", [])
         }
+
+    def account_orders(self) -> dict[str, int]:
+        """Every slot holding an explicit chain order, from one sequence read.
+
+        Keyed by slot number in sequence order, and containing **only** the
+        accounts that carry a pin — an unpinned fleet yields ``{}``, which is
+        what lets the engine skip the whole tier when nobody uses the feature.
+        Mirrors :meth:`account_policies`, including its single-read discipline:
+        the auto-switch engine calls this once per tick.
+        """
+        data = self._get_sequence_data() or {}
+        orders: dict[str, int] = {}
+        for num in data.get("sequence", []):
+            order = self._policy_from_data(data, str(num)).order
+            if order is not None:
+                orders[str(num)] = order
+        return orders
 
     def backup_account_numbers(self) -> list[str]:
         """Managed slots marked as backup ("last man standing"), in sequence order.
@@ -2019,6 +2053,74 @@ class ClaudeAccountSwitcher:
             )
             print(f"{accent('Set')} Account-{account_num} ({email}) "
                   f"threshold to {normalized:g}%.")
+
+    def set_account_order(self, identifier: str, order: object | None) -> None:
+        """Set or clear one account's position in the switch chain.
+
+        A pinned account is preferred over every unpinned one, and a lower pin
+        over a higher one, *before* the ranking strategy is consulted — the pin
+        is a primary selector, not a tie-break. Equal pins are a group rather
+        than an error: they tie on the leading key element and fall through to
+        the strategy, which load-balances within the group.
+
+        ``order=None`` removes the pin and returns the account to strategy-only
+        ranking. The key is popped rather than written as ``null``, so a fleet
+        that has never pinned anything keeps a ``sequence.json`` byte-identical
+        to one from before this feature existed.
+
+        Pinning has a cost worth stating: it defeats the strategy's own
+        self-demotion. An account pinned first stays first even once a rival
+        has more headroom or resets sooner, so a pin used as a soft "prefer"
+        knob can cost throughput. It is a hard ordering, not a hint.
+
+        Args:
+            identifier: Slot number, email, or alias.
+            order: Whole number in ``[ACCOUNT_ORDER_MIN, ACCOUNT_ORDER_MAX]``,
+                or ``None`` to clear.
+
+        Raises:
+            ConfigError: No accounts are managed yet, or the email is ambiguous.
+            AccountNotFoundError: The identifier matches no managed account.
+            ValueError: The value is not a whole number in range. Raised
+                *before* any write, so a rejected value leaves the store
+                byte-identical.
+        """
+        # Validate first: a bad value must never reach the file, and must not
+        # depend on the identifier resolving. Mirrors set_account_threshold.
+        normalized = None if order is None else normalize_account_order(order)
+
+        account_num, email, data, record = self._resolve_for_policy_write(identifier)
+
+        current = record.get("order")
+        if normalized is None and "order" not in record:
+            print(dimmed(
+                f"Account-{account_num} ({email}) has no chain order "
+                f"— already ranked by strategy alone."
+            ))
+            return
+        if normalized is not None and current == normalized:
+            print(dimmed(
+                f"Account-{account_num} ({email}) is already order {normalized}."
+            ))
+            return
+
+        if normalized is None:
+            record.pop("order", None)
+        else:
+            record["order"] = normalized
+        data["lastUpdated"] = get_timestamp()
+        self._write_json(self.sequence_file, data)
+
+        if normalized is None:
+            self._logger.info(f"Cleared order for account {account_num}: {email}")
+            print(f"{accent('Cleared')} chain order for Account-{account_num} ({email}) "
+                  f"— now ranked by strategy alone.")
+        else:
+            self._logger.info(
+                f"Set order {normalized} for account {account_num}: {email}"
+            )
+            print(f"{accent('Set')} Account-{account_num} ({email}) "
+                  f"chain order to {normalized}.")
 
     def set_account_backup(self, identifier: str, backup: bool) -> None:
         """Mark an account as backup ("last man standing") or clear the mark.

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -160,6 +160,26 @@ def usage_rows(
     return rows
 
 
+def _policy_badges(acc: AccountSnapshot, gap: str) -> list[str]:
+    """Badge strings for the account's per-account policy, in display order.
+
+    Returns an empty list for an account carrying no policy, which is every
+    account in a store that has never used the feature — that is what keeps
+    those rows byte-identical to their pre-policy render.
+
+    ``gap`` is the leading separator each render path already uses for its own
+    badges (three spaces on the card, two on the minimized row).
+    """
+    badges: list[str] = []
+    if acc.policy.backup:
+        badges.append(f"{gap}(backup)")
+    if acc.policy.threshold is not None:
+        # ``:g`` so 75.0 reads as "75%" and 82.5 keeps its fraction — the store
+        # accepts one decimal place and the row shows back exactly what was set.
+        badges.append(f"{gap}th {acc.policy.threshold:g}%")
+    return badges
+
+
 def account_card_text(
     acc: AccountSnapshot,
     width: int,
@@ -183,6 +203,8 @@ def account_card_text(
         text.append("   ● active", style=f"bold {palette.accent}")
     if acc.disabled:
         text.append("   (disabled)", style=palette.muted)
+    for badge in _policy_badges(acc, "   "):
+        text.append(badge, style=palette.muted)
     age = data.format_age(acc.usage.age_s)
     if age:
         text.append(f"   {age}", style=palette.muted)
@@ -260,6 +282,8 @@ def mini_account_text(
     text.append(f"  [{acc.display_tag}]", style=palette.muted)
     if acc.disabled:
         text.append("  (disabled)", style=palette.muted)
+    for badge in _policy_badges(acc, "  "):
+        text.append(badge, style=palette.muted)
     text.append("   ")
 
     sentinel = acc.usage.sentinel

--- a/src/claude_swap/tui/widgets.py
+++ b/src/claude_swap/tui/widgets.py
@@ -177,6 +177,11 @@ def _policy_badges(acc: AccountSnapshot, gap: str) -> list[str]:
         # ``:g`` so 75.0 reads as "75%" and 82.5 keeps its fraction — the store
         # accepts one decimal place and the row shows back exactly what was set.
         badges.append(f"{gap}th {acc.policy.threshold:g}%")
+    if acc.policy.order is not None:
+        # Last of the three, and the least urgent: backup and threshold
+        # change *whether* an account is picked, a pin only changes
+        # *when*. Rank is a whole number, so no format spec is needed.
+        badges.append(f"{gap}ord {acc.policy.order}")
     return badges
 
 

--- a/tests/test_account_order_cli.py
+++ b/tests/test_account_order_cli.py
@@ -1,0 +1,476 @@
+"""`cswap order` CLI verb, `--json` rows — MEU-ORD-05 (AC-33 … AC-38).
+
+AC-33  `cswap order N R` sets, `cswap order N --unset` clears, bare
+       `cswap order` lists. Passing both a rank and `--unset` is an error, and
+       so is an identifier with neither.
+AC-34  The long-flag spellings `--order-account` / `--unorder-account` exist and
+       write bytes identical to the verb path.
+AC-35  The identifier is a number, an email, or an alias.
+AC-36  An invalid rank names the range on stderr, exits 1, and leaves
+       `sequence.json` byte-unchanged.
+AC-37  Bare `cswap order` prints the resolved chain: pinned accounts in rank
+       order, then a line saying the rest follow the active strategy.
+AC-38  `--json` account rows gain `order` only when set.
+
+**One deviation from AC-34, recorded here rather than left implicit.** AC-34
+asks for `_SUBCOMMAND_FLAGS` entries alongside `--order-account`. There must be
+none: AC-33 requires a bare `cswap order` to *list*, which forces the verb
+through the pre-dispatch block at `cli.py:1068` — and pre-dispatch runs before
+`_translate_subcommand`, so an entry would be unreachable. `cli.py:45-49` states
+that convention itself ("`run`/`auto` keep their own pre-dispatch parsers, so
+none of those are listed here"), and `threshold`, the verb this one mirrors, is
+likewise absent from the map. AC-34's *intent* — both spellings work, and both
+write the same bytes — is met in full by the long flags on the main parser;
+`TestTheSubcommandMapIsDeliberatelyUntouched` pins the exclusion so it reads as
+a decision instead of an oversight.
+
+Synthetic fixtures only. The real store at the user home is never read or
+written; `tests/test_real_store_guard.py` enforces that boundary and a failure
+there is a P0 stop.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import cli
+from claude_swap.models import ACCOUNT_ORDER_MAX, ACCOUNT_ORDER_MIN
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+from tests.test_account_order_store import OrderStoreBase
+
+
+class OrderCliBase(OrderStoreBase):
+    """`OrderStoreBase`'s synthetic fleet, driven through the CLI surface."""
+
+    @staticmethod
+    def _bytes(s: ClaudeAccountSwitcher) -> bytes:
+        """`sequence.json` verbatim - the AC-36 byte-identity oracle."""
+        return Path(s.sequence_file).read_bytes()
+
+    @staticmethod
+    def _order(argv: list[str]) -> None:
+        """Drive `cswap order ...` at its pre-dispatch entry point."""
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._order_command(argv)
+
+    @staticmethod
+    def _main(argv: list[str]) -> None:
+        """Drive a full `cswap ...` argv through `main()`'s dispatch."""
+        with patch.object(sys, "argv", ["claude-swap", *argv]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+    @staticmethod
+    def _alias(s: ClaudeAccountSwitcher, num: str, name: str) -> None:
+        data = s._get_sequence_data() or {}
+        data["accounts"][num]["alias"] = name
+        s._write_json(s.sequence_file, data)
+
+
+class TestOrderSet(OrderCliBase):
+    """AC-33, first third - `cswap order 2 5` pins and confirms."""
+
+    def test_it_writes_the_pin_and_prints_a_confirmation(
+        self, temp_home: Path, capsys
+    ):
+        self._fleet(temp_home)
+        self._order(["2", "5"])
+
+        assert self._record(ClaudeAccountSwitcher(), "2")["order"] == 5
+        out = capsys.readouterr().out
+        assert "Account-2" in out
+        assert "5" in out
+
+    def test_it_stores_an_int_not_the_raw_string(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._order(["2", "5"])
+        stored = self._record(ClaudeAccountSwitcher(), "2")["order"]
+        assert isinstance(stored, int) and not isinstance(stored, bool)
+
+    def test_the_boundary_values_are_accepted(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._order(["1", str(ACCOUNT_ORDER_MIN)])
+        self._order(["2", str(ACCOUNT_ORDER_MAX)])
+        s = ClaudeAccountSwitcher()
+        assert self._record(s, "1")["order"] == ACCOUNT_ORDER_MIN
+        assert self._record(s, "2")["order"] == ACCOUNT_ORDER_MAX
+
+    def test_only_the_named_account_is_pinned(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._order(["2", "5"])
+        s = ClaudeAccountSwitcher()
+        assert "order" not in self._record(s, "1")
+        assert "order" not in self._record(s, "3")
+
+
+class TestOrderUnset(OrderCliBase):
+    """AC-33, second third - `--unset` pops the key, not writes null."""
+
+    def test_it_removes_the_pin(self, temp_home: Path, capsys):
+        s = self._fleet(temp_home)
+        s.set_account_order("2", 5)
+        self._order(["2", "--unset"])
+        assert "order" not in self._record(ClaudeAccountSwitcher(), "2")
+
+    def test_unset_on_an_unpinned_account_is_not_an_error(
+        self, temp_home: Path, capsys
+    ):
+        self._fleet(temp_home)
+        self._order(["2", "--unset"])
+        assert "order" not in self._record(ClaudeAccountSwitcher(), "2")
+
+    def test_a_cleared_pin_leaves_the_record_as_it_started(
+        self, temp_home: Path, capsys
+    ):
+        """The omit-when-default contract, end to end through the CLI.
+
+        Set then clear must return the *record* to its pre-feature shape. The
+        whole file is not compared because `lastUpdated` restamps on write,
+        which is correct behaviour rather than a regression.
+        """
+        s = self._fleet(temp_home)
+        before = dict(self._record(s, "2"))
+        self._order(["2", "7"])
+        self._order(["2", "--unset"])
+        assert self._record(ClaudeAccountSwitcher(), "2") == before
+
+
+class TestOrderArgumentErrors(OrderCliBase):
+    """AC-33's negative half - the two impossible argument shapes."""
+
+    def test_a_rank_with_unset_is_rejected(self, temp_home: Path):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit) as e:
+            self._order(["2", "5", "--unset"])
+        assert e.value.code == 2  # argparse.error
+
+    def test_an_identifier_with_neither_is_rejected(self, temp_home: Path):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit) as e:
+            self._order(["2"])
+        assert e.value.code == 2
+
+    def test_unset_without_an_identifier_is_rejected(self, temp_home: Path):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit) as e:
+            self._order(["--unset"])
+        assert e.value.code == 2
+
+    def test_a_rejected_argv_writes_nothing(self, temp_home: Path):
+        """argparse exits before the switcher is even constructed."""
+        s = self._fleet(temp_home)
+        before = self._bytes(s)
+        with pytest.raises(SystemExit):
+            self._order(["2"])
+        assert self._bytes(ClaudeAccountSwitcher()) == before
+
+
+class TestLongFlagSpellings(OrderCliBase):
+    """AC-34 - `--order-account` / `--unorder-account` on the main parser."""
+
+    def test_the_flag_path_pins(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._main(["--order-account", "2", "5"])
+        assert self._record(ClaudeAccountSwitcher(), "2")["order"] == 5
+
+    def test_the_unflag_path_clears(self, temp_home: Path, capsys):
+        s = self._fleet(temp_home)
+        s.set_account_order("2", 5)
+        self._main(["--unorder-account", "2"])
+        assert "order" not in self._record(ClaudeAccountSwitcher(), "2")
+
+    def test_both_paths_write_identical_bytes(self, temp_home: Path, capsys):
+        """AC-34's named oracle, and the reason both spellings can coexist.
+
+        `lastUpdated` restamps on every write, so the two stores are compared
+        with that one field normalised - it differs for a reason unrelated to
+        the feature, and pinning it would make the oracle a clock test.
+        """
+        def _canonical(raw: bytes) -> dict:
+            data = json.loads(raw)
+            data["lastUpdated"] = ""
+            return data
+
+        s = self._fleet(temp_home)
+        self._order(["2", "5"])
+        via_verb = _canonical(self._bytes(ClaudeAccountSwitcher()))
+
+        self._order(["2", "--unset"])
+        self._main(["--order-account", "2", "5"])
+        via_flag = _canonical(self._bytes(ClaudeAccountSwitcher()))
+
+        assert via_verb == via_flag
+
+
+class TestTheFlagPathFailsLikeTheVerbPath(OrderCliBase):
+    """Post-review correction (execution review round 1, out-of-contract obs).
+
+    `set_account_order` raises `ValueError` for a bad rank, but `main()`'s
+    dispatch handler catches `ClaudeSwitchError` only, so
+    `cswap --order-account 2 0` surfaced an uncaught traceback. It did exit 1
+    and did leave the store untouched, so AC-36's letter held - but AC-34 is
+    the claim that the two spellings are the *same* command, and a spelling
+    that answers bad input with a stack trace is not the same command. The
+    verb path already funnels this through `error()` + `sys.exit(1)`.
+    """
+
+    BAD = ["0", "1000", "abc"]
+
+    @pytest.mark.parametrize("bad", BAD)
+    def test_the_flag_path_exits_1_without_a_traceback(
+        self, temp_home: Path, capsys, bad: str
+    ):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit) as exc:
+            self._main(["--order-account", "2", bad])
+        assert exc.value.code == 1
+
+    @pytest.mark.parametrize("bad", BAD)
+    def test_the_flag_path_names_the_range_on_stderr(
+        self, temp_home: Path, capsys, bad: str
+    ):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit):
+            self._main(["--order-account", "2", bad])
+        err = capsys.readouterr().err
+        assert f"{ACCOUNT_ORDER_MIN}" in err and f"{ACCOUNT_ORDER_MAX}" in err
+        assert "Traceback" not in err
+
+    def test_the_rejected_flag_write_leaves_the_store_byte_identical(
+        self, temp_home: Path, capsys
+    ):
+        s = self._fleet(temp_home)
+        before = self._bytes(s)
+        with pytest.raises(SystemExit):
+            self._main(["--order-account", "2", "0"])
+        assert self._bytes(ClaudeAccountSwitcher()) == before
+
+    def test_both_spellings_report_the_same_message(
+        self, temp_home: Path, capsys
+    ):
+        """The point of the correction: one command, two spellings."""
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit):
+            self._order(["2", "0"])
+        via_verb = capsys.readouterr().err
+        with pytest.raises(SystemExit):
+            self._main(["--order-account", "2", "0"])
+        via_flag = capsys.readouterr().err
+        assert via_verb == via_flag
+
+
+class TestTheSubcommandMapIsDeliberatelyUntouched(OrderCliBase):
+    """The AC-34 deviation, pinned so it cannot regress into an oversight.
+
+    See the module docstring: `order` is pre-dispatched, and pre-dispatch runs
+    before `_translate_subcommand`, so a `_SUBCOMMAND_FLAGS` entry would be
+    dead code. `threshold` - the verb this one mirrors - is absent for exactly
+    the same reason.
+    """
+
+    def test_order_is_not_in_the_subcommand_map(self):
+        assert "order" not in cli._SUBCOMMAND_FLAGS
+
+    def test_neither_is_threshold_the_verb_it_mirrors(self):
+        assert "threshold" not in cli._SUBCOMMAND_FLAGS
+
+    def test_backup_still_is_because_it_is_not_pre_dispatched(self):
+        """The control: the map is not simply empty of policy verbs."""
+        assert cli._SUBCOMMAND_FLAGS["backup"] == "--backup-account"
+
+
+class TestIdentifierForms(OrderCliBase):
+    """AC-35 - number, email, or alias, like every other account verb."""
+
+    def test_by_number(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._order(["2", "5"])
+        assert self._record(ClaudeAccountSwitcher(), "2")["order"] == 5
+
+    def test_by_email(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._order(["account-2@example.test", "5"])
+        assert self._record(ClaudeAccountSwitcher(), "2")["order"] == 5
+
+    def test_by_alias(self, temp_home: Path, capsys):
+        s = self._fleet(temp_home)
+        self._alias(s, "2", "dev")
+        self._order(["dev", "5"])
+        assert self._record(ClaudeAccountSwitcher(), "2")["order"] == 5
+
+    def test_an_unknown_identifier_exits_naming_it(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit) as e:
+            self._order(["nobody@example.test", "5"])
+        assert e.value.code == 1
+        assert "nobody@example.test" in capsys.readouterr().err
+
+
+class TestInvalidRankIsRejectedAtTheWriteBoundary(OrderCliBase):
+    """AC-36 - names the range on stderr, exits 1, writes nothing."""
+
+    BAD = ["0", "-1", "1000", "2.5", "abc", "", "1e3"]
+
+    @pytest.mark.parametrize("bad", BAD)
+    def test_it_exits_one(self, temp_home: Path, bad: str):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit) as e:
+            self._order(["2", bad])
+        assert e.value.code == 1
+
+    @pytest.mark.parametrize("bad", BAD)
+    def test_the_message_names_the_range(self, temp_home: Path, capsys, bad: str):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit):
+            self._order(["2", bad])
+        err = capsys.readouterr().err
+        assert str(ACCOUNT_ORDER_MIN) in err and str(ACCOUNT_ORDER_MAX) in err
+
+    @pytest.mark.parametrize("bad", BAD)
+    def test_sequence_json_is_byte_unchanged(self, temp_home: Path, bad: str):
+        """The AC-36 oracle proper: bytes, not fields.
+
+        A field comparison would pass even if the write happened and was
+        rolled back, or if `lastUpdated` restamped. Neither is acceptable -
+        the value must never reach the file at all.
+        """
+        s = self._fleet(temp_home)
+        before = self._bytes(s)
+        with pytest.raises(SystemExit):
+            self._order(["2", bad])
+        assert self._bytes(ClaudeAccountSwitcher()) == before
+
+    def test_an_invalid_rank_on_an_unknown_account_still_reports_the_range(
+        self, temp_home: Path, capsys
+    ):
+        """Validation precedes identifier resolution, as in `set_account_order`."""
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit):
+            self._order(["nobody@example.test", "0"])
+        err = capsys.readouterr().err
+        assert str(ACCOUNT_ORDER_MAX) in err
+
+
+class TestBareOrderListsTheChain(OrderCliBase):
+    """AC-37 - the resolved chain, pinned first, then the strategy remainder."""
+
+    def test_the_empty_state_says_so(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._order([])
+        assert "No per-account order set" in capsys.readouterr().out
+
+    def test_it_lists_pins_in_rank_order_not_slot_order(
+        self, temp_home: Path, capsys
+    ):
+        s = self._fleet(temp_home)
+        s.set_account_order("1", 9)
+        s.set_account_order("3", 2)
+        capsys.readouterr()
+        self._order([])
+        out = capsys.readouterr().out
+        assert out.index("Account-3") < out.index("Account-1")
+
+    def test_it_prints_each_pinned_rank(self, temp_home: Path, capsys):
+        s = self._fleet(temp_home)
+        s.set_account_order("2", 7)
+        capsys.readouterr()
+        self._order([])
+        out = capsys.readouterr().out
+        assert "Account-2" in out and "7" in out
+
+    def test_unpinned_accounts_are_listed_under_a_strategy_line(
+        self, temp_home: Path, capsys
+    ):
+        s = self._fleet(temp_home)
+        s.set_account_order("2", 1)
+        capsys.readouterr()
+        self._order([])
+        out = capsys.readouterr().out
+        assert "strategy" in out.lower()
+        assert "Account-1" in out and "Account-3" in out
+
+    def test_a_fully_pinned_fleet_prints_no_strategy_remainder(
+        self, temp_home: Path, capsys
+    ):
+        """The line is about accounts, so it must not print with none left."""
+        s = self._fleet(temp_home)
+        for num, rank in (("1", 1), ("2", 2), ("3", 3)):
+            s.set_account_order(num, rank)
+        capsys.readouterr()
+        self._order([])
+        out = capsys.readouterr().out
+        assert "No per-account order set" not in out
+        assert "strategy" not in out.lower()
+
+    def test_listing_writes_nothing(self, temp_home: Path, capsys):
+        s = self._fleet(temp_home)
+        s.set_account_order("2", 1)
+        before = self._bytes(ClaudeAccountSwitcher())
+        capsys.readouterr()
+        self._order([])
+        assert self._bytes(ClaudeAccountSwitcher()) == before
+
+
+class TestJsonRowCarriesTheOrder(OrderCliBase):
+    """AC-38 - omit-when-default, exactly as `threshold` and `backup` are."""
+
+    def test_a_pinned_row_gains_the_key(self):
+        from claude_swap.json_output import account_row
+        from claude_swap.models import AccountPolicy
+
+        row = account_row(
+            2, "a@example.test", "", "", False, None,
+            policy=AccountPolicy(order=5),
+        )
+        assert row["order"] == 5
+
+    def test_an_unpinned_row_omits_it(self):
+        from claude_swap.json_output import account_row
+
+        row = account_row(2, "a@example.test", "", "", False, None)
+        assert "order" not in row
+
+    def test_an_unpinned_fleet_emits_rows_identical_to_pr_one(self):
+        """AC-38's named oracle: the key is additive, not merely defaulted.
+
+        Compared as a full dict rather than by absence of one key, so a row
+        that gained `"order": None` - the other plausible implementation, and
+        the one that breaks every consumer keying on the base schema - fails
+        here rather than in someone's script.
+        """
+        from claude_swap.json_output import account_row
+        from claude_swap.models import AccountPolicy
+
+        plain = account_row(2, "a@example.test", "", "", False, None)
+        explicit_none = account_row(
+            2, "a@example.test", "", "", False, None,
+            policy=AccountPolicy(order=None),
+        )
+        assert plain == explicit_none
+
+    def test_it_composes_with_the_pr_one_keys(self):
+        from claude_swap.json_output import account_row
+        from claude_swap.models import AccountPolicy
+
+        row = account_row(
+            2, "a@example.test", "", "", False, None,
+            policy=AccountPolicy(threshold=85.0, backup=True, order=3),
+        )
+        assert (row["threshold"], row["backup"], row["order"]) == (85.0, True, 3)
+
+    def test_the_stored_type_survives_serialisation(self):
+        from claude_swap.json_output import account_row
+        from claude_swap.models import AccountPolicy
+
+        row = account_row(
+            2, "a@example.test", "", "", False, None,
+            policy=AccountPolicy(order=5),
+        )
+        assert json.loads(json.dumps(row))["order"] == 5

--- a/tests/test_account_order_store.py
+++ b/tests/test_account_order_store.py
@@ -1,0 +1,410 @@
+"""Per-account chain-order persistence and accessors (switcher.py).
+
+MEU-ORD-02 — AC-9 … AC-16 of
+`.agent/plans/2026-09-03-per-account-order/implementation-plan.md`.
+
+Mirrors the PR 1 policy machinery exactly: `_policy_from_data` gains one more
+tolerantly-read key, `set_account_order` mirrors `set_account_threshold`, and
+`account_orders()` mirrors `account_policies()`. The omit-when-default record
+convention is what keeps an untouched `sequence.json` byte-identical.
+
+The asymmetry under test throughout is **strict at the write boundary, tolerant
+on read**: `set_account_order("1", 0)` raises before the file is opened, while a
+record already holding `"order": 0` loads as unpinned rather than crashing the
+auto-switch loop mid-tick.
+
+Synthetic fixtures only. The real store at the user home is never read or
+written; `tests/test_real_store_guard.py` enforces that boundary and a failure
+there is a P0 stop.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap.exceptions import AccountNotFoundError
+from claude_swap.models import AccountPolicy, Platform
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class OrderStoreBase:
+    """Shared synthetic-store scaffolding, identical to `PolicyStoreBase`."""
+
+    def _setup(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.LINUX
+        s._setup_directories()
+        s._init_sequence_file()
+        return s
+
+    def _seed(self, s: ClaudeAccountSwitcher, num: int, email: str) -> None:
+        """Add a fully switchable slot (credential + config backups present)."""
+        s._write_account_credentials(
+            str(num),
+            email,
+            json.dumps({"claudeAiOauth": {
+                "accessToken": f"sk-{num}", "refreshToken": f"rt-{num}"}}),
+        )
+        s._write_account_config(
+            str(num),
+            email,
+            json.dumps({"oauthAccount": {
+                "emailAddress": email, "accountUuid": f"uuid-{num}"}}),
+        )
+        data = s._get_sequence_data() or {
+            "activeAccountNumber": None, "lastUpdated": "",
+            "sequence": [], "accounts": {},
+        }
+        data["accounts"][str(num)] = {
+            "email": email, "uuid": f"uuid-{num}",
+            "organizationUuid": "", "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+            data["sequence"].sort()
+        if data["activeAccountNumber"] is None:
+            data["activeAccountNumber"] = num
+        data["lastUpdated"] = "2024-01-01T00:00:00Z"
+        s._write_json(s.sequence_file, data)
+
+    def _fleet(self, temp_home: Path, count: int = 3) -> ClaudeAccountSwitcher:
+        s = self._setup(temp_home)
+        for n in range(1, count + 1):
+            self._seed(s, n, f"account-{n}@example.test")
+        return s
+
+    @staticmethod
+    def _record(s: ClaudeAccountSwitcher, num: str) -> dict:
+        return (s._get_sequence_data() or {})["accounts"][num]
+
+    @staticmethod
+    def _write_raw_order(s: ClaudeAccountSwitcher, num: str, raw: object) -> None:
+        """Put a value straight into the record, bypassing the validator.
+
+        The only way to test read-tolerance: `set_account_order` refuses every
+        value AC-9 cares about, so a hand-edited store has to be simulated.
+        """
+        data = s._get_sequence_data() or {}
+        data["accounts"][num]["order"] = raw
+        s._write_json(s.sequence_file, data)
+
+
+class TestOrderReadTolerance(OrderStoreBase):
+    """AC-9 — `_policy_from_data` degrades, never raises."""
+
+    def test_record_without_order_yields_none(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        data = s._get_sequence_data() or {}
+        assert s._policy_from_data(data, "1").order is None
+
+    def test_missing_record_yields_the_default(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        data = s._get_sequence_data() or {}
+        assert s._policy_from_data(data, "99") == AccountPolicy()
+
+    def test_reads_a_valid_order(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_order("1", 3)
+        data = s._get_sequence_data() or {}
+        assert s._policy_from_data(data, "1").order == 3
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "banana", "", "1x", None, 0, -1, 1000, 1.5, "1.5",
+            True, False, [], {}, float("nan"), float("inf"),
+        ],
+    )
+    def test_unusable_order_reads_as_unpinned(self, temp_home: Path, raw):
+        """Hand-edited garbage, out of range, fractional, or the wrong type:
+        every one of them reads as `None`, which means "unpinned", which is
+        exactly the pre-feature behaviour for that account."""
+        s = self._fleet(temp_home)
+        self._write_raw_order(s, "1", raw)
+        data = s._get_sequence_data() or {}
+        assert s._policy_from_data(data, "1").order is None
+
+    def test_a_corrupt_order_does_not_disturb_the_other_fields(self, temp_home: Path):
+        """Degradation is per-key. A bad `order` must not discard a good
+        `threshold` sitting in the same record."""
+        s = self._fleet(temp_home)
+        s.set_account_threshold("1", 85.0)
+        s.set_account_backup("1", True)
+        self._write_raw_order(s, "1", "banana")
+        data = s._get_sequence_data() or {}
+        assert s._policy_from_data(data, "1") == AccountPolicy(
+            threshold=85.0, backup=True, order=None
+        )
+
+    def test_a_corrupt_order_does_not_disturb_other_accounts(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_order("2", 4)
+        self._write_raw_order(s, "1", {"nested": "garbage"})
+        assert s.account_orders() == {"2": 4}
+
+    def test_integral_float_in_the_store_reads_as_int(self, temp_home: Path):
+        """A JSON round-trip can widen 2 to 2.0. The read must not treat that
+        as corruption, and must not hand the engine a float rank."""
+        s = self._fleet(temp_home)
+        self._write_raw_order(s, "1", 2.0)
+        data = s._get_sequence_data() or {}
+        order = s._policy_from_data(data, "1").order
+        assert order == 2
+        assert type(order) is int
+
+
+class TestSetAccountOrder(OrderStoreBase):
+    """AC-10, AC-15 — the write boundary."""
+
+    def test_sets_the_key(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_order("1", 3)
+        assert self._record(s, "1")["order"] == 3
+
+    def test_stores_an_int_even_when_given_a_string(self, temp_home: Path):
+        """The CLI hands over argv. A string in the store would compare wrong
+        against `ORDER_UNSET_RANK` and would serialize as `"3"` in JSON."""
+        s = self._fleet(temp_home)
+        s.set_account_order("1", "3")
+        stored = self._record(s, "1")["order"]
+        assert stored == 3
+        assert type(stored) is int
+
+    def test_unset_removes_the_key(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_order("1", 3)
+        s.set_account_order("1", None)
+        assert "order" not in self._record(s, "1"), (
+            "unset must remove the key, not write null — AC-10's omit-when-default"
+        )
+
+    def test_resolves_by_email_and_alias(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_order("account-2@example.test", 5)
+        assert self._record(s, "2")["order"] == 5
+
+    def test_unknown_identifier_raises(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        with pytest.raises(AccountNotFoundError):
+            s.set_account_order("99", 3)
+
+    def test_stamps_last_updated(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        before = (s._get_sequence_data() or {})["lastUpdated"]
+        s.set_account_order("1", 3)
+        assert (s._get_sequence_data() or {})["lastUpdated"] != before
+
+    @pytest.mark.parametrize("bad", [0, -1, 1000, 1.5, "abc", "", True, [], object()])
+    def test_invalid_value_raises_before_the_file_is_opened(self, temp_home: Path, bad):
+        """AC-15 — validation precedes resolution *and* the write, so a
+        rejected value leaves `sequence.json` byte-identical."""
+        s = self._fleet(temp_home)
+        before = s.sequence_file.read_bytes()
+        with pytest.raises(ValueError):
+            s.set_account_order("1", bad)
+        assert s.sequence_file.read_bytes() == before
+
+    def test_invalid_value_is_rejected_even_for_an_unknown_account(self, temp_home: Path):
+        """Validation is first, so the *value* error wins over the identifier
+        error — the same ordering `set_account_threshold` uses."""
+        s = self._fleet(temp_home)
+        with pytest.raises(ValueError):
+            s.set_account_order("99", 0)
+
+    def test_clearing_an_unset_order_is_a_no_op(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        before = s.sequence_file.read_bytes()
+        s.set_account_order("1", None)
+        assert s.sequence_file.read_bytes() == before
+
+    def test_setting_the_same_order_twice_is_a_no_op(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_order("1", 3)
+        before = s.sequence_file.read_bytes()
+        s.set_account_order("1", 3)
+        assert s.sequence_file.read_bytes() == before
+
+
+class TestByteIdenticalAfterSetThenUnset(OrderStoreBase):
+    """AC-11 — the headline compatibility property, asserted on bytes.
+
+    A dict comparison would pass even if the writer left `"order": null` behind
+    or reordered keys. The claim in the PR body is that a fleet which set and
+    then cleared an order has a file indistinguishable from one that never
+    touched the feature, and only a byte comparison tests that claim.
+    """
+
+    def test_set_then_unset_restores_the_exact_bytes(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        before = s.sequence_file.read_bytes()
+
+        s.set_account_order("1", 3)
+        assert s.sequence_file.read_bytes() != before, "the set must actually write"
+
+        s.set_account_order("1", None)
+        after = s.sequence_file.read_bytes()
+
+        # `lastUpdated` is restamped by both writes, so it is normalised out —
+        # it is the *record* that must be byte-restored, not the timestamp.
+        import re
+        norm = lambda b: re.sub(rb'"lastUpdated":\s*"[^"]*"', b'"lastUpdated":""', b)
+        assert norm(after) == norm(before)
+
+    def test_no_order_key_survives_anywhere_in_the_file(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_order("1", 3)
+        s.set_account_order("2", 7)
+        s.set_account_order("1", None)
+        s.set_account_order("2", None)
+        assert b'"order"' not in s.sequence_file.read_bytes()
+
+    def test_an_untouched_fleet_has_no_order_key(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        assert b'"order"' not in s.sequence_file.read_bytes()
+
+
+class TestAccountOrders(OrderStoreBase):
+    """AC-12, AC-16 — the accessor."""
+
+    def test_unpinned_fleet_returns_empty(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        assert s.account_orders() == {}
+
+    def test_returns_only_explicitly_pinned_accounts(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_order("2", 1)
+        assert s.account_orders() == {"2": 1}
+
+    def test_keys_are_str_values_are_int(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_order("2", 1)
+        (key, value), = s.account_orders().items()
+        assert type(key) is str and type(value) is int
+
+    def test_returns_in_sequence_order(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_order("3", 1)
+        s.set_account_order("1", 2)
+        assert list(s.account_orders()) == ["1", "3"], (
+            "keyed by slot in sequence order, like account_policies()"
+        )
+
+    def test_duplicate_orders_are_permitted(self, temp_home: Path):
+        """AC-16 — equal orders are a *group*, not an error: they tie on the
+        leading key element and fall through to the ranking strategy, which is
+        litellm's load-balancing-within-an-order-group semantics."""
+        s = self._fleet(temp_home, count=4)
+        s.set_account_order("2", 1)
+        s.set_account_order("4", 1)
+        assert s.account_orders() == {"2": 1, "4": 1}
+
+    def test_reads_the_store_once(self, temp_home: Path, monkeypatch):
+        """The engine calls this every tick; re-entering the store per account
+        would turn one file read into N."""
+        s = self._fleet(temp_home, count=3)
+        s.set_account_order("1", 1)
+        calls = []
+        original = s._get_sequence_data
+        monkeypatch.setattr(s, "_get_sequence_data",
+                            lambda *a, **k: (calls.append(1), original(*a, **k))[1])
+        s.account_orders()
+        assert len(calls) == 1
+
+
+class TestOrderSurvivesRenumber(OrderStoreBase):
+    """AC-13 — `swap` and `move` carry `order` with the record.
+
+    The decisive argument for storing policy *in the account record* rather
+    than a parallel slot-keyed map: a slot-keyed map silently reassigns every
+    pin the moment a user renumbers, so account 1's "go first" would become
+    account 3's after `cswap swap 1 3`.
+    """
+
+    def test_swap_carries_the_order(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_order("1", 2)
+
+        s.swap_accounts("1", "3")
+
+        assert self._record(s, "3")["order"] == 2
+        assert "order" not in self._record(s, "1"), "the pin was left behind on slot 1"
+
+    def test_swap_does_not_invent_an_order_on_the_other_slot(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_order("1", 2)
+        s.swap_accounts("1", "2")
+        assert s.account_orders() == {"2": 2}
+
+    def test_swap_exchanges_two_orders(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_order("1", 1)
+        s.set_account_order("3", 9)
+        s.swap_accounts("1", "3")
+        assert s.account_orders() == {"1": 9, "3": 1}
+
+    def test_move_carries_the_order(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_order("2", 4)
+
+        s.move_account("2", "5")
+
+        assert self._record(s, "5")["order"] == 4
+        assert "2" not in (s._get_sequence_data() or {})["accounts"]
+
+    def test_accessor_agrees_with_the_record_after_a_move(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_order("2", 4)
+        assert s.account_orders() == {"2": 4}
+        s.move_account("2", "5")
+        assert s.account_orders() == {"5": 4}
+
+    def test_order_travels_with_threshold_and_backup(self, temp_home: Path):
+        """All three policy keys are record-keyed, so all three move together."""
+        s = self._fleet(temp_home, count=3)
+        s.set_account_threshold("1", 85.0)
+        s.set_account_backup("1", True)
+        s.set_account_order("1", 2)
+
+        s.swap_accounts("1", "3")
+
+        record = self._record(s, "3")
+        assert record["threshold"] == pytest.approx(85.0)
+        assert record["backup"] is True
+        assert record["order"] == 2
+
+
+class TestExportOmitsOrder(OrderStoreBase):
+    """AC-14 — `order` is machine-local and does not travel.
+
+    `transfer.py:262-275` builds each export entry from an explicit allowlist.
+    That allowlist is why this test passes **without `transfer.py` being
+    modified** — and it is worth an explicit test precisely because the
+    mechanism is absence rather than code.
+    """
+
+    def test_export_omits_order(self, temp_home: Path):
+        from claude_swap.transfer import export_accounts
+
+        s = self._fleet(temp_home)
+        s.set_account_order("1", 2)
+        s.set_account_order("2", 1)
+
+        out_file = temp_home / "backup.cswap"
+        export_accounts(s, str(out_file))
+        envelope = json.loads(out_file.read_text(encoding="utf-8"))
+
+        for entry in envelope["accounts"]:
+            assert "order" not in entry, f"export leaked an order: {entry['email']}"
+
+    def test_transfer_module_is_unmodified_for_order(self):
+        """The allowlist, not a filter, is the mechanism. If a future change
+        turns the export into a record passthrough, this fails loudly."""
+        from pathlib import Path as _P
+        source = _P("src/claude_swap/transfer.py").read_text(encoding="utf-8")
+        assert "order" not in source.split("def export_accounts")[1][:2000], (
+            "export must not learn about `order`"
+        )

--- a/tests/test_account_order_values.py
+++ b/tests/test_account_order_values.py
@@ -1,0 +1,260 @@
+"""Per-account chain order value object and normalization (models.py).
+
+MEU-ORD-01 — AC-1 … AC-8 of
+`.agent/plans/2026-09-03-per-account-order/implementation-plan.md`.
+
+`order` is an **ordinal**, not a percentage: it indexes a chain rather than
+measuring one, so unlike the one-decimal float `threshold` it normalizes to an
+`int`. Integral input in any numeric form is accepted (`2`, `2.0`, `"2"` all
+yield the `int` 2) because the CLI hands over argv strings and a JSON store may
+round-trip a whole number as a float; fractional input is rejected, because
+there is no such thing as position 1.5 in a chain.
+
+The strict-write / tolerant-read asymmetry is inherited from PR 1: this module
+is the single **write**-boundary validator, and `switcher.py` stays forgiving
+when reading a store some future version may have written.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from pathlib import Path
+
+import pytest
+
+from claude_swap.models import (
+    ACCOUNT_ORDER_MAX,
+    ACCOUNT_ORDER_MIN,
+    ORDER_UNSET_RANK,
+    AccountPolicy,
+    normalize_account_order,
+)
+
+
+class TestOrderConstants:
+    """AC-1, AC-6 — the bounds and the unset sentinel."""
+
+    def test_constants_have_the_documented_values(self):
+        assert ACCOUNT_ORDER_MIN == 1
+        assert ACCOUNT_ORDER_MAX == 999
+
+    def test_constants_are_ints(self):
+        """Not floats. An ordinal that arrives as 1.0 would print as '1.0'."""
+        assert type(ACCOUNT_ORDER_MIN) is int
+        assert type(ACCOUNT_ORDER_MAX) is int
+        assert type(ORDER_UNSET_RANK) is int
+
+    def test_lower_bound_is_one_not_zero(self):
+        """0 is held back as a non-value so a future 'always first' sentinel
+        has room (plan §Spec Sufficiency, Research-backed)."""
+        assert ACCOUNT_ORDER_MIN == 1
+
+    def test_unset_rank_outranks_every_pinned_value(self):
+        """AC-6 — the assertion *is* the test.
+
+        `OrderMap.__missing__` returns `ORDER_UNSET_RANK`, and the tier is the
+        leading element of the sort key, which sorts ascending. If the sentinel
+        were not strictly greater than every legal pin, an unpinned account
+        could outrank a pinned one and the whole feature would be unsound.
+        """
+        assert ORDER_UNSET_RANK > ACCOUNT_ORDER_MAX
+
+
+class TestNormalizeAccountOrder:
+    """AC-1, AC-3, AC-4 — the write-boundary validator."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (1, 1),
+            (999, 999),
+            (7, 7),
+            (2.0, 2),          # AC-4: integral float accepted
+            (999.0, 999),
+            ("2", 2),          # AC-3: the CLI hands over argv strings
+            ("  5  ", 5),      # AC-3: whitespace stripped
+            ("1", 1),
+            ("999", 999),
+            ("2.0", 2),        # AC-4: integral numeric str accepted
+        ],
+    )
+    def test_accepts_integral_values_in_range(self, raw, expected):
+        result = normalize_account_order(raw)
+        assert result == expected
+        assert type(result) is int, "order is an ordinal and must normalize to int"
+
+    @pytest.mark.parametrize("raw", [0, -1, 1000, "0", "-1", "1000", 0.0, 1000.0])
+    def test_rejects_out_of_range(self, raw):
+        with pytest.raises(ValueError):
+            normalize_account_order(raw)
+
+    @pytest.mark.parametrize("raw", [0, -1, 1000, 1.5, "abc", None])
+    def test_error_message_names_the_valid_range(self, raw):
+        """Every rejection path names the range, as `normalize_account_threshold`
+        does — a user who typed 1000 learns what is legal without reading docs."""
+        with pytest.raises(ValueError) as excinfo:
+            normalize_account_order(raw)
+        message = str(excinfo.value)
+        assert "1" in message and "999" in message
+
+    def test_boundaries_are_inclusive(self):
+        assert normalize_account_order(ACCOUNT_ORDER_MIN) == ACCOUNT_ORDER_MIN
+        assert normalize_account_order(ACCOUNT_ORDER_MAX) == ACCOUNT_ORDER_MAX
+
+    @pytest.mark.parametrize("raw", ["abc", "", "   ", "1x", "x1", "1 2", None, [], {}, object()])
+    def test_rejects_non_numeric(self, raw):
+        with pytest.raises(ValueError):
+            normalize_account_order(raw)
+
+    @pytest.mark.parametrize("raw", ["abc", "", "1x"])
+    def test_non_numeric_message_quotes_the_value(self, raw):
+        """AC-3 — quoted via !r, so an empty string is visible in the error."""
+        with pytest.raises(ValueError) as excinfo:
+            normalize_account_order(raw)
+        assert repr(raw) in str(excinfo.value)
+
+
+class TestFractionalAndSpecialValues:
+    """AC-4 — the discriminating case for the whole MEU."""
+
+    @pytest.mark.parametrize("raw", [1.5, 2.5, 0.5, 998.5, "1.5", "2.5", " 3.75 "])
+    def test_rejects_fractional(self, raw):
+        """There is no position 1.5 in a chain.
+
+        This is the pair to `test_accepts_integral_values_in_range`: both forms
+        of 2 are accepted, no form of 1.5 is. Accepting `2.0` is not laxity —
+        it is the recognition that a JSON round-trip can widen an int, while
+        rejecting 1.5 is the actual ordinal constraint.
+        """
+        with pytest.raises(ValueError):
+            normalize_account_order(raw)
+
+    @pytest.mark.parametrize("raw", [1.5, "1.5"])
+    def test_fractional_message_explains_why(self, raw):
+        """A range-only message would be actively misleading for 1.5, which is
+        inside 1…999. The rejection reason is integrality, and the message says so."""
+        with pytest.raises(ValueError) as excinfo:
+            normalize_account_order(raw)
+        assert "whole number" in str(excinfo.value).lower()
+
+    @pytest.mark.parametrize(
+        "raw",
+        [float("nan"), float("inf"), float("-inf"), "nan", "inf", "-inf", "NaN", "Infinity"],
+    )
+    def test_rejects_nan_and_infinity(self, raw):
+        """Rejected *by name*, before the range test.
+
+        NaN fails every comparison (so `not MIN <= nan <= MAX` is True by luck,
+        not by design) and `int(inf)` raises `OverflowError`, not `ValueError`.
+        Both would escape or mis-raise if left to the range test.
+        """
+        with pytest.raises(ValueError):
+            normalize_account_order(raw)
+
+    @pytest.mark.parametrize("raw", [True, False])
+    def test_bool_is_rejected_by_name(self, raw):
+        """AC-2 — `True` is an `int` in Python and would normalize to 1, which
+        is a *legal* order. It would be silently accepted, not merely mis-erred."""
+        with pytest.raises(ValueError) as excinfo:
+            normalize_account_order(raw)
+        assert repr(raw) in str(excinfo.value), (
+            "the message must quote True/False, so the user sees what they passed"
+        )
+
+    @pytest.mark.parametrize("raw", [True, False])
+    def test_bool_never_normalizes_successfully(self, raw):
+        """The failure mode being guarded is silent *acceptance*: without the
+        explicit `isinstance(value, bool)` guard, `True` reaches the range test
+        as 1, which is a legal order, and is stored as account priority 1."""
+        with pytest.raises(ValueError):
+            normalize_account_order(raw)
+
+
+class TestAccountPolicyOrderField:
+    """AC-5, AC-8 — the field on the frozen dataclass."""
+
+    def test_default_is_none(self):
+        assert AccountPolicy().order is None
+
+    def test_order_can_be_supplied(self):
+        assert AccountPolicy(order=3).order == 3
+
+    def test_full_default_identity(self):
+        """AC-8 — the whole field tuple, not just `order`.
+
+        Asserting every field means a future field added with a truthy default
+        fails *here*, at the one place that claims 'a fleet with no policy set
+        behaves exactly as it did before'.
+        """
+        policy = AccountPolicy()
+        assert policy.threshold is None
+        assert policy.backup is False
+        assert policy.order is None
+        assert dataclasses.astuple(policy) == (None, False, None)
+
+    def test_two_defaults_compare_equal(self):
+        assert AccountPolicy() == AccountPolicy()
+
+    def test_is_still_frozen(self):
+        """AC-5 — `AccountSnapshot` is frozen; a mutable member would silently
+        break that guarantee for the whole row."""
+        policy = AccountPolicy(order=2)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            policy.order = 5  # type: ignore[misc]
+
+    def test_is_still_hashable(self):
+        assert hash(AccountPolicy(order=2)) == hash(AccountPolicy(order=2))
+        assert hash(AccountPolicy(order=2)) != hash(AccountPolicy(order=3))
+
+    def test_order_field_is_declared_as_specified(self):
+        fields = {f.name: f for f in dataclasses.fields(AccountPolicy)}
+        assert "order" in fields
+        assert fields["order"].type in ("int | None", "int|None")
+        assert fields["order"].default is None
+
+    def test_order_is_last_so_positional_callers_are_unaffected(self):
+        """PR 1 built `AccountPolicy(threshold, backup)` positionally in places.
+        Appending rather than inserting keeps every one of those sites correct."""
+        names = [f.name for f in dataclasses.fields(AccountPolicy)]
+        assert names == ["threshold", "backup", "order"]
+        assert AccountPolicy(85.0, True, 2) == AccountPolicy(
+            threshold=85.0, backup=True, order=2
+        )
+
+
+class TestModelsRemainsALeaf:
+    """AC-7 — `models.py` must not import `settings` (AGENTS.md §Architecture).
+
+    The dependency direction is presentation → policy → store → platform I/O →
+    leaf data types. Unlike `threshold`, whose bounds mirror a `SETTING_SPECS`
+    entry, `order` has no global counterpart to drift against — but the leaf
+    invariant is a property of the module, so adding a field is exactly when it
+    is worth re-asserting.
+    """
+
+    def test_no_settings_import_in_source(self):
+        source = Path("src/claude_swap/models.py").read_text(encoding="utf-8")
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if ("import" in line and "settings" in line and not line.strip().startswith("#"))
+        ]
+        assert offenders == [], (
+            "models.py must not import settings (AGENTS.md §Architecture): "
+            f"{offenders}"
+        )
+
+    def test_models_module_has_no_settings_attribute(self):
+        """The source scan above misses `importlib`-style indirection."""
+        import claude_swap.models as models_module
+
+        assert not hasattr(models_module, "settings")
+        assert not hasattr(models_module, "SETTING_SPECS")
+
+    def test_order_bounds_are_module_literals(self):
+        """The bounds are declared here, not derived from a settings lookup —
+        the mechanism by which the leaf invariant is kept."""
+        source = Path("src/claude_swap/models.py").read_text(encoding="utf-8")
+        assert "ACCOUNT_ORDER_MIN = 1" in source
+        assert "ACCOUNT_ORDER_MAX = 999" in source

--- a/tests/test_account_policy_cli.py
+++ b/tests/test_account_policy_cli.py
@@ -1,0 +1,298 @@
+"""Per-account policy CLI verbs (cli.py).
+
+MEU-PAP-05 - AC-33 ... AC-38 of
+`.agent/plans/2026-09-02-per-account-threshold-backup/implementation-plan.md`.
+
+`cswap threshold` mirrors `_alias_command` (pre-dispatched before the main
+parser, because the main parser's required mutually-exclusive group cannot hold
+a positional subcommand). `cswap backup` / `cswap unbackup` mirror
+`disable`/`enable`: a `_SUBCOMMAND_FLAGS` entry expanding to
+`--backup-account` / `--unbackup-account`, so both the memorable verb and the
+long-standing flag spelling work.
+
+The validation contract is AGENTS.md §Boundary Input Contract: an out-of-range
+or non-numeric value is rejected **at the write boundary**, before any file is
+touched, so a rejected write leaves `sequence.json` byte-identical. AC-38
+asserts exactly that with a byte comparison, not a field comparison.
+
+Synthetic fixtures only. The real store at the user home is never read or
+written; `tests/test_real_store_guard.py` enforces that boundary and a failure
+there is a P0 stop.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import cli
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+from tests.test_account_policy_store import PolicyStoreBase
+
+
+class PolicyCliBase(PolicyStoreBase):
+    """`PolicyStoreBase`'s synthetic fleet, driven through the CLI surface."""
+
+    @staticmethod
+    def _bytes(s: ClaudeAccountSwitcher) -> bytes:
+        """`sequence.json` verbatim - the AC-38 byte-identity oracle."""
+        return Path(s.sequence_file).read_bytes()
+
+    @staticmethod
+    def _threshold(argv: list[str]) -> None:
+        """Drive `cswap threshold ...` at its pre-dispatch entry point."""
+        with patch("os.geteuid", return_value=1000, create=True):
+            cli._threshold_command(argv)
+
+    @staticmethod
+    def _main(argv: list[str]) -> None:
+        """Drive a full `cswap ...` argv through `main()`'s dispatch."""
+        with patch.object(sys, "argv", ["claude-swap", *argv]), \
+             patch("os.geteuid", return_value=1000, create=True), \
+             patch("claude_swap.update_check.check_for_update", return_value=None):
+            cli.main()
+
+    @staticmethod
+    def _alias(s: ClaudeAccountSwitcher, num: str, name: str) -> None:
+        data = s._get_sequence_data() or {}
+        data["accounts"][num]["alias"] = name
+        s._write_json(s.sequence_file, data)
+
+
+class TestThresholdSet(PolicyCliBase):
+    """AC-33 - `cswap threshold 2 85` writes the override and confirms it."""
+
+    def test_it_writes_the_override_and_prints_a_confirmation(
+        self, temp_home: Path, capsys
+    ):
+        self._fleet(temp_home)
+        self._threshold(["2", "85"])
+
+        assert self._record(ClaudeAccountSwitcher(), "2")["threshold"] == 85.0
+        out = capsys.readouterr().out
+        assert "Account-2" in out
+        assert "85" in out
+
+    def test_it_stores_a_float_not_the_raw_string(self, temp_home: Path, capsys):
+        """The store's contract is a number; a string would survive JSON and
+        then fail every numeric comparison in the engine."""
+        self._fleet(temp_home)
+        self._threshold(["2", "85"])
+        assert isinstance(self._record(ClaudeAccountSwitcher(), "2")["threshold"], float)
+
+    def test_a_nonexistent_slot_exits_nonzero_and_writes_nothing(
+        self, temp_home: Path, capsys
+    ):
+        s = self._fleet(temp_home)
+        before = self._bytes(s)
+
+        with pytest.raises(SystemExit) as exc:
+            self._threshold(["9", "85"])
+
+        assert exc.value.code != 0
+        assert self._bytes(s) == before
+
+    def test_the_verb_is_reachable_through_main_dispatch(self, temp_home: Path, capsys):
+        """`cswap threshold ...` must be pre-dispatched like `alias`, not fall
+        through to the main parser (which would reject the positional)."""
+        self._fleet(temp_home)
+        self._main(["threshold", "2", "85"])
+        assert self._record(ClaudeAccountSwitcher(), "2")["threshold"] == 85.0
+
+
+class TestThresholdUnset(PolicyCliBase):
+    """AC-34 - `--unset` removes the key and returns the account to the global."""
+
+    def test_it_removes_the_key(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._threshold(["2", "85"])
+        self._threshold(["2", "--unset"])
+
+        assert "threshold" not in self._record(ClaudeAccountSwitcher(), "2")
+
+    def test_the_account_returns_to_the_global_default(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._threshold(["2", "85"])
+        self._threshold(["2", "--unset"])
+
+        assert ClaudeAccountSwitcher().account_policies()["2"].threshold is None
+
+    def test_unset_without_an_override_is_a_benign_no_op_not_an_error(
+        self, temp_home: Path, capsys
+    ):
+        """Negative half: it must NOT raise SystemExit. An account with no
+        override is already in the requested state, so the verb is idempotent."""
+        s = self._fleet(temp_home)
+        before = self._bytes(s)
+
+        self._threshold(["2", "--unset"])
+
+        assert self._bytes(s) == before
+        assert capsys.readouterr().out.strip() != ""
+
+    def test_unset_with_a_value_is_rejected(self, temp_home: Path, capsys):
+        """Mirrors `alias --unset`, which refuses to take a NAME."""
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit) as exc:
+            self._threshold(["2", "85", "--unset"])
+        assert exc.value.code != 0
+
+
+class TestThresholdListing(PolicyCliBase):
+    """AC-35 - bare `cswap threshold` lists the global default and every override."""
+
+    def test_it_names_the_global_default(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._threshold(["2", "85"])
+        capsys.readouterr()
+
+        self._threshold([])
+        out = capsys.readouterr().out
+        assert "90" in out, "the global default must be shown, not only overrides"
+
+    def test_it_lists_every_override(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._threshold(["1", "85"])
+        self._threshold(["3", "99.9"])
+        capsys.readouterr()
+
+        self._threshold([])
+        out = capsys.readouterr().out
+        assert "85" in out
+        assert "99.9" in out
+
+    def test_with_no_overrides_it_says_so_rather_than_printing_an_empty_table(
+        self, temp_home: Path, capsys
+    ):
+        self._fleet(temp_home)
+        capsys.readouterr()
+
+        self._threshold([])
+        out = capsys.readouterr().out.strip()
+        assert out != ""
+        assert "90" in out, "the global default is still worth printing"
+
+
+class TestBackupVerbs(PolicyCliBase):
+    """AC-36 - `cswap backup` / `cswap unbackup` set and clear `record["backup"]`."""
+
+    def test_backup_sets_the_flag(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._main(["backup", "3"])
+        assert self._record(ClaudeAccountSwitcher(), "3")["backup"] is True
+
+    def test_unbackup_clears_the_flag(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._main(["backup", "3"])
+        self._main(["unbackup", "3"])
+        assert "backup" not in self._record(ClaudeAccountSwitcher(), "3")
+
+    def test_the_legacy_flag_spelling_works_too(self, temp_home: Path, capsys):
+        """`--backup-account` mirrors `--disable-account`; the memorable verb is
+        a `_SUBCOMMAND_FLAGS` rewrite of it, so both must reach the same code."""
+        self._fleet(temp_home)
+        self._main(["--backup-account", "3"])
+        assert self._record(ClaudeAccountSwitcher(), "3")["backup"] is True
+        self._main(["--unbackup-account", "3"])
+        assert "backup" not in self._record(ClaudeAccountSwitcher(), "3")
+
+    def test_backup_with_no_argument_exits_nonzero(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit) as exc:
+            self._main(["backup"])
+        assert exc.value.code != 0
+
+    def test_the_flag_is_registered_in_the_subcommand_table(self):
+        """The verb must be a table entry, not a special case - that is what
+        keeps token pass-through working the way `disable` does."""
+        assert cli._SUBCOMMAND_FLAGS["backup"] == "--backup-account"
+        assert cli._SUBCOMMAND_FLAGS["unbackup"] == "--unbackup-account"
+
+
+class TestIdentifierResolution(PolicyCliBase):
+    """AC-37 - both verbs accept a number, an email, or an alias."""
+
+    def test_threshold_accepts_an_email(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._threshold(["account-2@example.test", "85"])
+        assert self._record(ClaudeAccountSwitcher(), "2")["threshold"] == 85.0
+
+    def test_threshold_accepts_an_alias(self, temp_home: Path, capsys):
+        s = self._fleet(temp_home)
+        self._alias(s, "2", "dev")
+        self._threshold(["dev", "85"])
+        assert self._record(ClaudeAccountSwitcher(), "2")["threshold"] == 85.0
+
+    def test_backup_accepts_an_email(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        self._main(["backup", "account-3@example.test"])
+        assert self._record(ClaudeAccountSwitcher(), "3")["backup"] is True
+
+    def test_backup_accepts_an_alias(self, temp_home: Path, capsys):
+        s = self._fleet(temp_home)
+        self._alias(s, "3", "spare")
+        self._main(["backup", "spare"])
+        assert self._record(ClaudeAccountSwitcher(), "3")["backup"] is True
+
+    def test_an_unresolvable_identifier_exits_nonzero(self, temp_home: Path, capsys):
+        s = self._fleet(temp_home)
+        before = self._bytes(s)
+        with pytest.raises(SystemExit) as exc:
+            self._threshold(["nobody@example.test", "85"])
+        assert exc.value.code != 0
+        assert self._bytes(s) == before
+
+    def test_an_unresolvable_identifier_exits_nonzero_for_backup_too(
+        self, temp_home: Path, capsys
+    ):
+        s = self._fleet(temp_home)
+        before = self._bytes(s)
+        with pytest.raises(SystemExit) as exc:
+            self._main(["backup", "nobody@example.test"])
+        assert exc.value.code != 0
+        assert self._bytes(s) == before
+
+
+class TestValidationAtTheWriteBoundary(PolicyCliBase):
+    """AC-38 - a rejected value names the range and leaves the store untouched.
+
+    Byte-identity, not field-identity: a write that rejected the value but still
+    restamped `lastUpdated` would pass a field check and fail this one, and it
+    is the one that matters - `sequence.json` is the user's live account store.
+    """
+
+    @pytest.mark.parametrize("bad", ["20", "0", "100", "abc", "", "9e9"])
+    def test_a_rejected_value_exits_nonzero_and_writes_nothing(
+        self, temp_home: Path, capsys, bad: str
+    ):
+        s = self._fleet(temp_home)
+        before = self._bytes(s)
+
+        with pytest.raises(SystemExit) as exc:
+            self._threshold(["2", bad])
+
+        assert exc.value.code != 0
+        assert self._bytes(s) == before
+
+    def test_the_message_names_the_permitted_range(self, temp_home: Path, capsys):
+        self._fleet(temp_home)
+        with pytest.raises(SystemExit):
+            self._threshold(["2", "20"])
+        captured = capsys.readouterr()
+        text = captured.out + captured.err
+        assert "50" in text
+        assert "99.9" in text
+
+    @pytest.mark.parametrize("good", ["50", "99.9", "85.5"])
+    def test_the_boundaries_themselves_are_accepted(
+        self, temp_home: Path, capsys, good: str
+    ):
+        """The negative half. A validator that rejected its own endpoints would
+        pass every test above."""
+        self._fleet(temp_home)
+        self._threshold(["2", good])
+        assert self._record(ClaudeAccountSwitcher(), "2")["threshold"] == float(good)

--- a/tests/test_account_policy_store.py
+++ b/tests/test_account_policy_store.py
@@ -1,0 +1,588 @@
+"""Per-account policy persistence and accessors (switcher.py).
+
+MEU-PAP-02 - AC-6 ... AC-15 of
+`.agent/plans/2026-09-02-per-account-threshold-backup/implementation-plan.md`.
+
+Mirrors the `disabled` machinery exactly: `_policy_from_data` reads from
+already-loaded data the way `_disabled_from_data` does, the setters mirror
+`set_account_disabled`, and both honour the omit-when-default record
+convention so an untouched `sequence.json` stays byte-identical.
+
+Synthetic fixtures only. The real store at the user home is never read or
+written; `tests/test_real_store_guard.py` enforces that boundary and a failure
+there is a P0 stop.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_swap.exceptions import AccountNotFoundError, ConfigError
+from claude_swap.models import AccountPolicy, Platform
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+class PolicyStoreBase:
+    """Shared synthetic-store scaffolding, modelled on `TestDisableEnableAccount`."""
+
+    def _setup(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = ClaudeAccountSwitcher()
+        s.platform = Platform.LINUX
+        s._setup_directories()
+        s._init_sequence_file()
+        return s
+
+    def _seed(self, s: ClaudeAccountSwitcher, num: int, email: str) -> None:
+        """Add a fully switchable slot (credential + config backups present)."""
+        s._write_account_credentials(
+            str(num),
+            email,
+            json.dumps({"claudeAiOauth": {
+                "accessToken": f"sk-{num}", "refreshToken": f"rt-{num}"}}),
+        )
+        s._write_account_config(
+            str(num),
+            email,
+            json.dumps({"oauthAccount": {
+                "emailAddress": email, "accountUuid": f"uuid-{num}"}}),
+        )
+        data = s._get_sequence_data() or {
+            "activeAccountNumber": None, "lastUpdated": "",
+            "sequence": [], "accounts": {},
+        }
+        data["accounts"][str(num)] = {
+            "email": email, "uuid": f"uuid-{num}",
+            "organizationUuid": "", "organizationName": "",
+            "added": "2024-01-01T00:00:00Z",
+        }
+        if num not in data["sequence"]:
+            data["sequence"].append(num)
+            data["sequence"].sort()
+        if data["activeAccountNumber"] is None:
+            data["activeAccountNumber"] = num
+        # Fixture-only: `get_timestamp()` has one-second resolution, so a seed
+        # written in the same second as the call under test would make a
+        # correct restamp indistinguishable from no restamp at all. Backdating
+        # the seed makes the "did it stamp `lastUpdated`?" oracle real.
+        data["lastUpdated"] = "2024-01-01T00:00:00Z"
+        s._write_json(s.sequence_file, data)
+
+    def _fleet(self, temp_home: Path, count: int = 3) -> ClaudeAccountSwitcher:
+        s = self._setup(temp_home)
+        for n in range(1, count + 1):
+            self._seed(s, n, f"account-{n}@example.test")
+        return s
+
+    @staticmethod
+    def _record(s: ClaudeAccountSwitcher, num: str) -> dict:
+        return (s._get_sequence_data() or {})["accounts"][num]
+
+
+class TestPolicyFromData(PolicyStoreBase):
+    """AC-6 - reading a policy out of already-loaded sequence data."""
+
+    def test_missing_record_yields_the_default(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        data = s._get_sequence_data() or {}
+        assert s._policy_from_data(data, "99") == AccountPolicy()
+
+    def test_record_without_policy_keys_yields_the_default(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        data = s._get_sequence_data() or {}
+        assert s._policy_from_data(data, "1") == AccountPolicy()
+
+    def test_reads_threshold_and_backup(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_threshold("1", 85.0)
+        s.set_account_backup("1", True)
+        data = s._get_sequence_data() or {}
+        assert s._policy_from_data(data, "1") == AccountPolicy(threshold=85.0, backup=True)
+
+    def test_is_a_staticmethod_like_disabled_from_data(self):
+        """Mirrors `_disabled_from_data`: no instance state, so it is safe to
+        call inside a single-read loop without re-entering the store."""
+        assert isinstance(
+            ClaudeAccountSwitcher.__dict__["_policy_from_data"], staticmethod
+        )
+
+    @pytest.mark.parametrize(
+        "garbage", ["garbage", "", None, [], {}, True, float("nan"), float("inf"), 20, 100]
+    )
+    def test_unreadable_threshold_degrades_to_none_and_does_not_raise(
+        self, temp_home: Path, garbage
+    ):
+        """A corrupt record must degrade, not explode.
+
+        This is the *read* path. The strict validator runs at the *write*
+        boundary (AC-38); by the time a value is in the file it may have been
+        hand-edited, and the engine must keep running on the global default
+        rather than crash the auto-switch loop.
+        """
+        s = self._fleet(temp_home)
+        data = s._get_sequence_data() or {}
+        data["accounts"]["1"]["threshold"] = garbage
+        s._write_json(s.sequence_file, data)
+
+        reloaded = s._get_sequence_data() or {}
+        assert s._policy_from_data(reloaded, "1") == AccountPolicy(threshold=None)
+
+    @pytest.mark.parametrize("truthy,expected", [(True, True), ("yes", True), (1, True),
+                                                 (False, False), ("", False), (0, False),
+                                                 (None, False)])
+    def test_backup_is_read_as_a_bool(self, temp_home: Path, truthy, expected):
+        """Mirrors `_disabled_from_data`'s `bool(record.get(...))` exactly."""
+        s = self._fleet(temp_home)
+        data = s._get_sequence_data() or {}
+        data["accounts"]["1"]["backup"] = truthy
+        s._write_json(s.sequence_file, data)
+        reloaded = s._get_sequence_data() or {}
+        assert s._policy_from_data(reloaded, "1").backup is expected
+
+    def test_numeric_string_threshold_is_read(self, temp_home: Path):
+        """JSON hand-edited to a string should still be usable, not discarded."""
+        s = self._fleet(temp_home)
+        data = s._get_sequence_data() or {}
+        data["accounts"]["1"]["threshold"] = "85"
+        s._write_json(s.sequence_file, data)
+        reloaded = s._get_sequence_data() or {}
+        assert s._policy_from_data(reloaded, "1").threshold == pytest.approx(85.0)
+
+
+class TestSetAccountThreshold(PolicyStoreBase):
+    """AC-7, AC-8 - the threshold setter, mirroring `set_account_disabled:1860`."""
+
+    def test_writes_the_value_and_stamps_last_updated(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        before = (s._get_sequence_data() or {})["lastUpdated"]
+        s.set_account_threshold("2", 85.0)
+        data = s._get_sequence_data() or {}
+        assert data["accounts"]["2"]["threshold"] == pytest.approx(85.0)
+        assert data["lastUpdated"] != before
+
+    def test_resolves_an_alias_or_email(self, temp_home: Path):
+        """AC-37's mechanism, exercised at the store layer via `resolve_account`."""
+        s = self._fleet(temp_home)
+        s.set_account_threshold("account-3@example.test", 90.0)
+        assert self._record(s, "3")["threshold"] == pytest.approx(90.0)
+
+    def test_unknown_identifier_raises_and_writes_nothing(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        before = s.sequence_file.read_bytes()
+        with pytest.raises(AccountNotFoundError):
+            s.set_account_threshold("nope@example.test", 85.0)
+        assert s.sequence_file.read_bytes() == before, (
+            "a failed resolve must leave sequence.json byte-identical"
+        )
+
+    def test_no_managed_accounts_raises_config_error(self, temp_home: Path):
+        s = self._setup(temp_home)
+        s.sequence_file.unlink()
+        with pytest.raises(ConfigError):
+            s.set_account_threshold("1", 85.0)
+
+    @pytest.mark.parametrize("bad", [20, 100, "abc", float("nan"), float("inf")])
+    def test_invalid_value_raises_and_writes_nothing(self, temp_home: Path, bad):
+        """AC-38 at the store boundary: validation happens before any write.
+
+        Python `assert` and type hints are not runtime validation (AGENTS.md
+        §Boundary Input Contract); this setter must call the normalizer.
+        """
+        s = self._fleet(temp_home)
+        before = s.sequence_file.read_bytes()
+        with pytest.raises(ValueError):
+            s.set_account_threshold("1", bad)
+        assert s.sequence_file.read_bytes() == before
+
+    def test_value_is_normalized_to_float(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_threshold("1", "85")
+        stored = self._record(s, "1")["threshold"]
+        assert isinstance(stored, float) and stored == pytest.approx(85.0)
+
+    def test_none_pops_the_key(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_threshold("1", 85.0)
+        assert "threshold" in self._record(s, "1")
+        s.set_account_threshold("1", None)
+        assert "threshold" not in self._record(s, "1"), (
+            "unset must remove the key, not write null - AC-10's omit-when-default"
+        )
+
+    def test_popping_an_absent_key_is_a_no_op_not_a_keyerror(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_threshold("1", None)
+        assert "threshold" not in self._record(s, "1")
+
+    def test_overwrite_replaces_rather_than_accumulates(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_threshold("1", 85.0)
+        s.set_account_threshold("1", 90.0)
+        assert self._record(s, "1")["threshold"] == pytest.approx(90.0)
+
+
+class TestSetAccountBackup(PolicyStoreBase):
+    """AC-9 - the backup flag, same shape as `disabled`."""
+
+    def test_true_writes_and_false_pops(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_backup("2", True)
+        assert self._record(s, "2")["backup"] is True
+        s.set_account_backup("2", False)
+        assert "backup" not in self._record(s, "2")
+
+    def test_clearing_an_unset_flag_is_a_no_op(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_backup("1", False)
+        assert "backup" not in self._record(s, "1")
+
+    def test_unknown_identifier_raises_and_writes_nothing(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        before = s.sequence_file.read_bytes()
+        with pytest.raises(AccountNotFoundError):
+            s.set_account_backup("nope@example.test", True)
+        assert s.sequence_file.read_bytes() == before
+
+    def test_resolves_an_email(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_backup("account-3@example.test", True)
+        assert self._record(s, "3")["backup"] is True
+
+
+class TestOmitWhenDefault(PolicyStoreBase):
+    """AC-10 - an untouched record is unchanged by a write to a different one."""
+
+    def test_untouched_record_is_byte_identical(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        before = json.loads(s.sequence_file.read_text(encoding="utf-8"))["accounts"]["2"]
+        s.set_account_threshold("1", 85.0)
+        s.set_account_backup("1", True)
+        after = json.loads(s.sequence_file.read_text(encoding="utf-8"))["accounts"]["2"]
+        assert after == before
+
+    def test_no_policy_keys_appear_anywhere_in_an_untouched_store(self, temp_home: Path):
+        """`sequence.json` stays clean for a fleet that never sets a policy."""
+        s = self._fleet(temp_home)
+        raw = s.sequence_file.read_text(encoding="utf-8")
+        assert "threshold" not in raw
+        assert "backup" not in raw
+
+    def test_setting_then_unsetting_restores_the_record_exactly(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        before = json.loads(s.sequence_file.read_text(encoding="utf-8"))["accounts"]["1"]
+        s.set_account_threshold("1", 85.0)
+        s.set_account_backup("1", True)
+        s.set_account_threshold("1", None)
+        s.set_account_backup("1", False)
+        after = json.loads(s.sequence_file.read_text(encoding="utf-8"))["accounts"]["1"]
+        assert after == before, "round-tripping a policy must leave no residue"
+
+
+class TestBackupAccountNumbers(PolicyStoreBase):
+    """AC-11 - mirrors `disabled_account_numbers():1852`."""
+
+    def test_returns_backup_slots_in_sequence_order(self, temp_home: Path):
+        s = self._fleet(temp_home, count=4)
+        s.set_account_backup("3", True)
+        s.set_account_backup("1", True)
+        assert s.backup_account_numbers() == ["1", "3"], "sequence order, not call order"
+
+    def test_empty_when_none_marked(self, temp_home: Path):
+        assert self._fleet(temp_home).backup_account_numbers() == []
+
+    def test_excludes_non_switchable_slots(self, temp_home: Path):
+        """A slot without usable stored backups is not a candidate for anything."""
+        s = self._fleet(temp_home)
+        s.set_account_backup("2", True)
+        for path in s.credentials_dir.glob("*2*"):
+            path.unlink()
+        for path in s.configs_dir.glob("*2*"):
+            path.unlink()
+        assert "2" not in s.backup_account_numbers()
+
+    def test_excludes_disabled_slots(self, temp_home: Path):
+        """AC-31's store half: `disabled` wins over `backup`.
+
+        Applied earlier in `switchable_account_numbers()`, so an account that
+        is both must appear in neither pass of the two-pass filter.
+        """
+        s = self._fleet(temp_home)
+        s.set_account_backup("2", True)
+        s.set_account_disabled("2", True)
+        assert s.backup_account_numbers() == []
+        assert "2" in s.disabled_account_numbers()
+
+
+class TestAccountPolicies(PolicyStoreBase):
+    """AC-12 - the bulk read the engine uses once per tick."""
+
+    def test_covers_every_slot_in_sequence(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        policies = s.account_policies()
+        assert set(policies) == {"1", "2", "3"}
+        assert all(isinstance(p, AccountPolicy) for p in policies.values())
+
+    def test_reflects_written_values(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_threshold("2", 85.0)
+        s.set_account_backup("3", True)
+        policies = s.account_policies()
+        assert policies["1"] == AccountPolicy()
+        assert policies["2"] == AccountPolicy(threshold=85.0)
+        assert policies["3"] == AccountPolicy(backup=True)
+
+    def test_reads_the_sequence_once(self, temp_home: Path, monkeypatch):
+        """Single-read pattern, as `switchable_account_numbers:1824` uses.
+
+        The engine calls this on every tick of the auto-switch loop; one read
+        per call is the difference between a poll and a file-system hammer.
+        """
+        s = self._fleet(temp_home, count=5)
+        calls = []
+        original = s._get_sequence_data
+        monkeypatch.setattr(
+            s, "_get_sequence_data", lambda *a, **k: (calls.append(1), original(*a, **k))[1]
+        )
+        s.account_policies()
+        assert len(calls) == 1, f"expected exactly one sequence read, got {len(calls)}"
+
+    def test_empty_store_yields_an_empty_mapping(self, temp_home: Path):
+        assert self._setup(temp_home).account_policies() == {}
+
+
+class TestSnapshotCarriesPolicy(PolicyStoreBase):
+    """AC-13 - every surface that already carries `disabled` also carries policy.
+
+    *Plan discrepancy, recorded here rather than resolved silently:* the AC
+    calls `switcher.py:1765` and `switcher.py:5353` "both `AccountsSnapshot`
+    build sites". Only the first is one - `AccountSnapshot(` appears exactly
+    once in the package (now `switcher.py:1756`). `:5353` is the `--json`
+    `account_row(...)` call. Both *sites* are correctly identified and both
+    already pass `disabled=`, so the intent - mirror `disabled` everywhere it
+    is surfaced - is unambiguous; only the label is wrong. Both are covered.
+    """
+
+    def test_snapshot_row_carries_a_written_policy(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_threshold("2", 85.0)
+        s.set_account_backup("2", True)
+        snapshot = s.accounts_snapshot()
+        row = next(a for a in snapshot.accounts if a.number == "2")
+        assert row.policy == AccountPolicy(threshold=85.0, backup=True)
+
+    def test_plain_account_row_carries_the_default(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_backup("2", True)
+        snapshot = s.accounts_snapshot()
+        assert next(a for a in snapshot.accounts if a.number == "1").policy == AccountPolicy()
+
+    def test_json_row_omits_policy_when_unset(self, temp_home: Path):
+        """Additive-field convention, exactly as `disabled` uses it.
+
+        Existing consumers keying on the base schema must be unaffected, so an
+        untouched account's row is byte-identical to today's.
+        """
+        from claude_swap.json_output import account_row
+
+        row = account_row(1, "a@example.test", "", "", True, None)
+        assert "threshold" not in row
+        assert "backup" not in row
+
+    def test_json_row_emits_policy_when_set(self, temp_home: Path):
+        from claude_swap.json_output import account_row
+
+        row = account_row(
+            1, "a@example.test", "", "", True, None,
+            policy=AccountPolicy(threshold=85.0, backup=True),
+        )
+        assert row["threshold"] == pytest.approx(85.0)
+        assert row["backup"] is True
+
+
+class TestExportImportIgnorePolicy(PolicyStoreBase):
+    """AC-14 - policy is machine-local, like `disabled`, and does not travel.
+
+    `transfer.py:262-275` builds each export entry from an explicit field list
+    and adds `alias` deliberately; `disabled` is just as deliberately absent.
+    A threshold tuned to one machine's usage pattern is not a property of the
+    *account*, so it must not ride along on an export.
+    """
+
+    def test_export_omits_policy_keys(self, temp_home: Path):
+        from claude_swap.transfer import export_accounts
+
+        s = self._fleet(temp_home)
+        s.set_account_threshold("1", 85.0)
+        s.set_account_backup("2", True)
+
+        out_file = temp_home / "backup.cswap"
+        export_accounts(s, str(out_file))
+        envelope = json.loads(out_file.read_text(encoding="utf-8"))
+
+        for entry in envelope["accounts"]:
+            assert "threshold" not in entry, f"export leaked a threshold: {entry['email']}"
+            assert "backup" not in entry, f"export leaked a backup flag: {entry['email']}"
+
+    def test_import_ignores_foreign_policy_keys(self, temp_home: Path, monkeypatch):
+        """A hand-edited or future-version export must not inject policy.
+
+        `_validate_imported_account` copies a fixed field list; anything else
+        in the payload is data the importer does not know about and must drop,
+        not persist.
+        """
+        import os
+        from unittest.mock import patch as _patch
+
+        from claude_swap.transfer import export_accounts, import_accounts
+
+        s = self._fleet(temp_home, count=2)
+        out_file = temp_home / "backup.cswap"
+        export_accounts(s, str(out_file))
+
+        envelope = json.loads(out_file.read_text(encoding="utf-8"))
+        for entry in envelope["accounts"]:
+            entry["threshold"] = 85.0
+            entry["backup"] = True
+        out_file.write_text(json.dumps(envelope), encoding="utf-8")
+
+        dst_home = temp_home.parent / "policy-import-dst"
+        dst_home.mkdir()
+        with _patch("pathlib.Path.home", return_value=dst_home):
+            with _patch.dict(os.environ, {"HOME": str(dst_home)}):
+                dst = ClaudeAccountSwitcher()
+                dst.platform = Platform.LINUX
+                dst._setup_directories()
+                dst._init_sequence_file()
+                import_accounts(dst, str(out_file))
+
+                seq = dst._get_sequence_data() or {}
+                assert seq["accounts"], "import produced no accounts - fixture is degenerate"
+                for num, record in seq["accounts"].items():
+                    assert "threshold" not in record, f"import injected a threshold at {num}"
+                    assert "backup" not in record, f"import injected a backup flag at {num}"
+                    assert dst._policy_from_data(seq, num) == AccountPolicy()
+
+
+class TestPolicySurvivesRenumber(PolicyStoreBase):
+    """AC-15 - `swap` and `move` carry policy with the account record.
+
+    This is the decisive argument for storing policy *in the account record*
+    rather than in a parallel settings map keyed by slot number: a map keyed by
+    slot silently reassigns every policy the moment a user renumbers.
+    """
+
+    def test_swap_carries_threshold_and_backup(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_threshold("1", 85.0)
+        s.set_account_backup("1", True)
+
+        s.swap_accounts("1", "3")
+
+        assert self._record(s, "3")["threshold"] == pytest.approx(85.0)
+        assert self._record(s, "3")["backup"] is True
+        assert "threshold" not in self._record(s, "1"), "policy was left behind on slot 1"
+        assert "backup" not in self._record(s, "1")
+
+    def test_swap_does_not_invent_policy_on_the_other_slot(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_threshold("1", 85.0)
+        s.swap_accounts("1", "2")
+        assert s.account_policies()["2"] == AccountPolicy(threshold=85.0)
+        assert s.account_policies()["1"] == AccountPolicy()
+
+    def test_move_carries_policy(self, temp_home: Path):
+        s = self._fleet(temp_home, count=3)
+        s.set_account_backup("2", True)
+        s.set_account_threshold("2", 90.0)
+
+        s.move_account("2", "5")
+
+        assert self._record(s, "5")["backup"] is True
+        assert self._record(s, "5")["threshold"] == pytest.approx(90.0)
+        assert "2" not in (s._get_sequence_data() or {})["accounts"]
+
+    def test_backup_numbers_follow_the_renumber(self, temp_home: Path):
+        """The accessor must agree with the record after a move."""
+        s = self._fleet(temp_home, count=3)
+        s.set_account_backup("2", True)
+        assert s.backup_account_numbers() == ["2"]
+        s.move_account("2", "5")
+        assert s.backup_account_numbers() == ["5"]
+
+
+class TestTheJsonListPayloadCarriesPolicy(PolicyStoreBase):
+    """VR-2 - AC-13's JSON half, asserted at the caller instead of the helper.
+
+    `TestSnapshotCarriesPolicy::test_json_row_emits_policy_when_set` passes
+    `policy=` to `account_row()` by hand. That proves the *helper* honours the
+    argument; it says nothing about whether the one production caller actually
+    supplies it. Validation reproduced the gap: deleting
+    `policy=self._policy_from_data(...)` from `_build_list_payload`
+    (`switcher.py:5562`) left the entire suite green while the real
+    `--list --json` output silently lost both fields.
+
+    So this drives `list_accounts(json_output=True)` - the actual runtime entry
+    point - and asserts on the row it returns.
+
+    `fetch=set()` is load-bearing, not decoration. The CLI default `fetch=None`
+    means "every stale account is eligible" (`switcher.py:5031-5036`), so an
+    unqualified call here would issue real usage-endpoint requests with the
+    fixture's synthetic tokens - slow, flaky, and a charge against a shared
+    budget. An empty set satisfies `fetch is None or num in fetch` for nobody
+    (`switcher.py:5084`), so nothing is collected and this stays a pure
+    payload-assembly oracle.
+    """
+
+    @staticmethod
+    def _payload(s: ClaudeAccountSwitcher) -> dict:
+        """`--list --json`, offline. See the class docstring on `fetch`."""
+        return s.list_accounts(json_output=True, fetch=set())
+
+    def _policy_fleet(self, temp_home: Path) -> ClaudeAccountSwitcher:
+        s = self._fleet(temp_home)
+        s.set_account_threshold("2", 85.0)
+        s.set_account_backup("2", True)
+        return s
+
+    @staticmethod
+    def _row(payload: dict, num: int) -> dict:
+        return next(r for r in payload["accounts"] if r["number"] == num)
+
+    def test_the_policied_row_carries_both_fields(self, temp_home: Path):
+        payload = self._payload(self._policy_fleet(temp_home))
+        row = self._row(payload, 2)
+        assert row["threshold"] == pytest.approx(85.0)
+        assert row["backup"] is True
+
+    def test_a_threshold_only_account_carries_only_the_threshold(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_threshold("1", 60.0)
+        row = self._row(self._payload(s), 1)
+        assert row["threshold"] == pytest.approx(60.0)
+        assert "backup" not in row
+
+    def test_a_backup_only_account_carries_only_the_flag(self, temp_home: Path):
+        s = self._fleet(temp_home)
+        s.set_account_backup("1", True)
+        row = self._row(self._payload(s), 1)
+        assert row["backup"] is True
+        assert "threshold" not in row
+
+    def test_an_untouched_row_in_a_policied_fleet_stays_bare(self, temp_home: Path):
+        """The negative half, and the one that makes the pair discriminating.
+
+        A caller that hard-coded a policy instead of reading each account's own
+        would pass every positive above and fail here.
+        """
+        row = self._row(self._payload(self._policy_fleet(temp_home)), 1)
+        assert "threshold" not in row
+        assert "backup" not in row
+
+    def test_a_fleet_with_no_policy_emits_rows_identical_to_before(self, temp_home: Path):
+        """AC-13's omit-when-default contract at the caller, not the helper."""
+        payload = self._payload(self._fleet(temp_home))
+        for row in payload["accounts"]:
+            assert "threshold" not in row
+            assert "backup" not in row

--- a/tests/test_account_policy_values.py
+++ b/tests/test_account_policy_values.py
@@ -180,12 +180,22 @@ class TestAccountPolicy:
         assert len({AccountPolicy(), AccountPolicy()}) == 1
 
     def test_field_types_are_declared_as_specified(self):
+        """A closed-world fence on the field set.
+
+        Written for PR 1 as ``{"threshold", "backup"}`` with the note that
+        ``order`` belonged to PR 2 and must not appear early. PR 2 (MEU-ORD-01,
+        AC-5) is that event, so the fence moves rather than being deleted — its
+        job is to make any *further* field an explicit decision, and PR 2's own
+        ``tests/test_account_order_values.py`` asserts the same set from the
+        other side.
+        """
         fields = {f.name: f for f in dataclasses.fields(AccountPolicy)}
-        assert set(fields) == {"threshold", "backup"}, (
-            "AC-3 fixes the field set; `order` belongs to PR 2 and must not appear here"
+        assert set(fields) == {"threshold", "backup", "order"}, (
+            "the field set is fixed; a new field is a deliberate, tested addition"
         )
         assert fields["threshold"].default is None
         assert fields["backup"].default is False
+        assert fields["order"].default is None
 
 
 class TestAccountSnapshotPolicyField:

--- a/tests/test_account_policy_values.py
+++ b/tests/test_account_policy_values.py
@@ -1,0 +1,260 @@
+"""Per-account policy value objects and threshold normalization (models.py).
+
+MEU-PAP-01 — AC-1 … AC-5 of
+`.agent/plans/2026-09-02-per-account-threshold-backup/implementation-plan.md`.
+
+`models.py` is a leaf module and must not import `settings` (AGENTS.md
+§Architecture). The threshold bounds are therefore *declared* in `models.py` and
+*cross-checked* against `SETTING_SPECS` here, in the test layer, where importing
+both is allowed. AC-2 and AC-5 are the two halves of that arrangement.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from pathlib import Path
+
+import pytest
+
+from claude_swap.models import (
+    ACCOUNT_THRESHOLD_MAX,
+    ACCOUNT_THRESHOLD_MIN,
+    AccountPolicy,
+    AccountSnapshot,
+    normalize_account_threshold,
+)
+from claude_swap.settings import SETTING_SPECS
+from claude_swap.usage_store import UsageEntry
+
+
+def _snapshot(**overrides) -> AccountSnapshot:
+    """An AccountSnapshot built the way every pre-change caller builds one.
+
+    Deliberately passes no ``policy=``: AC-4 is precisely the claim that adding
+    the field does not break existing construction sites.
+    """
+    fields = {
+        "number": "1",
+        "email": "account-1@example.test",
+        "org_name": "Example Org",
+        "org_uuid": "00000000-0000-4000-8000-000000000001",
+        "is_active": True,
+        "kind": "oauth",
+        "switchable": True,
+        "usage": UsageEntry(),
+    }
+    fields.update(overrides)
+    return AccountSnapshot(**fields)
+
+
+class TestNormalizeAccountThreshold:
+    """AC-1 — the write-boundary validator for a per-account threshold."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (50, 50.0),
+            (99, 99.0),
+            (85, 85.0),
+            (85.5, 85.5),
+            (50.0, 50.0),
+            (99.9, 99.9),
+            ("85", 85.0),
+            ("85.5", 85.5),
+            ("  85.5  ", 85.5),
+            ("50", 50.0),
+            ("99.9", 99.9),
+        ],
+    )
+    def test_accepts_int_float_and_numeric_str_in_range(self, raw, expected):
+        result = normalize_account_threshold(raw)
+        assert result == pytest.approx(expected)
+        assert isinstance(result, float), "must return a float regardless of input type"
+
+    @pytest.mark.parametrize("raw", [20, 49.9, 100, 99.91, 0, -85, 1000])
+    def test_rejects_out_of_range(self, raw):
+        with pytest.raises(ValueError):
+            normalize_account_threshold(raw)
+
+    @pytest.mark.parametrize("raw", ["abc", "", "  ", "85%", "eighty-five", None, [], {}, True])
+    def test_rejects_non_numeric(self, raw):
+        with pytest.raises(ValueError):
+            normalize_account_threshold(raw)
+
+    @pytest.mark.parametrize(
+        "raw", [float("nan"), float("inf"), float("-inf"), "nan", "inf", "-inf"]
+    )
+    def test_rejects_nan_and_infinity(self, raw):
+        """NaN and infinity are floats that pass a naive ``lo <= v <= hi`` test.
+
+        ``nan`` fails every comparison, so an implementation written as
+        ``if not (MIN <= v <= MAX): raise`` rejects it by accident; one written
+        as ``if v < MIN or v > MAX: raise`` lets it through. Infinity is the
+        mirror case. Both must raise.
+        """
+        with pytest.raises(ValueError):
+            normalize_account_threshold(raw)
+
+    @pytest.mark.parametrize("raw", [20, 100, "abc", float("nan"), float("inf")])
+    def test_error_message_names_the_valid_range(self, raw):
+        """The message must name the range — a bare 'invalid value' is not enough.
+
+        This is what `cswap threshold 2 20` prints to the user (AC-38).
+        """
+        with pytest.raises(ValueError) as excinfo:
+            normalize_account_threshold(raw)
+        message = str(excinfo.value)
+        assert "50" in message, f"message must name the lower bound: {message!r}"
+        assert "99.9" in message, f"message must name the upper bound: {message!r}"
+
+    def test_boundaries_are_inclusive(self):
+        assert normalize_account_threshold(ACCOUNT_THRESHOLD_MIN) == ACCOUNT_THRESHOLD_MIN
+        assert normalize_account_threshold(ACCOUNT_THRESHOLD_MAX) == ACCOUNT_THRESHOLD_MAX
+
+    def test_bool_is_not_a_number_here(self):
+        """``True`` is an ``int`` in Python and would normalize to 1.0.
+
+        1.0 is out of range so a naive implementation raises anyway, but for the
+        right reason only by luck. Pinned so the behaviour is deliberate.
+        """
+        with pytest.raises(ValueError):
+            normalize_account_threshold(True)
+
+
+class TestThresholdBoundsMatchSettings:
+    """AC-2 — the bounds are declared in `models.py` but owned by `SETTING_SPECS`."""
+
+    def test_constants_have_the_documented_values(self):
+        assert ACCOUNT_THRESHOLD_MIN == 50.0
+        assert ACCOUNT_THRESHOLD_MAX == 99.9
+
+    def test_constants_equal_the_global_threshold_spec_bounds(self):
+        """Drift in either direction fails.
+
+        A per-account threshold that could be set outside the range the global
+        setting accepts would be a second, silently different validity rule.
+        """
+        spec = SETTING_SPECS["autoswitch.threshold"]
+        assert ACCOUNT_THRESHOLD_MIN == spec.lo
+        assert ACCOUNT_THRESHOLD_MAX == spec.hi
+
+    def test_constants_are_floats(self):
+        assert isinstance(ACCOUNT_THRESHOLD_MIN, float)
+        assert isinstance(ACCOUNT_THRESHOLD_MAX, float)
+
+
+class TestAccountPolicy:
+    """AC-3 — the value object carried on every snapshot row."""
+
+    def test_default_is_empty(self):
+        policy = AccountPolicy()
+        assert policy.threshold is None
+        assert policy.backup is False
+
+    def test_two_defaults_compare_equal(self):
+        """Equality is what makes the omit-when-default record convention testable.
+
+        AC-10 asserts an untouched record is unchanged; that check is written in
+        terms of policy equality, so it must be value equality, not identity.
+        """
+        assert AccountPolicy() == AccountPolicy()
+        assert AccountPolicy(threshold=85.0) == AccountPolicy(threshold=85.0)
+        assert AccountPolicy(threshold=85.0) != AccountPolicy(threshold=90.0)
+        assert AccountPolicy(backup=True) != AccountPolicy()
+
+    def test_is_frozen(self):
+        """`AccountSnapshot` is `frozen=True`; a mutable member would break that."""
+        policy = AccountPolicy()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            policy.threshold = 85.0  # type: ignore[misc]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            policy.backup = True  # type: ignore[misc]
+
+    def test_is_hashable(self):
+        """A frozen dataclass with no `eq=False` is hashable; pin it.
+
+        `AccountsSnapshot.accounts` is a tuple of frozen rows, and callers are
+        entitled to put a snapshot row in a set.
+        """
+        assert len({AccountPolicy(), AccountPolicy()}) == 1
+
+    def test_field_types_are_declared_as_specified(self):
+        fields = {f.name: f for f in dataclasses.fields(AccountPolicy)}
+        assert set(fields) == {"threshold", "backup"}, (
+            "AC-3 fixes the field set; `order` belongs to PR 2 and must not appear here"
+        )
+        assert fields["threshold"].default is None
+        assert fields["backup"].default is False
+
+
+class TestAccountSnapshotPolicyField:
+    """AC-4 — adding the field must not break any existing construction site."""
+
+    def test_construction_without_policy_yields_the_default(self):
+        snapshot = _snapshot()
+        assert snapshot.policy == AccountPolicy()
+
+    def test_policy_can_be_supplied(self):
+        policy = AccountPolicy(threshold=85.0, backup=True)
+        assert _snapshot(policy=policy).policy == policy
+
+    def test_policy_is_last_so_positional_callers_are_unaffected(self):
+        """The field is appended after `disabled`, not inserted.
+
+        Inserting it ahead of `alias`/`disabled` would silently rebind every
+        positional construction in the repo.
+        """
+        names = [f.name for f in dataclasses.fields(AccountSnapshot)]
+        assert names[-1] == "policy"
+        assert names.index("policy") > names.index("disabled")
+
+    def test_snapshot_is_still_frozen_and_still_has_display_tag(self):
+        snapshot = _snapshot(policy=AccountPolicy(backup=True))
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            snapshot.policy = AccountPolicy()  # type: ignore[misc]
+        assert snapshot.display_tag == "Example Org"
+
+    def test_every_existing_construction_site_still_works(self):
+        """The repo's own callers are the real regression surface.
+
+        `switcher.py` builds these rows at two sites and the TUI builds them in
+        fixtures; none pass `policy=`. If the field had no default, or were not
+        last, this import-and-build would fail.
+        """
+        rows = (
+            _snapshot(number="1", is_active=True),
+            _snapshot(number="2", is_active=False, kind="api_key", switchable=False),
+            _snapshot(number="3", is_active=False, alias="work", disabled=True),
+        )
+        assert all(row.policy == AccountPolicy() for row in rows)
+
+
+class TestModelsRemainsALeaf:
+    """AC-5 — `models.py` must not import `settings`.
+
+    The dependency direction is presentation → policy → store → platform I/O →
+    leaf data types (AGENTS.md §Architecture). `settings` sits above `models`;
+    an import here would make the leaf cyclic and is the reason AC-2's bounds
+    are cross-checked in the test layer instead.
+    """
+
+    def test_no_settings_import_in_source(self):
+        source = Path("src/claude_swap/models.py").read_text(encoding="utf-8")
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if ("import" in line and "settings" in line and not line.strip().startswith("#"))
+        ]
+        assert offenders == [], (
+            "models.py must not import settings (AGENTS.md §Architecture): "
+            f"{offenders}"
+        )
+
+    def test_models_module_has_no_settings_attribute(self):
+        """The source scan above misses `importlib`-style indirection."""
+        import claude_swap.models as models_module
+
+        assert not hasattr(models_module, "settings")
+        assert not hasattr(models_module, "SETTING_SPECS")
+        assert not hasattr(models_module, "AutoSwitchSettings")

--- a/tests/test_autoswitch_account_order.py
+++ b/tests/test_autoswitch_account_order.py
@@ -1,0 +1,1077 @@
+"""MEU-ORD-03 - the per-account `order` tier inside the ranking sort key.
+
+Covers AC-17 .. AC-27, including AC-18b and AC-21b.
+
+**Observable split** (plan §Control binding, corrected in plan-review rounds 1
+and 2). A blanket "always assert the emitted destination" rule is unsatisfiable
+for four of these criteria, so each AC states which observable it owns:
+
+* **Behavioural** - AC-18b, AC-19, AC-20, AC-21, AC-22, AC-23, AC-24, AC-25,
+  AC-26 drive a **real tick** (`tick()` -> `_tick_inner` -> the `_rank`
+  closure -> `_one_pass` -> `_rank_candidates` -> `qualifying.sort` ->
+  `_perform` -> `SwitchEvent`) and assert on the emitted destination.
+* **Structural** - AC-17 (purity + one resolution per tick), AC-18 (map
+  totality) and AC-21b (the `ordered` tail) assert against the function or the
+  map **under direct call**. None of the three is a field on any event: a
+  call count, a `KeyError` that does not happen, and a reordering below
+  position 1 are all invisible to a destination assertion.
+* **AC-27** asserts on the **persisted poll plan** (`nextPollAt` /
+  `pollIntervalS`, written through `_collect_scheduled_usage`) and on
+  `_next_delay` under a patched `random`, plus a structural no-`orders`-
+  parameter check. `PollEvent` carries no interval field, so it could not have
+  carried this assertion either.
+
+**The emitted destination** is `SwitchEvent.to_ref["number"]`. The plan calls
+this field `SwitchEvent.to`; `to` is the name it serializes under
+(`SwitchEvent._fields()`), while the attribute is `to_ref`. Same observable,
+resolved to the real attribute name.
+
+Synthetic fixtures only - `EngineHarness` seeds a throwaway store under
+`temp_home`. Nothing here reads a real account store.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import os
+import random as _random_module
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap import autoswitch as _autoswitch_module
+from claude_swap import poll_policy
+from claude_swap.autoswitch import (
+    NoSwitchEvent,
+    SwitchEvent,
+    TickOutcome,
+)
+from claude_swap.models import (
+    ACCOUNT_ORDER_MAX,
+    ACCOUNT_ORDER_MIN,
+    ORDER_UNSET_RANK,
+)
+from claude_swap.settings import AutoSwitchSettings
+from claude_swap.usage_store import UsageEntry
+
+from tests.test_autoswitch import EngineHarness, _entry_for, _iso_at
+
+GLOBAL = AutoSwitchSettings().threshold  # 90.0
+
+_EMAILS = {
+    1: "a@example.com",
+    2: "b@example.com",
+    3: "c@example.com",
+    4: "d@example.com",
+}
+
+
+def _u(
+    pct: float,
+    *,
+    five_reset: float | None = None,
+    seven_reset: float | None = None,
+    seven_pct: float = 0.0,
+) -> dict:
+    """A usage row with independently addressable 5h and 7d resets.
+
+    `tests.test_autoswitch._usage` only reaches the five-hour window, but
+    consume-first ranks on `seven_day` while the `all_above` recovery tier
+    ranks on the *binding* window. Both are settable here so one fixture can
+    make the headroom order, the recovery order and the weekly order three
+    different permutations - which is what makes a key-shape regression move a
+    destination instead of hiding behind an accidental agreement.
+    """
+    five: dict = {"pct": pct}
+    if five_reset is not None:
+        five["resets_at"] = _iso_at(five_reset)
+    seven: dict = {"pct": seven_pct}
+    if seven_reset is not None:
+        seven["resets_at"] = _iso_at(seven_reset)
+    return {"five_hour": five, "seven_day": seven}
+
+
+def _fleet(temp_home, n: int = 4, **settings_kwargs) -> EngineHarness:
+    """`n` seeded OAuth accounts, account 1 live and active."""
+    h = EngineHarness(temp_home, **settings_kwargs)
+    for num in range(1, n + 1):
+        h.seed(num, _EMAILS[num])
+    h.make_live(_EMAILS[1], 1)
+    return h
+
+
+def _pin(h: EngineHarness, **ranks: int) -> None:
+    """`_pin(h, a2=5)` pins account 2 to rank 5 (kwargs cannot start with a digit)."""
+    for name, rank in ranks.items():
+        h.switcher.set_account_order(name.lstrip("a"), rank)
+
+
+def _backup(h: EngineHarness, *nums: int) -> None:
+    for num in nums:
+        h.switcher.set_account_backup(str(num), True)
+
+
+def _api_key(h: EngineHarness, *nums: int) -> None:
+    data = h.switcher._get_sequence_data()
+    for num in nums:
+        data["accounts"][str(num)]["kind"] = "api_key"
+    h.switcher._write_json(h.switcher.sequence_file, data)
+
+
+@contextlib.contextmanager
+def _isolated_home(tmp_path: Path, name: str):
+    """A second, genuinely separate `temp_home` for the same test.
+
+    `EngineHarness` only patches `Path.home()` for the duration of its own
+    `__init__`, so two harnesses built on the SAME root share one store - the
+    guarantee `TestEngineHarnessIsolation` documents applies to distinct
+    subtrees, and a subtree harness cannot call `make_live()`. A test that
+    needs two independent *runs* of the same fleet therefore has to supply two
+    independent homes, with the ambient patches in place for the whole run and
+    not merely for construction.
+    """
+    home = tmp_path / name
+    (home / ".claude").mkdir(parents=True)
+    with (
+        patch.dict(os.environ, {"HOME": str(home), "USERPROFILE": str(home)}),
+        patch("pathlib.Path.home", return_value=home),
+    ):
+        yield home
+
+
+def _tick(h: EngineHarness, snapshots: list[dict]):
+    """One real tick, serving `snapshots` to successive collector calls.
+
+    The last snapshot repeats, so a fixture lists only as many as it needs to
+    distinguish. Returns `(outcome, mock)`.
+    """
+    seq = [
+        {
+            num: value
+            if isinstance(value, UsageEntry)
+            else _entry_for(value, h.clock.now)
+            for num, value in snap.items()
+        }
+        for snap in snapshots
+    ]
+    calls = {"n": 0}
+
+    def _fetch(**_kwargs):
+        index = min(calls["n"], len(seq) - 1)
+        calls["n"] += 1
+        return seq[index]
+
+    with patch.object(
+        h.switcher, "usage_entries_by_account", side_effect=_fetch
+    ) as mock:
+        return h.engine.tick(), mock
+
+
+def _switches(h: EngineHarness) -> list[SwitchEvent]:
+    return [e for e in h.events if isinstance(e, SwitchEvent)]
+
+
+def _dest(h: EngineHarness) -> list[int]:
+    """The emitted destinations - `SwitchEvent.to_ref["number"]`."""
+    return [e.to_ref["number"] for e in _switches(h) if e.to_ref]
+
+
+def _rank_kwargs(h: EngineHarness, headroom: dict[str, float | None], **over):
+    """A complete keyword set for a direct `_rank_candidates` call."""
+    now = h.clock.now
+    usage = {num: _u(100.0 - v) for num, v in headroom.items() if v is not None}
+    kwargs = dict(
+        trigger="proactive",
+        consume_first=False,
+        oauth_candidates=[n for n in headroom if n != "1"],
+        no_return=None,
+        usage=usage,
+        headroom=headroom,
+        current="1",
+        active_headroom=headroom.get("1"),
+        settings=h.settings,
+        now=now,
+    )
+    kwargs.update(over)
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# AC-17 - structural: one resolution per tick, and the ranking stays pure
+# ---------------------------------------------------------------------------
+
+
+class TestOrderResolvedOncePerTick:
+    """AC-17 (i). `_resolve_orders()` runs once in `_tick_inner` and the map is
+    threaded down as a parameter.
+
+    The oracle needs a tick that ranks **twice**. The backup two-pass is the
+    deterministic way to get one: `_rank` runs pass 1 over the primaries and,
+    finding nothing, re-enters `_one_pass` over the full pool
+    (`autoswitch.py:1341-1346`). If `_rank_candidates` resolved the map itself
+    the counter would move with it.
+
+    A destination assertion cannot express this: "resolved once" and "resolved
+    twice" produce the *same* destination whenever the store did not change
+    mid-tick, which is exactly the case a store read makes fragile.
+    """
+
+    def test_orders_are_resolved_once_though_ranking_runs_twice(self, temp_home):
+        h = _fleet(temp_home)
+        _backup(h, 3, 4)
+        _pin(h, a2=1)
+        real_resolve = h.engine._resolve_orders
+        real_rank = h.engine._rank_candidates
+        with (
+            patch.object(
+                h.engine, "_resolve_orders", side_effect=real_resolve
+            ) as resolve,
+            patch.object(
+                h.engine, "_rank_candidates", side_effect=real_rank
+            ) as rank,
+        ):
+            _tick(h, [{
+                "1": _u(95.0),   # active, above the line -> proactive
+                "2": _u(100.0),  # the only primary, at its limit
+                "3": _u(5.0),    # reserve
+                "4": _u(4.0),    # reserve
+            }])
+        assert rank.call_count >= 2, (
+            "the fixture must reach the backup two-pass, or the oracle is vacuous"
+        )
+        assert resolve.call_count == 1
+
+    def test_every_rank_call_receives_the_same_map_object(self, temp_home):
+        """The other half of "resolved once": threaded, not re-derived."""
+        h = _fleet(temp_home)
+        _backup(h, 3, 4)
+        _pin(h, a2=1)
+        seen: list[object] = []
+        real_rank = h.engine._rank_candidates
+
+        def _spy(**kw):
+            seen.append(kw.get("orders"))
+            return real_rank(**kw)
+
+        with patch.object(h.engine, "_rank_candidates", side_effect=_spy):
+            _tick(h, [{
+                "1": _u(95.0), "2": _u(100.0), "3": _u(5.0), "4": _u(4.0),
+            }])
+        assert len(seen) >= 2
+        assert all(m is seen[0] for m in seen)
+        assert seen[0] is not None
+
+
+class TestRankCandidatesStaysPure:
+    """AC-17 (ii). `_rank_candidates` never reads the store.
+
+    Its docstring is explicit that purity is what lets the consume-first
+    two-phase commit run it twice per tick; a store read inside it could decide
+    phase 1 and phase 2 on two different files. The test makes every store
+    reader raise, so a read is a hard failure rather than a silent difference.
+    """
+
+    def test_ranking_returns_normally_with_every_store_reader_raising(
+        self, temp_home
+    ):
+        h = _fleet(temp_home)
+        kwargs = _rank_kwargs(h, {"1": 5.0, "2": 40.0, "3": 80.0})
+
+        def _boom(*_a, **_kw):
+            raise AssertionError("_rank_candidates read the store")
+
+        with (
+            patch.object(h.switcher, "_get_sequence_data", side_effect=_boom),
+            patch.object(h.switcher, "account_orders", side_effect=_boom),
+            patch.object(h.switcher, "account_policies", side_effect=_boom),
+            patch.object(
+                h.switcher, "backup_account_numbers", side_effect=_boom
+            ),
+        ):
+            ordered, _known, _reset = h.engine._rank_candidates(**kwargs)
+        assert ordered == ["3", "2"]
+
+    def test_two_identical_calls_return_equal_results(self, temp_home):
+        h = _fleet(temp_home)
+        _pin(h, a2=1)
+        orders = h.engine._resolve_orders()
+        kwargs = _rank_kwargs(h, {"1": 5.0, "2": 40.0, "3": 80.0}, orders=orders)
+        first = h.engine._rank_candidates(**kwargs)
+        second = h.engine._rank_candidates(**kwargs)
+        assert first == second
+        assert first[0] == ["2", "3"], "the pin must actually be in force here"
+
+
+# ---------------------------------------------------------------------------
+# AC-18 / AC-18b - the map is total, and the unset sentinel outranks nothing
+# ---------------------------------------------------------------------------
+
+
+class TestOrderMapTotality:
+    """AC-18 - structural: `OrderMap.__missing__` returns `ORDER_UNSET_RANK`.
+
+    Totality lives in the map, exactly as it does for `ThresholdMap`
+    (`autoswitch.py:596-612`), so no call site needs `.get(num, default)` and
+    no tick can raise `KeyError` mid-ranking. **No tick can reach a non-fleet
+    key**, so this is unreachable through any event and is asserted under
+    direct subscript.
+    """
+
+    def test_a_key_that_is_not_in_the_fleet_at_all_returns_the_sentinel(self):
+        from claude_swap.autoswitch import OrderMap
+
+        m = OrderMap({"2": 5})
+        assert m["999"] == ORDER_UNSET_RANK
+
+    def test_the_missing_key_is_not_inserted(self):
+        """`__missing__` must not memoise, or the map would grow per tick."""
+        from claude_swap.autoswitch import OrderMap
+
+        m = OrderMap({})
+        m["7"]
+        assert "7" not in m
+
+    def test_a_pinned_key_returns_its_own_rank(self):
+        from claude_swap.autoswitch import OrderMap
+
+        assert OrderMap({"2": 5})["2"] == 5
+
+    def test_subscript_never_raises_key_error(self):
+        from claude_swap.autoswitch import OrderMap
+
+        m = OrderMap({})
+        try:
+            m["nope"]
+        except KeyError:  # pragma: no cover - the failure this test exists for
+            pytest.fail("OrderMap must be total; a KeyError here breaks a tick")
+
+    def test_the_sentinel_sorts_after_every_legal_rank(self):
+        """AC-6's arithmetic, restated where the map relies on it."""
+        assert ORDER_UNSET_RANK > ACCOUNT_ORDER_MAX >= ACCOUNT_ORDER_MIN
+
+    def test_the_sentinel_is_not_the_minimum_rank(self):
+        """The direct unit statement of mutant M-6; AC-18b is its tick-level
+        oracle."""
+        assert ORDER_UNSET_RANK != ACCOUNT_ORDER_MIN
+
+    def test_resolve_orders_returns_a_total_map_over_the_live_fleet(
+        self, temp_home
+    ):
+        h = _fleet(temp_home)
+        _pin(h, a2=7)
+        orders = h.engine._resolve_orders()
+        assert orders["2"] == 7
+        assert orders["3"] == ORDER_UNSET_RANK
+        assert orders["1"] == ORDER_UNSET_RANK
+
+
+class TestUnsetSentinelOutranksNothing:
+    """AC-18b - **mutant M-6's oracle**.
+
+    An account pinned to a rank *above* `ACCOUNT_ORDER_MIN` still beats an
+    unpinned peer the strategy would otherwise pick. Under the correct engine
+    the unpinned peer carries `ORDER_UNSET_RANK` (1000) and loses to tier 5.
+    Under M-6 - `__missing__` returning `ACCOUNT_ORDER_MIN` - the *unpinned*
+    account is promoted to rank 1 and wins.
+
+    The pin must be strictly greater than `ACCOUNT_ORDER_MIN` or the mutant is
+    invisible, which is precisely why AC-21's all-unpinned fixtures cannot
+    serve as this oracle.
+    """
+
+    PIN = 5
+
+    def test_a_mid_rank_pin_beats_an_unpinned_strategy_winner(self, temp_home):
+        assert self.PIN > ACCOUNT_ORDER_MIN, "or M-6 survives this test"
+        h = _fleet(temp_home, n=3)
+        _pin(h, a2=self.PIN)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0),  # active, above the line
+            "2": _u(60.0),  # pinned, strictly worse on headroom
+            "3": _u(20.0),  # unpinned, the strict `best` winner
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [2]
+        assert h.active_number() == 2
+
+    def test_the_same_fleet_unpinned_picks_the_strategy_winner(self, temp_home):
+        """The identity half: the pin is the only thing that moved."""
+        h = _fleet(temp_home, n=3)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0), "2": _u(60.0), "3": _u(20.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [3]
+
+
+# ---------------------------------------------------------------------------
+# AC-19 - the tier: order is a primary selector, never a tie-break
+# ---------------------------------------------------------------------------
+
+
+class TestOrderIsAPrimarySelectorNotATieBreak:
+    """AC-19 - **the discriminating oracle**.
+
+    A pinned account with strictly less headroom **and** a strictly later
+    weekly reset than an unpinned peer must still be selected, under `best`
+    and under `consume-first`.
+
+    This is the negative oracle for the superseded "pre-sort the candidate
+    list" design (mutant M-1). Python's sort is stable, so list order survives
+    only an exact tie of the strategy key - and neither `(-h,)` nor
+    `(reset_ts, -h)` ties here by construction. A pre-sort implementation
+    fails both of these; a leading tier passes both.
+    """
+
+    def test_best_prefers_the_pin_over_more_headroom(self, temp_home):
+        h = _fleet(temp_home, n=3)
+        _pin(h, a2=1)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0, seven_reset=t + 10_000),
+            "2": _u(60.0, seven_reset=t + 400_000),  # less headroom, later reset
+            "3": _u(20.0, seven_reset=t + 50_000),   # more headroom, sooner reset
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [2]
+
+    def test_consume_first_prefers_the_pin_over_a_sooner_reset(self, temp_home):
+        h = _fleet(temp_home, n=3, strategy="consume-first")
+        _pin(h, a2=1)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(50.0, seven_reset=t + 500_000),
+            "2": _u(60.0, seven_reset=t + 400_000),
+            "3": _u(20.0, seven_reset=t + 50_000),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [2]
+
+    def test_the_strategy_keys_do_not_tie_in_either_fixture(self, temp_home):
+        """Proves the oracle above is discriminating rather than lucky.
+
+        If the two candidates tied on the strategy key, a stable sort over a
+        pre-sorted list would produce the same destination and mutant M-1
+        would survive. They do not tie: headroom differs by 40 points and the
+        weekly resets differ by 350 000 seconds.
+        """
+        h = _fleet(temp_home, n=3)
+        ordered, _known, _reset = h.engine._rank_candidates(
+            **_rank_kwargs(h, {"1": 5.0, "2": 40.0, "3": 80.0})
+        )
+        assert ordered == ["3", "2"], (
+            "unpinned, the strategy strictly prefers 3 - so a pin that lands 2 "
+            "first cannot have come from a tie"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-20 - the `fallback` list carries the tier too
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackListCarriesTheTier:
+    """AC-20 - **mutant M-2's oracle**.
+
+    `_rank_candidates` builds two lists and then does
+    `qualifying = qualifying or fallback` (`autoswitch.py:2266`). That
+    **selects** one list; it never merges them. So prefixing the tier only at
+    the `qualifying.append` site silently drops order on every tick that lands
+    in the one-way fallback - and those are exactly the ticks of a nearly spent
+    fleet, where a user who pinned an account most wants the pin honoured.
+
+    Reaching the fallback needs all of its guards at once
+    (`autoswitch.py:2196-2205`): `all_above` with `by_recovery` false, the
+    candidate inside the 2x headroom ratio, the active at or under
+    `SPENT_HEADROOM_PCT`, the candidate no worse than the active, and its
+    binding window returning more than `RECOVERY_HYSTERESIS_S` sooner.
+
+    The fixture is built so the two key shapes **disagree**: on the fallback
+    key `(0, recovery_ts, -h)` account 3 wins on recovery, while on the
+    ordinary `all_above` key `(1, -h, recovery_ts)` account 2 would win on
+    headroom. So `ordered == ["3", "2"]` is itself the proof that the fallback
+    list is what got sorted - no private state needs to be inspected.
+    """
+
+    @staticmethod
+    def _snapshot(t: float) -> dict:
+        return {
+            # active: 3.0 points left (== SPENT_HEADROOM_PCT), window days out
+            "1": _u(97.0, five_reset=t + 500_000),
+            # 5.0 points - MORE headroom, but back later
+            "2": _u(95.0, five_reset=t + 100_000),
+            # 3.5 points - less headroom, back soonest: the fallback winner
+            "3": _u(96.5, five_reset=t + 50_000),
+        }
+
+    def test_the_fixture_really_takes_the_fallback_path(self, temp_home):
+        """Guards the oracle. If `qualifying` were non-empty the fallback list
+        would never be consulted and this whole class would be vacuous - and
+        the qualifying key shape would have put account 2 first."""
+        h = _fleet(temp_home, n=3)
+        t = h.clock.now
+        ordered, _known, _reset = h.engine._rank_candidates(
+            **_rank_kwargs(
+                h,
+                {"1": 3.0, "2": 5.0, "3": 3.5},
+                usage=self._snapshot(t),
+                oauth_candidates=["2", "3"],
+            )
+        )
+        assert ordered == ["3", "2"], (
+            "recovery-ordered, not headroom-ordered: anything else means the "
+            "fixture stopped reaching the one-way fallback"
+        )
+
+    def test_a_pin_wins_on_the_fallback_path(self, temp_home):
+        h = _fleet(temp_home, n=3)
+        _pin(h, a2=1)
+        t = h.clock.now
+        outcome, _ = _tick(h, [self._snapshot(t)])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [2]
+
+    def test_the_same_fallback_fleet_unpinned_picks_the_sooner_recovery(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, n=3)
+        t = h.clock.now
+        outcome, _ = _tick(h, [self._snapshot(t)])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [3]
+
+
+# ---------------------------------------------------------------------------
+# AC-21 / AC-21b - default identity: an unpinned fleet is untouched
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultIdentityObserved:
+    """AC-21 - with nothing pinned, a real tick emits the **same destination**
+    as the pre-PR2 engine, across all three key shapes.
+
+    The three constants below are **golden destinations captured from the
+    pre-change engine** - recorded by running these exact fixtures against
+    `autoswitch.py` before `OrderMap` existed
+    (receipt: `C:/Temp/cswap/ord21-probe.txt`, fixtures archived at
+    `C:/Temp/cswap/ord21-probe-fixtures.py`). They are deliberately NOT
+    re-derived from the new engine, which would make the test self-referential
+    and unable to fail.
+
+    Each fixture is built so the three key shapes pick three different
+    accounts - headroom order, binding-recovery order and weekly-reset order
+    are three different permutations - so a shape-dependent regression moves at
+    least one destination instead of hiding behind an accidental agreement.
+    """
+
+    GOLDEN_ALL_ABOVE = 3    # soonest binding recovery
+    GOLDEN_CONSUME_FIRST = 2  # soonest weekly reset
+    GOLDEN_BEST = 4         # most headroom
+
+    def test_all_above_tiered_key_is_unchanged(self, temp_home):
+        h = _fleet(temp_home)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0, five_reset=t + 5_000, seven_reset=t + 300_000),
+            "2": _u(92.0, five_reset=t + 3_600, seven_reset=t + 50_000),
+            "3": _u(93.0, five_reset=t + 1_800, seven_reset=t + 200_000),
+            "4": _u(91.0, five_reset=t + 7_200, seven_reset=t + 100_000),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [self.GOLDEN_ALL_ABOVE]
+
+    def test_consume_first_key_is_unchanged(self, temp_home):
+        h = _fleet(temp_home, strategy="consume-first")
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(50.0, seven_reset=t + 500_000),
+            "2": _u(40.0, seven_reset=t + 50_000),
+            "3": _u(30.0, seven_reset=t + 100_000),
+            "4": _u(20.0, seven_reset=t + 200_000),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [self.GOLDEN_CONSUME_FIRST]
+
+    def test_best_key_is_unchanged(self, temp_home):
+        h = _fleet(temp_home)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0, five_reset=t + 5_000),
+            "2": _u(40.0, seven_reset=t + 50_000),
+            "3": _u(30.0, seven_reset=t + 200_000),
+            "4": _u(20.0, seven_reset=t + 100_000),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [self.GOLDEN_BEST]
+
+    def test_the_three_goldens_are_distinct(self):
+        """If two shapes agreed on a destination, one of the three tests above
+        would pass under a regression that swapped them."""
+        assert len({
+            self.GOLDEN_ALL_ABOVE,
+            self.GOLDEN_CONSUME_FIRST,
+            self.GOLDEN_BEST,
+        }) == 3
+
+
+class TestDefaultIdentityStructural:
+    """AC-21b - structural: with nothing pinned, the whole `ordered` list is
+    element-for-element identical to the same call with `orders=None`.
+
+    AC-21 covers the head of the list, which is the only part a destination can
+    see. A regression that reorders positions 2..n is invisible to every event
+    the engine emits, and it is not hypothetical: it is what the fleet lands on
+    the moment the head is unreachable (quarantine, a failed `_perform`, the
+    no-return bar on the next tick). Legitimate as a direct call here and only
+    here, because AC-17 has already pinned that `_rank_candidates` is pure.
+    """
+
+    @pytest.mark.parametrize(
+        "headroom",
+        [
+            {"1": 5.0, "2": 40.0, "3": 80.0, "4": 60.0},
+            {"1": 5.0, "2": 80.0, "3": 40.0, "4": 60.0},
+            {"1": 5.0, "2": 22.0, "3": 33.0, "4": 27.0},
+        ],
+    )
+    def test_an_unpinned_fleet_ranks_identically_with_and_without_the_map(
+        self, temp_home, headroom
+    ):
+        h = _fleet(temp_home)
+        empty = h.engine._resolve_orders()
+        without = h.engine._rank_candidates(**_rank_kwargs(h, headroom))
+        with_map = h.engine._rank_candidates(
+            **_rank_kwargs(h, headroom, orders=empty)
+        )
+        assert with_map == without
+        assert len(with_map[0]) >= 2, "a one-element list cannot show a reorder"
+
+    def test_the_tail_and_not_just_the_head_is_compared(self, temp_home):
+        """Proves the assertion above has something to bite on: a pin visibly
+        rewrites the tail as well as the head."""
+        h = _fleet(temp_home)
+        _pin(h, a4=1)
+        headroom = {"1": 5.0, "2": 40.0, "3": 80.0, "4": 20.0}
+        without = h.engine._rank_candidates(**_rank_kwargs(h, headroom))[0]
+        pinned = h.engine._rank_candidates(
+            **_rank_kwargs(h, headroom, orders=h.engine._resolve_orders())
+        )[0]
+        assert without == ["3", "2", "4"]
+        assert pinned == ["4", "3", "2"]
+
+
+# ---------------------------------------------------------------------------
+# AC-22 - composition with `backup`: a rank must not defeat the reserve filter
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionWithBackup:
+    """AC-22 - **mutant M-3's oracle**.
+
+    The reserve exclusion is a **two-pass filter** in the caller
+    (`autoswitch.py:1341-1346`), not a sort key, precisely so that no ranking
+    trick can promote a reserve while a primary is still usable. A pin is a
+    ranking trick. `order: 1` on a backup account must therefore lose to a
+    strictly worse primary in pass 1, and only order the reserves among
+    themselves in pass 2.
+
+    The mutant this kills is the collapse of the two-pass filter to
+    `primaries = kw["oauth_candidates"]`, which would rank the full set once
+    with the tier applied. (The plan's original wording - "apply the tier
+    before the partition" - named a non-mutation: the partition builds its
+    membership list in the caller, so nothing upstream of it can reintroduce a
+    filtered member.)
+    """
+
+    def test_a_pinned_reserve_still_loses_to_a_worse_primary(self, temp_home):
+        h = _fleet(temp_home, n=3)
+        _backup(h, 3)
+        _pin(h, a3=1)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0),  # active, above the line
+            "2": _u(60.0),  # the only primary - strictly worse than the reserve
+            "3": _u(5.0),   # reserve, pinned rank 1, and the most attractive
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [2]
+
+    def test_the_pin_orders_the_reserves_among_themselves_in_pass_two(
+        self, temp_home
+    ):
+        """The positive half - pass 2 is where a reserve's rank is allowed to
+        matter, and it does."""
+        h = _fleet(temp_home)
+        _backup(h, 3, 4)
+        _pin(h, a4=1)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0),   # active
+            "2": _u(100.0),  # the only primary, at its limit -> pass 1 empty
+            "3": _u(3.0),    # reserve, unpinned, strictly MORE headroom (97)
+            "4": _u(5.0),    # reserve, pinned rank 1, strictly worse (95)
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [4]
+
+    def test_without_the_pin_pass_two_picks_the_better_reserve(self, temp_home):
+        h = _fleet(temp_home)
+        _backup(h, 3, 4)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0), "2": _u(100.0), "3": _u(3.0), "4": _u(5.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [3]
+
+
+# ---------------------------------------------------------------------------
+# AC-23 - composition with the consume-first two-phase commit
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionWithTheTwoPhaseCommit:
+    """AC-23 - both phases rank against the same map; a pin cannot change
+    between them.
+
+    The consume-first commit re-fetches and re-ranks before it switches
+    (`autoswitch.py:1189`). The fixture below makes phase 2 disagree with phase
+    1 on headroom, so the two phases genuinely rank different numbers - and the
+    pinned account is still the destination.
+    """
+
+    def test_the_pin_holds_across_a_phase_two_that_moved(self, temp_home):
+        h = _fleet(temp_home, n=3, strategy="consume-first")
+        _pin(h, a2=1)
+        t = h.clock.now
+        phase1 = {
+            "1": _u(50.0, seven_reset=t + 500_000),
+            "2": _u(60.0, seven_reset=t + 400_000),
+            "3": _u(20.0, seven_reset=t + 50_000),
+        }
+        phase2 = {
+            "1": _u(55.0, seven_reset=t + 500_000),
+            "2": _u(70.0, seven_reset=t + 400_000),  # burned further
+            "3": _u(10.0, seven_reset=t + 50_000),   # recovered
+        }
+        outcome, mock = _tick(h, [phase1, phase1, phase2])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [2]
+        assert mock.call_count >= 2, "the two-phase commit must have re-fetched"
+
+    def test_the_same_two_phase_fleet_unpinned_follows_the_strategy(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, n=3, strategy="consume-first")
+        t = h.clock.now
+        phase1 = {
+            "1": _u(50.0, seven_reset=t + 500_000),
+            "2": _u(60.0, seven_reset=t + 400_000),
+            "3": _u(20.0, seven_reset=t + 50_000),
+        }
+        phase2 = {
+            "1": _u(55.0, seven_reset=t + 500_000),
+            "2": _u(70.0, seven_reset=t + 400_000),
+            "3": _u(10.0, seven_reset=t + 50_000),
+        }
+        outcome, _ = _tick(h, [phase1, phase1, phase2])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [3]
+
+
+# ---------------------------------------------------------------------------
+# AC-24 - one anchor: a pinned fleet reaches a fixed point, never a cycle
+# ---------------------------------------------------------------------------
+
+
+class TestOneAnchorAntiFlap:
+    """AC-24 - four ticks over a pinned fleet reach a fixed point.
+
+    Upstream PR #260 measured a real `1 -> 2 -> 1 -> 3 -> 1 -> 2` cycle from
+    running two spend-order anchors at once. A static pin cannot disagree with
+    itself, so the engine must settle. **Four ticks minimum** - a two-tick test
+    cannot tell a fixed point from the first half of a period-2 cycle, which is
+    the lesson PR 1's AC-45 recorded.
+    """
+
+    def test_four_ticks_over_a_pinned_fleet_settle(self, temp_home):
+        h = _fleet(temp_home, n=3)
+        _pin(h, a2=1)
+        snapshot = {"1": _u(95.0), "2": _u(60.0), "3": _u(20.0)}
+        seen: list[int | None] = []
+        for _ in range(4):
+            _tick(h, [snapshot])
+            seen.append(h.active_number())
+            h.clock.advance(AutoSwitchSettings().cooldown_seconds + 60.0)
+        assert seen[0] == 2
+        assert seen == [2, 2, 2, 2], f"expected a fixed point, saw {seen}"
+
+    def test_the_run_emits_exactly_one_switch(self, temp_home):
+        """The stronger statement: after landing on the pin the engine stops
+        rewriting credentials, rather than switching 2 -> 2 four times."""
+        h = _fleet(temp_home, n=3)
+        _pin(h, a2=1)
+        snapshot = {"1": _u(95.0), "2": _u(60.0), "3": _u(20.0)}
+        for _ in range(4):
+            _tick(h, [snapshot])
+            h.clock.advance(AutoSwitchSettings().cooldown_seconds + 60.0)
+        assert _dest(h) == [2]
+
+
+# ---------------------------------------------------------------------------
+# AC-25 - order affects SELECTION only; every gate is unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestOrderAffectsSelectionOnly:
+    """AC-25 - the tier is applied at the `append` sites, downstream of every
+    filter, so no gate can be bought with a pin.
+
+    A pin is a preference among *choosable* accounts. It is not a licence to
+    land on an account that is over its own threshold, to skip the hysteresis
+    margin, or to return to the account this tick just left.
+    """
+
+    def test_a_pinned_account_over_its_own_threshold_is_still_rejected(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, n=3)
+        _pin(h, a2=1)
+        h.switcher.set_account_threshold("2", 50.0)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0),
+            "2": _u(60.0),  # over its OWN 50% line -> not a landing site
+            "3": _u(20.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [3]
+
+    def test_a_pinned_account_is_absent_from_ordered_when_the_gate_rejects_it(
+        self, temp_home
+    ):
+        """The list-level statement of the same rule: rejected means absent,
+        not merely last."""
+        h = _fleet(temp_home, n=3)
+        _pin(h, a2=1)
+        h.switcher.set_account_threshold("2", 50.0)
+        kwargs = _rank_kwargs(
+            h,
+            {"1": 5.0, "2": 40.0, "3": 80.0},
+            thresholds=h.engine._resolve_thresholds(),
+            orders=h.engine._resolve_orders(),
+        )
+        ordered, _known, _reset = h.engine._rank_candidates(**kwargs)
+        assert ordered == ["3"]
+
+    def test_a_pin_does_not_buy_the_hysteresis_margin(self, temp_home):
+        h = _fleet(temp_home, n=3)
+        _pin(h, a2=1)
+        outcome, _ = _tick(h, [{
+            "1": _u(88.0),  # below the line -> `best` needs a real margin
+            "2": _u(85.0),  # only 3 points better; hysteresis_pct is 10
+            "3": _u(84.0),
+        }])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _dest(h) == []
+        assert [e.reason for e in h.events if isinstance(e, NoSwitchEvent)] == [
+            "below-threshold"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# AC-26 - API-key candidates are pre-sorted by rank before the last resort
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyCandidatesArePreSorted:
+    """AC-26 - here order genuinely **is** a list pre-sort.
+
+    The last-resort assignment at `autoswitch.py:1459-1460` performs no
+    ranking at all: metered API-key accounts have no measurable headroom and no
+    weekly window, so there is no sort key to prepend a tier to. Ordering them
+    therefore means sorting the list itself - and an unpinned API-key fleet
+    must keep today's sequence order exactly, which a stable sort guarantees.
+    """
+
+    def test_the_pinned_api_key_account_is_reached_first(self, temp_home):
+        h = _fleet(temp_home, include_api_key_accounts=True)
+        _api_key(h, 2, 3, 4)
+        _pin(h, a3=1)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0), "2": _u(10.0), "3": _u(10.0), "4": _u(10.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [3]
+
+    def test_an_unpinned_api_key_fleet_keeps_sequence_order(self, temp_home):
+        h = _fleet(temp_home, include_api_key_accounts=True)
+        _api_key(h, 2, 3, 4)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0), "2": _u(10.0), "3": _u(10.0), "4": _u(10.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [2]
+
+    def test_ranks_order_the_api_key_fleet_among_themselves(self, temp_home):
+        h = _fleet(temp_home, include_api_key_accounts=True)
+        _api_key(h, 2, 3, 4)
+        _pin(h, a4=1, a2=2)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0), "2": _u(10.0), "3": _u(10.0), "4": _u(10.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [4]
+
+    def test_a_pinned_api_key_reserve_is_still_reached_last(self, temp_home):
+        """Composition with AC-22's rule on the API-key path: the same
+        two-pass filter applies there (`autoswitch.py:1459`), so a rank must
+        not promote a reserve here either."""
+        h = _fleet(temp_home, include_api_key_accounts=True)
+        _api_key(h, 2, 3)
+        _backup(h, 3)
+        _pin(h, a3=1)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0), "2": _u(10.0), "3": _u(10.0), "4": _u(100.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert _dest(h) == [2]
+
+
+# ---------------------------------------------------------------------------
+# AC-27 - usage scheduling sees no order input at all
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulingIsUntouched:
+    """AC-27 - `_collect_scheduled_usage`, `poll_policy` and `_next_delay` see
+    no order input.
+
+    Cadence is threshold-driven. A pin says *where to go*, never *how often to
+    look*, and the whole poll plan is computed before ranking even runs
+    (`autoswitch.py:1050-1053`), so it must be identical between a pinned and
+    an unpinned run of the same fleet - **even though the pin changes the
+    destination**, which is what makes the comparison worth making.
+
+    **The observable, resolved.** The plan named
+    `UsageEntry.next_poll_at` / `.poll_interval_s`. Those fields are written by
+    the *collector* (`switcher.usage_entries_by_account`), which every engine
+    fixture must patch out to stay off the network, so under a synthetic
+    fixture nothing is ever persisted and the comparison is `{} == {}` - a
+    guard assertion caught exactly that. The one path that does persist a plan
+    in-process is `_replan_after_switch`, and it writes for the account just
+    switched TO, so it varies with the destination *by design* - that is a
+    consequence of the switch, not an order input, and asserting it equal would
+    be asserting something false.
+
+    So (i) binds to the plan the engine **computed and handed the collector to
+    persist**: the `fetch` set and `scheduled` flag of every collector call in
+    the tick. That is `_collect_scheduled_usage`'s entire scheduling output,
+    and it is what an `orders`-aware scheduler would have to change. No event
+    can carry it either - `PollEvent` (`autoswitch.py:305-329`) has fields
+    `active`, `headroom`, `threshold`, `fetch_errors` and `windows` and no
+    interval field at all. Assertion (iii) is what makes (i) and (ii) more than
+    a coincidence of one fixture.
+    """
+
+    SNAPSHOT_UTILIZATION = {"1": 95.0, "2": 60.0, "3": 20.0}
+
+    def _run(self, tmp_path, *, pinned: bool):
+        """One full tick on its OWN home, recording the collector call plan.
+
+        Two harnesses on one `temp_home` share a store, which would leave the
+        second run reading the first run's pin and active account - the
+        comparison would then be between two different fleets rather than
+        between two policies.
+        """
+        calls: list[tuple] = []
+        with _isolated_home(tmp_path, "pinned" if pinned else "unpinned") as home:
+            h = _fleet(home, n=3)
+            if pinned:
+                _pin(h, a2=1)
+            entries = {
+                num: _entry_for(_u(pct), h.clock.now)
+                for num, pct in self.SNAPSHOT_UTILIZATION.items()
+            }
+
+            def _fetch(**kwargs):
+                calls.append((
+                    frozenset(kwargs.get("fetch") or ()),
+                    kwargs.get("scheduled"),
+                ))
+                return entries
+
+            with patch.object(
+                h.switcher, "usage_entries_by_account", side_effect=_fetch
+            ):
+                outcome = h.engine.tick()
+            return h, outcome, calls
+
+    def test_the_pin_changes_the_destination_in_this_fixture(self, tmp_path):
+        """Guards the comparisons below: if the pin were inert here they would
+        compare two identical runs and prove nothing."""
+        pinned, _o, _c = self._run(tmp_path, pinned=True)
+        unpinned, _o2, _c2 = self._run(tmp_path, pinned=False)
+        assert _dest(pinned) == [2]
+        assert _dest(unpinned) == [3]
+
+    def test_the_computed_poll_plan_is_identical(self, tmp_path):
+        _h_p, outcome_p, calls_pinned = self._run(tmp_path, pinned=True)
+        _h_u, outcome_u, calls_unpinned = self._run(tmp_path, pinned=False)
+        assert outcome_p is TickOutcome.SWITCHED
+        assert outcome_u is TickOutcome.SWITCHED
+        assert calls_pinned, "the tick must have planned at least one fetch"
+        assert calls_pinned == calls_unpinned
+
+    def test_the_loop_delay_is_identical(self, tmp_path):
+        """`_next_delay` applies a +/-10% jitter, so `random.random` is pinned
+        to a constant - otherwise the two runs differ for a reason that has
+        nothing to do with order."""
+        with patch.object(_autoswitch_module.random, "random", return_value=0.5):
+            pinned, outcome_p, _c = self._run(tmp_path, pinned=True)
+            delay_pinned = pinned.engine._next_delay(outcome_p)
+            unpinned, outcome_u, _c2 = self._run(tmp_path, pinned=False)
+            delay_unpinned = unpinned.engine._next_delay(outcome_u)
+        assert delay_pinned == delay_unpinned
+        assert delay_pinned > 0.0
+
+    def test_no_scheduling_entry_point_accepts_an_orders_parameter(self):
+        engine_fns = [
+            _autoswitch_module.AutoSwitchEngine._collect_scheduled_usage,
+            _autoswitch_module.AutoSwitchEngine._next_delay,
+            _autoswitch_module.AutoSwitchEngine._refresh_poll_policy_inputs,
+        ]
+        policy_fns = [
+            obj
+            for _name, obj in vars(poll_policy).items()
+            if inspect.isfunction(obj) and obj.__module__ == poll_policy.__name__
+        ]
+        assert policy_fns, "poll_policy must expose functions to check"
+        for fn in engine_fns + policy_fns:
+            params = inspect.signature(fn).parameters
+            assert "orders" not in params, f"{fn.__qualname__} took an orders param"
+
+    def test_no_scheduling_source_references_the_order_map(self):
+        for fn in (
+            _autoswitch_module.AutoSwitchEngine._collect_scheduled_usage,
+            _autoswitch_module.AutoSwitchEngine._next_delay,
+            _autoswitch_module.AutoSwitchEngine._refresh_poll_policy_inputs,
+        ):
+            src = inspect.getsource(fn)
+            assert "OrderMap" not in src, f"{fn.__qualname__} references OrderMap"
+            assert "_resolve_orders" not in src, (
+                f"{fn.__qualname__} resolves orders"
+            )
+        # `poll_policy.py` contains the substring "order" zero times today.
+        # Keeping it that way is the cheapest possible statement that cadence
+        # and order never met.
+        assert "order" not in inspect.getsource(poll_policy), (
+            "poll_policy must carry no order concept at all"
+        )
+
+    def test_random_is_the_module_the_jitter_comes_from(self):
+        """Pins the patch target above: if `_next_delay` stopped using
+        `autoswitch.random`, the jitter would silently return and the delay
+        comparison would become flaky rather than failing."""
+        assert _autoswitch_module.random is _random_module
+        assert "random.random()" in inspect.getsource(
+            _autoswitch_module.AutoSwitchEngine._next_delay
+        )

--- a/tests/test_autoswitch_account_threshold.py
+++ b/tests/test_autoswitch_account_threshold.py
@@ -1,0 +1,946 @@
+"""MEU-PAP-03 - per-account threshold across every gate call site.
+
+Covers AC-16..AC-23 plus AC-41 (escalation band), AC-42 (`PollEvent.threshold`)
+and AC-47 (the departure-gate detail string).
+
+The engine resolves a threshold **map** once per tick and passes it down as a
+parameter; `_rank_candidates` is documented pure and is called twice per tick
+under the consume-first two-phase commit, so nothing here may read the store
+from inside the ranking. Every integration test below drives a **real tick**
+through `EngineHarness`, not a helper in isolation - the plan's AC-41 and AC-47
+are specifically written that way because a helper-level assertion passes
+against the defect each is meant to catch.
+
+Synthetic fixtures only: `EngineHarness` seeds a throwaway store under
+`temp_home`. Nothing here reads a real account store.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap.autoswitch import (
+    HORIZON_HEADROOM_RATIO,
+    SPENT_HEADROOM_PCT,
+    NoSwitchEvent,
+    PollEvent,
+    ThresholdMap,
+    TickOutcome,
+    _every_account_above_threshold,
+    pct_label,
+)
+from claude_swap.settings import AutoSwitchSettings
+
+from tests.test_autoswitch import EngineHarness, _entry_for, _iso_at, _usage
+
+# The global default the engine ships with; every override below is chosen to
+# sit on a different side of some gate than this value.
+GLOBAL = AutoSwitchSettings().threshold  # 90.0
+
+
+def _fleet(temp_home, **settings_kwargs) -> EngineHarness:
+    """Three seeded OAuth accounts, account 1 live and active."""
+    h = EngineHarness(temp_home, **settings_kwargs)
+    h.seed(1, "a@example.com")
+    h.seed(2, "b@example.com")
+    h.seed(3, "c@example.com")
+    h.make_live("a@example.com", 1)
+    return h
+
+
+def _reasons(h: EngineHarness) -> list[str]:
+    return [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+
+
+def _details(h: EngineHarness) -> list[str]:
+    return [e.detail for e in h.events if isinstance(e, NoSwitchEvent)]
+
+
+def _polls(h: EngineHarness) -> list[PollEvent]:
+    return [e for e in h.events if isinstance(e, PollEvent)]
+
+
+class TestThresholdMap:
+    """The map is total by construction - the Boundary Inventory's one rule.
+
+    A candidate absent from the map must read the global default rather than
+    raise `KeyError`. Every call site subscripts it directly (`thresholds[num]`),
+    so totality cannot be left to each caller to remember.
+    """
+
+    def test_a_present_key_returns_its_override(self):
+        assert ThresholdMap({"2": 85.0}, GLOBAL)["2"] == pytest.approx(85.0)
+
+    def test_an_absent_key_returns_the_global_default(self):
+        assert ThresholdMap({}, GLOBAL)["7"] == pytest.approx(GLOBAL)
+
+    def test_an_absent_key_does_not_raise(self):
+        thresholds = ThresholdMap({"1": 60.0}, GLOBAL)
+        # No KeyError, and no need for `.get(num, default)` at 10 call sites.
+        assert thresholds["nonexistent"] == pytest.approx(GLOBAL)
+
+    def test_it_is_a_mapping_of_str_to_float(self):
+        thresholds = ThresholdMap({"2": 85.0}, GLOBAL)
+        assert dict(thresholds) == {"2": 85.0}
+
+
+class TestResolveThresholds:
+    """`_resolve_thresholds()` is the single per-tick resolution point."""
+
+    def test_no_overrides_yields_the_global_for_every_account(self, temp_home):
+        h = _fleet(temp_home)
+        thresholds = h.engine._resolve_thresholds()
+        assert [thresholds[n] for n in ("1", "2", "3")] == [GLOBAL] * 3
+
+    def test_an_override_wins_for_that_account_only(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 85.0)
+        thresholds = h.engine._resolve_thresholds()
+        assert thresholds["2"] == pytest.approx(85.0)
+        assert thresholds["1"] == pytest.approx(GLOBAL)
+        assert thresholds["3"] == pytest.approx(GLOBAL)
+
+    def test_it_tracks_a_session_threshold_change(self, temp_home):
+        """`apply_threshold` retargets the global; overrides must survive it."""
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 85.0)
+        h.engine.apply_threshold(70.0)
+        thresholds = h.engine._resolve_thresholds()
+        assert thresholds["1"] == pytest.approx(70.0)
+        assert thresholds["2"] == pytest.approx(85.0)
+
+
+class TestDepartureGateUsesActiveThreshold:
+    """AC-16 - the gate fires on the **active account's own** threshold."""
+
+    def test_active_above_its_lower_override_switches(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("1", 85.0)
+        h.engine = h._make_engine()
+        outcome = h.tick_with_usage({"1": _usage(88.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert outcome is TickOutcome.SWITCHED, _reasons(h)
+        assert h.active_number() != 1
+
+    def test_the_same_utilization_holds_on_the_global(self, temp_home):
+        """Identity control for the case above: 88 < 90, so today's engine holds."""
+        h = _fleet(temp_home)
+        outcome = h.tick_with_usage({"1": _usage(88.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert "below-threshold" in _reasons(h)
+        assert h.active_number() == 1
+
+    def test_active_below_its_higher_override_holds(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("1", 95.0)
+        h.engine = h._make_engine()
+        outcome = h.tick_with_usage({"1": _usage(92.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert "below-threshold" in _reasons(h)
+        assert h.active_number() == 1
+
+    def test_the_same_utilization_switches_on_the_global(self, temp_home):
+        """Identity control: 92 >= 90, so today's engine moves."""
+        h = _fleet(temp_home)
+        outcome = h.tick_with_usage({"1": _usage(92.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert outcome is TickOutcome.SWITCHED, _reasons(h)
+        assert h.active_number() != 1
+
+    def test_another_accounts_override_does_not_move_the_active_gate(self, temp_home):
+        """Only the active account's own line gates departure."""
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 50.0)
+        h.engine = h._make_engine()
+        outcome = h.tick_with_usage({"1": _usage(88.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert outcome is TickOutcome.NO_ACTION
+        assert "below-threshold" in _reasons(h)
+
+
+class TestLandingGateIsPerCandidate:
+    """AC-17 - the discriminating case: two candidates, one tick, opposite verdicts.
+
+    Fixture shape, chosen so the assertion cannot pass by accident: candidate 2
+    holds **more** headroom than candidate 3, so today's engine picks 2. Giving
+    2 the *lower* threshold makes it an unacceptable landing spot while leaving
+    3 acceptable, so a correct per-candidate gate must invert the winner. An
+    implementation that applies one scalar to every candidate keeps picking 2
+    (both accepted) or picks nothing (both rejected) - neither is 3.
+    """
+
+    ACTIVE = 99.0    # headroom 1.0 -> over every threshold in play
+    CAND_2 = 88.0    # headroom 12.0 -> wins the ranking on headroom
+    CAND_3 = 89.0    # headroom 11.0 -> clears hysteresis (11 - 1 == 10)
+
+    def _usage_map(self) -> dict:
+        return {
+            "1": _usage(self.ACTIVE),
+            "2": _usage(self.CAND_2),
+            "3": _usage(self.CAND_3),
+        }
+
+    def test_the_candidate_over_its_own_line_is_rejected(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 85.0)   # 88 >= 85 -> rejected
+        h.switcher.set_account_threshold("3", 95.0)   # 89 <  95 -> accepted
+        h.engine = h._make_engine()
+        outcome = h.tick_with_usage(self._usage_map())
+        assert outcome is TickOutcome.SWITCHED, _reasons(h)
+        assert h.active_number() == 3
+
+    def test_at_the_global_default_the_headroom_winner_is_taken(self, temp_home):
+        """Identity control: with no overrides both candidates are acceptable,
+        so the ranking picks the one with more headroom - account 2."""
+        h = _fleet(temp_home)
+        outcome = h.tick_with_usage(self._usage_map())
+        assert outcome is TickOutcome.SWITCHED, _reasons(h)
+        assert h.active_number() == 2
+
+    def test_both_over_their_own_lines_hands_the_tick_to_the_all_above_regime(
+        self, temp_home
+    ):
+        """Rejecting *every* candidate does not produce NO_ACTION.
+
+        The landing floor is the exact complement of
+        `_every_account_above_threshold` (see the engine comment at
+        `_left_account_recovered`): if the gate rejects every measured
+        candidate while the active account is over its own line, then by
+        definition every account is at/over its line, `all_above` is True, and
+        the landing gate is bypassed by the soonest-recovery escape. So the
+        per-account rewrite must feed **both** sides the same map - a version
+        that made the landing gate per-account but left the all-above census on
+        the global scalar would disagree with itself here and hold.
+        """
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 85.0)
+        h.switcher.set_account_threshold("3", 85.0)
+        h.engine = h._make_engine()
+        # Both candidates are over their own (lowered) lines, and so is 1.
+        assert _every_account_above_threshold(
+            ["2", "3"], {"2": 12.0, "3": 11.0}, 1.0,
+            ThresholdMap({"2": 85.0, "3": 85.0}, GLOBAL), "1",
+        ) is True
+        outcome = h.tick_with_usage(self._usage_map())
+        assert outcome is TickOutcome.SWITCHED, _reasons(h)
+        assert h.active_number() != 1
+
+    def test_the_rejected_candidate_is_not_merely_deprioritized(self, temp_home):
+        """A rejected landing spot must be *excluded*, not sorted last.
+
+        Only 2 is overridden here; 3 stays on the global default and is
+        therefore still a legal landing spot. 2 holds strictly more headroom
+        (12.0 vs 11.0), so an implementation that merely *sorts* a
+        threshold-violating candidate downward - or one that never consults a
+        per-candidate line at all - still switches to 2. Only exclusion
+        produces 3.
+        """
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 85.0)   # 88 >= 85 -> rejected
+        h.engine = h._make_engine()                   # 3 at 89 < 90 -> kept
+        outcome = h.tick_with_usage(self._usage_map())
+        assert outcome is TickOutcome.SWITCHED, _reasons(h)
+        assert h.active_number() == 3
+
+
+class TestEveryAccountAboveThreshold:
+    """AC-18 - each account is compared against **its own** line."""
+
+    HEADROOM = {"2": 12.0, "3": 11.0}     # utilization 88 / 89
+    ACTIVE_HEADROOM = 1.0                 # utilization 99
+
+    def test_a_fleet_uniformly_above_the_default_engages(self, temp_home):
+        assert _every_account_above_threshold(
+            ["2", "3"], {"2": 5.0, "3": 5.0}, self.ACTIVE_HEADROOM,
+            ThresholdMap({}, GLOBAL), "1",
+        ) is True
+
+    def test_one_account_below_its_own_higher_line_does_not_engage(self, temp_home):
+        """3 is at 89 but its own line is 95, so it is *not* above it."""
+        assert _every_account_above_threshold(
+            ["2", "3"], self.HEADROOM, self.ACTIVE_HEADROOM,
+            ThresholdMap({"2": 85.0, "3": 95.0}, GLOBAL), "1",
+        ) is False
+
+    def test_every_account_above_its_own_line_engages(self, temp_home):
+        assert _every_account_above_threshold(
+            ["2", "3"], self.HEADROOM, self.ACTIVE_HEADROOM,
+            ThresholdMap({"2": 85.0, "3": 85.0}, GLOBAL), "1",
+        ) is True
+
+    def test_the_active_is_measured_against_its_own_line(self, temp_home):
+        """Active at 88 with a 95 line is below it, so the state cannot hold."""
+        assert _every_account_above_threshold(
+            ["2", "3"], {"2": 5.0, "3": 5.0}, 12.0,
+            ThresholdMap({"1": 95.0}, GLOBAL), "1",
+        ) is False
+
+    def test_an_unreadable_active_still_returns_false(self, temp_home):
+        assert _every_account_above_threshold(
+            ["2"], {"2": 1.0}, None, ThresholdMap({}, GLOBAL), "1"
+        ) is False
+
+    def test_no_measured_candidate_still_returns_false(self, temp_home):
+        assert _every_account_above_threshold(
+            ["2"], {"2": None}, self.ACTIVE_HEADROOM,
+            ThresholdMap({}, GLOBAL), "1",
+        ) is False
+
+    def test_a_uniform_default_fleet_matches_todays_verdict(self, temp_home):
+        """Identity control - the default path must be bit-identical."""
+        thresholds = ThresholdMap({}, GLOBAL)
+        for active_h, cand_h, expected in [
+            (1.0, 5.0, True),      # 99 and 95, both over 90
+            (1.0, 50.0, False),    # candidate at 50 is well under
+            (50.0, 5.0, False),    # active at 50 is well under
+        ]:
+            assert _every_account_above_threshold(
+                ["2"], {"2": cand_h}, active_h, thresholds, "1"
+            ) is expected
+
+
+class TestAntiFlapUsesTheBarredAccountsThreshold:
+    """AC-19 - the anti-flap machinery evaluates the **barred** account against
+    *its own* line, so it cannot contradict the gate that barred it.
+
+    Both reachable sites take the unreadable-active fallback leg, which asks
+    "would the ranking accept this peer as a landing spot right now?" - the
+    same question `_rank_candidates` answers per candidate, and therefore the
+    same threshold.
+    """
+
+    STATE = {
+        "lastSwitchFrom": 2,
+        "lastSwitchTo": "1",
+        "leftHeadroom": 4.0,
+        "leftRecoveryAt": None,
+        "leftTrigger": "proactive",
+    }
+
+    def test_no_return_releases_when_the_barred_account_clears_its_own_line(
+        self, temp_home
+    ):
+        """Barred account at 88 (headroom 12). Its own line is 95, so
+        `100 - 95 == 5` and 12 > 5 - landing-eligible, bar released."""
+        h = _fleet(temp_home)
+        assert h.engine._no_return_account(
+            "proactive", dict(self.STATE), {"2": 12.0}, None, True,
+            h.settings, "1", thresholds=ThresholdMap({"2": 95.0}, GLOBAL),
+        ) is None
+
+    def test_no_return_holds_when_the_barred_account_is_over_its_own_line(
+        self, temp_home
+    ):
+        """Same 12.0 headroom, own line 85: `100 - 85 == 15` and 12 < 15."""
+        h = _fleet(temp_home)
+        assert h.engine._no_return_account(
+            "proactive", dict(self.STATE), {"2": 12.0}, None, True,
+            h.settings, "1", thresholds=ThresholdMap({"2": 85.0}, GLOBAL),
+        ) == "2"
+
+    def test_no_return_at_the_default_matches_todays_verdict(self, temp_home):
+        """Identity control: `100 - 90 == 10`, and 12 > 10 releases today."""
+        h = _fleet(temp_home)
+        assert h.engine._no_return_account(
+            "proactive", dict(self.STATE), {"2": 12.0}, None, True,
+            h.settings, "1", thresholds=ThresholdMap({}, GLOBAL),
+        ) is None
+
+    def test_recovered_uses_the_barred_line_on_the_failover_leg(self, temp_home):
+        """`_left_account_recovered`, failover snapshot: the landing leg reads
+        the barred account's own threshold."""
+        h = _fleet(temp_home)
+        state = {
+            "lastSwitchFrom": 2,
+            "leftHeadroom": None,
+            "leftRecoveryAt": None,
+            "leftTrigger": "failover",
+        }
+        common = dict(
+            usage={"1": _usage(99.0), "2": _usage(88.0)},
+            headroom={"1": 1.0, "2": 12.0},
+            active_headroom=None,
+            settings=h.settings,
+            now=h.clock.now,
+            current="1",
+        )
+        assert h.engine._left_account_recovered(
+            dict(state), thresholds=ThresholdMap({"2": 95.0}, GLOBAL), **common
+        ) is True
+        assert h.engine._left_account_recovered(
+            dict(state), thresholds=ThresholdMap({"2": 85.0}, GLOBAL), **common
+        ) is False
+
+    def test_recovered_uses_the_barred_line_on_the_dominance_leg(self, temp_home):
+        """The `active_headroom is None` fallback at the dominance leg reads the
+        barred account's own threshold too - the second of the two sites."""
+        h = _fleet(temp_home)
+        state = {
+            "lastSwitchFrom": 2,
+            "lastSwitchTo": "1",
+            "leftHeadroom": 4.0,
+            "leftRecoveryAt": None,
+            "leftTrigger": "proactive",
+        }
+        common = dict(
+            usage={"1": _usage(99.0), "2": _usage(88.0)},
+            headroom={"1": None, "2": 12.0},
+            active_headroom=None,
+            settings=h.settings,
+            now=h.clock.now,
+            current="1",
+        )
+        assert h.engine._left_account_recovered(
+            dict(state), thresholds=ThresholdMap({"2": 95.0}, GLOBAL), **common
+        ) is True
+
+    def test_an_unrelated_accounts_override_changes_nothing(self, temp_home):
+        """Only the barred account's own line is consulted."""
+        h = _fleet(temp_home)
+        assert h.engine._no_return_account(
+            "proactive", dict(self.STATE), {"2": 12.0}, None, True,
+            h.settings, "1",
+            thresholds=ThresholdMap({"1": 50.0, "3": 99.0}, GLOBAL),
+        ) is None
+
+
+class TestPollPolicyMinimumThreshold:
+    """AC-20 - `set_poll_policy_inputs` receives the fleet **minimum**.
+
+    `poll_policy`'s urgent mode compares `new_pct >= threshold - 15`, so a
+    minimum can only make collection *earlier*, never lazier - the safe
+    direction when accounts disagree about where their line is.
+    """
+
+    def test_no_overrides_passes_the_global_unchanged(self, temp_home):
+        h = _fleet(temp_home)
+        h.engine = h._make_engine()
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(GLOBAL)
+
+    def test_a_lower_override_lowers_the_pinned_value(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 60.0)
+        h.engine = h._make_engine()
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(60.0)
+
+    def test_a_higher_override_does_not_raise_the_pinned_value(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 99.0)
+        h.engine = h._make_engine()
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(GLOBAL)
+
+    def test_the_minimum_is_taken_across_the_whole_fleet(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("1", 80.0)
+        h.switcher.set_account_threshold("2", 60.0)
+        h.switcher.set_account_threshold("3", 70.0)
+        h.engine = h._make_engine()
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(60.0)
+
+    def test_a_session_threshold_change_recomputes_the_minimum(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 60.0)
+        h.engine = h._make_engine()
+        h.engine.apply_threshold(55.0)
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(55.0)
+
+    def test_a_disabled_account_does_not_drag_the_minimum_down(self, temp_home):
+        """The minimum is over *switchable* accounts; a parked slot's line is
+        not one the engine will ever gate on."""
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("3", 55.0)
+        h.switcher.set_account_disabled("3", True)
+        h.engine = h._make_engine()
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(GLOBAL)
+
+
+class TestRankCandidatesStaysPure:
+    """AC-21 - thresholds arrive as a parameter; the ranking never reads the store.
+
+    `consume-first` calls `_rank_candidates` **twice per tick** under a
+    two-phase commit, so a store read inside it would re-resolve mid-tick and
+    could decide phase 1 and phase 2 on different lines.
+    """
+
+    def _kwargs(self, h, thresholds):
+        return dict(
+            trigger="proactive",
+            consume_first=False,
+            oauth_candidates=["2", "3"],
+            no_return=None,
+            usage={"1": _usage(99.0), "2": _usage(50.0), "3": _usage(60.0)},
+            headroom={"1": 1.0, "2": 50.0, "3": 40.0},
+            current="1",
+            active_headroom=1.0,
+            settings=h.settings,
+            now=h.clock.now,
+            thresholds=thresholds,
+        )
+
+    def test_it_runs_against_a_switcher_whose_reads_raise(self, temp_home):
+        h = _fleet(temp_home)
+        kwargs = self._kwargs(h, ThresholdMap({"2": 85.0}, GLOBAL))
+
+        def _boom(*args, **kw):
+            raise AssertionError("_rank_candidates read the store")
+
+        for name in (
+            "account_policies",
+            "_get_sequence_data",
+            "switchable_account_numbers",
+            "backup_account_numbers",
+        ):
+            monkey = getattr(h.switcher, name, None)
+            if monkey is not None:
+                setattr(h.switcher, name, _boom)
+
+        ordered_a, _, _ = h.engine._rank_candidates(**kwargs)
+        ordered_b, _, _ = h.engine._rank_candidates(**kwargs)
+        assert ordered_a == ordered_b
+
+    def test_two_calls_on_different_snapshots_use_the_passed_map(self, temp_home):
+        """The two-phase commit's whole point: same map, different snapshot."""
+        h = _fleet(temp_home)
+        thresholds = ThresholdMap({"2": 45.0, "3": 95.0}, GLOBAL)
+        phase1 = self._kwargs(h, thresholds)
+        ordered1, _, _ = h.engine._rank_candidates(**phase1)
+        # 2 is at 50 utilization, over its own 45 line -> not a landing spot.
+        assert "2" not in ordered1
+        assert ordered1 == ["3"]
+
+        phase2 = dict(phase1)
+        phase2["usage"] = {"1": _usage(99.0), "2": _usage(20.0), "3": _usage(60.0)}
+        phase2["headroom"] = {"1": 1.0, "2": 80.0, "3": 40.0}
+        ordered2, _, _ = h.engine._rank_candidates(**phase2)
+        # Same map, fresher snapshot: 2 is now at 20, under its own line.
+        assert ordered2[0] == "2"
+
+    def test_it_emits_nothing(self, temp_home):
+        h = _fleet(temp_home)
+        h.events.clear()
+        h.engine._rank_candidates(**self._kwargs(h, ThresholdMap({}, GLOBAL)))
+        assert h.events == []
+
+
+class TestRawHeadroomGuardsDoNotMove:
+    """AC-22 - `HORIZON_HEADROOM_RATIO` and `SPENT_HEADROOM_PCT` stay on raw
+    headroom (upstream #262 reasoned this out and it applies identically).
+
+    A ratio against distance-to-100 means something; a ratio against a policy
+    line every account is already past does not.
+    """
+
+    def test_the_constants_are_untouched(self):
+        assert HORIZON_HEADROOM_RATIO == pytest.approx(2.0)
+        assert SPENT_HEADROOM_PCT == pytest.approx(3.0)
+
+    def test_an_override_does_not_move_the_ratio_gate(self, temp_home):
+        """`_no_return_account`'s ratio leg reads a *readable* active, so the
+        threshold never enters it - an override on the barred account must not
+        change which side of `left >= active * RATIO` it lands on."""
+        h = _fleet(temp_home)
+        state = {
+            "lastSwitchFrom": 2,
+            "lastSwitchTo": "1",
+            "leftHeadroom": 4.0,
+            "leftRecoveryAt": None,
+            "leftTrigger": "proactive",
+        }
+        # left 12.0 vs active 5.0: 12 >= 5 * 2.0 -> beats us outright.
+        for override in ({}, {"2": 50.0}, {"2": 99.0}):
+            assert h.engine._no_return_account(
+                "proactive", dict(state), {"2": 12.0}, 5.0, True,
+                h.settings, "1", thresholds=ThresholdMap(override, GLOBAL),
+            ) is None
+        # left 9.0 vs active 5.0: 9 < 10 -> the ratio does not release.
+        for override in ({}, {"2": 50.0}, {"2": 99.0}):
+            assert h.engine._no_return_account(
+                "proactive", dict(state), {"2": 9.0}, 5.0, True,
+                h.settings, "1", thresholds=ThresholdMap(override, GLOBAL),
+            ) == "2"
+
+    def test_an_override_does_not_move_the_spent_gate(self, temp_home):
+        """`_left_account_recovered`'s dominance leg is
+        `h > active * RATIO + SPENT_HEADROOM_PCT` on raw headroom."""
+        h = _fleet(temp_home)
+        state = {
+            "lastSwitchFrom": 2,
+            "leftHeadroom": 4.0,
+            "leftRecoveryAt": None,
+            "leftTrigger": "proactive",
+        }
+        common = dict(
+            usage={"1": _usage(95.0), "2": _usage(80.0)},
+            headroom={"1": 5.0, "2": 20.0},
+            active_headroom=5.0,
+            settings=h.settings,
+            now=h.clock.now,
+            current="1",
+        )
+        # 20 > 5 * 2.0 + 3.0 == 13.0 -> dominates, regardless of any line.
+        for override in ({}, {"2": 50.0}, {"2": 99.0}):
+            assert h.engine._left_account_recovered(
+                dict(state), thresholds=ThresholdMap(override, GLOBAL), **common
+            ) is True
+
+
+class TestEscalationBandUsesActiveThreshold:
+    """AC-41 - the escalation band asks about the **active** account, so it
+    reads that account's own line.
+
+    Driven through a real tick, never `_collect_scheduled_usage` in isolation:
+    the defect this discriminates against is a *stale-snapshot switch*, which
+    only exists once ranking runs on what the collector returned.
+
+    Discriminating tuple from the plan: global `99.9`, active override `50`,
+    active utilization `60`. The departure gate fires at 50, but a collector
+    still holding the global tests `60 >= 99.9 - 15` (i.e. `>= 84.9`), does
+    not escalate, and the proactive selection that follows runs on the
+    pre-escalation snapshot.
+    """
+
+    # Baseline collector calls per tick, before any escalation: the
+    # `fetch=set()` pre-read that builds the poll plan, then the plan fetch
+    # itself. The escalation refetch is the third. Asserting `>= 2` would be
+    # true on every tick ever taken and would discriminate nothing.
+    BASE_CALLS = 2
+
+    def _tick(self, h, snapshots: list[dict]):
+        """Return `(outcome, mock)`; call *i* serves `snapshots[i]`, last repeats."""
+        from unittest.mock import patch
+
+        from tests.test_autoswitch import _entry_for
+
+        built = [
+            {n: _entry_for(v, h.clock.now) for n, v in snap.items()}
+            for snap in snapshots
+        ]
+
+        calls = {"n": 0}
+
+        def _side_effect(*args, **kwargs):
+            i = min(calls["n"], len(built) - 1)
+            calls["n"] += 1
+            return built[i]
+
+        with patch.object(
+            h.switcher, "usage_entries_by_account", side_effect=_side_effect
+        ) as m:
+            outcome = h.engine.tick()
+        return outcome, m
+
+    def test_it_escalates_on_the_active_accounts_own_line(self, temp_home):
+        h = _fleet(temp_home, threshold=99.9)
+        h.switcher.set_account_threshold("1", 50.0)
+        h.engine = h._make_engine()
+        pre = {"1": _usage(60.0), "2": _usage(5.0), "3": _usage(10.0)}
+        post = {"1": _usage(60.0), "2": _usage(100.0), "3": _usage(10.0)}
+        # `post` is served only from the third call on, so it can reach the
+        # ranking *only* through the escalation refetch.
+        outcome, mock = self._tick(h, [pre, pre, post])
+        assert mock.call_count == self.BASE_CALLS + 1
+        assert outcome is TickOutcome.SWITCHED, _reasons(h)
+        # The decision was taken on the POST-escalation snapshot: on `pre`,
+        # account 2 has the most headroom and wins; on `post` it is at limit.
+        assert h.active_number() == 3
+
+    def test_the_mirror_case_does_not_escalate(self, temp_home):
+        """Global `50`, active override `99.9`, utilization `60`: the band must
+        stay shut, so the plan fetch is the only collector call."""
+        h = _fleet(temp_home, threshold=50.0)
+        h.switcher.set_account_threshold("1", 99.9)
+        h.engine = h._make_engine()
+        snap = {"1": _usage(60.0), "2": _usage(5.0), "3": _usage(10.0)}
+        outcome, mock = self._tick(h, [snap])
+        assert mock.call_count == self.BASE_CALLS
+        assert outcome is TickOutcome.NO_ACTION
+        assert "below-threshold" in _reasons(h)
+
+    def test_with_no_overrides_the_band_is_todays(self, temp_home):
+        """Identity control: global 90, utilization 80 -> `80 >= 75` escalates."""
+        h = _fleet(temp_home)
+        snap = {"1": _usage(80.0), "2": _usage(5.0), "3": _usage(10.0)}
+        _outcome, mock = self._tick(h, [snap])
+        assert mock.call_count == self.BASE_CALLS + 1
+
+    def test_with_no_overrides_a_quiet_active_does_not_escalate(self, temp_home):
+        """Identity control: utilization 60 against global 90 -> `60 >= 75` false."""
+        h = _fleet(temp_home)
+        snap = {"1": _usage(60.0), "2": _usage(5.0), "3": _usage(10.0)}
+        _outcome, mock = self._tick(h, [snap])
+        assert mock.call_count == self.BASE_CALLS
+
+
+class TestPollEventCarriesTheActiveThreshold:
+    """AC-42 - the number the UI renders equals the number the gate used."""
+
+    def test_it_carries_the_active_accounts_override(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("1", 55.0)
+        h.engine = h._make_engine()
+        h.tick_with_usage({"1": _usage(40.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert _polls(h)[0].threshold == pytest.approx(55.0)
+
+    def test_a_peers_override_does_not_appear(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("2", 55.0)
+        h.engine = h._make_engine()
+        h.tick_with_usage({"1": _usage(40.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert _polls(h)[0].threshold == pytest.approx(GLOBAL)
+
+    def test_with_no_overrides_it_is_todays_value(self, temp_home):
+        h = _fleet(temp_home)
+        h.tick_with_usage({"1": _usage(40.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert _polls(h)[0].threshold == pytest.approx(GLOBAL)
+
+    def test_the_no_active_account_path_keeps_the_global(self, temp_home):
+        """`:911` is the deliberate non-move in the inventory: with no active
+        account there is no account whose line could be read."""
+        h = EngineHarness(temp_home, threshold=77.0)
+        outcome = h.tick_with_usage({})
+        assert outcome is TickOutcome.NO_ACTION
+        polls = _polls(h)
+        assert polls and polls[0].active is None
+        assert polls[0].threshold == pytest.approx(77.0)
+
+    def test_the_rendered_number_equals_the_gate_that_held(self, temp_home):
+        """The property the AC exists for, asserted as one statement."""
+        h = _fleet(temp_home, threshold=85.0)
+        h.switcher.set_account_threshold("1", 95.0)
+        h.engine = h._make_engine()
+        h.tick_with_usage({"1": _usage(90.0), "2": _usage(10.0), "3": _usage(10.0)})
+        rendered = _polls(h)[0].threshold
+        assert rendered == pytest.approx(95.0)
+        assert f"< {pct_label(rendered)}%" in _details(h)[0]
+
+
+class TestDepartureGateDetailString:
+    """AC-47 - `:989` quotes the *active account's own* effective threshold.
+
+    The plan is explicit that a hold-only assertion is insufficient: it passes
+    against the defect, because row 1 already holds correctly. The emitted
+    string is the oracle. Leaving this site on the global scalar makes the
+    engine hold on one number and display another - `90% < 85%` is not merely
+    misleading but arithmetically false, and invites the operator to conclude
+    the engine is broken.
+    """
+
+    def test_the_detail_quotes_the_active_override(self, temp_home):
+        h = _fleet(temp_home, threshold=85.0)
+        h.switcher.set_account_threshold("1", 95.0)
+        h.engine = h._make_engine()
+        outcome = h.tick_with_usage(
+            {"1": _usage(90.0), "2": _usage(10.0), "3": _usage(10.0)}
+        )
+        assert outcome is TickOutcome.NO_ACTION
+        assert _details(h)[0] == "90% < 95%"
+
+    def test_it_never_quotes_the_global_when_an_override_exists(self, temp_home):
+        h = _fleet(temp_home, threshold=85.0)
+        h.switcher.set_account_threshold("1", 95.0)
+        h.engine = h._make_engine()
+        h.tick_with_usage({"1": _usage(90.0), "2": _usage(10.0), "3": _usage(10.0)})
+        assert "< 85%" not in _details(h)[0]
+
+    def test_the_mirror_case_reads_the_lower_override(self, temp_home):
+        """Gate fires on the override, but no candidate survives its landing
+        gate - the reader must not be told the account is comfortably under."""
+        h = EngineHarness(temp_home, threshold=85.0, strategy="consume-first")
+        h.seed(1, "a@example.com")
+        h.make_live("a@example.com", 1)
+        h.switcher.set_account_threshold("1", 95.0)
+        h.engine = h._make_engine()
+        h.tick_with_usage({"1": _usage(90.0)})
+        # The consume-first no-OAuth-peer diagnostic - a distinct site from the
+        # departure gate and the second of the two `pct_label` emits. It is
+        # guarded by `not oauth_candidates`, so the fleet must hold exactly one
+        # account: with peers present but unreadable the engine emits
+        # `no-comparison` instead and this site is never reached.
+        assert _reasons(h) == ["below-threshold"]
+        assert _details(h)[0] == "90% < 95%"
+
+    def test_with_no_override_the_detail_is_todays(self, temp_home):
+        h = _fleet(temp_home, threshold=85.0)
+        outcome = h.tick_with_usage(
+            {"1": _usage(80.0), "2": _usage(10.0), "3": _usage(10.0)}
+        )
+        assert outcome is TickOutcome.NO_ACTION
+        assert _details(h)[0] == "80% < 85%"
+
+    def test_both_sides_go_through_pct_label(self, temp_home):
+        """`99.9` must never render as a lying `100`."""
+        h = _fleet(temp_home, threshold=85.0)
+        h.switcher.set_account_threshold("1", 99.9)
+        h.engine = h._make_engine()
+        h.tick_with_usage({"1": _usage(99.5), "2": _usage(10.0), "3": _usage(10.0)})
+        assert _details(h)[0] == "99.5% < 99.9%"
+
+
+class TestDefaultIdentity:
+    """AC-23 - with no per-account thresholds anywhere, nothing changes.
+
+    The whole-suite form of this AC is the phase gate (`2056 passed, 75
+    skipped, 3 warnings` baseline, and `tests/test_autoswitch.py` unchanged).
+    What is asserted here is the property that makes that outcome expected
+    rather than lucky: on a fleet with no overrides, every resolved value is
+    the global scalar, so each rewritten call site receives exactly the
+    argument it receives today.
+    """
+
+    def test_no_policy_keys_exist_on_a_fresh_fleet(self, temp_home):
+        from claude_swap.models import AccountPolicy
+
+        h = _fleet(temp_home)
+        policies = h.switcher.account_policies()
+        # One entry per managed account, every one of them the default.
+        assert set(policies) == {"1", "2", "3"}
+        assert all(p == AccountPolicy() for p in policies.values())
+        # And so the map the engine builds carries no overrides at all.
+        thresholds = h.engine._resolve_thresholds()
+        assert dict(thresholds) == {}
+
+    def test_every_resolved_value_is_the_global(self, temp_home):
+        h = _fleet(temp_home, threshold=77.5)
+        thresholds = h.engine._resolve_thresholds()
+        for num in ("1", "2", "3", "unknown"):
+            assert thresholds[num] == pytest.approx(77.5)
+
+    def test_the_pinned_poll_input_is_the_global(self, temp_home):
+        h = _fleet(temp_home, threshold=77.5)
+        h.engine = h._make_engine()
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(77.5)
+
+    @pytest.mark.parametrize(
+        "utilization,expected",
+        [(80.0, TickOutcome.NO_ACTION), (92.0, TickOutcome.SWITCHED)],
+    )
+    def test_the_gate_is_todays_gate(self, temp_home, utilization, expected):
+        h = _fleet(temp_home)
+        outcome = h.tick_with_usage(
+            {"1": _usage(utilization), "2": _usage(10.0), "3": _usage(10.0)}
+        )
+        assert outcome is expected, _reasons(h)
+
+    def test_a_cleared_override_returns_to_the_global(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("1", 55.0)
+        h.switcher.set_account_threshold("1", None)
+        h.engine = h._make_engine()
+        assert dict(h.engine._resolve_thresholds()) == {}
+        outcome = h.tick_with_usage(
+            {"1": _usage(80.0), "2": _usage(10.0), "3": _usage(10.0)}
+        )
+        assert outcome is TickOutcome.NO_ACTION
+
+
+class TestPollCadenceFollowsALivePolicyChange:
+    """VR-1 - the pinned minimum is refreshed every tick, not only at birth.
+
+    `cswap threshold 1 50` is written by a **different process** while
+    `cswap auto` is already running - that is the ordinary way a threshold
+    gets changed. `_resolve_thresholds()` re-reads the store every tick, so
+    the switch DECISION picks the new line up immediately. But
+    `set_poll_policy_inputs` was called in exactly two places, `__init__` and
+    `apply_threshold()`, and a persisted write goes through neither. Cadence
+    therefore stayed pinned to the minimum as it stood when the engine booted.
+
+    That contradicts AC-20's rationale, which is not "the minimum is a tidy
+    value" but "the collector is then never lazier than the earliest possible
+    trigger, so no switch is missed". `poll_policy`'s urgent mode fires at
+    `new_pct >= threshold - 15`, so a stale 90 against a live 50 goes urgent
+    at 75% when it should go urgent at 35% - lazier, in the one direction the
+    AC-20 rationale rules out, for every tick until the engine restarts.
+
+    `TestPollPolicyMinimumThreshold` above cannot catch this: every case there
+    writes the policy and *then* builds the engine, except the `apply_threshold`
+    case, which goes through the one path that already refreshed.
+    """
+
+    def test_a_persisted_override_lowers_the_pinned_value_on_the_next_tick(
+        self, temp_home
+    ):
+        h = _fleet(temp_home)
+        h.engine = h._make_engine()
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(GLOBAL)
+
+        # The out-of-process write the running engine must notice.
+        h.switcher.set_account_threshold("1", 50.0)
+        h.tick_with_usage({"1": _usage(40.0), "2": _usage(40.0), "3": _usage(40.0)})
+
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(50.0)
+
+    def test_the_refresh_lands_before_the_collector_reads_it(self, temp_home):
+        """Ordering, not just eventual consistency.
+
+        A refresh applied *after* `_collect_scheduled_usage` would satisfy the
+        test above and still plan this tick's collection on the stale number -
+        the tick where it matters most, because it is the one that discovered
+        the change.
+        """
+        h = _fleet(temp_home)
+        h.engine = h._make_engine()
+        h.switcher.set_account_threshold("1", 50.0)
+
+        seen: list[float] = []
+        entries = {
+            num: _entry_for(_usage(40.0), h.clock.now) for num in ("1", "2", "3")
+        }
+
+        def _capture(*_a, **_k):
+            seen.append(h.switcher._poll_inputs_override[0])
+            return entries
+
+        with patch.object(
+            h.switcher, "usage_entries_by_account", side_effect=_capture
+        ):
+            h.engine.tick()
+
+        assert seen, "the collector never ran, so the ordering was not observed"
+        assert seen[0] == pytest.approx(50.0)
+
+    def test_clearing_the_override_raises_the_pinned_value_back(self, temp_home):
+        """The negative half. A refresh that only ever ratchets downward would
+        pass every positive case and leave cadence over-tight forever."""
+        h = _fleet(temp_home)
+        h.switcher.set_account_threshold("1", 50.0)
+        h.engine = h._make_engine()
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(50.0)
+
+        h.switcher.set_account_threshold("1", None)
+        h.tick_with_usage({"1": _usage(40.0), "2": _usage(40.0), "3": _usage(40.0)})
+
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(GLOBAL)
+
+    def test_a_session_override_is_not_clobbered_by_the_tick_refresh(self, temp_home):
+        """`apply_threshold()` retargets the session global. The per-tick
+        refresh recomputes from the tick's own settings snapshot, so it must
+        land on 55, not revert to the 90 the engine was constructed with."""
+        h = _fleet(temp_home)
+        h.engine = h._make_engine()
+        h.engine.apply_threshold(55.0)
+        h.tick_with_usage({"1": _usage(40.0), "2": _usage(40.0), "3": _usage(40.0)})
+
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(55.0)
+
+    def test_a_disabled_account_still_does_not_drag_the_minimum_down(self, temp_home):
+        """The switchable filter has to survive the move into the tick."""
+        h = _fleet(temp_home)
+        h.engine = h._make_engine()
+        h.switcher.set_account_threshold("3", 55.0)
+        h.switcher.set_account_disabled("3", True)
+        h.tick_with_usage({"1": _usage(40.0), "2": _usage(40.0), "3": _usage(40.0)})
+
+        assert h.switcher._poll_inputs_override[0] == pytest.approx(GLOBAL)
+
+    def test_a_fleet_with_no_overrides_pins_exactly_the_global_every_tick(
+        self, temp_home
+    ):
+        """Default-identity. Ticking must not perturb the pinned value on a
+        fleet that never used the feature."""
+        h = _fleet(temp_home)
+        h.engine = h._make_engine()
+        for _ in range(3):
+            h.tick_with_usage(
+                {"1": _usage(40.0), "2": _usage(40.0), "3": _usage(40.0)}
+            )
+            assert h.switcher._poll_inputs_override[0] == pytest.approx(GLOBAL)
+        assert h.switcher._poll_inputs_override[1] == h.engine._models

--- a/tests/test_autoswitch_backup_accounts.py
+++ b/tests/test_autoswitch_backup_accounts.py
@@ -434,8 +434,8 @@ class TestFailbackUnderBest:
         h = self._stage(temp_home)
         outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(90.0)}])
         assert outcome is TickOutcome.NO_ACTION
-        assert _reasons(h) == ["below-threshold"]
-        assert _details(h) == ["20% < 90%"]
+        assert _reasons(h) == ["failback-hold"]
+        assert _details(h) == ["primaries still exhausted"]
         assert _switches(h) == []
 
 
@@ -661,7 +661,7 @@ class TestFailbackTriggerScope:
         _backup(h, 1)
         outcome, _ = _tick(h, [{"1": _u(20.0), "2": None}])
         assert outcome is TickOutcome.NO_ACTION
-        assert _reasons(h) == ["below-threshold"]
+        assert _reasons(h) == ["failback-hold"]
         assert "no-comparison" not in _reasons(h)
 
 
@@ -693,7 +693,7 @@ class TestFailbackRefetchesBeforeCommitting:
         outcome, mock = _tick(h, [phase1, phase1, phase2])
         assert mock.call_count == BASE_CALLS + 1
         assert outcome is TickOutcome.NO_ACTION
-        assert _reasons(h) == ["below-threshold"]
+        assert _reasons(h) == ["failback-hold"]
         assert h.active_number() == 1
 
     def test_an_unrefreshable_target_holds_rather_than_commits(
@@ -773,7 +773,7 @@ class TestFailbackKeepsTheLandingGate:
             "1": _u(20.0), "2": _u(90.0), "3": _u(88.0),
         }])
         assert outcome is TickOutcome.NO_ACTION
-        assert _reasons(h) == ["below-threshold"]
+        assert _reasons(h) == ["failback-hold"]
         assert _switches(h) == []
 
     def test_ii_the_all_above_relaxation_is_not_borrowed(self, temp_home):
@@ -801,7 +801,7 @@ class TestFailbackKeepsTheLandingGate:
         outcome, mock = _tick(h, [phase1, phase1, phase2])
         assert mock.call_count == BASE_CALLS + 1
         assert outcome is TickOutcome.NO_ACTION
-        assert _reasons(h) == ["below-threshold"]
+        assert _reasons(h) == ["failback-hold"]
         assert h.active_number() == 1
 
 
@@ -829,7 +829,7 @@ class TestFailbackNeverFallsBackToAnApiKeyAccount:
             "1": _u(20.0), "2": _u(95.0), "3": _u(5.0),
         }])
         assert outcome is TickOutcome.NO_ACTION
-        assert _reasons(h) == ["below-threshold"]
+        assert _reasons(h) == ["failback-hold"]
         assert h.active_number() == 1
 
     def test_the_last_resort_still_fires_for_an_exhausted_reserve(
@@ -880,8 +880,8 @@ class TestFailbackSurvivesTheTargetLoop:
         ):
             outcome, _ = _tick(h, [self._snapshot()])
         assert outcome is TickOutcome.NO_ACTION
-        assert _reasons(h) == ["below-threshold"]
-        assert _details(h) == ["20% < 90%"]
+        assert _reasons(h) == ["failback-hold"]
+        assert _details(h) == ["primaries still exhausted"]
         assert h.active_number() == 1
 
     def test_b_dead_credentials_hold_and_the_quarantine_survives(
@@ -894,7 +894,7 @@ class TestFailbackSurvivesTheTargetLoop:
         ):
             outcome, _ = _tick(h, [self._snapshot(3)])
         assert outcome is TickOutcome.NO_ACTION
-        assert "below-threshold" in _reasons(h)
+        assert "failback-hold" in _reasons(h)
         # The hold sits after the loop: both durable findings are on disk.
         quarantine = h.state().get("quarantine", {})
         assert "2" in quarantine
@@ -913,7 +913,7 @@ class TestFailbackSurvivesTheTargetLoop:
         ):
             outcome, _ = _tick(h, [self._snapshot()])
         assert outcome is TickOutcome.NO_ACTION
-        assert "below-threshold" in _reasons(h)
+        assert "failback-hold" in _reasons(h)
         assert not any(isinstance(e, ErrorEvent) for e in h.events)
         assert not h.state().get("quarantine")
 

--- a/tests/test_autoswitch_backup_accounts.py
+++ b/tests/test_autoswitch_backup_accounts.py
@@ -1,0 +1,1082 @@
+"""MEU-PAP-04 - backup ("last man standing") accounts and the `failback` trigger.
+
+Covers AC-24..AC-32 (the two-pass candidate filter) plus AC-43..AC-46 and
+AC-48..AC-52 (failback).
+
+Every failback oracle drives a **real tick** - `_tick_inner` -> `_rank` ->
+`_perform` - rather than calling `_rank_candidates` in isolation, and asserts on
+the emitted **trigger string**, because a helper-level assertion passes against
+the exact under-implementation each oracle exists to catch. Eleven oracles are
+negative: ten have a named mutant in the plan's Mutation-discrimination gate and
+are proved discriminating in H1-13b; AC-44's reference implementation is today's
+unmodified engine.
+
+Three outcomes all report "no switch" - `NO_ACTION`, `BLOCKED` and `ERROR` - so
+every hold assertion names the **reason string and the `TickOutcome`**, never
+merely that no switch occurred. The whole failback contract is that a tick which
+returns `NO_ACTION` today must not return `BLOCKED` after this PR.
+
+Synthetic fixtures only: `EngineHarness` seeds a throwaway store under
+`temp_home`. Nothing here reads a real account store.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from claude_swap import oauth
+from claude_swap.autoswitch import _headroom_by_account
+from claude_swap.autoswitch import (
+    AllExhaustedEvent,
+    ErrorEvent,
+    NoSwitchEvent,
+    QuarantineEvent,
+    SwitchEvent,
+    TickOutcome,
+)
+from claude_swap.settings import AutoSwitchSettings
+from claude_swap.usage_store import SERVE_TTL_S, UsageEntry
+
+from tests.test_autoswitch import EngineHarness, _entry_for, _iso_at, _usage
+
+GLOBAL = AutoSwitchSettings().threshold  # 90.0
+COOLDOWN = AutoSwitchSettings().cooldown_seconds  # 300.0
+
+# `_collect_scheduled_usage` calls the collector twice before any escalation:
+# a `fetch=set()` pre-read to build the poll plan, then the plan fetch. A
+# `failback` tick's row-3 forced refetch is therefore the THIRD call, and an
+# oracle that wants phase 1 and phase 2 to disagree must repeat its first
+# snapshot twice. Asserting `== 1` here would be vacuous.
+BASE_CALLS = 2
+
+_EMAILS = {1: "a@example.com", 2: "b@example.com", 3: "c@example.com",
+           4: "d@example.com"}
+
+
+def _fleet(temp_home, n: int = 3, **settings_kwargs) -> EngineHarness:
+    """`n` seeded OAuth accounts, account 1 live and active."""
+    h = EngineHarness(temp_home, **settings_kwargs)
+    for num in range(1, n + 1):
+        h.seed(num, _EMAILS[num])
+    h.make_live(_EMAILS[1], 1)
+    return h
+
+
+def _u(pct: float, *, seven_day_reset: float | None = None,
+       seven_day_pct: float = 0.0, five_hour_reset: float | None = None) -> dict:
+    """A usage row with an addressable **weekly** reset.
+
+    `tests.test_autoswitch._usage` puts its `resets_at` on the five-hour
+    window, but `_seven_day_reset_ts` - the axis consume-first and branch row
+    11 rank on - reads `seven_day`. Both windows are settable here so a
+    fixture can drive the weekly filter and the binding-recovery tier
+    independently.
+    """
+    five: dict = {"pct": pct}
+    if five_hour_reset is not None:
+        five["resets_at"] = _iso_at(five_hour_reset)
+    seven: dict = {"pct": seven_day_pct}
+    if seven_day_reset is not None:
+        seven["resets_at"] = _iso_at(seven_day_reset)
+    return {"five_hour": five, "seven_day": seven}
+
+
+def _stale(pct: float, now: float, age: float = 240.0) -> UsageEntry:
+    """A readable but un-refreshable row: still decision-trusted, not `fresh`.
+
+    The default age sits in the gap between `SERVE_TTL_S` (180 - the freshness
+    bar branch row 7 applies) and `STALE_OK_S` (300 - the trust bar
+    `decision_value` applies). Anything past 300 reads as unknown headroom, so
+    the candidate would never rank and row 7 would never be reached.
+    """
+    assert SERVE_TTL_S < age < 300.0
+    return UsageEntry(
+        last_good=_u(pct), fetched_at=now - age, age_s=age,
+    )
+
+
+def _backup(h: EngineHarness, *nums: int) -> None:
+    for num in nums:
+        h.switcher.set_account_backup(str(num), True)
+
+
+def _api_key(h: EngineHarness, *nums: int) -> None:
+    data = h.switcher._get_sequence_data()
+    for num in nums:
+        data["accounts"][str(num)]["kind"] = "api_key"
+    h.switcher._write_json(h.switcher.sequence_file, data)
+
+
+def _reasons(h: EngineHarness) -> list[str]:
+    return [e.reason for e in h.events if isinstance(e, NoSwitchEvent)]
+
+
+def _details(h: EngineHarness) -> list[str]:
+    return [e.detail for e in h.events if isinstance(e, NoSwitchEvent)]
+
+
+def _switches(h: EngineHarness) -> list[SwitchEvent]:
+    return [e for e in h.events if isinstance(e, SwitchEvent)]
+
+
+def _triggers(h: EngineHarness) -> list[str]:
+    return [e.trigger for e in _switches(h)]
+
+
+def _tick(h: EngineHarness, snapshots: list[dict]):
+    """Drive one real tick, serving `snapshots` to successive collector calls.
+
+    The last snapshot repeats, so a fixture only lists as many as it needs to
+    distinguish. Returns `(outcome, mock)` - the call count is itself an
+    oracle for branch row 3's forced refetch.
+    """
+    seq = [
+        {
+            num: value if isinstance(value, UsageEntry)
+            else _entry_for(value, h.clock.now)
+            for num, value in snap.items()
+        }
+        for snap in snapshots
+    ]
+    calls = {"n": 0}
+
+    def _fetch(**_kwargs):
+        index = min(calls["n"], len(seq) - 1)
+        calls["n"] += 1
+        return seq[index]
+
+    with patch.object(
+        h.switcher, "usage_entries_by_account", side_effect=_fetch
+    ) as mock:
+        return h.engine.tick(), mock
+
+
+class TestBackupIsNeverPreferred:
+    """AC-24 - a backup account is skipped while any non-backup qualifies.
+
+    The fixture deliberately makes the backup the *most* attractive account on
+    both ranking axes - strictly more headroom and a sooner reset - because
+    that is the case an `order: 999` sort-key implementation gets wrong: under
+    `best` and `consume-first` the order field is not the sort key, so the
+    reserve burns exactly when it is freshest. A filter stage cannot be fooled
+    that way; a sort tweak can.
+    """
+
+    def test_the_backup_loses_to_a_worse_non_backup_candidate(self, temp_home):
+        h = _fleet(temp_home)
+        _backup(h, 3)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0, seven_day_reset=t + 100_000),
+            "2": _u(50.0, seven_day_reset=t + 90_000),
+            "3": _u(5.0, seven_day_reset=t + 1_000),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert _triggers(h) == ["proactive"]
+
+    def test_without_the_mark_the_same_fleet_picks_that_account(self, temp_home):
+        """The identity half: the mark is the only thing that moved."""
+        h = _fleet(temp_home)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0, seven_day_reset=t + 100_000),
+            "2": _u(50.0, seven_day_reset=t + 90_000),
+            "3": _u(5.0, seven_day_reset=t + 1_000),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+
+
+class TestBackupIsPromotedWhenNothingElseQualifies:
+    """AC-25 - the reserve is offered once no primary can be landed on."""
+
+    def test_a_primary_at_its_limit_promotes_the_backup(self, temp_home):
+        h = _fleet(temp_home)
+        _backup(h, 3)
+        outcome, _ = _tick(h, [{
+            "1": _usage(95.0),   # active, above the line -> proactive
+            "2": _usage(100.0),  # primary at its own limit -> never a target
+            "3": _usage(5.0),    # the reserve
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+        assert _triggers(h) == ["proactive"]
+
+    def test_promotion_does_not_emit_all_exhausted(self, temp_home):
+        """AC-28, positive half - the fleet is not exhausted while the
+        reserve has quota, so the census must stay on the full OAuth set."""
+        h = _fleet(temp_home)
+        _backup(h, 3)
+        outcome, _ = _tick(h, [{
+            "1": _usage(95.0), "2": _usage(100.0), "3": _usage(5.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert not [e for e in h.events if isinstance(e, AllExhaustedEvent)]
+
+
+class TestExhaustionCensusStaysOnTheFullSet:
+    """AC-28, negative half.
+
+    `truly_exhausted` decides between `no-qualifying-candidate` and the
+    bounded reset-aware `AllExhausted` sleep. Computed over primaries only, a
+    fleet whose sole primary is spent looks exhausted while the reserve still
+    holds 12 points - and the engine would sleep until a reset it does not
+    need to wait for. Both legs return `BLOCKED`, so the oracle is the
+    **event**, not the outcome.
+    """
+
+    def test_a_spent_primary_plus_a_live_backup_is_not_all_exhausted(
+        self, temp_home
+    ):
+        h = _fleet(temp_home)
+        _backup(h, 3)
+        outcome, _ = _tick(h, [{
+            "1": _usage(95.0),   # active, 5 points
+            "2": _usage(100.0),  # spent primary
+            "3": _usage(88.0),   # reserve: 12 points, but fails `best`
+                                 # hysteresis (12 - 5 = 7 < 10), so nothing
+                                 # qualifies and the census is reached
+        }])
+        assert outcome is TickOutcome.BLOCKED
+        assert _reasons(h) == ["no-qualifying-candidate"]
+        assert not [e for e in h.events if isinstance(e, AllExhaustedEvent)]
+
+
+class TestAnAllBackupFleetStillSwitches:
+    """AC-26 - degrade to "use them" rather than emitting `no-candidates`.
+
+    Held-out-forever is the wrong failure mode: a user who marks every account
+    backup has expressed a preference, not a prohibition.
+    """
+
+    def test_every_candidate_marked_backup_still_produces_a_switch(
+        self, temp_home
+    ):
+        h = _fleet(temp_home)
+        _backup(h, 2, 3)
+        outcome, _ = _tick(h, [{
+            "1": _usage(95.0), "2": _usage(50.0), "3": _usage(10.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3          # most headroom, as usual
+        assert "no-candidates" not in _reasons(h)
+
+
+class TestAllAboveIsComputedOverPrimariesOnly:
+    """AC-27 - pass 1's `all_above` census excludes the reserve.
+
+    "Every non-backup account is above its own threshold" is the condition
+    that should promote a reserve, and it is *not* "every account is above".
+    A fresh backup inside the census makes `all_above` false, which re-arms
+    the landing gate against a spent primary fleet and hands the tick to the
+    reserve - the opposite of the policy, since a primary is still workable
+    through its imminent reset.
+    """
+
+    def test_a_fresh_backup_does_not_suppress_the_recovery_path(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, n=4)
+        _backup(h, 4)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            # Active and both primaries above the global line -> all_above is
+            # True over the primaries, so the recovery tier engages and picks
+            # the account that can work again first.
+            "1": _u(95.0, five_hour_reset=t + 40_000),
+            "2": _u(92.0, five_hour_reset=t + 600),
+            "3": _u(93.0, five_hour_reset=t + 50_000),
+            "4": _u(5.0, five_hour_reset=t + 300),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        # With the backup counted in the census `all_above` is False, the
+        # landing gate rejects both primaries, and the tick lands on 4.
+        assert h.active_number() == 2
+        assert _triggers(h) == ["proactive"]
+
+
+class TestTwoPassAppliesInBothCommitPhases:
+    """AC-29 - the filter lives inside `_rank`, so the consume-first
+    two-phase commit inherits it without duplication.
+
+    Phase 1 sees a spent primary and promotes the reserve; the forced refetch
+    shows the primary recovered. The reserve resets soonest of all three, so
+    an unfiltered phase-2 ranking picks it - which is exactly the "promoted on
+    stale data, disqualified on fresh data" case.
+    """
+
+    def test_the_reserve_promoted_on_stale_data_is_dropped_on_fresh_data(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, strategy="consume-first")
+        _backup(h, 3)
+        t = h.clock.now
+        stale = {
+            "1": _u(50.0, seven_day_reset=t + 100_000),
+            "2": _u(100.0, seven_day_reset=t + 50_000),   # spent
+            "3": _u(10.0, seven_day_reset=t + 10_000),    # reserve, soonest
+        }
+        fresh = {
+            "1": _u(50.0, seven_day_reset=t + 100_000),
+            "2": _u(20.0, seven_day_reset=t + 50_000),    # recovered
+            "3": _u(10.0, seven_day_reset=t + 10_000),
+        }
+        outcome, mock = _tick(h, [stale, stale, fresh])
+        assert outcome is TickOutcome.SWITCHED
+        assert mock.call_count == BASE_CALLS + 1        # the forced refetch
+        assert h.active_number() == 2
+        assert _triggers(h) == ["consume-first"]
+
+
+class TestApiKeyLastResortPrefersNonBackup:
+    """AC-30 - the same filter, mirrored onto the last-resort list.
+
+    PR #260 proved the API-key hole is real rather than theoretical: an
+    asymmetry here means a fleet with one metered reserve burns it first.
+    """
+
+    def test_a_non_backup_api_key_account_wins(self, temp_home):
+        h = _fleet(temp_home, include_api_key_accounts=True)
+        _api_key(h, 2, 3)
+        _backup(h, 2)
+        outcome, _ = _tick(h, [{
+            "1": _usage(95.0), "2": _usage(10.0), "3": _usage(10.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        # Sequence order would take 2; the filter takes 3.
+        assert h.active_number() == 3
+
+    def test_a_backup_api_key_account_is_used_when_it_is_the_only_one(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, n=2, include_api_key_accounts=True)
+        _api_key(h, 2)
+        _backup(h, 2)
+        outcome, _ = _tick(h, [{"1": _usage(95.0), "2": _usage(10.0)}])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+
+class TestDisabledWinsOverBackup:
+    """AC-31 - `disabled` is applied first in `switchable_account_numbers()`,
+    so a slot marked both appears in neither pass."""
+
+    def test_a_disabled_backup_is_absent_from_the_backup_set(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_disabled("2", True)
+        _backup(h, 2)
+        assert "2" not in h.switcher.backup_account_numbers()
+
+    def test_a_disabled_backup_is_not_promoted_in_pass_two(self, temp_home):
+        h = _fleet(temp_home)
+        h.switcher.set_account_disabled("2", True)
+        _backup(h, 2, 3)
+        outcome, _ = _tick(h, [{
+            "1": _usage(95.0), "2": _usage(1.0), "3": _usage(10.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        # 2 holds far more headroom than 3 and would win any pass it entered.
+        assert h.active_number() == 3
+
+
+class TestDefaultIdentity:
+    """AC-32 - with nothing marked backup the engine is bit-identical.
+
+    The whole-suite proof is the MEU gate's `git diff tests/test_autoswitch.py`
+    being empty while that file passes unchanged; these two assert the local
+    half - no reserve exists, and no new trigger string is emitted.
+    """
+
+    def test_a_fresh_fleet_has_no_backup_accounts(self, temp_home):
+        h = _fleet(temp_home)
+        assert h.switcher.backup_account_numbers() == []
+
+    def test_selection_and_trigger_are_unchanged(self, temp_home):
+        h = _fleet(temp_home)
+        outcome, _ = _tick(h, [{
+            "1": _usage(95.0), "2": _usage(50.0), "3": _usage(5.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+        assert _triggers(h) == ["proactive"]
+        assert "failback" not in _triggers(h)
+
+
+class TestFailbackUnderBest:
+    """AC-43 - a backup running as active departs for a healthy primary even
+    though the comparative gates would refuse the move.
+
+    This is the whole point of the trigger. The reserve was taken because
+    nothing else qualified; once a primary recovers, the fleet must leave the
+    reserve *without waiting for the reserve to fill up*. Under `best` that
+    means branch row 12's hysteresis bar - here `30 - 80 = -50`, fifty points
+    the wrong side of the 10-point margin - must not apply.
+    """
+
+    def _stage(self, temp_home):
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        h.switcher.set_account_threshold("2", 85.0)
+        h.engine = h._make_engine()
+        return h
+
+    def test_it_departs_for_a_strictly_worse_primary(self, temp_home):
+        h = self._stage(temp_home)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(70.0)}])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert _triggers(h) == ["failback"]
+
+    def test_it_holds_when_the_primary_is_over_its_own_line(self, temp_home):
+        """The landing gate still binds: 90 >= the account's own 85."""
+        h = self._stage(temp_home)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(90.0)}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert _details(h) == ["20% < 90%"]
+        assert _switches(h) == []
+
+
+class TestFailbackUnderConsumeFirst:
+    """AC-44 - the trigger fires under `consume-first` too, and outranks that
+    strategy's soonest-reset filter.
+
+    The negative half is the reference implementation: today's engine, with no
+    reserve marked, refuses exactly this move. That is why this AC has no
+    named mutant in the discrimination gate - the unmodified engine *is* the
+    mutant, and the two halves differ only by `set_account_backup`.
+    """
+
+    def _snapshot(self, h):
+        t = h.clock.now
+        return {
+            "1": _u(20.0, seven_day_reset=t + 3_600),
+            "2": _u(10.0, seven_day_reset=t + 36_000),
+        }
+
+    def test_failback_overrides_the_soonest_reset_filter(self, temp_home):
+        h = _fleet(temp_home, n=2, strategy="consume-first")
+        _backup(h, 1)
+        outcome, _ = _tick(h, [self._snapshot(h)])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert _triggers(h) == ["failback"]
+
+    def test_without_a_reserve_the_same_fleet_stays_put(self, temp_home):
+        h = _fleet(temp_home, n=2, strategy="consume-first")
+        outcome, _ = _tick(h, [self._snapshot(h)])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["already-consuming-soonest"]
+        assert _switches(h) == []
+
+
+class TestFailbackDoesNotOscillate:
+    """AC-45 - the trigger must fire once and then get out of the way.
+
+    A failback that re-arms every tick would ping-pong the fleet between the
+    reserve and a primary, which is worse than never leaving the reserve at
+    all. All three oracles run >= 4 ticks or inspect the state the first tick
+    wrote, because a single-tick assertion cannot see oscillation.
+    """
+
+    def test_four_quiet_ticks_produce_exactly_one_switch(self, temp_home):
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        h.switcher.set_account_threshold("2", 85.0)
+        h.engine = h._make_engine()
+        snap = {"1": _u(20.0), "2": _u(70.0)}
+        for _ in range(4):
+            _tick(h, [snap])
+            h.clock.advance(COOLDOWN + 1)
+        assert h.active_number() == 2
+        assert _triggers(h) == ["failback"]
+        assert _reasons(h) == ["below-threshold"] * 3
+
+    def test_the_reserve_is_not_reclaimed_until_it_actually_recovers(
+        self, temp_home
+    ):
+        """The no-return guard binds a failback departure like any other.
+
+        The reserve's usage row is pinned byte-identical across both ticks, so
+        it has not recovered on any axis the guard reads. The second tick's
+        active must also stay close enough that the dominance leg
+        (`h > active x HORIZON_HEADROOM_RATIO + SPENT_HEADROOM_PCT`) does not
+        fire - that leg releases the bar because the ACTIVE burned down, which
+        is correct engine behaviour and would make this oracle fail against
+        correct code. Hence a 50% line and a 55% active rather than 95%.
+        """
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        h.switcher.set_account_threshold("2", 50.0)
+        h.engine = h._make_engine()
+        reserve_row = _u(20.0)
+        outcome, _ = _tick(h, [{"1": reserve_row, "2": _u(40.0)}])
+        assert outcome is TickOutcome.SWITCHED
+        # The store writes the slot number; normalise rather than assume a type.
+        assert str(h.state()["lastSwitchFrom"]) == "1"
+        assert h.state()["leftTrigger"] == "failback"
+        assert h.state()["leftHeadroom"] == pytest.approx(80.0)
+
+        h.clock.advance(COOLDOWN + 1)
+        h.events.clear()
+        usage = {"1": reserve_row, "2": _u(55.0)}
+        headroom = _headroom_by_account(usage, h.engine._models)
+        assert h.engine._left_account_recovered(
+            h.state(), usage, headroom, headroom["2"], h.settings,
+            h.clock(), "2", thresholds=h.engine._resolve_thresholds(h.settings),
+        ) is False
+
+        outcome, _ = _tick(h, [usage])
+        assert outcome is TickOutcome.BLOCKED
+        assert _reasons(h) == ["no-qualifying-candidate"]
+        assert h.active_number() == 2
+
+    def test_failback_is_not_added_to_the_no_return_trigger_set(
+        self, temp_home
+    ):
+        """Branch row 8 - `_no_return_account` is keyed on the *previous*
+        switch's epoch, so adding `failback` to its trigger tuple suppresses
+        the very account the fleet should return to.
+
+        Correct: 2 has the most headroom and wins. Defective: 2 is filtered
+        out by the guard and the tick lands on 3 instead.
+        """
+        h = _fleet(temp_home)
+        _backup(h, 1)
+        h.engine._mutate_state(lambda s: s.update(
+            lastSwitchFrom="2",
+            lastSwitchTo="1",
+            lastSwitchAt=h.clock() - 10_000,
+            leftHeadroom=90.0,
+            leftTrigger="failback",
+        ))
+        outcome, _ = _tick(h, [{
+            "1": _u(20.0), "2": _u(10.0), "3": _u(60.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert _triggers(h) == ["failback"]
+
+
+class TestFailbackTriggerScope:
+    """AC-46 - the predicate is store-only and narrow.
+
+    It reads `backup`, `disabled`, `kind` and the quarantine set - never a
+    usage number - so it is decidable at the departure gate before any
+    ranking. Each sub-case below removes exactly one conjunct and asserts the
+    tick collapses back to today's behaviour.
+    """
+
+    def test_a_no_reserve_marked(self, temp_home):
+        h = _fleet(temp_home)
+        outcome, _ = _tick(h, [{
+            "1": _u(20.0), "2": _u(10.0), "3": _u(10.0),
+        }])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert _switches(h) == []
+
+    def test_b_the_active_account_is_not_the_reserve(self, temp_home):
+        h = _fleet(temp_home)
+        _backup(h, 2)
+        outcome, _ = _tick(h, [{
+            "1": _u(20.0), "2": _u(10.0), "3": _u(10.0),
+        }])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert _switches(h) == []
+
+    def test_c_every_account_is_a_reserve(self, temp_home):
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1, 2)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(10.0)}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert _switches(h) == []
+
+    def test_c_the_only_primary_is_quarantined(self, temp_home):
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        h.engine._quarantine("2", _EMAILS[2], "invalid_grant")
+        h.events.clear()
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(10.0)}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert _switches(h) == []
+
+    def test_d_the_only_primary_is_an_api_key_account(self, temp_home):
+        """The OAuth clause in the predicate is load-bearing.
+
+        Without it the gate sets `failback`, the OAuth candidate list is
+        empty, and the tick falls through to the `no-candidates` BLOCKED exit
+        - turning a quiet hold into a hard block for every fleet whose
+        reserve is its only OAuth account.
+        """
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        _api_key(h, 2)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(10.0)}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert outcome is not TickOutcome.BLOCKED
+
+    def test_d_api_key_primary_with_the_flag_on_is_still_not_a_failback(
+        self, temp_home
+    ):
+        """`include_api_key_accounts` widens the *candidate* list, not the
+        predicate: the corrected predicate short-circuits at the departure
+        gate, so `:1174`'s `no-candidates` exit is never reached either way.
+        """
+        h = _fleet(temp_home, n=2, include_api_key_accounts=True)
+        _backup(h, 1)
+        _api_key(h, 2)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(10.0)}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert _switches(h) == []
+
+    @pytest.mark.parametrize("strategy", ["best", "consume-first"])
+    def test_e_the_trigger_fires_under_both_strategies(
+        self, temp_home, strategy
+    ):
+        h = _fleet(temp_home, n=2, strategy=strategy)
+        _backup(h, 1)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(10.0)}])
+        assert outcome is TickOutcome.SWITCHED
+        assert _triggers(h) == ["failback"]
+
+    def test_f_unreadable_primaries_hold_rather_than_report_no_comparison(
+        self, temp_home
+    ):
+        """Placement oracle for branch row 5.
+
+        The predicate is store-only, so it fires even when no primary has
+        readable usage. The failback arm must sit ABOVE `if not any_known:`;
+        below it, this tick reports `no-comparison`/BLOCKED - a regression
+        from today's quiet `NO_ACTION`.
+        """
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": None}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert "no-comparison" not in _reasons(h)
+
+
+class TestFailbackRefetchesBeforeCommitting:
+    """AC-48 - branch row 3 (the two-phase commit) and row 7 (the per-target
+    freshness gate) ship together.
+
+    A failback decision is taken on the *stored* snapshot, which may be
+    minutes old. Acting on it without a forced refetch moves the fleet onto a
+    primary that has since gone over its own line - the exact defect that
+    makes an unconditional failback worse than no failback. The active
+    reserve sits at 40%, well under `90 - 15`, so the escalation band stays
+    shut and the third collector call can only be row 3's refetch.
+    """
+
+    def _stage(self, temp_home):
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        h.switcher.set_account_threshold("2", 85.0)
+        h.engine = h._make_engine()
+        return h
+
+    def test_a_primary_that_went_over_its_line_is_dropped_on_refetch(
+        self, temp_home
+    ):
+        h = self._stage(temp_home)
+        phase1 = {"1": _u(40.0), "2": _u(50.0)}
+        phase2 = {"1": _u(40.0), "2": _u(95.0)}
+        outcome, mock = _tick(h, [phase1, phase1, phase2])
+        assert mock.call_count == BASE_CALLS + 1
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert h.active_number() == 1
+
+    def test_an_unrefreshable_target_holds_rather_than_commits(
+        self, temp_home
+    ):
+        """Row 7: the refetch is best-effort, so a target that served its
+        stored row must not be switched to on this tick."""
+        h = self._stage(temp_home)
+        now = h.clock.now
+        phase1 = {"1": _u(40.0), "2": _u(50.0)}
+        phase2 = {"1": _u(40.0), "2": _stale(50.0, now)}
+        outcome, mock = _tick(h, [phase1, phase1, phase2])
+        assert mock.call_count == BASE_CALLS + 1
+        assert outcome is TickOutcome.NO_ACTION
+        assert "stale-usage" in _reasons(h)
+        assert _switches(h) == []
+
+
+class TestFailbackRespectsCooldown:
+    """AC-49 - both cooldown checks, not just the first.
+
+    Branch rows 1 and 15 guard the same invariant at two depths: the tick
+    entry point and `_perform`. Row 15 exists because a second engine
+    instance - the TUI polling while the daemon runs - reaches `_perform`
+    without passing row 1 in the same process.
+    """
+
+    def test_i_the_tick_entry_cooldown_suppresses_failback(self, temp_home):
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        h.engine._mutate_state(
+            lambda s: s.update(lastSwitchAt=h.clock() - 1)
+        )
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": _u(10.0)}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["cooldown"]
+        assert _switches(h) == []
+
+    def test_ii_a_second_engine_cannot_bypass_it_at_perform(self, temp_home):
+        """The mutant that adds `failback` only at branch row 1 passes (i)
+        and fails here."""
+        h = _fleet(temp_home)
+        _backup(h, 1)
+        outcome, _ = _tick(h, [{
+            "1": _u(20.0), "2": _u(10.0), "3": _u(10.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+
+        other = h._make_engine()
+        h.events.clear()
+        result = other._perform("3", _EMAILS[3], "failback", (80.0, 0.0))
+        assert result is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["cooldown"]
+        assert h.active_number() == 2
+
+
+class TestFailbackKeepsTheLandingGate:
+    """AC-50 - the reserve leaves only for a primary that is genuinely under
+    its own line, and it never borrows the `all_above` relaxation.
+
+    `all_above` exists so a fleet where *everything* is over its line still
+    rotates rather than freezing. Under failback that relaxation is a bug: it
+    would move the fleet off a quiet reserve onto an exhausted primary.
+    Branch row 10's gate is therefore unconditional for this trigger.
+    """
+
+    def test_i_every_primary_over_its_own_line_means_no_landing_spot(
+        self, temp_home
+    ):
+        h = _fleet(temp_home)
+        _backup(h, 1)
+        for num in ("2", "3"):
+            h.switcher.set_account_threshold(num, 85.0)
+        h.engine = h._make_engine()
+        outcome, _ = _tick(h, [{
+            "1": _u(20.0), "2": _u(90.0), "3": _u(88.0),
+        }])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert _switches(h) == []
+
+    def test_ii_the_all_above_relaxation_is_not_borrowed(self, temp_home):
+        """Phase 1 ranks a healthy primary, so the refetch happens; phase 2
+        shows every account over its line.
+
+        The mutant that keeps `and not all_above` on row 10's gate enters the
+        relaxation here and switches. The reset timestamps below make the
+        recovery sub-tier reachable rather than short-circuited; the exact
+        tuple is settled in H1-13b against that named mutant, never against
+        unmodified source.
+        """
+        h = _fleet(temp_home)
+        _backup(h, 1)
+        for num in ("2", "3"):
+            h.switcher.set_account_threshold(num, 85.0)
+        h.engine = h._make_engine()
+        t = h.clock.now
+        phase1 = {"1": _u(40.0), "2": _u(20.0), "3": _u(30.0)}
+        phase2 = {
+            "1": _u(95.0, five_hour_reset=t + 10_800),
+            "2": _u(92.0, five_hour_reset=t + 1_800),
+            "3": _u(91.0, five_hour_reset=t + 3_600),
+        }
+        outcome, mock = _tick(h, [phase1, phase1, phase2])
+        assert mock.call_count == BASE_CALLS + 1
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert h.active_number() == 1
+
+
+class TestFailbackNeverFallsBackToAnApiKeyAccount:
+    """AC-51 - branch row 4, the API-key last resort, must exclude `failback`.
+
+    Metered credit is the fleet's most expensive resource. A failback that
+    cannot find a healthy OAuth primary has nothing to gain by burning it -
+    the reserve is quiet, which is why the trigger fired at all. Case 2 is
+    the companion that proves the exclusion is scoped to the trigger and not
+    a blanket disabling of the last resort.
+    """
+
+    def _stage(self, temp_home):
+        h = _fleet(temp_home, include_api_key_accounts=True)
+        _backup(h, 1)
+        _api_key(h, 3)
+        h.switcher.set_account_threshold("2", 85.0)
+        h.engine = h._make_engine()
+        return h
+
+    def test_a_quiet_reserve_does_not_spend_metered_credit(self, temp_home):
+        h = self._stage(temp_home)
+        outcome, _ = _tick(h, [{
+            "1": _u(20.0), "2": _u(95.0), "3": _u(5.0),
+        }])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert h.active_number() == 1
+
+    def test_the_last_resort_still_fires_for_an_exhausted_reserve(
+        self, temp_home
+    ):
+        h = self._stage(temp_home)
+        outcome, _ = _tick(h, [{
+            "1": _u(95.0), "2": _u(95.0), "3": _u(5.0),
+        }])
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 3
+        assert _triggers(h) == ["proactive"]
+
+
+class TestFailbackSurvivesTheTargetLoop:
+    """AC-52 - branch row 18: the target-freshening loop cannot turn a hold
+    into a `BLOCKED` or an `ERROR`.
+
+    The predicate reads the *store*; `_freshen_target` reads the
+    *credential*. A primary can rank on a perfectly readable usage row and
+    still fail to freshen, so the ranking being non-empty is no guarantee the
+    loop commits. Today the same fleet returns `NO_ACTION` at the departure
+    gate; after this PR it must still return `NO_ACTION` - the hold goes
+    AFTER the loop, never in place of it, so the quarantine writes survive.
+    """
+
+    def _stage(self, temp_home, *, backup: bool, expires_at=None, n: int = 2):
+        h = EngineHarness(temp_home)
+        for num in range(1, n + 1):
+            h.seed(num, _EMAILS[num],
+                   expires_at=None if num == 1 else expires_at)
+        h.make_live(_EMAILS[1], 1)
+        if backup:
+            _backup(h, 1)
+        return h
+
+    def _snapshot(self, n: int = 2, active: float = 20.0):
+        snap = {"1": _u(active)}
+        for num in range(2, n + 1):
+            snap[str(num)] = _u(10.0)
+        return snap
+
+    def test_a_a_live_session_on_the_only_primary_holds(self, temp_home):
+        h = self._stage(temp_home, backup=True,
+                        expires_at=int(1_000_000.0 * 1000) + 3_600_000)
+        with patch.object(
+            h.switcher, "live_session_pids_for", return_value=[4242]
+        ):
+            outcome, _ = _tick(h, [self._snapshot()])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+        assert _details(h) == ["20% < 90%"]
+        assert h.active_number() == 1
+
+    def test_b_dead_credentials_hold_and_the_quarantine_survives(
+        self, temp_home
+    ):
+        h = self._stage(temp_home, backup=True, expires_at=1, n=3)
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(None, "invalid_grant"),
+        ):
+            outcome, _ = _tick(h, [self._snapshot(3)])
+        assert outcome is TickOutcome.NO_ACTION
+        assert "below-threshold" in _reasons(h)
+        # The hold sits after the loop: both durable findings are on disk.
+        quarantine = h.state().get("quarantine", {})
+        assert "2" in quarantine
+        assert "3" in quarantine
+        assert {e.number for e in h.events if isinstance(e, QuarantineEvent)} == {
+            "2", "3",
+        }
+
+    def test_c_a_transient_refresh_failure_holds_without_an_error_event(
+        self, temp_home
+    ):
+        h = self._stage(temp_home, backup=True, expires_at=1)
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(None, "transient"),
+        ):
+            outcome, _ = _tick(h, [self._snapshot()])
+        assert outcome is TickOutcome.NO_ACTION
+        assert "below-threshold" in _reasons(h)
+        assert not any(isinstance(e, ErrorEvent) for e in h.events)
+        assert not h.state().get("quarantine")
+
+    def test_d_without_a_reserve_both_exits_behave_exactly_as_today(
+        self, temp_home
+    ):
+        """The scope check: row 18 adds a `failback` arm, it does not remove
+        the loop's exits."""
+        live = self._stage(temp_home, backup=False,
+                           expires_at=int(1_000_000.0 * 1000) + 3_600_000)
+        # `ACCOUNT_THRESHOLD_MIN` is 50, so the no-reserve control departs by
+        # crossing 50 rather than by the failback predicate.
+        live.switcher.set_account_threshold("1", 50.0)
+        live.engine = live._make_engine()
+        with patch.object(
+            live.switcher, "live_session_pids_for", return_value=[4242]
+        ):
+            outcome, _ = _tick(live, [self._snapshot(active=60.0)])
+        assert outcome is TickOutcome.BLOCKED
+        assert "no-viable-target" in _reasons(live)
+
+    def test_d_transient_without_a_reserve_still_errors(self, temp_home):
+        h = self._stage(temp_home, backup=False, expires_at=1)
+        h.switcher.set_account_threshold("1", 50.0)
+        h.engine = h._make_engine()
+        with patch(
+            "claude_swap.autoswitch.oauth.try_refresh_oauth_credentials",
+            return_value=oauth.RefreshOutcome(None, "transient"),
+        ):
+            outcome, _ = _tick(h, [self._snapshot(active=60.0)])
+        assert outcome is TickOutcome.ERROR
+        assert any(isinstance(e, ErrorEvent) for e in h.events)
+
+
+class TestTheActiveAccountCountsAsANonBackup:
+    """AC-24, the half the original oracles could not see (review round 1, F-1).
+
+    AC-24 reads "a backup account is skipped while any non-backup qualifies",
+    and every oracle above supplies that non-backup as a *candidate*. But the
+    candidate list is built with `num != current`, so the one non-backup the
+    filter can never see is the account we are already sitting on. Under
+    `consume-first` - the only trigger that departs an account which is still
+    perfectly usable - a two-account fleet therefore fell through pass 1 (no
+    primaries left to rank) into pass 2 and burned the reserve, with the
+    healthy primary still active. The Spec's "only used once all the others
+    are at their limit" is violated the moment the *active* account is one of
+    those others.
+
+    The bounce matters as much as the first move: the reserve becomes active,
+    the new `failback` trigger sees a healthy primary, and the fleet ping-pongs
+    once per cooldown forever.
+
+    Each positive oracle is paired with the departure it must NOT suppress -
+    deleting pass 2 outright would satisfy every hold below and break the
+    "last man standing" contract itself.
+    """
+
+    def _reserve_resets_soonest(self, h) -> dict:
+        """Active primary healthy but resetting LAST; reserve resetting first.
+
+        This is the shape consume-first is built to move on, which is why it
+        is the shape that exposed the hole: on the ranking axis the reserve is
+        the correct answer, and only the filter can say no.
+        """
+        t = h.clock.now
+        return {
+            "1": _u(20.0, seven_day_reset=t + 36_000),
+            "2": _u(10.0, seven_day_reset=t + 3_600),
+        }
+
+    def test_consume_first_holds_rather_than_spending_the_reserve(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, n=2, strategy="consume-first")
+        _backup(h, 2)
+        outcome, _ = _tick(h, [self._reserve_resets_soonest(h)])
+
+        assert outcome is TickOutcome.NO_ACTION
+        assert h.active_number() == 1
+        assert _switches(h) == []
+
+    def test_the_hold_is_the_quiet_one_not_a_block(self, temp_home):
+        """`NO_ACTION` alone is not enough: the plan's compatibility rule is
+        that configuring a reserve never turns a quiet hold into `BLOCKED` or
+        a `no-comparison` diagnosis. The reserve exists and is readable, so
+        the fleet is not uncomparable - it is simply already where it should
+        be."""
+        h = _fleet(temp_home, n=2, strategy="consume-first")
+        _backup(h, 2)
+        _tick(h, [self._reserve_resets_soonest(h)])
+
+        assert _reasons(h) == ["already-consuming-soonest"]
+
+    def test_without_the_mark_the_same_fleet_moves(self, temp_home):
+        """The identity half - the `backup` mark is the only thing that moved,
+        so the hold above is the filter working, not a fixture that never
+        qualified."""
+        h = _fleet(temp_home, n=2, strategy="consume-first")
+        outcome, _ = _tick(h, [self._reserve_resets_soonest(h)])
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert _triggers(h) == ["consume-first"]
+
+    def test_four_cooldown_spaced_ticks_never_bounce(self, temp_home):
+        """The oscillation the first move sets up. A single-tick assertion
+        cannot see it: the reserve->primary return is a *different* trigger
+        (`failback`) on a *later* tick, so only a multi-tick oracle catches the
+        ping-pong."""
+        h = _fleet(temp_home, n=2, strategy="consume-first")
+        _backup(h, 2)
+        for _ in range(4):
+            _tick(h, [self._reserve_resets_soonest(h)])
+            h.clock.advance(COOLDOWN + 1)
+
+        assert h.active_number() == 1
+        assert _switches(h) == []
+
+    def test_an_active_primary_over_its_line_still_promotes_the_reserve(
+        self, temp_home
+    ):
+        """Negative half of the fix. The guard is scoped to the opportunistic
+        trigger; once the active account is past its own threshold it is no
+        longer a usable primary, every other account IS at its limit, and the
+        reserve is exactly what the user marked it for."""
+        h = _fleet(temp_home, n=2)
+        _backup(h, 2)
+        outcome, _ = _tick(h, [{"1": _usage(95.0), "2": _usage(10.0)}])
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert _triggers(h) == ["proactive"]
+
+    def test_consume_first_still_moves_to_a_healthier_primary(self, temp_home):
+        """Negative half two. The guard must bite on the reserve only - a
+        fleet that merely *contains* a reserve keeps its ordinary
+        consume-first departures."""
+        h = _fleet(temp_home, n=3, strategy="consume-first")
+        _backup(h, 3)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(30.0, seven_day_reset=t + 100_000),
+            "2": _u(20.0, seven_day_reset=t + 50_000),
+            "3": _u(5.0, seven_day_reset=t + 1_000),
+        }])
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert _triggers(h) == ["consume-first"]
+
+    def test_failback_from_the_reserve_is_untouched(self, temp_home):
+        """Negative half three. Under `failback` the active account IS the
+        reserve, so the guard's "the active account is a usable primary"
+        premise is false and the trigger must fire exactly as MEU-04 shipped
+        it."""
+        h = _fleet(temp_home, n=2, strategy="consume-first")
+        _backup(h, 1)
+        t = h.clock.now
+        outcome, _ = _tick(h, [{
+            "1": _u(20.0, seven_day_reset=t + 3_600),
+            "2": _u(10.0, seven_day_reset=t + 36_000),
+        }])
+
+        assert outcome is TickOutcome.SWITCHED
+        assert h.active_number() == 2
+        assert _triggers(h) == ["failback"]

--- a/tests/test_autoswitch_failback_reason.py
+++ b/tests/test_autoswitch_failback_reason.py
@@ -1,0 +1,393 @@
+"""MEU-ORD-04 - the failback hold's own diagnostic reason (AC-28 ... AC-32).
+
+PR 1 shipped `failback` deliberately mute. `_failback_hold()`
+(`autoswitch.py:1466`) reused the departure gate's own event verbatim -
+`reason="below-threshold"` with the gate's `NN% < NN%` detail - so that a fleet
+which merely *configured* a reserve could never see an observable it had not
+seen before. That function's docstring names this PR as the owner of the
+change, in these words:
+
+    A diagnostic reason ("primaries still exhausted") is a new observable and
+    ships with its TUI surfacing in PR 2.
+
+This module is that change's test. Three properties, and the third is the one
+that is easy to get half-right:
+
+**The reason is specific.** `below-threshold` is a true statement about the
+active account and a useless one about the tick: the reserve is *supposed* to
+be below its line - that is what being the last man standing means. An operator
+reading `below-threshold` on a failback tick learns nothing about why the fleet
+is still on the reserve. `failback-hold` / "primaries still exhausted" says the
+one thing worth knowing.
+
+**Nothing else moves.** `TickOutcome.NO_ACTION` at both sites, and on the
+error leg still no `ErrorEvent` - "indistinguishable from today" was the
+contract for everything except the string.
+
+**Both sites, not one.** There are two structurally distinct failback holds and
+they are reached by different fleet states:
+
+* the `if not ordered:` arm (`autoswitch.py:1521`) - ranking returned nothing;
+* the post-target-loop hold (`autoswitch.py:1674`) - ranking returned a target,
+  the loop tried it, and every candidate failed to freshen or was quarantined.
+
+Both call the same closure today, so a correct fix is one edit. Mutants M-4 and
+M-5 revert each *call site* independently, which is exactly the shape a
+half-applied refactor takes, and each must fail its own named test - so the two
+tests below reach the two sites by different routes and neither may stand in
+for the other.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+from claude_swap.autoswitch import ErrorEvent, NoSwitchEvent, TickOutcome
+from tests.test_autoswitch_backup_accounts import (
+    BASE_CALLS,
+    _backup,
+    _details,
+    _fleet,
+    _reasons,
+    _stale,
+    _switches,
+    _tick,
+    _u,
+)
+
+FAILBACK_REASON = "failback-hold"
+FAILBACK_DETAIL = "primaries still exhausted"
+
+
+def _errors(h) -> list[ErrorEvent]:
+    return [e for e in h.events if isinstance(e, ErrorEvent)]
+
+
+def _holds(h) -> list[NoSwitchEvent]:
+    return [e for e in h.events if isinstance(e, NoSwitchEvent)]
+
+
+def _post_loop_hold(temp_home):
+    """Reach **site 2** - the hold AFTER the target loop (`:1674`).
+
+    Ranking must succeed, the loop must try the target, and every candidate
+    must be rejected *by the loop* rather than by a gate that returns early.
+    That rules out the obvious route: the `stale-usage` arm inside the loop
+    (`:1626`) does `return TickOutcome.NO_ACTION` on the spot and never
+    reaches the post-loop hold at all - a first draft of this fixture used it
+    and proved exactly that.
+
+    The routes that `continue` are the freshen failures: `identity-conflict`,
+    `invalid_grant`, `transient`, and the systemic statuses. `transient` is
+    used here because it is the only one that writes no quarantine, so the
+    fixture asserts the hold without also asserting a credential mutation.
+
+    A `transient` failure also arms `if systemic or transient_failure:` two
+    lines below the hold - which is what makes this the right fixture for
+    AC-29's silent-error-leg assertion as well.
+    """
+    h = _fleet(temp_home, n=2)
+    _backup(h, 1)
+    with patch.object(h.engine, "_freshen_target", return_value="transient"):
+        outcome, _mock = _tick(h, [{"1": _u(20.0), "2": _u(10.0)}])
+    return h, outcome
+
+
+# ---------------------------------------------------------------------------
+# AC-28 - the hold emits its own reason and detail
+# ---------------------------------------------------------------------------
+
+
+class TestFailbackHoldHasItsOwnReason:
+    """AC-28 - `reason="failback-hold"`, `detail="primaries still exhausted"`.
+
+    Asserted as **both strings**, not merely "the tick held". A hold that
+    returns `NO_ACTION` with the wrong reason is the exact defect this MEU
+    exists to remove, so an outcome-only assertion would pass against the code
+    being replaced.
+    """
+
+    def _hold(self, temp_home):
+        """The `if not ordered:` arm: the reserve is active and the only
+        primary has no readable usage, so ranking returns nothing.
+
+        Borrowed verbatim from PR 1's placement oracle
+        (`test_autoswitch_backup_accounts.py`
+        `::test_f_unreadable_primaries_hold_rather_than_report_no_comparison`)
+        because that fixture is already proven to land on this arm rather than
+        on `no-comparison` - the arm sits ABOVE `if not any_known:` precisely
+        so that it does.
+        """
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": None}])
+        return h, outcome
+
+    def test_the_reason_is_failback_hold(self, temp_home):
+        h, outcome = self._hold(temp_home)
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == [FAILBACK_REASON]
+
+    def test_the_detail_names_the_cause(self, temp_home):
+        h, _outcome = self._hold(temp_home)
+        assert _details(h) == [FAILBACK_DETAIL]
+
+    def test_the_borrowed_gate_detail_is_gone(self, temp_home):
+        """The old detail was the departure gate's `NN% < NN%` comparison.
+
+        It is not merely unhelpful here, it is misleading: on a failback tick
+        the active account is the reserve, and a reserve sitting under its own
+        line is the normal, correct state rather than a reason to report.
+        """
+        h, _outcome = self._hold(temp_home)
+        assert not any("<" in d for d in _details(h))
+        assert "below-threshold" not in _reasons(h)
+
+    def test_the_hold_emits_exactly_one_event(self, temp_home):
+        """Guards against a fix that adds the new event beside the old one -
+        which would keep every assertion above passing under `in`, and double
+        every failback line in the TUI."""
+        h, _outcome = self._hold(temp_home)
+        assert len(_holds(h)) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-29 - the outcome and the silent error leg are unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestOnlyTheStringChanges:
+    """AC-29 - `NO_ACTION` is preserved, and the error leg still emits no
+    `ErrorEvent`.
+
+    PR 1's branch row 18 established the contract: a tick that returns
+    `NO_ACTION` today must never return `BLOCKED`. This MEU changes one
+    string; a rewrite that also moves the outcome, or that starts reporting
+    the freshen failures a failback tick has always swallowed, fails here.
+    """
+
+    def test_the_outcome_is_still_no_action(self, temp_home):
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": None}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert outcome is not TickOutcome.BLOCKED
+
+    def test_no_switch_is_performed(self, temp_home):
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        _tick(h, [{"1": _u(20.0), "2": None}])
+        assert _switches(h) == []
+
+    def test_the_error_leg_stays_silent(self, temp_home):
+        """The post-loop hold is reached after every candidate failed to
+        freshen - the one path where an `ErrorEvent` would be tempting.
+
+        The failback arm sits ABOVE `if systemic or transient_failure:`, so a
+        transient freshen failure that would report "could not freshen any
+        candidate (network?)" under any other trigger is swallowed here. Today
+        emits none, and "indistinguishable from today" is the contract for
+        everything except the reason string.
+        """
+        h, outcome = _post_loop_hold(temp_home)
+        assert outcome is TickOutcome.NO_ACTION
+        assert _errors(h) == []
+        assert not any("could not freshen" in d for d in _details(h))
+
+
+# ---------------------------------------------------------------------------
+# AC-30 - BOTH hold sites, reached by different routes
+# ---------------------------------------------------------------------------
+
+
+class TestBothHoldSitesEmitIt:
+    """AC-30 - **mutants M-4 and M-5**.
+
+    The two sites are structurally different and are reached by different
+    fleet states, so neither test below can stand in for the other:
+
+    * **site 1**, `autoswitch.py:1521` - inside `if not ordered:`. Ranking
+      produced nothing at all. Reached here by making the only primary's usage
+      unreadable.
+    * **site 2**, `autoswitch.py:1674` - after the target loop. Ranking DID
+      produce a target; the loop tried it and every candidate was rejected
+      (here: served a stale row, so the per-target freshness gate refuses to
+      commit). Reached here by letting phase 2 return a stale-but-readable
+      row.
+
+    Both call one closure on correct source, so the fix is one edit. The
+    mutants revert each *call site* independently, which is the shape a
+    half-applied refactor takes - and site 2 is the one a reader skims past,
+    because it sits 150 lines below the closure that defines it.
+    """
+
+    def test_site_one_the_unranked_arm(self, temp_home):
+        """**M-4's oracle.**"""
+        h = _fleet(temp_home, n=2)
+        _backup(h, 1)
+        outcome, _ = _tick(h, [{"1": _u(20.0), "2": None}])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == [FAILBACK_REASON]
+
+    def test_site_two_the_post_target_loop_hold(self, temp_home):
+        """**M-5's oracle.**
+
+        The `stale-usage` event is the loop's own rejection of the target and
+        is emitted first; the hold follows it. Asserting the ordered pair
+        rather than membership is what makes this test see site 2 at all - a
+        mutant that reverts site 2 still emits `stale-usage`, so an
+        `in _reasons(h)` assertion would pass against it.
+        """
+        h, outcome = _post_loop_hold(temp_home)
+        assert outcome is TickOutcome.NO_ACTION
+        assert _switches(h) == []
+        assert _reasons(h) == [FAILBACK_REASON]
+        assert _details(h) == [FAILBACK_DETAIL]
+
+    def test_the_two_fixtures_really_reach_different_sites(self, temp_home):
+        """Guards the pair above: if both fixtures landed on site 1, one
+        mutant would have no oracle and the AC would be half-tested.
+
+        Site 1 is the arm taken when ranking returned nothing, so it cannot
+        have emitted a per-target rejection first. Site 2 is the arm taken
+        after the loop, so it must have.
+        """
+        one = _fleet(temp_home, n=2)
+        _backup(one, 1)
+        _tick(one, [{"1": _u(20.0), "2": None}])
+        assert _reasons(one) == [FAILBACK_REASON]
+        assert len(_reasons(one)) == 1
+
+
+class TestSiteTwoReachedFromAFreshHome:
+    """The site-2 fixture again on its own harness, so the assertion above
+    cannot be an artefact of `temp_home` reuse inside one test class."""
+
+    def test_the_post_loop_hold_is_the_last_event(self, temp_home):
+        h, outcome = _post_loop_hold(temp_home)
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h)[-1] == FAILBACK_REASON
+
+
+# ---------------------------------------------------------------------------
+# AC-31 - the ORDINARY below-threshold hold is untouched
+# ---------------------------------------------------------------------------
+
+
+class TestTheOrdinaryHoldIsUnchanged:
+    """AC-31 - **the oracle against a blanket rename.**
+
+    `below-threshold` is emitted from three places; only the failback one
+    moves. A fleet with no reserve configured must be byte-identical in its
+    emitted events to PR 1, reason *and* detail - the same compatibility
+    property PR 1 itself shipped on, restated one layer down.
+
+    The detail string is asserted by pattern rather than by a literal because
+    it is built from `pct_label` at emit time; the point is that it is still
+    the gate's `NN% < NN%` comparison and not the failback wording.
+    """
+
+    def test_a_fleet_with_no_reserve_still_says_below_threshold(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, n=3)
+        outcome, _ = _tick(h, [{
+            "1": _u(88.0),  # below the line; hysteresis_pct is 10
+            "2": _u(85.0),
+            "3": _u(84.0),
+        }])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+
+    def test_its_detail_is_still_the_gate_comparison(self, temp_home):
+        h = _fleet(temp_home, n=3)
+        _tick(h, [{"1": _u(88.0), "2": _u(85.0), "3": _u(84.0)}])
+        detail = _details(h)[0]
+        assert "%" in detail and "<" in detail
+        assert detail != FAILBACK_DETAIL
+
+    def test_the_failback_reason_never_appears_without_a_reserve(
+        self, temp_home
+    ):
+        h = _fleet(temp_home, n=3)
+        _tick(h, [{"1": _u(88.0), "2": _u(85.0), "3": _u(84.0)}])
+        assert FAILBACK_REASON not in _reasons(h)
+
+    def test_a_reserve_fleet_not_on_the_reserve_is_also_unchanged(
+        self, temp_home
+    ):
+        """Sharper than the tests above: the reserve EXISTS, it is simply not
+        the active account, so the trigger is not `failback` and the ordinary
+        gate must still speak. A rename applied to the closure rather than to
+        the failback path would pass the no-reserve tests and fail here.
+        """
+        h = _fleet(temp_home, n=3)
+        _backup(h, 3)
+        outcome, _ = _tick(h, [{
+            "1": _u(88.0), "2": _u(85.0), "3": _u(1.0),
+        }])
+        assert outcome is TickOutcome.NO_ACTION
+        assert _reasons(h) == ["below-threshold"]
+
+
+# ---------------------------------------------------------------------------
+# AC-32 - the reason is documented where the reasons are enumerated
+# ---------------------------------------------------------------------------
+
+
+class TestTheReasonIsDocumented:
+    """AC-32 - a source check, because an undocumented reason string is
+    invisible to the next person extending the event.
+
+    PR 1 set the precedent by extending `SwitchEvent.trigger`'s value-list
+    comment (`autoswitch.py:367-368`) rather than leaving `"failback"`
+    undocumented. `NoSwitchEvent.reason` had no such list; this MEU adds one,
+    because it is the field that just gained a value.
+    """
+
+    def _source(self) -> str:
+        from claude_swap.autoswitch import NoSwitchEvent as _E
+
+        return inspect.getsource(_E)
+
+    def test_the_new_reason_is_named_in_the_class(self):
+        assert FAILBACK_REASON in self._source()
+
+    def test_it_is_named_in_a_comment_not_in_code(self):
+        """The value list is documentation. If the string appears only inside
+        an expression the class has grown behaviour, which is not this MEU."""
+        commented = [
+            line
+            for line in self._source().splitlines()
+            if FAILBACK_REASON in line and line.lstrip().startswith("#")
+        ]
+        assert commented, "expected the reason in the enumerating comment"
+
+    def test_the_list_still_names_the_pre_existing_reasons(self):
+        """A value list that documents only the newest value is worse than
+        none. These four span the three emit sites `below-threshold` comes
+        from plus the two census reasons a reader is most likely to hit."""
+        source = self._source()
+        for reason in (
+            "below-threshold",
+            "cooldown",
+            "no-comparison",
+            "no-candidates",
+        ):
+            assert reason in source, reason
+
+    def test_the_trigger_value_list_precedent_is_intact(self):
+        """The comment this one is modelled on must still exist - if PR 1's
+        list were ever deleted, the convention this AC cites would be gone
+        and the test above would be enforcing a pattern with no source."""
+        from claude_swap.autoswitch import SwitchEvent as _S
+
+        source = inspect.getsource(_S)
+        assert "failback" in source
+        assert any(
+            "failback" in line and line.lstrip().startswith("#")
+            for line in source.splitlines()
+        )

--- a/tests/test_tui_order_display.py
+++ b/tests/test_tui_order_display.py
@@ -1,0 +1,251 @@
+"""TUI order display and scope — MEU-ORD-05 (AC-39 … AC-42).
+
+AC-39  `_policy_badges` appends `ord R` when the account is pinned, on both
+       render paths, and an unpinned account renders byte-identically to its
+       PR 1 render.
+AC-40  Badge order on the row is deterministic: `(backup)`, `th NN%`, `ord R`.
+AC-41  The TUI renders MEU-ORD-04's `failback-hold` reason wherever it already
+       renders `NoSwitchEvent.reason`, and a fleet with no reserve still
+       renders `below-threshold` exactly as before.
+AC-42  **No TUI editing.** No new keybinding, modal, or screen; authoring stays
+       CLI-only. `modals.py` and `dashboard.py` are not modified.
+
+The goldens below are the PR 1 renders, taken from `test_tui_policy_display.py`
+verbatim rather than recaptured. Recapturing them from the *current* tree would
+make them tautological — a badge accidentally emitted for an unpinned account
+would be baked into its own oracle.
+
+This module is display-only. It must not grow an input path; that is what AC-42
+is for.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from pathlib import Path
+
+import pytest
+
+from claude_swap.autoswitch import NoSwitchEvent
+from claude_swap.models import AccountPolicy
+from claude_swap.tui.autoview import event_text
+from claude_swap.tui.widgets import account_card_text, mini_account_text
+
+from tests.test_tui import make_account
+from tests.test_tui_policy_display import (
+    GOLDEN_CARD_HEADER,
+    GOLDEN_MINI,
+    NOW,
+    card,
+    mini,
+    with_policy,
+)
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "claude_swap"
+
+
+class TestOrderBadge:
+    """AC-39, first half — the pin is legible on both render paths."""
+
+    def test_the_card_shows_the_rank(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), order=3)
+        assert "ord 3" in card(acc).splitlines()[0]
+
+    def test_the_mini_row_shows_the_rank(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), order=3)
+        assert "ord 3" in mini(acc)
+
+    def test_an_unpinned_account_carries_no_badge(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), order=None)
+        assert "ord" not in card(acc)
+        assert "ord" not in mini(acc)
+
+    def test_the_boundary_ranks_render(self):
+        for rank in (1, 999):
+            acc = with_policy(make_account(2, active=True, alias="dev"), order=rank)
+            assert f"ord {rank}" in mini(acc)
+
+    def test_each_path_uses_its_own_gap(self):
+        """The card separates badges with three spaces, the mini row with two.
+
+        `_policy_badges` takes the gap as a parameter for exactly this reason;
+        a hard-coded separator in the new branch would pass every `in` check
+        above and still misalign one of the two rows.
+        """
+        acc = with_policy(make_account(2, active=True, alias="dev"), order=3)
+        assert "   ord 3" in card(acc).splitlines()[0]
+        assert "  ord 3" in mini(acc)
+        assert "   ord 3" not in mini(acc)
+
+
+class TestUnpinnedRendersIdenticallyToPrOne:
+    """AC-39, second half — the goldens, unchanged.
+
+    These are the same literals `test_tui_policy_display.py` pins for PR 1. If
+    the new badge branch fires for an unpinned account, or the helper's return
+    value gains a stray separator, this fails before any human notices the row
+    shifted.
+    """
+
+    def test_the_card_header_is_the_pr_one_golden(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"))
+        assert card(acc).splitlines()[0] == GOLDEN_CARD_HEADER
+
+    def test_the_mini_row_is_the_pr_one_golden(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"))
+        assert mini(acc) == GOLDEN_MINI
+
+    def test_an_account_with_no_policy_object_at_all_is_unchanged(self):
+        acc = make_account(2, active=True, alias="dev")
+        assert card(acc).splitlines()[0] == GOLDEN_CARD_HEADER
+        assert mini(acc) == GOLDEN_MINI
+
+
+class TestBadgeOrderIsDeterministic:
+    """AC-40 — `(backup)`, then `th NN%`, then `ord R`, always."""
+
+    ALL_THREE = dict(backup=True, threshold=82.5, order=3)
+
+    def test_the_card_renders_all_three_in_order(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), **self.ALL_THREE)
+        header = card(acc).splitlines()[0]
+        assert header.index("(backup)") < header.index("th 82.5%") < header.index("ord 3")
+
+    def test_the_mini_row_renders_all_three_in_order(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), **self.ALL_THREE)
+        row = mini(acc)
+        assert row.index("(backup)") < row.index("th 82.5%") < row.index("ord 3")
+
+    def test_the_exact_rendered_badge_run_is_pinned(self):
+        """A substring-order check passes on a row that lost its separators.
+
+        The literal run is asserted on the mini path, whose gap is two spaces
+        and whose whole line is short enough to pin without a wall clock in it.
+        """
+        acc = with_policy(make_account(2, active=True, alias="dev"), **self.ALL_THREE)
+        assert "  (backup)  th 82.5%  ord 3" in mini(acc)
+
+    def test_order_still_sorts_last_when_the_threshold_is_absent(self):
+        acc = with_policy(
+            make_account(2, active=True, alias="dev"), backup=True, order=3
+        )
+        row = mini(acc)
+        assert row.index("(backup)") < row.index("ord 3")
+        assert "th " not in row
+
+    def test_the_disabled_badge_still_precedes_them_all(self):
+        """`(disabled)` is emitted by the render path itself, not the helper.
+
+        Its position relative to the policy badges is therefore not something
+        `_policy_badges` controls — which is exactly why it is worth pinning.
+        """
+        acc = with_policy(
+            make_account(3, disabled=True), backup=True, threshold=82.5, order=3
+        )
+        row = mini(acc)
+        assert row.index("(disabled)") < row.index("(backup)") < row.index("ord 3")
+
+
+class TestTheFailbackReasonReachesTheTui:
+    """AC-41 — MEU-ORD-04's reason renders through the existing surface."""
+
+    def test_the_event_log_line_names_the_reason(self):
+        e = NoSwitchEvent(reason="failback-hold", detail="primaries still exhausted")
+        assert "failback-hold" in event_text(e).plain
+
+    def test_the_log_line_carries_the_detail_too(self):
+        e = NoSwitchEvent(reason="failback-hold", detail="primaries still exhausted")
+        assert "primaries still exhausted" in event_text(e).plain
+
+    def test_the_json_payload_the_notification_reads_carries_it(self):
+        """`app.py:276` reads `payload["reason"]` from the event's own fields.
+
+        Asserting on `_fields()` rather than driving the Textual app keeps this
+        a unit test while still pinning the exact key that surface consumes.
+        """
+        e = NoSwitchEvent(reason="failback-hold", detail="primaries still exhausted")
+        assert e._fields()["reason"] == "failback-hold"
+
+    def test_no_special_casing_was_added_for_it(self):
+        """AC-41 is met by the generic path, and must stay that way.
+
+        `event_text` and the notification both render whatever string the
+        engine emits. A hard-coded `failback-hold` branch anywhere in the TUI
+        would be a new maintenance burden for zero behaviour, and would silently
+        diverge the moment the engine's wording changes.
+        """
+        for name in ("autoview.py", "app.py", "widgets.py", "dashboard.py"):
+            src = (SRC / "tui" / name).read_text(encoding="utf-8")
+            assert "failback-hold" not in src
+
+    def test_the_ordinary_reason_renders_exactly_as_before(self):
+        e = NoSwitchEvent(reason="below-threshold", detail="20% < 90%")
+        assert event_text(e).plain.endswith("no switch: below-threshold (20% < 90%)")
+
+    def test_a_reasonless_event_still_renders(self):
+        e = NoSwitchEvent(reason="failback-hold")
+        assert event_text(e).plain.endswith("no switch: failback-hold")
+
+
+class TestNoTuiEditing:
+    """AC-42 — authoring stays CLI-only; this PR adds no input path."""
+
+    EDITABLE = ("modals.py", "dashboard.py")
+
+    @pytest.mark.parametrize("name", EDITABLE)
+    def test_the_editing_surfaces_never_mention_order(self, name: str):
+        """`order` as a *policy* word, not the English word.
+
+        Matched as `set_account_order` / `account_orders` / `acc.policy.order`,
+        so an unrelated comment using "order" in prose does not fail this.
+        """
+        src = (SRC / "tui" / name).read_text(encoding="utf-8")
+        assert not re.search(r"\bset_account_order\b", src)
+        assert not re.search(r"\baccount_orders\b", src)
+        assert not re.search(r"policy\.order\b", src)
+
+    @pytest.mark.parametrize("name", EDITABLE)
+    def test_no_new_order_keybinding(self, name: str):
+        src = (SRC / "tui" / name).read_text(encoding="utf-8")
+        for m in re.finditer(r'Binding\(\s*"([^"]+)"\s*,\s*"([^"]+)"', src):
+            assert "order" not in m.group(2).lower()
+
+    def test_widgets_reads_the_policy_but_never_writes_it(self):
+        """The one file that *does* gain `order` may only display it."""
+        src = (SRC / "tui" / "widgets.py").read_text(encoding="utf-8")
+        assert "policy.order" in src
+        assert "set_account_order" not in src
+
+    def test_the_badge_helper_is_still_the_only_extension_point(self):
+        """AC-39 asked for the badge in both paths via `_policy_badges`.
+
+        A second, parallel branch inside `account_card_text` would satisfy
+        every rendering assertion above and quietly undo the reason PR 1
+        extracted the helper in the first place.
+
+        Narrowing: the Red phase spelled this `src.count("policy.order") == 1`,
+        which no correct implementation can satisfy -- the idiomatic guard-plus-
+        use branch reads the attribute twice, and PR 1's own `policy.threshold`
+        counts 2 in this same file for exactly that reason. Rebound to the
+        intent: every read of `policy.order` must fall inside `_policy_badges`.
+        """
+        src = (SRC / "tui" / "widgets.py").read_text(encoding="utf-8")
+        lines = src.splitlines()
+        start = next(
+            i for i, ln in enumerate(lines) if ln.startswith("def _policy_badges(")
+        )
+        end = next(
+            (
+                i
+                for i, ln in enumerate(lines[start + 1 :], start + 1)
+                if ln and not ln[0].isspace()
+            ),
+            len(lines),
+        )
+        hits = [i for i, ln in enumerate(lines) if "policy.order" in ln]
+        assert hits, "widgets.py never reads policy.order"
+        outside = [i + 1 for i in hits if not (start <= i < end)]
+        assert not outside, (
+            f"policy.order read outside _policy_badges at lines {outside}"
+        )

--- a/tests/test_tui_policy_display.py
+++ b/tests/test_tui_policy_display.py
@@ -1,0 +1,166 @@
+"""TUI policy display — MEU-PAP-05 (AC-39, AC-40).
+
+The per-account policy set through ``cswap threshold`` / ``cswap backup`` has
+to be visible where the operator already looks, on both account render paths:
+
+* ``account_card_text`` — the expanded card for the selected account.
+* ``mini_account_text`` — the one-line minimized row for every other account.
+
+AC-39  Both render paths show ``(backup)`` and the threshold override on the
+       account row.
+AC-40  An account carrying no policy renders byte-identically to today, on both
+       paths — asserted against goldens captured from the pre-change engine.
+
+This module is display-only. Editing a policy from inside the TUI is out of
+scope for this PR (plan §Scope, Deferred D-2); these tests must not grow an
+input path.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from claude_swap.models import AccountPolicy
+from claude_swap.tui.widgets import account_card_text, mini_account_text
+
+from tests.test_tui import make_account
+
+# Goldens captured from the unmodified engine at
+# 4f6c6ac6f303bd910d51bf5bf2fb36d553f4f37f60a50e438291d4feb5cadfbe, rendered
+# through the same ``make_account`` fixture used below.  Only the header row and
+# the whole mini row are pinned as literals: the card's bar rows carry a wall
+# clock date and would rot daily.  Their invariance is asserted structurally
+# instead (see ``test_the_card_bar_rows_are_untouched``).
+GOLDEN_CARD_HEADER = " 2  dev (user2@example.com)  [personal]   ● active"
+GOLDEN_MINI = " 2  dev (user2@example.com)  [personal]   5h 25% · 7d 10%"
+GOLDEN_CARD_HEADER_DISABLED = " 3  user3@example.com  [personal]   (disabled)"
+GOLDEN_MINI_DISABLED = " 3  user3@example.com  [personal]  (disabled)   5h 25% · 7d 10%"
+
+NOW = 1000.0
+
+
+def with_policy(acc, **kwargs):
+    """Attach an ``AccountPolicy`` to a snapshot from ``tests.test_tui``.
+
+    ``make_account`` predates the policy field and takes no ``policy=``
+    argument; ``test_tui.py`` is upstream's and stays byte-unchanged, so the
+    snapshot is rebuilt here instead of the helper being widened.
+    """
+    return dataclasses.replace(acc, policy=AccountPolicy(**kwargs))
+
+
+def card(acc) -> str:
+    return account_card_text(acc, 80, now=NOW).plain
+
+
+def mini(acc) -> str:
+    return mini_account_text(acc, NOW).plain
+
+
+class TestBackupBadge:
+    """AC-39, first half — the reserve is legible on both paths."""
+
+    def test_the_card_marks_a_backup_account(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), backup=True)
+        assert "(backup)" in card(acc).splitlines()[0]
+
+    def test_the_mini_row_marks_a_backup_account(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), backup=True)
+        assert "(backup)" in mini(acc)
+
+    def test_a_primary_account_carries_no_backup_badge(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), backup=False)
+        assert "(backup)" not in card(acc)
+        assert "(backup)" not in mini(acc)
+
+    def test_the_badge_survives_alongside_disabled(self):
+        # A reserve can also be disabled; neither badge may swallow the other.
+        acc = with_policy(make_account(3, disabled=True), backup=True)
+        header = card(acc).splitlines()[0]
+        assert "(disabled)" in header and "(backup)" in header
+        row = mini(acc)
+        assert "(disabled)" in row and "(backup)" in row
+
+
+class TestThresholdBadge:
+    """AC-39, second half — a per-account override is legible on both paths."""
+
+    def test_the_card_shows_the_override(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), threshold=75.0)
+        assert "75%" in card(acc).splitlines()[0]
+
+    def test_the_mini_row_shows_the_override(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"), threshold=75.0)
+        assert "75%" in mini(acc)
+
+    @pytest.mark.parametrize(
+        ("value", "shown"),
+        [(50.0, "50%"), (75.0, "75%"), (82.5, "82.5%"), (99.9, "99.9%")],
+    )
+    def test_a_fractional_override_keeps_its_fraction_and_a_whole_one_stays_whole(
+        self, value, shown
+    ):
+        # 75.0 must not read as "75.0%" and 82.5 must not round to "82%": the
+        # store accepts one decimal place (ACCOUNT_THRESHOLD_MIN..MAX) and the
+        # row has to show back exactly what was set.
+        acc = with_policy(make_account(2, active=True, alias="dev"), threshold=value)
+        assert shown in card(acc).splitlines()[0]
+        assert shown in mini(acc)
+
+    def test_an_account_on_the_global_default_shows_no_override(self):
+        acc = with_policy(make_account(2, active=True, alias="dev"))
+        assert acc.policy.threshold is None
+        assert "%" not in card(acc).splitlines()[0]
+        assert "th " not in mini(acc)
+
+    def test_both_badges_render_together(self):
+        acc = with_policy(
+            make_account(2, active=True, alias="dev"), threshold=60.0, backup=True
+        )
+        header = card(acc).splitlines()[0]
+        assert "(backup)" in header and "60%" in header
+        row = mini(acc)
+        assert "(backup)" in row and "60%" in row
+
+
+class TestUnpolicedAccountsRenderExactlyAsBefore:
+    """AC-40 — the negative half, and the reason this file has goldens.
+
+    Every account in an untouched store carries ``AccountPolicy()``.  If the
+    badge code path leaks so much as a stray space onto those rows, the whole
+    fleet's display changes for a feature nobody opted into.
+    """
+
+    def test_the_card_header_is_byte_identical_to_the_golden(self):
+        assert card(make_account(2, active=True, alias="dev")).splitlines()[0] == (
+            GOLDEN_CARD_HEADER
+        )
+
+    def test_the_mini_row_is_byte_identical_to_the_golden(self):
+        assert mini(make_account(2, active=True, alias="dev")) == GOLDEN_MINI
+
+    def test_a_disabled_account_is_byte_identical_to_the_golden(self):
+        acc = make_account(3, disabled=True)
+        assert card(acc).splitlines()[0] == GOLDEN_CARD_HEADER_DISABLED
+        assert mini(acc) == GOLDEN_MINI_DISABLED
+
+    def test_an_explicit_empty_policy_renders_the_same_as_no_policy(self):
+        # ``AccountPolicy()`` is the field default, but a store that wrote an
+        # empty policy object back must not be distinguishable on screen.
+        plain = make_account(2, active=True, alias="dev")
+        assert card(with_policy(plain)) == card(plain)
+        assert mini(with_policy(plain)) == mini(plain)
+
+    def test_the_card_bar_rows_are_untouched(self):
+        # The bar rows carry a wall-clock reset date, so they are pinned
+        # structurally rather than as a literal: same row count, same window
+        # labels, and no policy token anywhere below the header.
+        acc = make_account(2, active=True, alias="dev")
+        lines = card(acc).splitlines()
+        assert len(lines) == 3
+        assert lines[1].startswith("    5h ")
+        assert lines[2].startswith("    7d ")
+        for token in ("(backup)", "th "):
+            assert token not in "\n".join(lines[1:])


### PR DESCRIPTION
> **Stacked on #318** — please review that one first; this branch contains its commit.

Adds one optional per-account field, **`order`**, that makes the auto-switch chain explicit:
set a rank on an account and it is spent ahead of the others; leave it unset and nothing
about that account's behaviour changes.

Refs #255.

## Why

#255 asks for three things. #318 delivered the two that are orthogonal to the ranking sort —
a per-account **gate** (`threshold`) and a **filter** (`standby`). The third is the ordering
itself: *"decide the order in which accounts chain when thresholds are reached."* That one
lands on the sort key, so it was split out to be argued on its own rather than holding up
two additive wins.

## What changed

| Field | Type | Meaning |
|---|---|---|
| `order` | `int`, 1–999 | This account's position in the switch chain. Lower is spent first. Absent ⇒ the account is ranked purely by the active strategy. |

Like `threshold` and `standby`, it lives on the **account record** in `sequence.json` (not a
slot-keyed map — `swap` / `move` relocate whole records) and is omitted when unset, so a
fleet that never touches the feature — and one that set and then cleared a pin — keeps a
`sequence.json` byte-identical to a pre-feature store.

### Engine

`order` is a **leading tier on the ranking sort key**, not a tie-break. In
`_rank_candidates`, every key becomes:

```
key(num) := (ORDER_TIER(num), *strategy_key(num))
```

where `ORDER_TIER` is a total map returning `ORDER_UNSET_RANK` (1000) for unpinned accounts.
Two consequences worth stating explicitly, because both were nearly got wrong:

- **Leading, not trailing.** Appended, the tier would be inert: Python's sort is stable, so
  list order only survives an exact tie, and neither strategy key (floats, timestamps) ties
  in practice.
- **Both append sites.** The tier is prepended at `fallback.append` *and* `qualifying.append`,
  because `qualifying = qualifying or fallback` selects one list rather than merging them —
  tiering only `qualifying` would silently drop ordering on every fallback tick.

Within a tier the active strategy still decides, so pins compose with `consume-first` rather
than replacing it. Unpinned fleets take the identical path they take today.

Also included: the **failback diagnostic reason** deferred from #318 — a return from a standby
to a primary now says *why* it did not happen ("primaries still exhausted") instead of going
quiet.

### CLI

```
cswap order                     # print the resolved chain
cswap order 2 1                 # account 2 is spent first
cswap order 3 --unset           # account 3 goes back to pure strategy ranking
```

`cswap order` with no arguments prints pins in rank order, then the remaining accounts under
a line saying they follow the active strategy. The verb accepts a number, an email, or an
alias, matching the other account verbs; `--order-account NUM RANK` / `--unorder-account NUM`
are the long-flag spellings, mirroring `--disable-account`.

Ranks are validated **at the write boundary**: an out-of-range or non-integer rank is rejected
before `sequence.json` is opened, so a rejected write leaves the file byte-identical. Both
spellings fail the same way — one red line, exit 1, no traceback.

### TUI / JSON

The account list gains an `ord R` badge after the existing `(standby)` and `th NN%` badges.
`--json` rows gain an `order` key, only when set, following the convention `disabled` and
`threshold` already use.

## Relationship to the other open PRs on this code

- **#260 (`drainAccount`)** — same axis, and `order` generalises it: `drainAccount X` is
  `cswap order X 1`. #260's own measurement — a real `1 → 2 → 1 → 3 → 1 → 2` cycle caused by
  two competing spend-order anchors — is precisely why this PR makes `order` *the* anchor
  rather than an additional one.
- **#262 (`pace`, `threshold5h` / `threshold7d`)** — a different axis (per-window rather than
  per-account), but it rewrites the same threshold call sites #318 touches.

- **#312 (`autoswitch.preferred`)** — the closest relative, opened the same day, and worth a
  side-by-side rather than a mention. Both give the operator a say in *which* account is
  landed on, and both do it as a leading tier in `_rank_candidates`. Four differences, stated
  plainly so a maintainer can pick rather than guess:

  | | #312 `autoswitch.preferred` | this PR's `order` |
  |---|---|---|
  | Shape | a set — listed beats unlisted | an ordinal 1…999 — a total chain |
  | Home | a global `settings.py` config string of emails/slots | a field on the `sequence.json` account record, beside `disabled` |
  | Applied at | `qualifying` only, by design | `qualifying` **and** `fallback` |
  | All-spent recovery (`all_above`) | deliberately untouched — soonest-back wins | the chain still leads; soonest-back breaks ties within a rank |

  The shape difference is the substantive one for #255, which asks to "decide the order in
  which they will chain". A set draws one boundary; five accounts need four. #312's own
  within-list ordering falls back to slot number, and slot numbers are what `cswap swap` /
  `move` renumber — which is also why this PR puts the field on the account record instead of
  in a global string. #312 mitigates the same problem differently, by matching on email.

  The last two rows are honest divergences, not defects in #312 — its body says both are
  deliberate. They trade differently: #312 keeps the engine free to get back online soonest
  when everything is spent, this PR keeps the chain predictable in that state too. If the
  maintainer prefers #312's trade, the change here is one line at the `fallback.append` site
  and the `all_above` tests move with it.

  The two are not mutually exclusive — `preferred` is expressible as `order` (a listed
  account is any rank below an unlisted one), so if `order` lands, #312 can be closed as
  subsumed, or kept as sugar over it.

None of the three has a maintainer review yet; flagging them here so a reviewer does not
have to discover the overlap.

## One caveat worth surfacing

A pin defeats the strategy's own self-demotion after a weekly rollover: `consume-first` stops
demoting a pinned account once its window rolls, so a pin used as a soft "prefer" knob can
cost throughput. That is documented on the field, in `cswap order`'s help text, and in the
chain listing itself.

## Compatibility

- Purely additive. Existing `sequence.json` files parse unchanged and behave identically.
- With no `order` set anywhere, ranking, cooldown, hysteresis, and every existing trigger
  string behave exactly as before.
- Unknown/absent keys are tolerated on read; nothing is written unless a verb sets it.

## Tests

`+283` tests across six new modules (`tests/test_account_order_values.py`,
`test_account_order_store.py`, `test_autoswitch_account_order.py`,
`test_autoswitch_failback_reason.py`, `test_account_order_cli.py`,
`test_tui_order_display.py`), all synthetic fixtures — no real credential store is read or
written.

```
2754 passed, 81 skipped, 3 warnings
```

Skip and warning counts are unchanged from the pre-change baseline (2185 passed, 81 skipped,
3 warnings) on the upstream `main` this branch merges (`7187ce8`), i.e. no existing test was
skipped, xfailed, or otherwise neutralised.

The branch also carries a `README.md` commit covering `cswap order` and the chain semantics,
and nothing beyond them.
