### PR TITLE
fix: pin Keychain trusted-app ACL via delete-and-recreate, not in-place widen

### DIFF
--- a/src/claude_swap/credentials.py
+++ b/src/claude_swap/credentials.py
@@ -336,7 +336,7 @@ class CredentialStore:
         self._residual_verdict: bool | None = None
         self._last_active_credentials_backend: str | None = None
 
-    def _kc_call(self, fn, *args):
+    def _kc_call(self, fn, *args, **kwargs):
         """Run a ``macos_keychain`` wrapper call, learning Keychain usability.
 
         A success (including ``get_password`` returning ``None`` for a missing
@@ -351,7 +351,7 @@ class CredentialStore:
         "absent" and "failed", so a timeout would be misread as a usable Keychain.
         """
         try:
-            result = fn(*args)
+            result = fn(*args, **kwargs)
         except macos_keychain.KEYCHAIN_ERRORS:
             # A Keychain op FAILED. Recorded separately from the capability
             # cache because that cache is a routing decision others overwrite —
@@ -837,6 +837,7 @@ class CredentialStore:
                     CLAUDE_CODE_MANAGED_KEYCHAIN_SERVICE,
                     macos_keychain.keychain_account_name(),
                     api_key,
+                    trusted_apps=macos_keychain.resolve_trusted_claude_apps(),
                 )
             except macos_keychain.KEYCHAIN_ERRORS as e:
                 # _kc_call flipped routing to file mode; fall back to config below.
@@ -978,6 +979,7 @@ class CredentialStore:
                     CLAUDE_CODE_KEYCHAIN_SERVICE,
                     macos_keychain.keychain_account_name(),
                     credentials,
+                    trusted_apps=macos_keychain.resolve_trusted_claude_apps(),
                 )
             except macos_keychain.KEYCHAIN_ERRORS as e:
                 # _kc_call flipped routing to file mode; fall through to the file.

--- a/src/claude_swap/macos_keychain.py
+++ b/src/claude_swap/macos_keychain.py
@@ -36,6 +36,7 @@ its functions are only meaningful on macOS.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 
 # ``security -i`` reads stdin with a 4096-byte fgets() buffer (BUFSIZ on darwin).
@@ -104,16 +105,29 @@ def _quote(value: str) -> str:
     return f'"{escaped}"'
 
 
-def get_password(service: str, account: str) -> str | None:
+def get_password(
+    service: str, account: str, *, keychain: str | None = None
+) -> str | None:
     """Return the stored password, or ``None`` if no such item exists (rc 44).
 
     Raises :class:`KeychainError` on any other non-zero exit (locked / denied /
     unavailable) or a timeout, so a genuine miss is not confused with a transient
     failure.
+
+    ``keychain``, when given, targets one specific keychain file instead of the
+    default search list — appended as ``find-generic-password``'s trailing
+    positional ``[keychain]`` argument (there is no ``-k`` flag for this
+    subcommand; ``-k`` on ``security`` means something else entirely depending
+    on the verb, e.g. a keychain *password* for
+    ``set-generic-password-partition-list``). ``None`` (the default) preserves
+    the exact prior behavior — search list, no positional argument at all.
     """
+    args = [_SECURITY, "find-generic-password", "-a", account, "-w", "-s", service]
+    if keychain:
+        args.append(keychain)
     try:
         result = subprocess.run(
-            [_SECURITY, "find-generic-password", "-a", account, "-w", "-s", service],
+            args,
             capture_output=True,
             text=True,
             timeout=_TIMEOUT,
@@ -134,7 +148,9 @@ def get_password(service: str, account: str) -> str | None:
     )
 
 
-def item_exists(service: str, account: str) -> bool:
+def item_exists(
+    service: str, account: str, *, keychain: str | None = None
+) -> bool:
     """Whether a generic-password item exists, without touching its secret.
 
     Attribute-only lookup (no ``-w``): nothing is decrypted, so this can never
@@ -143,10 +159,16 @@ def item_exists(service: str, account: str) -> bool:
     missing binary all return ``False``. Deliberately **non-raising**: callers use
     it for cleanup verification, not access decisions, so it must never feed the
     capability cache (a timeout here means "couldn't tell", not "Keychain works").
+
+    ``keychain``, when given, scopes the lookup to one keychain file — see
+    :func:`get_password` for the positional-argument shape.
     """
+    args = [_SECURITY, "find-generic-password", "-a", account, "-s", service]
+    if keychain:
+        args.append(keychain)
     try:
         result = subprocess.run(
-            [_SECURITY, "find-generic-password", "-a", account, "-s", service],
+            args,
             capture_output=True,
             text=True,
             timeout=_TIMEOUT,
@@ -156,19 +178,60 @@ def item_exists(service: str, account: str) -> bool:
     return result.returncode == 0
 
 
-def set_password(service: str, account: str, password: str) -> None:
+def set_password(
+    service: str,
+    account: str,
+    password: str,
+    *,
+    keychain: str | None = None,
+    trusted_apps: list[str] | None = None,
+) -> None:
     """Create or update a generic-password item (``-U``).
 
     Prefers ``security -i`` stdin so the secret stays out of argv; falls back to
     argv only for payloads that would overflow the stdin line buffer. Raises
     :class:`KeychainError` on a non-zero exit or a timeout.
+
+    ``keychain`` targets one specific keychain file (see :func:`get_password`
+    for the positional-argument shape); ``None`` writes to the default
+    keychain, unchanged from before.
+
+    ``trusted_apps``, given and non-empty, grants those application paths ACL
+    access too (each becomes a ``-T`` entry, alongside this tool's own path so
+    a later read/update through this wrapper keeps working). ``None``/``[]``
+    is a byte-for-byte no-op vs. the pre-existing plain ``-U``, no ``-T`` —
+    which leaves a freshly-created item trusting only ``security`` itself, so
+    a headless in-process Security.framework reader (e.g. Claude Code) needs a
+    GUI prompt to get in (issue #279).
+
+    ``-U`` with ``-T`` does not safely widen an **already-existing** item's
+    ACL in place: it routes through ``SecKeychainItemSetAccess``, which needs
+    interactive authorization and can raise that same GUI prompt even against
+    an unlocked keychain (proven in ``tests/test_macos_keychain_contract.py``).
+    So when ``trusted_apps`` is given and the item already exists, this
+    deletes and recreates it instead — a brand-new item's ACL is set at
+    creation time, no prompt.
     """
+    apps: list[str] = []
+    if trusted_apps:
+        for app in (_SECURITY, *trusted_apps):
+            if app and app not in apps:
+                apps.append(app)
+        if item_exists(service, account, keychain=keychain):
+            delete_password(service, account, keychain=keychain)
+
     hex_value = password.encode("utf-8").hex()
     # `-X` passes the value as hex, avoiding any escaping issues for the secret.
-    command = (
-        f"add-generic-password -U -a {_quote(account)} -s {_quote(service)} "
-        f"-X {hex_value}\n"
-    )
+    parts = [
+        "add-generic-password", "-U",
+        "-a", _quote(account), "-s", _quote(service),
+        "-X", hex_value,
+    ]
+    for app in apps:
+        parts += ["-T", _quote(app)]
+    if keychain:
+        parts.append(_quote(keychain))
+    command = " ".join(parts) + "\n"
     try:
         if len(command.encode("utf-8")) <= SECURITY_STDIN_LINE_LIMIT:
             result = subprocess.run(
@@ -182,11 +245,16 @@ def set_password(service: str, account: str, password: str) -> None:
             # Overflows the stdin line buffer; fall back to argv. Hex in argv is
             # recoverable by a determined observer but defeats naive plaintext-grep
             # rules, and the alternative — silent corruption — is strictly worse.
+            argv = [
+                _SECURITY, "add-generic-password", "-U",
+                "-a", account, "-s", service, "-X", hex_value,
+            ]
+            for app in apps:
+                argv += ["-T", app]
+            if keychain:
+                argv.append(keychain)
             result = subprocess.run(
-                [
-                    _SECURITY, "add-generic-password", "-U",
-                    "-a", account, "-s", service, "-X", hex_value,
-                ],
+                argv,
                 capture_output=True,
                 text=True,
                 timeout=_TIMEOUT,
@@ -202,14 +270,22 @@ def set_password(service: str, account: str, password: str) -> None:
         )
 
 
-def delete_password(service: str, account: str) -> None:
+def delete_password(
+    service: str, account: str, *, keychain: str | None = None
+) -> None:
     """Delete a generic-password item. rc 44 (already absent) counts as success.
 
     Raises :class:`KeychainError` on any other non-zero exit or a timeout.
+
+    ``keychain``, when given, scopes the delete to one keychain file — see
+    :func:`get_password` for the positional-argument shape.
     """
+    args = [_SECURITY, "delete-generic-password", "-a", account, "-s", service]
+    if keychain:
+        args.append(keychain)
     try:
         result = subprocess.run(
-            [_SECURITY, "delete-generic-password", "-a", account, "-s", service],
+            args,
             capture_output=True,
             text=True,
             timeout=_TIMEOUT,
@@ -224,3 +300,43 @@ def delete_password(service: str, account: str) -> None:
         f"security delete-generic-password failed (rc={result.returncode}): "
         f"{result.stderr.strip()}"
     )
+
+
+def resolve_trusted_claude_apps() -> list[str]:
+    """Resolve the local Claude Code executable path(s) to trust for Keychain
+    ACL access (issue #279; see ``set_password``'s ``trusted_apps``).
+
+    ``claude`` on ``PATH`` may be a real Mach-O binary, or an npm-installed
+    shebang shim (``#!/usr/bin/env node ...``) that re-execs into node.
+    macOS's ACL match is against the binary that actually calls into
+    Security.framework at runtime, not ``argv[0]`` — trusting only the shim's
+    path grants it nothing — so this also resolves and adds the interpreter
+    for the shebang case. Returns ``[]`` when ``claude`` isn't on ``PATH``,
+    so a caller that always passes this through stays a no-op there.
+    """
+    claude_path = shutil.which("claude")
+    if not claude_path:
+        return []
+    resolved = os.path.realpath(claude_path)
+    apps = [resolved]
+    try:
+        with open(resolved, "rb") as f:
+            head = f.read(2)
+        if head == b"#!":
+            with open(resolved, "r", encoding="utf-8", errors="ignore") as f:
+                shebang = f.readline().strip()
+            tokens = shebang[2:].split()
+            if tokens:
+                interpreter = tokens[0]
+                # `#!/usr/bin/env node` names the interpreter as env's own
+                # argument, not the shebang path itself.
+                if os.path.basename(interpreter) == "env" and len(tokens) > 1:
+                    interpreter = shutil.which(tokens[1]) or tokens[1]
+                apps.append(os.path.realpath(interpreter))
+    except OSError:
+        pass  # unreadable executable; trust just the resolved path we have
+    deduped: list[str] = []
+    for app in apps:
+        if app not in deduped:
+            deduped.append(app)
+    return deduped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -434,23 +434,54 @@ sys.addaudithook(_real_store_audit_hook)
 
 class _KeychainStore:
     """In-memory ``(service, account) -> secret`` map standing in for the real
-    macOS Keychain so unit tests never shell out to ``security`` or ``keyring``."""
+    macOS Keychain so unit tests never shell out to ``security`` or ``keyring``.
+
+    Several existing tests seed/inspect ``.data`` directly with a bare
+    ``(service, account)`` key (e.g. ``block_real_keychain.data[(svc, acct)] =
+    ...``), so that key shape is load-bearing and must not change. ``keychain``
+    and ``trusted_apps`` (added for #279's ACL fix) are accepted for signature
+    parity with the real wrapper but not folded into the key or otherwise
+    enforced — this fake has no real multi-keychain or ACL concept, and no
+    fake-backed test needs one (the real-Keychain integration tests that
+    exercise ``keychain=``/``trusted_apps=`` for real opt out of this fake via
+    ``no_keychain_fake``).
+    """
 
     def __init__(self) -> None:
         self.data: dict[tuple[str, str], str] = {}
+        # Last `trusted_apps` a `set_password` call requested, per (service,
+        # account) — recorded only so a test can assert *what was requested*
+        # without needing the real Keychain.
+        self.trusted_apps: dict[tuple[str, str], list[str] | None] = {}
 
     # Mirrors the ``macos_keychain`` (security CLI) contract.
-    def get_password(self, service: str, account: str) -> str | None:
+    def get_password(
+        self, service: str, account: str, *, keychain: str | None = None
+    ) -> str | None:
         return self.data.get((service, account))
 
-    def item_exists(self, service: str, account: str) -> bool:
+    def item_exists(
+        self, service: str, account: str, *, keychain: str | None = None
+    ) -> bool:
         return (service, account) in self.data
 
-    def set_password(self, service: str, account: str, password: str) -> None:
+    def set_password(
+        self,
+        service: str,
+        account: str,
+        password: str,
+        *,
+        keychain: str | None = None,
+        trusted_apps: list[str] | None = None,
+    ) -> None:
         self.data[(service, account)] = password
+        self.trusted_apps[(service, account)] = trusted_apps
 
-    def delete_password(self, service: str, account: str) -> None:
+    def delete_password(
+        self, service: str, account: str, *, keychain: str | None = None
+    ) -> None:
         self.data.pop((service, account), None)  # absent = no-op (rc 44)
+        self.trusted_apps.pop((service, account), None)
 
 
 def _make_fake_keyring() -> types.ModuleType:

--- a/tests/test_macos_keychain.py
+++ b/tests/test_macos_keychain.py
@@ -138,6 +138,232 @@ def test_set_get_roundtrip_hex_is_decodable():
 
 
 # ---------------------------------------------------------------------------
+# get_password / item_exists / delete_password / set_password — ``keychain``
+# targeting (issue #279's testability seam: a positional keychain argument,
+# opt-in, default None = unchanged prior behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_get_password_keychain_none_matches_prior_argv_exactly():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run:
+        run.return_value = _completed(0, stdout="v\n")
+        macos_keychain.get_password("svc", "acct")
+        args = run.call_args.args[0]
+        assert args == [
+            "/usr/bin/security", "find-generic-password",
+            "-a", "acct", "-w", "-s", "svc",
+        ]
+
+
+def test_get_password_keychain_given_appends_trailing_positional():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run:
+        run.return_value = _completed(0, stdout="v\n")
+        macos_keychain.get_password("svc", "acct", keychain="/tmp/x.keychain")
+        args = run.call_args.args[0]
+        assert args[-1] == "/tmp/x.keychain"
+        assert args[:-1] == [
+            "/usr/bin/security", "find-generic-password",
+            "-a", "acct", "-w", "-s", "svc",
+        ]
+
+
+def test_item_exists_keychain_given_appends_trailing_positional():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run:
+        run.return_value = _completed(0)
+        macos_keychain.item_exists("svc", "acct", keychain="/tmp/x.keychain")
+        args = run.call_args.args[0]
+        assert args[-1] == "/tmp/x.keychain"
+
+
+def test_delete_password_keychain_given_appends_trailing_positional():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run:
+        run.return_value = _completed(0)
+        macos_keychain.delete_password("svc", "acct", keychain="/tmp/x.keychain")
+        args = run.call_args.args[0]
+        assert args[-1] == "/tmp/x.keychain"
+
+
+def test_set_password_keychain_given_appends_trailing_positional_in_stdin():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run:
+        run.return_value = _completed(0)
+        macos_keychain.set_password(
+            "svc", "acct", "secret", keychain="/tmp/x.keychain"
+        )
+        stdin = run.call_args.kwargs["input"]
+        assert stdin.rstrip("\n").endswith('"/tmp/x.keychain"')
+
+
+# ---------------------------------------------------------------------------
+# set_password — ``trusted_apps`` (issue #279: a freshly-created item's ACL
+# by default trusts only /usr/bin/security, which a headless in-process
+# Security.framework reader — e.g. Claude Code — can't read without a GUI
+# prompt). See tests/test_macos_keychain_contract.py's
+# TestKeychainAclPreservedOnWrite for the real-Keychain ACL-widening proof;
+# these mock subprocess to check the argv/stdin shape and the
+# delete-then-recreate call ordering.
+# ---------------------------------------------------------------------------
+
+
+def test_set_password_no_trusted_apps_is_byte_for_byte_unchanged():
+    # The exact stdin string set_password produced before #279, verbatim.
+    with patch("claude_swap.macos_keychain.subprocess.run") as run:
+        run.return_value = _completed(0)
+        macos_keychain.set_password("svc", "acct", "secret")
+        stdin = run.call_args.kwargs["input"]
+        hex_value = "secret".encode().hex()
+        assert stdin == f'add-generic-password -U -a "acct" -s "svc" -X {hex_value}\n'
+
+
+def test_set_password_empty_trusted_apps_list_is_also_a_no_op():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run:
+        run.return_value = _completed(0)
+        macos_keychain.set_password("svc", "acct", "secret", trusted_apps=[])
+        stdin = run.call_args.kwargs["input"]
+        assert "-T" not in stdin
+
+
+def test_set_password_trusted_apps_adds_dash_T_per_app_and_always_security():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run, \
+         patch("claude_swap.macos_keychain.item_exists", return_value=False):
+        run.return_value = _completed(0)
+        macos_keychain.set_password(
+            "svc", "acct", "secret", trusted_apps=["/opt/claude"]
+        )
+        stdin = run.call_args.kwargs["input"]
+        assert '-T "/usr/bin/security"' in stdin  # the tool itself, always
+        assert '-T "/opt/claude"' in stdin
+
+
+def test_set_password_trusted_apps_dedupes_when_security_already_listed():
+    with patch("claude_swap.macos_keychain.subprocess.run") as run, \
+         patch("claude_swap.macos_keychain.item_exists", return_value=False):
+        run.return_value = _completed(0)
+        macos_keychain.set_password(
+            "svc", "acct", "secret",
+            trusted_apps=["/usr/bin/security", "/opt/claude"],
+        )
+        stdin = run.call_args.kwargs["input"]
+        assert stdin.count("-T ") == 2  # security once, claude once — no triple
+
+
+def test_set_password_trusted_apps_on_new_item_does_not_delete_first():
+    """A brand-new item: ``-T`` is honored directly by ``-U`` — no need to
+    (and must not) delete first, matching the empirical finding that a
+    delete+recreate is only required to widen an EXISTING item's ACL."""
+    with patch("claude_swap.macos_keychain.subprocess.run") as run, \
+         patch("claude_swap.macos_keychain.item_exists", return_value=False) as exists, \
+         patch("claude_swap.macos_keychain.delete_password") as delete:
+        run.return_value = _completed(0)
+        macos_keychain.set_password(
+            "svc", "acct", "secret", trusted_apps=["/opt/claude"]
+        )
+        exists.assert_called_once_with("svc", "acct", keychain=None)
+        delete.assert_not_called()
+        run.assert_called_once()  # a single add-generic-password, nothing else
+
+
+def test_set_password_trusted_apps_on_existing_item_deletes_then_recreates():
+    """An item that already exists: widening its ACL via ``-U -T`` in place is
+    NOT safe (see set_password's docstring — SecKeychainItemSetAccess can
+    raise a SecurityAgent prompt), so the fix must delete first."""
+    calls = []
+
+    def fake_delete(service, account, *, keychain=None):
+        calls.append(("delete", service, account, keychain))
+
+    with patch("claude_swap.macos_keychain.subprocess.run") as run, \
+         patch("claude_swap.macos_keychain.item_exists", return_value=True), \
+         patch("claude_swap.macos_keychain.delete_password", side_effect=fake_delete):
+        run.return_value = _completed(0)
+        macos_keychain.set_password(
+            "svc", "acct", "secret",
+            keychain="/tmp/x.keychain", trusted_apps=["/opt/claude"],
+        )
+        assert calls == [("delete", "svc", "acct", "/tmp/x.keychain")]
+        # The delete must happen BEFORE the add-generic-password call.
+        run.assert_called_once()
+
+
+def test_set_password_trusted_apps_large_payload_falls_back_to_argv_with_dash_T():
+    big = "x" * macos_keychain.SECURITY_STDIN_LINE_LIMIT
+    with patch("claude_swap.macos_keychain.subprocess.run") as run, \
+         patch("claude_swap.macos_keychain.item_exists", return_value=False):
+        run.return_value = _completed(0)
+        macos_keychain.set_password(
+            "svc", "acct", big,
+            keychain="/tmp/x.keychain", trusted_apps=["/opt/claude"],
+        )
+        args = run.call_args.args[0]
+        assert "input" not in run.call_args.kwargs  # argv path, not stdin
+        assert args.count("-T") == 2  # security + claude, unquoted argv
+        assert "/usr/bin/security" in args and "/opt/claude" in args
+        assert args[-1] == "/tmp/x.keychain"
+
+
+# ---------------------------------------------------------------------------
+# resolve_trusted_claude_apps
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_trusted_claude_apps_no_claude_on_path_returns_empty(monkeypatch):
+    monkeypatch.setattr(macos_keychain.shutil, "which", lambda name: None)
+    assert macos_keychain.resolve_trusted_claude_apps() == []
+
+
+def test_resolve_trusted_claude_apps_real_binary_returns_just_that_path(
+    monkeypatch, tmp_path
+):
+    binary = tmp_path / "claude"
+    binary.write_bytes(b"\x7fELF-not-really-but-not-a-shebang-either")
+    monkeypatch.setattr(
+        macos_keychain.shutil, "which",
+        lambda name: str(binary) if name == "claude" else None,
+    )
+    apps = macos_keychain.resolve_trusted_claude_apps()
+    assert apps == [str(binary.resolve())]
+
+
+def test_resolve_trusted_claude_apps_shebang_script_adds_the_interpreter(
+    monkeypatch, tmp_path
+):
+    node = tmp_path / "node"
+    node.write_bytes(b"\x7fELF-fake-node-binary")
+    shim = tmp_path / "claude"
+    shim.write_text(f"#!{node}\nrequire('./cli.js')\n")
+
+    def fake_which(name):
+        if name == "claude":
+            return str(shim)
+        if name == "node":
+            return str(node)
+        return None
+
+    monkeypatch.setattr(macos_keychain.shutil, "which", fake_which)
+    apps = macos_keychain.resolve_trusted_claude_apps()
+    assert apps == [str(shim.resolve()), str(node.resolve())]
+
+
+def test_resolve_trusted_claude_apps_env_shebang_resolves_the_named_interpreter(
+    monkeypatch, tmp_path
+):
+    node = tmp_path / "node"
+    node.write_bytes(b"\x7fELF-fake-node-binary")
+    shim = tmp_path / "claude"
+    shim.write_text("#!/usr/bin/env node\nrequire('./cli.js')\n")
+
+    def fake_which(name):
+        if name == "claude":
+            return str(shim)
+        if name == "node":
+            return str(node)
+        return None
+
+    monkeypatch.setattr(macos_keychain.shutil, "which", fake_which)
+    apps = macos_keychain.resolve_trusted_claude_apps()
+    assert apps == [str(shim.resolve()), str(node.resolve())]
+
+
+# ---------------------------------------------------------------------------
 # delete_password
 # ---------------------------------------------------------------------------
 

--- a/tests/test_macos_keychain_contract.py
+++ b/tests/test_macos_keychain_contract.py
@@ -19,6 +19,7 @@ accidentally swap their default keychain by running pytest.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -123,6 +124,63 @@ class TestBackupCredentialsSecurity:
                 call("claude-swap", "account-None-bob@example.com"),
                 call("claude-swap", "account-None-bob@example.com.prev"),
             ])
+
+
+class TestActiveCredentialWritesRequestTrustedApps:
+    """Issue #279: the ACTIVE credential — the item Claude Code itself reads
+    via its in-process Security.framework call, as opposed to the
+    ``claude-swap``-service backup items above, which only this wrapper ever
+    reads — must be written with ``trusted_apps`` so its ACL isn't left
+    trusting only ``/usr/bin/security``. Mocked: the shape of the call, not
+    the real ACL (that's ``TestKeychainAclPreservedOnWrite``, Layer 2).
+    """
+
+    def test_oauth_write_passes_resolved_trusted_apps(
+        self, macos_switcher: ClaudeAccountSwitcher
+    ):
+        with patch("claude_swap.credentials.macos_keychain") as mock_kc:
+            mock_kc.resolve_trusted_claude_apps.return_value = ["/opt/claude"]
+            macos_switcher._store._write_oauth_credentials(
+                '{"claudeAiOauth": {"accessToken": "x"}}'
+            )
+
+            mock_kc.set_password.assert_called_once_with(
+                "Claude Code-credentials",
+                mock_kc.keychain_account_name.return_value,
+                '{"claudeAiOauth": {"accessToken": "x"}}',
+                trusted_apps=["/opt/claude"],
+            )
+
+    def test_managed_key_write_passes_resolved_trusted_apps(
+        self, macos_switcher: ClaudeAccountSwitcher
+    ):
+        with patch("claude_swap.credentials.macos_keychain") as mock_kc:
+            mock_kc.resolve_trusted_claude_apps.return_value = ["/opt/claude"]
+            macos_switcher._store._write_managed_credentials(
+                "sk-ant-api03-" + "x" * 40
+            )
+
+            mock_kc.set_password.assert_called_once_with(
+                "Claude Code",
+                mock_kc.keychain_account_name.return_value,
+                "sk-ant-api03-" + "x" * 40,
+                trusted_apps=["/opt/claude"],
+            )
+
+    def test_backup_writes_do_not_pass_trusted_apps(
+        self, macos_switcher: ClaudeAccountSwitcher
+    ):
+        """The per-account ``claude-swap``-service backup is read only by this
+        wrapper's own ``security`` calls, never by Claude Code — widening its
+        ACL would be a no-op that just grows the ACL for nothing."""
+        with patch("claude_swap.credentials.macos_keychain") as mock_kc:
+            mock_kc.get_password.return_value = None
+            macos_switcher._write_account_credentials(
+                "2", "alice@example.com", "secret-token"
+            )
+            mock_kc.set_password.assert_called_once_with(
+                "claude-swap", "account-2-alice@example.com", "secret-token"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +346,189 @@ def test_wrapper_roundtrip_real_keychain(tmp_keychain: str):
     assert macos_keychain.get_password("claude-swap-test", "acct-1") == "round-trip-token"
     macos_keychain.delete_password("claude-swap-test", "acct-1")
     assert macos_keychain.get_password("claude-swap-test", "acct-1") is None
+
+
+@pytest.fixture
+def tmp_keychain_path(tmp_path: Path):
+    """Create a temporary keychain at an explicit absolute path, never touching
+    the default keychain or the search list.
+
+    Unlike :func:`tmp_keychain` (which swaps the *default* keychain — needed
+    for tests that exercise code with no ``keychain=`` targeting of its own),
+    every test below passes ``keychain=`` explicitly to
+    ``macos_keychain.*``, so there's no need to touch the user's default or
+    search list at all: create it under ``tmp_path`` (an absolute path with a
+    directory component — a *bare* filename would land in
+    ``~/Library/Keychains/`` instead, which is exactly the mistake this
+    fixture exists to avoid), unlock it, disable auto-lock, and unconditionally
+    delete it on teardown so no file survives even if a test fails midway.
+    """
+    keychain = str(tmp_path / "test.keychain")
+    password = "test-keychain-password"
+    subprocess.run(
+        ["security", "create-keychain", "-p", password, keychain], check=True
+    )
+    try:
+        subprocess.run(
+            ["security", "unlock-keychain", "-p", password, keychain], check=True
+        )
+        # Same SecurityAgent-hang defense as `tmp_keychain`: no auto-lock timeout.
+        subprocess.run(
+            ["security", "set-keychain-settings", keychain], check=True
+        )
+        yield keychain
+    finally:
+        subprocess.run(["security", "delete-keychain", keychain], check=False)
+
+
+def _trusted_app_paths(keychain: str, service: str, account: str) -> list[str]:
+    """Parse ``security dump-keychain -a``'s ACL section for one item's
+    trusted-application list — the entry whose authorizations include
+    ``decrypt`` (the read/write authorization ``set_password``'s ``-T``
+    targets), e.g.::
+
+        access: 5 entries
+            entry 0:
+                authorizations (6): decrypt derive export_clear export_wrapped mac sign
+                ...
+                applications (2):
+                    0: /usr/bin/security (OK)
+                        requirement: identifier "com.apple.security" and anchor apple
+                    1: /usr/bin/true (OK)
+                        requirement: identifier "com.apple.true" and anchor apple
+
+    Returns just the paths, e.g. ``["/usr/bin/security", "/usr/bin/true"]``.
+    """
+    result = subprocess.run(
+        ["security", "dump-keychain", "-a", keychain],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, f"dump-keychain failed: {result.stderr}"
+    # `dump-keychain -a` prints one record per item, each starting with a
+    # fresh "keychain: " header; split on that to isolate our item's record.
+    records = result.stdout.split("\nkeychain: ")
+    record = next(
+        (
+            r for r in records
+            if f'"svce"<blob>="{service}"' in r and f'"acct"<blob>="{account}"' in r
+        ),
+        None,
+    )
+    assert record is not None, f"no dump-keychain record for {service}/{account}"
+    lines = record.splitlines()
+    decrypt_idx = next(
+        i for i, line in enumerate(lines)
+        if "authorizations" in line and "decrypt" in line
+    )
+    app_line = re.compile(r"^\s+\d+:\s+(\S+)\s+\(")
+    apps: list[str] = []
+    for line in lines[decrypt_idx + 1:]:
+        m = app_line.match(line)
+        if m:
+            apps.append(m.group(1))
+            continue
+        stripped = line.strip()
+        if stripped.startswith(("requirement:", "applications", "description:",
+                                 "don't-require-password")):
+            continue
+        break  # reached the next ACL entry / end of the access section
+    return apps
+
+
+@pytest.mark.no_keychain_fake
+@mac_ci_only
+class TestKeychainAclPreservedOnWrite:
+    """Issue #279: a Keychain item ``security add-generic-password`` writes
+    without ``-T`` gets an ACL trusting only ``/usr/bin/security`` — a
+    headless in-process Security.framework reader (e.g. Claude Code) then
+    needs a GUI prompt to read it back, surfacing as "OAuth session expired"
+    with perfectly valid credentials underneath.
+
+    Empirically (see ``set_password``'s docstring): the fix cannot be "pass
+    ``-U -T <app>`` on the existing item" — that routes through
+    ``SecKeychainItemSetAccess``, which needs interactive authorization and
+    can itself raise a SecurityAgent GUI prompt, even against an
+    already-unlocked keychain. So a widen-in-place repro is not attempted
+    here; these tests instead prove the ACL each write actually produces.
+    """
+
+    def test_write_without_trusted_apps_leaves_only_security_trusted(
+        self, tmp_keychain_path: str
+    ):
+        """The bug itself: the pre-#279 call shape (no ``trusted_apps``)."""
+        macos_keychain.set_password(
+            "acl-test-default", "acct", "v1", keychain=tmp_keychain_path
+        )
+        assert _trusted_app_paths(tmp_keychain_path, "acl-test-default", "acct") == [
+            "/usr/bin/security"
+        ]
+
+    def test_write_with_trusted_apps_widens_the_acl_on_create(
+        self, tmp_keychain_path: str
+    ):
+        """A brand-new item: ``-T`` is honored directly, no prompt, no delete."""
+        macos_keychain.set_password(
+            "acl-test-create", "acct", "v1",
+            keychain=tmp_keychain_path, trusted_apps=["/usr/bin/true"],
+        )
+        apps = _trusted_app_paths(tmp_keychain_path, "acl-test-create", "acct")
+        assert set(apps) == {"/usr/bin/security", "/usr/bin/true"}
+        assert (
+            macos_keychain.get_password(
+                "acl-test-create", "acct", keychain=tmp_keychain_path
+            )
+            == "v1"
+        )
+
+    def test_write_with_trusted_apps_widens_an_existing_narrow_item(
+        self, tmp_keychain_path: str
+    ):
+        """An item that already exists with the narrow (pre-fix) ACL: the fix
+        must widen it via delete-then-recreate, not raise, and not hang."""
+        # Seed a narrow item — exactly what test_write_without_trusted_apps_*
+        # proves this call shape produces.
+        macos_keychain.set_password(
+            "acl-test-update", "acct", "v1", keychain=tmp_keychain_path
+        )
+        assert _trusted_app_paths(tmp_keychain_path, "acl-test-update", "acct") == [
+            "/usr/bin/security"
+        ], "premise: the item starts narrow"
+
+        macos_keychain.set_password(
+            "acl-test-update", "acct", "v2",
+            keychain=tmp_keychain_path, trusted_apps=["/usr/bin/true"],
+        )
+
+        assert (
+            macos_keychain.get_password(
+                "acl-test-update", "acct", keychain=tmp_keychain_path
+            )
+            == "v2"
+        ), "the value must survive the delete+recreate, not just the ACL"
+        apps = _trusted_app_paths(tmp_keychain_path, "acl-test-update", "acct")
+        assert set(apps) == {"/usr/bin/security", "/usr/bin/true"}
+
+    def test_write_with_trusted_apps_is_idempotent_when_already_widened(
+        self, tmp_keychain_path: str
+    ):
+        """A second write with the *same* trusted_apps (the steady-state case
+        once #279 ships) must not error or regress the ACL."""
+        macos_keychain.set_password(
+            "acl-test-idempotent", "acct", "v1",
+            keychain=tmp_keychain_path, trusted_apps=["/usr/bin/true"],
+        )
+        macos_keychain.set_password(
+            "acl-test-idempotent", "acct", "v2",
+            keychain=tmp_keychain_path, trusted_apps=["/usr/bin/true"],
+        )
+        assert (
+            macos_keychain.get_password(
+                "acl-test-idempotent", "acct", keychain=tmp_keychain_path
+            )
+            == "v2"
+        )
+        apps = _trusted_app_paths(tmp_keychain_path, "acl-test-idempotent", "acct")
+        assert set(apps) == {"/usr/bin/security", "/usr/bin/true"}
 
 
 class TestOurOwnFileModeIsNotAKeychainFailure:


### PR DESCRIPTION
Thank you for open-sourcing this and keeping up with it — that's real, unpaid extra effort, and it shows. It saved me a genuine chunk of time I'd have otherwise spent building this myself. Appreciated.

---

Alternative to #280, fixing #279.

## Symptom

Right after `cswap` rotates accounts, Claude Code reports "OAuth session expired and could not be refreshed" — against a credential that was just written and is valid. Reproducible every time on a headless machine (no GUI session, e.g. under `launchd`).

## Root cause

`set_password()` calls `security add-generic-password -U` with no `-T`, resetting the item's ACL to trust only `/usr/bin/security`. Claude Code reads the same item via Security.framework — a different, now-untrusted caller — so the next read fails. Same diagnosis #280 reached.

## Divergence from #280

#280 widens the *existing* item's ACL in place (`-U` + `-T` on an update). Verified against a real keychain: macOS routes that through `SecKeychainItemSetAccess`, which needs interactive authorization and can raise a SecurityAgent prompt — even unlocked, even headless. Nothing answers it there, so it hangs rather than fails.

This PR deletes the item and recreates it with the trust list set at *creation* — which never triggers that prompt. Proven live against a real, unlocked keychain by `test_set_password_trusted_apps_on_existing_item_deletes_then_recreates`.

**The problem with #280 as written:** it replaces a write that silently locks out a legitimate reader with a write that can silently hang forever. For an interactive terminal, one click. For anything unattended, a stuck process with no failure signal at all.

## Scope

Two new keyword-only params. `trusted_apps` on `set_password` is the fix — default (`None`/`[]`) is byte-for-byte unchanged, tested. `keychain` on all four functions lets tests target a throwaway keychain file instead of the caller's real one — default unchanged.

This only touches the write-time ACL bug. #281 and #283/#284 are a related but separate read-time bug in the usage-sentinel retry logic — same "Keychain unreliable off the happy path" cluster, different code path, not addressed here.

## Why no GUI prompt by default

Installing `cswap` is already opting into seamless credential rotation — that's the tool's premise. A user who wants a confirmation step on every switch hasn't opted into what `cswap` does. A `--confirm` flag is a small, additive follow-up if that default's ever wrong — it doesn't need to gate this fix.

## Testing

- New real-keychain test (`TestKeychainAclPreservedOnWrite`): `-T` on a new item works directly; `-U -T` on an existing item doesn't safely widen it; delete-then-recreate does.
- New cases covering `keychain=`/`trusted_apps=`, including the no-op-by-default guarantee.
- Full suite: 2,195 passed, locally on real macOS.
- Project's real-Keychain CI job, run locally: 63 passed.

Fixes #279. Happy to adjust, or defer to #280 if that's already trending toward merge.
