### PR TITLE
Read setup-token usage from a one-turn Claude Code session

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,21 @@ cswap add-token --email user@example.com     # optional label override
 `--email` is optional; omitted values use `setup-token-{slot}@token.local`
 (or `api-key-{slot}@token.local` for API keys). No Anthropic API calls are made.
 
+**Usage for setup-token accounts.** A setup-token carries only the `user:inference`
+scope, so the usage endpoint every other account is read from answers 403 for it,
+and a few such probes get the endpoint rate-limited for an hour for every account
+on the host. cswap therefore never queries the endpoint for these accounts. It reads
+their usage the way Claude Code itself sees it: one isolated, non-interactive Claude
+Code turn (`claude -p`, Haiku, one turn, no tools) under the account's `cswap run`
+session profile, parsing the rate-limit event Claude Code emits from the response
+headers. An exhausted account still emits that event and the read costs nothing; a
+healthy account spends one tiny Haiku turn per poll. The probe runs in a private
+`usage-probe/` directory inside the profile, so nothing lands in a real project's
+history. `claude` must be on PATH, and a slot's session profile must exist (run
+`cswap run <num>` once); until then the account shows `usage unavailable
+(no-session-profile)`. The active/default login is probed in Claude Code's own
+config directory instead.
+
 **API-key accounts.** An `sk-ant-api...` value registers a managed API-key account
 (the kind Claude Code uses after `/login` with a key) rather than an OAuth
 setup-token. It switches like any other account; since API keys have no subscription

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
+import shutil
+import subprocess
+import sys
 import urllib.error
 import urllib.request
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 
 from claude_swap.printer import warning as print_warning
 
@@ -17,6 +22,23 @@ OAUTH_BETA_HEADER = "oauth-2025-04-20"
 OAUTH_EXPIRY_BUFFER_MS = 5 * 60 * 1000
 OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+# Setup-tokens (`claude setup-token`, registered via `cswap add-token`) are
+# inference-only server-side; wider scopes trigger 403s on profile endpoints.
+# Matches Claude Code's CLAUDE_CODE_OAUTH_TOKEN path.
+SETUP_TOKEN_SCOPES = ("user:inference",)
+
+# The usage endpoint answers 403 for inference-only tokens, and a handful of
+# such probes trip a host-wide 429 for an hour. Setup-token accounts read
+# usage the way Claude Code itself sees it instead: one non-interactive turn
+# whose stream-json output carries a ``rate_limit_event`` built from the
+# inference response headers. The cheapest model, one turn, no tools.
+USAGE_PROBE_MODEL = "claude-haiku-4-5-20251001"
+USAGE_PROBE_PROMPT = "ok"
+USAGE_PROBE_TIMEOUT_S = 90.0
+# Private cwd for the probe inside the profile, so its transcript never lands
+# in a real project's history.
+USAGE_PROBE_DIRNAME = "usage-probe"
 
 _logger = logging.getLogger("claude-swap")
 
@@ -581,6 +603,209 @@ class UsageOutcome:
     struck_fp: str | None = None
 
 
+def is_setup_token_credential(credentials: str) -> bool:
+    """Is this an inference-only setup-token credential?
+
+    Exactly ``SETUP_TOKEN_SCOPES`` and no refresh token — the shape
+    ``add-token`` writes. A full-scope OAuth login (or anything carrying a
+    refresh token) is not, and keeps using the usage endpoint.
+    """
+    oauth = extract_oauth_data(credentials)
+    if not oauth or oauth.get("refreshToken"):
+        return False
+    return oauth.get("scopes") == list(SETUP_TOKEN_SCOPES)
+
+
+@dataclass(frozen=True)
+class UsageProbeProfile:
+    """Where a setup-token usage probe runs.
+
+    ``config_dir`` is exported as ``CLAUDE_CONFIG_DIR`` for the child; ``None``
+    leaves the variable exactly as inherited so claude resolves its default
+    store itself (on macOS the Keychain service name hashes the raw env
+    value, so setting it to the default path would miss the default entry).
+    ``scratch_root`` is where the private ``usage-probe/`` cwd is created.
+    """
+
+    config_dir: Path | None
+    scratch_root: Path
+
+
+def _usage_probe_env(config_dir: Path | None) -> dict[str, str]:
+    """Child env: auth overrides dropped (they would fake another identity),
+    ``CLAUDE_CONFIG_DIR`` pointed at the profile when one is given."""
+    from claude_swap.session import AUTH_OVERRIDE_ENV_VARS
+
+    env = {k: v for k, v in os.environ.items() if k not in AUTH_OVERRIDE_ENV_VARS}
+    if config_dir is not None:
+        env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+    return env
+
+
+def _usage_probe_argv(claude_bin: str) -> list[str]:
+    # Verified against Claude Code 2.1.257/2.1.260.
+    return [
+        claude_bin, "-p", USAGE_PROBE_PROMPT,
+        "--output-format", "stream-json", "--verbose",
+        "--model", USAGE_PROBE_MODEL,
+        "--max-turns", "1",
+        "--tools", "",
+    ]
+
+
+def _spawn_usage_probe(
+    argv: list[str], env: dict[str, str], cwd: Path, timeout_s: float
+) -> subprocess.CompletedProcess:
+    """The one subprocess call of the probe (tests replace this).
+
+    ``subprocess.run`` kills the child on timeout before re-raising.
+    """
+    return subprocess.run(
+        argv, env=env, cwd=str(cwd), capture_output=True, text=True,
+        timeout=timeout_s, stdin=subprocess.DEVNULL,
+    )
+
+
+def parse_rate_limit_event(stdout: str) -> dict | None:
+    """Raw usage-API-shaped data from stream-json output, or ``None``.
+
+    Scans one JSON object per line, skipping anything that does not parse
+    (claude prints non-JSON noise on some paths), and takes the last
+    ``rate_limit_event``. ``unifiedWindows`` utilization is 0..1 and
+    ``resetsAt`` is epoch seconds; the usage endpoint's shape (which
+    :func:`build_usage_result` consumes) is percent 0..100 and an ISO 8601
+    UTC string, so both are converted here.
+    """
+    event: dict | None = None
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("type") == "rate_limit_event":
+            info = obj.get("rate_limit_info")
+            if isinstance(info, dict):
+                event = info
+    if event is None:
+        return None
+    windows = event.get("unifiedWindows")
+    if not isinstance(windows, dict):
+        return None
+    data: dict = {}
+    for key in ("five_hour", "seven_day"):
+        window = windows.get(key)
+        if not isinstance(window, dict):
+            continue
+        utilization = window.get("utilization")
+        if not isinstance(utilization, (int, float)):
+            continue
+        entry: dict = {"utilization": float(utilization) * 100.0}
+        resets_at = window.get("resetsAt")
+        if isinstance(resets_at, (int, float)) and not isinstance(resets_at, bool):
+            entry["resets_at"] = datetime.fromtimestamp(
+                resets_at, tz=timezone.utc
+            ).isoformat()
+        else:
+            entry["resets_at"] = None
+        data[key] = entry
+    return data or None
+
+
+def _probe_result_error(stdout: str) -> str | None:
+    """The ``result`` line's error text when it reports ``is_error``."""
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("type") == "result" and obj.get("is_error"):
+            return str(obj.get("result") or obj.get("error") or "is_error")
+    return None
+
+
+def probe_usage_via_claude(
+    account_num: str,
+    profile: UsageProbeProfile,
+    timeout_s: float = USAGE_PROBE_TIMEOUT_S,
+) -> UsageOutcome:
+    """Usage for a setup-token account from one Claude Code turn.
+
+    Runs ``claude -p`` non-interactively under the account's profile and
+    parses the ``rate_limit_event`` from its stream-json output. An
+    exhausted account still emits the event (status ``rejected``,
+    utilization 1.0) and the process exits non-zero — stdout is parsed
+    regardless of exit code, and that read costs nothing. A healthy account
+    spends one tiny Haiku turn. All network activity is the ``claude``
+    binary's own; nothing here talks to the API directly.
+
+    Error kinds: ``"no-claude-binary"`` (not on PATH or would not spawn),
+    ``"probe-timeout"`` (child killed after ``timeout_s``),
+    ``"no-rate-limit-event"`` (ran, but no usable event in the output).
+    None of them is a permanent auth verdict, so none strikes the account.
+    """
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        _logger.warning(
+            "Usage probe for account %s skipped: 'claude' not on PATH", account_num,
+        )
+        return UsageOutcome(None, error="no-claude-binary")
+
+    scratch = profile.scratch_root / USAGE_PROBE_DIRNAME
+    try:
+        scratch.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            os.chmod(scratch, 0o700)
+    except OSError as e:
+        _logger.warning(
+            "Usage probe for account %s skipped: cannot create %s (%r)",
+            account_num, scratch, e,
+        )
+        return UsageOutcome(None, error="no-session-profile")
+
+    _logger.info("Usage via Claude Code turn for account %s", account_num)
+    try:
+        completed = _spawn_usage_probe(
+            _usage_probe_argv(claude_bin), _usage_probe_env(profile.config_dir),
+            scratch, timeout_s,
+        )
+    except subprocess.TimeoutExpired as e:
+        _logger.warning(
+            "Usage probe for account %s timed out after %.0fs", account_num, timeout_s,
+        )
+        _logger.debug("Usage probe timeout detail for account %s: %r", account_num, e)
+        return UsageOutcome(None, error="probe-timeout")
+    except OSError as e:
+        _logger.warning("Usage probe for account %s could not start: %r", account_num, e)
+        return UsageOutcome(None, error="no-claude-binary")
+
+    stdout = completed.stdout or ""
+    data = parse_rate_limit_event(stdout)
+    if data is None:
+        result_error = _probe_result_error(stdout)
+        _logger.warning(
+            "Usage probe for account %s produced no rate_limit_event (exit %s%s)",
+            account_num, completed.returncode,
+            f"; result error: {result_error}" if result_error else "",
+        )
+        _logger.debug(
+            "Usage probe output for account %s:\nstdout=%s\nstderr=%s",
+            account_num, stdout[-4000:], (completed.stderr or "")[-4000:],
+        )
+        return UsageOutcome(None, error="no-rate-limit-event")
+    if completed.returncode != 0:
+        _logger.debug(
+            "Usage probe for account %s exited %s but carried a rate_limit_event",
+            account_num, completed.returncode,
+        )
+    return UsageOutcome(build_usage_result(data))
+
+
 def fetch_usage(access_token: str) -> dict | None:
     """Fetch 5-hour and 7-day utilization from the Anthropic usage API."""
     try:
@@ -610,6 +835,7 @@ def try_fetch_usage_for_account(
     is_active: bool,
     persist_credentials: Callable[[str, str, str], None] | None = None,
     refresh_via: Callable[[str, str, str], RefreshOutcome] | None = None,
+    probe_profile_for: Callable[[str, str], UsageProbeProfile | None] | None = None,
 ) -> UsageOutcome:
     """Fetch usage for an account, refreshing expired tokens for inactive accounts only.
 
@@ -619,12 +845,29 @@ def try_fetch_usage_for_account(
     freshest copy under the slot lock, persists via fingerprint CAS, and
     never consumes a superseded snapshot. ``persist_credentials`` is then
     unused for the refresh (the gate persists internally).
+
+    Setup-token credentials (see :func:`is_setup_token_credential`) never
+    reach the usage endpoint (403, then a host-wide 429): they go through
+    :func:`probe_usage_via_claude` under the profile that
+    ``probe_profile_for(account_num, email)`` names. Without a callable, or
+    when it answers ``None`` (no profile bootstrapped yet), the outcome is
+    ``"no-session-profile"``.
     """
     context = f"for account {account_num}"  # no email: paste-safe for public issues
     oauth = extract_oauth_data(credentials)
     access_token = oauth.get("accessToken") if oauth else None
     if not access_token:
         return UsageOutcome(None, error="no-access-token")
+
+    if is_setup_token_credential(credentials):
+        profile = probe_profile_for(account_num, email) if probe_profile_for else None
+        if profile is None:
+            _logger.warning(
+                "Usage fetch skipped %s: setup-token account has no session "
+                "profile yet (run `cswap run %s` once)", context, account_num,
+            )
+            return UsageOutcome(None, error="no-session-profile")
+        return probe_usage_via_claude(account_num, profile)
 
     working_credentials = credentials
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -76,6 +76,7 @@ from claude_swap.printer import (
 )
 from claude_swap.paths import (
     get_backup_root,
+    get_claude_config_home,
     get_credentials_path,
     get_default_claude_config_home,
     get_global_config_path,
@@ -102,7 +103,9 @@ KEYRING_SERVICE = "claude-code"
 
 # Setup-tokens are inference-only server-side; wider scopes trigger 403s
 # on profile endpoints. Matches Claude Code's CLAUDE_CODE_OAUTH_TOKEN path.
-SETUP_TOKEN_SCOPES = ("user:inference",)
+# Defined in oauth (the usage path detects setup-tokens by it); re-exported
+# here for add-token and the test suite.
+SETUP_TOKEN_SCOPES = oauth.SETUP_TOKEN_SCOPES
 
 # Delay between successive usage-request launches in one collect pass, so N
 # accounts never burst the shared usage endpoint from one IP in the same
@@ -192,6 +195,21 @@ ERROR_NOTES = {
     "stash-unreadable": (
         "this slot's stashed successor is unreadable — unlock the keychain "
         "or fix the file, then retry; `cswap unclaimed` inspects it"
+    ),
+    # Setup-token accounts read usage from a one-turn Claude Code session
+    # under the account's profile (the usage endpoint 403s inference-only
+    # tokens); these are that probe's failure kinds.
+    "no-session-profile": (
+        "setup-token usage needs a session profile — run `cswap run <num>` once"
+    ),
+    "no-claude-binary": (
+        "setup-token usage runs a Claude Code turn — `claude` is not on PATH"
+    ),
+    "probe-timeout": (
+        "the Claude Code usage turn timed out — retries next pass"
+    ),
+    "no-rate-limit-event": (
+        "the Claude Code usage turn reported no rate-limit data — retries next pass"
     ),
 }
 
@@ -2681,6 +2699,33 @@ class ClaudeAccountSwitcher:
 
         return session_dir_for(self.backup_dir, account_num, email)
 
+    # -- setup-token usage probe profiles -----------------------------------
+    # Setup-token accounts read usage from one Claude Code turn (see
+    # oauth.probe_usage_via_claude); these name the profile it runs under.
+    # Full-scope credentials never consult them.
+
+    def _usage_probe_profile_default(
+        self, account_num: str, email: str
+    ) -> oauth.UsageProbeProfile:
+        """The active/default login: claude's own store, env left as is."""
+        return oauth.UsageProbeProfile(
+            config_dir=None, scratch_root=get_claude_config_home(),
+        )
+
+    def _usage_probe_profile_session(
+        self, account_num: str, email: str
+    ) -> oauth.UsageProbeProfile | None:
+        """An inactive slot: its `cswap run` session profile, or ``None``
+        when none has been bootstrapped yet (bootstrapping takes the backup
+        lock and probes `claude auth status`, too heavy for a collect pass;
+        the caller reports ``no-session-profile`` with the remedy)."""
+        session_dir = self._session_dir(account_num, email)
+        if not session_dir.is_dir():
+            return None
+        return oauth.UsageProbeProfile(
+            config_dir=session_dir, scratch_root=session_dir,
+        )
+
     def _token_status_lines(
         self, account_info: tuple[int, str, str, str, bool, str, str]
     ) -> list[str]:
@@ -4137,6 +4182,7 @@ class ClaudeAccountSwitcher:
         if not oauth.is_oauth_token_expired(oauth_data.get("expiresAt")):
             outcome = oauth.try_fetch_usage_for_account(
                 account_num, email, creds, is_active=True,
+                probe_profile_for=self._usage_probe_profile_default,
             )
             if outcome.error != "http-401":
                 if outcome.usage is not None:
@@ -4620,6 +4666,7 @@ class ClaudeAccountSwitcher:
 
         outcome = oauth.try_fetch_usage_for_account(
             account_num, email, working, is_active=True,
+            probe_profile_for=self._usage_probe_profile_default,
         )
         return FetchRecord(
             usage=outcome.usage,
@@ -4869,6 +4916,7 @@ class ClaudeAccountSwitcher:
                 if not oauth.is_oauth_token_expired(session_oauth.get("expiresAt")):
                     outcome = oauth.try_fetch_usage_for_account(
                         str(num), email, session_creds, is_active=True,
+                        probe_profile_for=self._usage_probe_profile_session,
                     )
                     return FetchRecord(
                         usage=outcome.usage,
@@ -4886,6 +4934,7 @@ class ClaudeAccountSwitcher:
             refresh_via=(
                 None if has_live_session else self.consume_backup_grant
             ),
+            probe_profile_for=self._usage_probe_profile_session,
         )
         return FetchRecord(
             usage=outcome.usage,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -573,6 +573,25 @@ def block_real_oauth_profile_fetch(request, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def block_real_usage_probe(monkeypatch):
+    """Safety net: no test may spawn a real ``claude`` usage probe.
+
+    Setup-token accounts fetch usage by running one Claude Code turn
+    (``oauth.probe_usage_via_claude``); a test that reaches that path with
+    ``claude`` on PATH would spend a real turn under the developer's own
+    login. Stub the single spawn point to "could not start" (the
+    ``no-claude-binary`` outcome, which every caller tolerates). Tests of
+    the probe itself re-patch the same attribute inside the test body,
+    which wins over this fixture.
+    """
+    def _refuse(argv, env, cwd, timeout_s):
+        raise FileNotFoundError("usage probe blocked in tests")
+
+    monkeypatch.setattr("claude_swap.oauth._spawn_usage_probe", _refuse)
+    yield
+
+
 @pytest.fixture
 def temp_home(tmp_path: Path):
     """Create a temporary home directory for testing."""

--- a/tests/test_setup_token_usage.py
+++ b/tests/test_setup_token_usage.py
@@ -1,0 +1,271 @@
+"""Usage for setup-token accounts via a one-turn Claude Code probe."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from claude_swap import oauth
+from claude_swap.session import AUTH_OVERRIDE_ENV_VARS
+
+SAMPLE_EVENT = (
+    '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected",'
+    '"resetsAt":1788528600,"rateLimitType":"five_hour","overageStatus":"rejected",'
+    '"overageDisabledReason":"org_level_disabled","isUsingOverage":false,'
+    '"unifiedWindows":{"five_hour":{"utilization":1,"resetsAt":1788528600},'
+    '"seven_day":{"utilization":0.36,"resetsAt":1788541200},'
+    '"seven_day_overage_included":{"utilization":0.1,"resetsAt":1788541200}}},'
+    '"uuid":"u","session_id":"s"}'
+)
+SYSTEM_LINE = '{"type":"system","subtype":"init","session_id":"s"}'
+RESULT_ERROR_LINE = '{"type":"result","is_error":true,"result":"rate limited"}'
+
+
+def setup_token_creds(**extra) -> str:
+    return json.dumps({"claudeAiOauth": {
+        "accessToken": "sk-ant-oat01-x", "scopes": ["user:inference"], **extra,
+    }})
+
+
+def full_scope_creds() -> str:
+    return json.dumps({"claudeAiOauth": {
+        "accessToken": "at", "refreshToken": "rt", "expiresAt": 4102444800000,
+        "scopes": ["user:profile", "user:inference", "user:sessions:claude_code"],
+    }})
+
+
+def completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["claude"], returncode=returncode, stdout=stdout, stderr="",
+    )
+
+
+@pytest.fixture
+def profile(tmp_path: Path) -> oauth.UsageProbeProfile:
+    session_dir = tmp_path / "sessions" / "3-x"
+    session_dir.mkdir(parents=True)
+    return oauth.UsageProbeProfile(config_dir=session_dir, scratch_root=session_dir)
+
+
+@pytest.fixture
+def spawn(monkeypatch):
+    """Record the probe's spawn call; ``spawn.stdout``/``spawn.returncode``
+    shape the answer, ``spawn.raises`` makes it raise instead."""
+    class Recorder:
+        calls: list[dict] = []
+        stdout = SAMPLE_EVENT + "\n"
+        returncode = 0
+        raises: BaseException | None = None
+
+        def __call__(self, argv, env, cwd, timeout_s):
+            self.calls.append({"argv": argv, "env": env, "cwd": cwd, "timeout_s": timeout_s})
+            if self.raises is not None:
+                raise self.raises
+            return completed(self.stdout, self.returncode)
+
+    rec = Recorder()
+    monkeypatch.setattr(oauth, "_spawn_usage_probe", rec)
+    monkeypatch.setattr(oauth.shutil, "which", lambda name: "/usr/local/bin/claude")
+    return rec
+
+
+class TestDetection:
+    def test_exact_inference_scope_without_refresh_token(self):
+        assert oauth.is_setup_token_credential(setup_token_creds())
+
+    def test_refresh_token_present_is_not_a_setup_token(self):
+        assert not oauth.is_setup_token_credential(setup_token_creds(refreshToken="rt"))
+
+    def test_full_scopes_are_not_a_setup_token(self):
+        assert not oauth.is_setup_token_credential(full_scope_creds())
+
+    def test_superset_or_missing_scopes_are_not(self):
+        assert not oauth.is_setup_token_credential(json.dumps({"claudeAiOauth": {
+            "accessToken": "a", "scopes": ["user:inference", "user:profile"],
+        }}))
+        assert not oauth.is_setup_token_credential(json.dumps({"claudeAiOauth": {
+            "accessToken": "a",
+        }}))
+
+    def test_garbage_is_not(self):
+        assert not oauth.is_setup_token_credential("not json")
+        assert not oauth.is_setup_token_credential("")
+
+
+class TestParseRateLimitEvent:
+    def test_sample_line_maps_to_usage_shape(self):
+        data = oauth.parse_rate_limit_event(SYSTEM_LINE + "\n" + SAMPLE_EVENT + "\n")
+        assert data["five_hour"]["utilization"] == 100.0
+        assert data["seven_day"]["utilization"] == pytest.approx(36.0)
+        assert data["five_hour"]["resets_at"] == datetime.fromtimestamp(
+            1788528600, tz=timezone.utc
+        ).isoformat()
+        assert "seven_day_overage_included" not in data
+
+    def test_builds_usage_result(self):
+        data = oauth.parse_rate_limit_event(SAMPLE_EVENT)
+        result = oauth.build_usage_result(data)
+        assert result["five_hour"]["pct"] == 100.0
+        assert result["seven_day"]["pct"] == pytest.approx(36.0)
+        assert "countdown" in result["five_hour"] and "clock" in result["five_hour"]
+        assert oauth.account_headroom(result) == 0.0
+
+    def test_non_json_lines_are_skipped(self):
+        stdout = "warning: something\n{not json\n" + SAMPLE_EVENT + "\n[1,2]\n"
+        assert oauth.parse_rate_limit_event(stdout)["five_hour"]["utilization"] == 100.0
+
+    def test_no_event_is_none(self):
+        assert oauth.parse_rate_limit_event(SYSTEM_LINE + "\n" + RESULT_ERROR_LINE) is None
+        assert oauth.parse_rate_limit_event("") is None
+
+    def test_missing_reset_is_tolerated(self):
+        line = json.dumps({"type": "rate_limit_event", "rate_limit_info": {
+            "unifiedWindows": {"five_hour": {"utilization": 0.5}},
+        }})
+        data = oauth.parse_rate_limit_event(line)
+        assert data == {"five_hour": {"utilization": 50.0, "resets_at": None}}
+        assert oauth.build_usage_result(data)["five_hour"]["pct"] == 50.0
+
+
+class TestProbe:
+    def test_healthy_account_yields_usage(self, spawn, profile):
+        spawn.stdout = SYSTEM_LINE + "\n" + SAMPLE_EVENT + '\n{"type":"result","is_error":false}\n'
+        outcome = oauth.probe_usage_via_claude("3", profile)
+        assert outcome.error is None
+        assert outcome.usage["seven_day"]["pct"] == pytest.approx(36.0)
+
+    def test_exhausted_account_nonzero_exit_still_yields_usage(self, spawn, profile):
+        spawn.returncode = 1
+        spawn.stdout = SAMPLE_EVENT + "\n" + RESULT_ERROR_LINE + "\n"
+        outcome = oauth.probe_usage_via_claude("3", profile)
+        assert outcome.error is None
+        assert outcome.usage["five_hour"]["pct"] == 100.0
+
+    def test_missing_binary(self, spawn, profile, monkeypatch):
+        monkeypatch.setattr(oauth.shutil, "which", lambda name: None)
+        outcome = oauth.probe_usage_via_claude("3", profile)
+        assert outcome == oauth.UsageOutcome(None, error="no-claude-binary")
+        assert spawn.calls == []
+
+    def test_spawn_oserror_is_no_binary(self, spawn, profile):
+        spawn.raises = FileNotFoundError("claude")
+        assert oauth.probe_usage_via_claude("3", profile).error == "no-claude-binary"
+
+    def test_timeout(self, spawn, profile):
+        spawn.raises = subprocess.TimeoutExpired(cmd="claude", timeout=90)
+        assert oauth.probe_usage_via_claude("3", profile).error == "probe-timeout"
+
+    def test_no_event(self, spawn, profile):
+        spawn.returncode = 1
+        spawn.stdout = SYSTEM_LINE + "\n" + RESULT_ERROR_LINE + "\n"
+        assert oauth.probe_usage_via_claude("3", profile).error == "no-rate-limit-event"
+
+    def test_env_cwd_and_argv(self, spawn, profile, monkeypatch):
+        for var in AUTH_OVERRIDE_ENV_VARS:
+            monkeypatch.setenv(var, "leak")
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/elsewhere")
+        oauth.probe_usage_via_claude("3", profile)
+        call = spawn.calls[0]
+        assert call["env"]["CLAUDE_CONFIG_DIR"] == str(profile.config_dir)
+        assert not any(var in call["env"] for var in AUTH_OVERRIDE_ENV_VARS)
+        assert call["timeout_s"] == oauth.USAGE_PROBE_TIMEOUT_S == 90.0
+        scratch = profile.scratch_root / oauth.USAGE_PROBE_DIRNAME
+        assert call["cwd"] == scratch and scratch.is_dir()
+        argv = call["argv"]
+        assert argv[0] == "/usr/local/bin/claude"
+        assert argv[1:3] == ["-p", "ok"]
+        assert "stream-json" in argv and "--verbose" in argv
+        assert argv[argv.index("--model") + 1] == oauth.USAGE_PROBE_MODEL
+        assert argv[argv.index("--max-turns") + 1] == "1"
+        assert argv[argv.index("--tools") + 1] == ""
+
+    def test_default_profile_leaves_config_dir_untouched(self, spawn, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        default = oauth.UsageProbeProfile(config_dir=None, scratch_root=tmp_path)
+        oauth.probe_usage_via_claude("1", default)
+        assert "CLAUDE_CONFIG_DIR" not in spawn.calls[0]["env"]
+
+    def test_logs_one_info_line_without_email(self, spawn, profile, caplog):
+        import logging
+        with caplog.at_level(logging.INFO, logger="claude-swap"):
+            oauth.probe_usage_via_claude("3", profile)
+        lines = [r.getMessage() for r in caplog.records if "Usage via Claude Code turn" in r.getMessage()]
+        assert lines == ["Usage via Claude Code turn for account 3"]
+
+
+class TestFetchEntryPoint:
+    def test_setup_token_routes_to_probe(self, spawn, profile):
+        outcome = oauth.try_fetch_usage_for_account(
+            "3", "setup-token-3@token.local", setup_token_creds(), is_active=False,
+            probe_profile_for=lambda num, email: profile,
+        )
+        assert outcome.error is None
+        assert outcome.usage["five_hour"]["pct"] == 100.0
+        assert len(spawn.calls) == 1
+
+    def test_setup_token_without_profile(self, spawn, monkeypatch):
+        seen = []
+        outcome = oauth.try_fetch_usage_for_account(
+            "3", "e", setup_token_creds(), is_active=False,
+            probe_profile_for=lambda num, email: seen.append((num, email)),
+        )
+        assert outcome.error == "no-session-profile"
+        assert seen == [("3", "e")]
+        assert spawn.calls == []
+
+    def test_setup_token_without_callable(self, spawn):
+        outcome = oauth.try_fetch_usage_for_account("3", "e", setup_token_creds(), is_active=True)
+        assert outcome.error == "no-session-profile"
+        assert spawn.calls == []
+
+    def test_full_scope_never_spawns(self, spawn, profile, monkeypatch):
+        def fake_request(token):
+            return {"five_hour": {"utilization": 5.0, "resets_at": None}}
+        monkeypatch.setattr(oauth, "request_usage_data", fake_request)
+        outcome = oauth.try_fetch_usage_for_account(
+            "1", "e", full_scope_creds(), is_active=True,
+            probe_profile_for=lambda num, email: profile,
+        )
+        assert outcome.usage["five_hour"]["pct"] == 5.0
+        assert spawn.calls == []
+
+    def test_setup_token_never_hits_usage_endpoint(self, spawn, profile, monkeypatch):
+        def boom(token):
+            raise AssertionError("usage endpoint must not be called for setup-tokens")
+        monkeypatch.setattr(oauth, "request_usage_data", boom)
+        oauth.try_fetch_usage_for_account(
+            "3", "e", setup_token_creds(), is_active=False,
+            probe_profile_for=lambda num, email: profile,
+        )
+
+    def test_probe_errors_are_not_permanent_auth_errors(self):
+        from claude_swap.usage_store import PERMANENT_AUTH_ERRORS
+        for kind in ("no-claude-binary", "probe-timeout", "no-rate-limit-event", "no-session-profile"):
+            assert kind not in PERMANENT_AUTH_ERRORS
+
+    def test_error_notes_cover_probe_kinds(self):
+        from claude_swap.switcher import ERROR_NOTES
+        for kind in ("no-claude-binary", "probe-timeout", "no-rate-limit-event", "no-session-profile"):
+            assert kind in ERROR_NOTES
+
+
+class TestSwitcherProfiles:
+    def test_session_profile_only_when_bootstrapped(self, temp_home, monkeypatch):
+        from claude_swap.switcher import ClaudeAccountSwitcher
+        sw = ClaudeAccountSwitcher()
+        assert sw._usage_probe_profile_session("3", "x@y") is None
+        d = sw._session_dir("3", "x@y")
+        d.mkdir(parents=True)
+        prof = sw._usage_probe_profile_session("3", "x@y")
+        assert prof == oauth.UsageProbeProfile(config_dir=d, scratch_root=d)
+
+    def test_default_profile_uses_claude_home_without_config_dir(self, temp_home):
+        from claude_swap.paths import get_claude_config_home
+        from claude_swap.switcher import ClaudeAccountSwitcher
+        prof = ClaudeAccountSwitcher()._usage_probe_profile_default("1", "x@y")
+        assert prof.config_dir is None
+        assert prof.scratch_root == get_claude_config_home()

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -1782,7 +1782,7 @@ class TestActiveAccountRefresh:
             locks_held_during_post["config"] = config_lock_dir().is_dir()
             return oauth.RefreshOutcome(self._REFRESHED, None)
 
-        def mock_fetch(account_num, email, credentials, is_active):
+        def mock_fetch(account_num, email, credentials, is_active, **kwargs):
             from claude_swap.claude_locks import config_lock_dir
             assert is_active is True
             assert credentials == self._REFRESHED  # rotated token used for usage
@@ -1852,7 +1852,7 @@ class TestActiveAccountRefresh:
             }
         })
 
-        def mock_fetch(account_num, email, credentials, is_active):
+        def mock_fetch(account_num, email, credentials, is_active, **kwargs):
             assert credentials == cc_rotated
             return oauth.UsageOutcome({"five_hour": {"pct": 7}})
 
@@ -2183,7 +2183,7 @@ class TestActiveAccountRefresh:
         })
         fetch_calls = []
 
-        def mock_fetch(account_num, email, credentials, is_active):
+        def mock_fetch(account_num, email, credentials, is_active, **kwargs):
             fetch_calls.append(credentials)
             if credentials == valid_but_revoked:
                 return oauth.UsageOutcome(None, error="http-401")
@@ -7681,7 +7681,7 @@ class TestActiveRefreshProvenance:
             "expiresAt": 9_999_999_999_000,
         }})
 
-        def mock_fetch(account_num, email, credentials, is_active):
+        def mock_fetch(account_num, email, credentials, is_active, **kwargs):
             assert is_active is True
             assert credentials == refreshed  # rotated under the locks
             return oauth.UsageOutcome({"five_hour": {"pct": 10}})


### PR DESCRIPTION
## Problem

A `claude setup-token` credential carries only the `user:inference` scope. The usage endpoint (`/api/oauth/usage`) needs profile scope, so every setup-token account answers 403 there on every pass, renders a permanent `usage unavailable (http-403)`, and is invisible to `cswap auto` and the rankings. Worse, a handful of those 403s trip a host-wide 429 on the endpoint for an hour, which then blanks the full-scope accounts on the same host too. Observed on a host with three setup-token slots: the log cycles `http-403` x4 then `http-429, retry-after 3600s` all day.

## Approach

Read usage for setup-token accounts the way Claude Code itself sees it. Every inference response carries the plan windows, and Claude Code surfaces them in stream-json as a `rate_limit_event`. So for these accounts cswap runs one isolated, non-interactive turn under the account's `cswap run` session profile:

```
CLAUDE_CONFIG_DIR=<profile> claude -p ok --output-format stream-json --verbose --model claude-haiku-4-5-20251001 --max-turns 1 --tools ""
```

and parses the last `rate_limit_event` line into the raw usage-API shape, so `build_usage_result` and everything downstream (list, status, TUI, menubar, autoswitch) are unchanged.

All network activity is the `claude` binary's own ordinary client request. cswap never builds an API request with the token itself, deliberately: that keeps consumer accounts inside normal Claude Code traffic.

## Cost

- An exhausted account still emits the event (`status: rejected`, utilization 1.0) and the process exits non-zero; stdout is parsed regardless of exit code. That read costs nothing.
- A healthy account spends one tiny Haiku turn (empty prompt, no tools) per poll, on the existing `usage_store`/`poll_policy` cadence. No new flags or settings.
- The probe runs with cwd `<profile>/usage-probe/` (0700), so its transcript never lands in a real project's history.

## Details

- Detection is narrow: scopes exactly `["user:inference"]` and no refresh token, the shape `add-token` writes. Full-scope logins never touch this path.
- `try_fetch_usage_for_account` gains an optional `probe_profile_for(account_num, email)` callable (same pattern as `refresh_via`). The switcher passes the session profile for inactive slots and Claude Code's own config dir for the active login (`CLAUDE_CONFIG_DIR` left as inherited there, since on macOS the keychain service name hashes the raw env value).
- A slot without a bootstrapped session profile reports `no-session-profile` with an `ERROR_NOTES` remedy (`cswap run <num>` once) rather than bootstrapping inside a collect pass. Other kinds: `no-claude-binary`, `probe-timeout` (90 s, child killed), `no-rate-limit-event`. None is a permanent auth verdict, so none strikes or quarantines.
- Tests: 28 new in `tests/test_setup_token_usage.py`; an autouse fixture in `conftest.py` stubs the spawn seam so no test can spend a real turn. Full suite: 2204 passed.

## Verified live

Ubuntu host, Claude Code 2.1.257, two setup-token slots (one at 100% of its 5-hour window). `cswap status` and `cswap list` show both accounts' 5h/7d windows; the log carries one `Usage via Claude Code turn for account N` line per slot; `ls` confirms nothing but `usage-probe/` was created in the profiles.

One migration note: a store that already holds an `http-429` backoff from the endpoint path keeps that backoff until it expires (up to an hour) before the first probe runs.
