### PR TITLE
Treat a live session's rejected credential as expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP ser
 
 Running the account that is already your default login launches plain `claude` on that login instead of a session (a second copy of the active credential would go stale). Scripts that need the isolation guaranteed can pass `--require-session`, which refuses in that case instead.
   
-A session refreshes its own copy of the account's token, so once it exits, the credential it rotated is captured back into the account's stored backup before a switch or usage check uses that backup. While a session is still running, `cswap switch` refuses to move the default login onto its account if the stored backup has already fallen behind (activating it could only fail); exit the session first, or pick another account. While a session runs, its account's usage is read with the session's own credential and never refreshed by cswap; a read the server refuses shows as token expired until the session renews the credential on its next call.
+A session refreshes its own copy of the account's token, so once it exits, the credential it rotated is captured back into the account's stored backup before a switch or usage check uses that backup. While a session is still running, `cswap switch` refuses to move the default login onto its account if the stored backup has already fallen behind (activating it could only fail); exit the session first, or pick another account. While a session runs, its account's usage is read with the session's own credential and never refreshed by cswap; a read the server refuses shows as token expired, and is not requested again, until the session renews the credential on its next call.
 
 <details>
 <summary>Sharing details — MCP servers & chat history</summary>

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Sessions use your normal `~/.claude` setup (settings, CLAUDE.md, skills, MCP ser
 
 Running the account that is already your default login launches plain `claude` on that login instead of a session (a second copy of the active credential would go stale). Scripts that need the isolation guaranteed can pass `--require-session`, which refuses in that case instead.
   
-A session refreshes its own copy of the account's token, so once it exits, the credential it rotated is captured back into the account's stored backup before a switch or usage check uses that backup. While a session is still running, `cswap switch` refuses to move the default login onto its account if the stored backup has already fallen behind (activating it could only fail); exit the session first, or pick another account.
+A session refreshes its own copy of the account's token, so once it exits, the credential it rotated is captured back into the account's stored backup before a switch or usage check uses that backup. While a session is still running, `cswap switch` refuses to move the default login onto its account if the stored backup has already fallen behind (activating it could only fail); exit the session first, or pick another account. While a session runs, its account's usage is read with the session's own credential and never refreshed by cswap; a read the server refuses shows as token expired until the session renews the credential on its next call.
 
 <details>
 <summary>Sharing details — MCP servers & chat history</summary>

--- a/src/claude_swap/json_output.py
+++ b/src/claude_swap/json_output.py
@@ -140,7 +140,8 @@ def usage_fields(
     A collected entry is one of: a usage dict, the ``USAGE_TOKEN_EXPIRED`` sentinel
     (active token expired and the refresh was deferred this pass — lock
     contention, unattributable lineage, or a failed persist; retried
-    automatically), the ``USAGE_API_KEY`` sentinel
+    automatically — or a live session's credential refused, which only that
+    session may renew), the ``USAGE_API_KEY`` sentinel
     (managed API-key account, no subscription quota), the
     ``USAGE_KEYCHAIN_UNAVAILABLE`` sentinel (active Keychain unreadable), the
     ``USAGE_FOREIGN_CREDENTIAL`` sentinel (live credential proven to belong to

--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -60,6 +60,16 @@ def credential_fingerprint(credentials: str) -> str | None:
     return "sha256-full:" + hashlib.sha256(credentials.encode()).hexdigest()
 
 
+def access_token_fingerprint(credentials: str) -> str | None:
+    """Hash of the access token alone: the part that rotates within a
+    lineage, so a refused token and its replacement compare unequal."""
+    data = extract_oauth_data(credentials)
+    token = data.get("accessToken") if data else None
+    if not isinstance(token, str) or not token:
+        return None
+    return "sha256-at:" + hashlib.sha256(token.encode()).hexdigest()
+
+
 def login_expires_at_iso(credentials: str) -> str | None:
     """When the stored *login* itself lapses, as ISO-8601 UTC, or ``None``.
 

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -4867,32 +4867,53 @@ class ClaudeAccountSwitcher:
         if session_creds:
             session_oauth = oauth.extract_oauth_data(session_creds)
             if session_oauth and session_oauth.get("accessToken"):
-                if not oauth.is_oauth_token_expired(session_oauth.get("expiresAt")):
-                    outcome = oauth.try_fetch_usage_for_account(
-                        str(num), email, session_creds, is_active=True,
-                    )
-                    return FetchRecord(
-                        usage=outcome.usage,
-                        error=outcome.error,
-                        retry_after_s=outcome.retry_after_s,
-                    )
                 # The live claude refreshes lazily on its next API call;
                 # requesting now would just 401 (same rule as the owned
                 # active account in _fetch_active_usage).
+                if oauth.is_oauth_token_expired(session_oauth.get("expiresAt")):
+                    return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
+                return self._read_only_record(oauth.try_fetch_usage_for_account(
+                    str(num), email, session_creds, is_active=True,
+                ))
+
+        if has_live_session:
+            # No profile credential to read (wiped under the session, or
+            # unreadable): the backup copy serves read-only, and once the
+            # live claude has rotated past it the server refuses it for
+            # good. An expired copy is known refused without asking.
+            backup_oauth = oauth.extract_oauth_data(creds) or {}
+            if oauth.is_oauth_token_expired(backup_oauth.get("expiresAt")):
                 return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
+            return self._read_only_record(oauth.try_fetch_usage_for_account(
+                str(num), email, creds, is_active=True,
+            ))
 
         outcome = oauth.try_fetch_usage_for_account(
             str(num), email, creds,
-            is_active=has_live_session,
-            refresh_via=(
-                None if has_live_session else self.consume_backup_grant
-            ),
+            is_active=False,
+            refresh_via=self.consume_backup_grant,
         )
         return FetchRecord(
             usage=outcome.usage,
             error=outcome.error,
             retry_after_s=outcome.retry_after_s,
             struck_fp=outcome.struck_fp,
+        )
+
+    @staticmethod
+    def _read_only_record(outcome: oauth.UsageOutcome) -> FetchRecord:
+        """A fetch made with a live session's credential, which cswap must
+        never refresh. A 401 is the live claude having rotated past the copy
+        we hold; it refreshes on its own next call, so the slot is expired,
+        not failing: recording the 401 would back the slot off and draw a
+        429 from the usage endpoint for nothing. Every other error keeps its
+        identity, a 429 above all, since that budget is the account's."""
+        if outcome.error == "http-401":
+            return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
+        return FetchRecord(
+            usage=outcome.usage,
+            error=outcome.error,
+            retry_after_s=outcome.retry_after_s,
         )
 
     def _run_usage_fetches(

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -4806,9 +4806,12 @@ class ClaudeAccountSwitcher:
         return None
 
     def _fetch_account_usage(
-        self, account_info: tuple[int, str, str, str, bool, str, str]
+        self,
+        account_info: tuple[int, str, str, str, bool, str, str],
+        rejected_fp: str | None = None,
     ) -> FetchRecord:
-        """One network fetch for one account. Never raises."""
+        """One network fetch for one account. Never raises. ``rejected_fp``
+        is the row's refused-credential stamp, if any."""
         num, email, _, org_uuid, is_active, creds, _alias = account_info
 
         # The active/default account owns the live credential — route it
@@ -4872,9 +4875,7 @@ class ClaudeAccountSwitcher:
                 # active account in _fetch_active_usage).
                 if oauth.is_oauth_token_expired(session_oauth.get("expiresAt")):
                     return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
-                return self._read_only_record(oauth.try_fetch_usage_for_account(
-                    str(num), email, session_creds, is_active=True,
-                ))
+                return self._read_only_fetch(str(num), email, session_creds, rejected_fp)
 
         if has_live_session:
             # No profile credential to read (wiped under the session, or
@@ -4884,9 +4885,7 @@ class ClaudeAccountSwitcher:
             backup_oauth = oauth.extract_oauth_data(creds) or {}
             if oauth.is_oauth_token_expired(backup_oauth.get("expiresAt")):
                 return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
-            return self._read_only_record(oauth.try_fetch_usage_for_account(
-                str(num), email, creds, is_active=True,
-            ))
+            return self._read_only_fetch(str(num), email, creds, rejected_fp)
 
         outcome = oauth.try_fetch_usage_for_account(
             str(num), email, creds,
@@ -4900,16 +4899,22 @@ class ClaudeAccountSwitcher:
             struck_fp=outcome.struck_fp,
         )
 
-    @staticmethod
-    def _read_only_record(outcome: oauth.UsageOutcome) -> FetchRecord:
-        """A fetch made with a live session's credential, which cswap must
-        never refresh. A 401 is the live claude having rotated past the copy
-        we hold; it refreshes on its own next call, so the slot is expired,
-        not failing: recording the 401 would back the slot off and draw a
-        429 from the usage endpoint for nothing. Every other error keeps its
-        identity, a 429 above all, since that budget is the account's."""
-        if outcome.error == "http-401":
+    def _read_only_fetch(
+        self, num: str, email: str, creds: str, rejected_fp: str | None
+    ) -> FetchRecord:
+        """A fetch with a live session's credential, which cswap must never
+        refresh. A 401 is the live claude having rotated past the copy we
+        hold, and it renews on its own next call, so the slot is expired
+        rather than failing; the refused token is stamped on the row so no
+        pass asks again until the credential has changed. Every other error
+        keeps its identity, a 429 above all, since that budget is the
+        account's."""
+        stamp = oauth.access_token_fingerprint(creds)
+        if stamp is not None and stamp == rejected_fp:
             return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED)
+        outcome = oauth.try_fetch_usage_for_account(num, email, creds, is_active=True)
+        if outcome.error == "http-401":
+            return FetchRecord(sentinel=USAGE_TOKEN_EXPIRED, rejected_fp=stamp)
         return FetchRecord(
             usage=outcome.usage,
             error=outcome.error,
@@ -4917,17 +4922,24 @@ class ClaudeAccountSwitcher:
         )
 
     def _run_usage_fetches(
-        self, infos: list[tuple[int, str, str, str, bool, str, str]]
+        self,
+        infos: list[tuple[int, str, str, str, bool, str, str]],
+        entries: dict[str, UsageEntry] | None = None,
     ) -> dict[str, FetchRecord]:
         """Fetch the given accounts in parallel, staggering request starts so
-        N accounts never hit the endpoint in the same instant."""
+        N accounts never hit the endpoint in the same instant. ``entries``
+        is the pre-fetch snapshot, for each row's refused-credential stamp."""
         def fetch_one(
             idx_info: tuple[int, tuple[int, str, str, str, bool, str, str]]
         ) -> tuple[str, FetchRecord]:
             idx, info = idx_info
             if idx and _FETCH_STAGGER_S:
                 time.sleep(idx * _FETCH_STAGGER_S)
-            return str(info[0]), self._fetch_account_usage(info)
+            num = str(info[0])
+            entry = entries.get(num) if entries else None
+            return num, self._fetch_account_usage(
+                info, entry.rejected_fingerprint if entry else None
+            )
 
         with ThreadPoolExecutor() as executor:
             return dict(
@@ -5037,7 +5049,7 @@ class ClaudeAccountSwitcher:
         if claims:
             pre = entries
             records = self._run_usage_fetches(
-                [info_by_num[num] for num in claims]
+                [info_by_num[num] for num in claims], pre
             )
             plans = self._plans_after_fetch(records, pre, info_by_num)
             accepted = store.record(records, identities, claims, plans)

--- a/src/claude_swap/usage_store.py
+++ b/src/claude_swap/usage_store.py
@@ -262,6 +262,11 @@ class FetchRecord:
     # predate the field — those strikes bind unconditionally, the legacy
     # behavior).
     struck_fp: str | None = None
+    # Hash of the access token a live session's read-only fetch was refused
+    # with. Rides on the sentinel and is the one thing a sentinel record
+    # persists: later passes skip the request while the credential still
+    # carries that token, and a success clears it.
+    rejected_fp: str | None = None
 
 
 @dataclass(frozen=True)
@@ -294,6 +299,9 @@ class UsageEntry:
     # Fingerprint of the generation the strikes condemned (absent on legacy
     # rows → strikes bind unconditionally). See ``token_dead``.
     struck_fingerprint: str | None = None
+    # The refused access token a live session's fetch stamped (see
+    # ``FetchRecord.rejected_fp``); None once a fetch succeeds.
+    rejected_fingerprint: str | None = None
     # Staleness past STALE_OK_S is still decision-trusted when it is
     # *deliberate*: the server is refusing fresher data (failure state), or the
     # scheduler itself chose the cadence (within nextPollAt). Capped at
@@ -937,6 +945,7 @@ class UsageStore:
                 last_429_at=_num_or_none(row.get("last429At")),
                 auth_dead_strikes=int(row.get("authDeadStrikes") or 0),
                 struck_fingerprint=row.get("struckFingerprint"),
+                rejected_fingerprint=row.get("rejectedFingerprint"),
                 trust_extended=trust_extended,
                 claim_until=claim_until,
             )
@@ -1052,7 +1061,8 @@ class UsageStore:
         exclusive writers: success resets the failure fields, failure never
         touches ``lastGood``/``fetchedAt``. A supplied success plan commits
         in the same transaction as its measurement. Sentinel records clear
-        only the claim and are otherwise never persisted. Unfenced callers
+        only the claim and are otherwise never persisted, save the refused
+        credential stamp one may carry. Unfenced callers
         (no ``claims``) defer to a live lease but never to an expired one.
         Returns the accepted slots.
         """
@@ -1067,6 +1077,8 @@ class UsageStore:
             row["claimId"] = None
             row["claimUntil"] = 0.0
             if rec.sentinel is not None:
+                if rec.rejected_fp is not None:
+                    row["rejectedFingerprint"] = rec.rejected_fp
                 return
             row["lastAttemptAt"] = now
             if rec.error is None:
@@ -1080,6 +1092,7 @@ class UsageStore:
                 row["consecutiveFailures"] = 0
                 row["lastError"] = None
                 row["backoffUntil"] = None
+                row["rejectedFingerprint"] = None
                 row["authDeadStrikes"] = 0  # a success proves the token is alive
             else:
                 failures = int(row.get("consecutiveFailures") or 0) + 1

--- a/tests/test_macos_keychain_contract.py
+++ b/tests/test_macos_keychain_contract.py
@@ -777,7 +777,7 @@ class TestOurOwnFileModeIsNotAKeychainFailure:
 
         seen: dict = {}
 
-        def spy(info):
+        def spy(info, rejected_fp=None):
             seen["degraded"] = s._active_verdict().degraded
             return FetchRecord(error="timeout")
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1803,6 +1803,11 @@ class TestGuards:
         session_dir = session_dir_for(
             seeded_switcher.backup_dir, ACCOUNT_NUM, ACCOUNT_EMAIL
         )
+        # Unexpired, so the read-only request is made; an expired copy under
+        # a live session is not requested at all.
+        seeded_switcher._write_account_credentials(
+            ACCOUNT_NUM, ACCOUNT_EMAIL, ROTATED_CREDS
+        )
         make_live(session_dir)
         seen: dict[str, bool] = {}
 

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -809,7 +809,41 @@ class TestFetchAccountUsageSessionProfile:
 
         assert record.sentinel == USAGE_TOKEN_EXPIRED
         assert record.error is None
+        assert record.rejected_fp == oauth.access_token_fingerprint(session)
         assert switcher.read_account_credentials("2", "test@example.com") == backup
+
+    def test_stamped_session_credential_is_not_requested_again(self, temp_home: Path):
+        """Once refused, the same credential draws no request: the live
+        claude renews it, and only a rotated token is worth asking about."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", 7200)
+        stamp = oauth.access_token_fingerprint(session)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup), stamp)
+
+        assert record.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_not_called()
+
+    def test_rotated_session_credential_after_a_stamp_is_requested(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session-2", 7200)
+        stamp = oauth.access_token_fingerprint(_oauth_creds("sk-session", 7200))
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 3}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup), stamp)
+
+        assert record.usage == {"five_hour": {"pct": 3}}
+        mock_fetch.assert_called_once()
 
     def test_live_session_without_profile_credentials_serves_backup_read_only(
         self, temp_home: Path
@@ -861,6 +895,45 @@ class TestFetchAccountUsageSessionProfile:
 
         assert record.sentinel == USAGE_TOKEN_EXPIRED
         assert record.error is None
+        assert record.rejected_fp == oauth.access_token_fingerprint(backup)
+
+    def test_stamped_backup_under_live_session_is_not_requested_again(
+        self, temp_home: Path
+    ):
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=None), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            record = switcher._fetch_account_usage(
+                self._info(backup), oauth.access_token_fingerprint(backup)
+            )
+
+        assert record.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_not_called()
+
+    def test_refused_credential_is_requested_once_across_passes(self, temp_home: Path):
+        """The collect pass carries the stamp: a live session whose
+        credential the server refuses costs one request, not one per pass."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", 7200)
+        info = self._info(backup)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None, error="http-401")) as mock_fetch:
+            first = switcher._collect_usage_entries([info])["2"]
+            second = switcher._collect_usage_entries([info])["2"]
+
+        assert first.sentinel == USAGE_TOKEN_EXPIRED
+        assert second.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_called_once()
 
     def test_live_session_other_errors_keep_their_identity(self, temp_home: Path):
         """A 429 is the account's budget, not the credential: it must keep

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -788,6 +788,99 @@ class TestFetchAccountUsageSessionProfile:
         assert record.sentinel == USAGE_TOKEN_EXPIRED
         mock_fetch.assert_not_called()
 
+    def test_rejected_session_credentials_with_live_session_is_sentinel(
+        self, temp_home: Path
+    ):
+        """A 401 on a live session's credential is the claude having rotated
+        past the copy we read; it renews on its own next call. Recording the
+        401 would back the slot off and probe the endpoint into a 429."""
+        switcher = ClaudeAccountSwitcher()
+        switcher._setup_directories()
+        backup = _oauth_creds("sk-backup", -3600)
+        session = _oauth_creds("sk-session", 7200)
+        switcher._write_account_credentials("2", "test@example.com", backup)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=session), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None, error="http-401")):
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.sentinel == USAGE_TOKEN_EXPIRED
+        assert record.error is None
+        assert switcher.read_account_credentials("2", "test@example.com") == backup
+
+    def test_live_session_without_profile_credentials_serves_backup_read_only(
+        self, temp_home: Path
+    ):
+        """No profile credential to read: the backup copy serves, but the live
+        claude owns the family, so no refresh is offered."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=None), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome({"five_hour": {"pct": 7}})) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.usage == {"five_hour": {"pct": 7}}
+        args, kwargs = mock_fetch.call_args
+        assert args[2] == backup
+        assert kwargs.get("is_active") is True
+        assert "refresh_via" not in kwargs
+
+    def test_live_session_without_profile_credentials_and_expired_backup_is_sentinel(
+        self, temp_home: Path
+    ):
+        """An expired backup copy under a live session is known refused."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", -60)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=None), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account") as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.sentinel == USAGE_TOKEN_EXPIRED
+        mock_fetch.assert_not_called()
+
+    def test_live_session_rejected_backup_is_sentinel(self, temp_home: Path):
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=None), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None, error="http-401")):
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.sentinel == USAGE_TOKEN_EXPIRED
+        assert record.error is None
+
+    def test_live_session_other_errors_keep_their_identity(self, temp_home: Path):
+        """A 429 is the account's budget, not the credential: it must keep
+        pacing the slot exactly as before."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[123]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=None), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(
+                       None, error="http-429", retry_after_s=3600.0
+                   )):
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.sentinel is None
+        assert record.error == "http-429"
+        assert record.retry_after_s == 3600.0
+
     def test_expired_session_credentials_without_live_session_falls_back(
         self, temp_home: Path
     ):
@@ -876,6 +969,25 @@ class TestFetchAccountUsageSessionProfile:
         assert args[2] == backup
         assert kwargs.get("is_active") is False
         assert kwargs.get("refresh_via") is not None  # consume gate replaces persist
+
+    def test_exited_session_rejected_backup_still_refreshes(self, temp_home: Path):
+        """With nobody live the backup is cswap's to refresh: a 401 stays an
+        error for the store's own retry-and-strike accounting."""
+        switcher = ClaudeAccountSwitcher()
+        backup = _oauth_creds("sk-backup", 7200)
+
+        with patch.object(switcher, "_live_session_pids", return_value=[]), \
+             patch("claude_swap.session.read_session_credentials",
+                   return_value=None), \
+             patch("claude_swap.oauth.try_fetch_usage_for_account",
+                   return_value=oauth.UsageOutcome(None, error="http-401")) as mock_fetch:
+            record = switcher._fetch_account_usage(self._info(backup))
+
+        assert record.sentinel is None
+        assert record.error == "http-401"
+        kwargs = mock_fetch.call_args.kwargs
+        assert kwargs.get("is_active") is False
+        assert kwargs.get("refresh_via") is not None
 
     def _write_profile_identity(self, switcher, email: str, org_uuid) -> None:
         session_dir = switcher._session_dir("2", "test@example.com")

--- a/tests/test_usage_store.py
+++ b/tests/test_usage_store.py
@@ -1103,6 +1103,20 @@ class TestSentinels:
         assert entry.sentinel is None  # never persisted
         assert entry.last_good == USAGE
 
+    def test_refused_credential_stamp_rides_a_sentinel(self, store):
+        """The one thing a sentinel persists: which access token a live
+        session's fetch was refused with. Kept across plain sentinels,
+        cleared by a success."""
+        store.record(
+            {"1": FetchRecord(sentinel="token expired", rejected_fp="sha256-at:abc")},
+            IDENT,
+        )
+        assert store.entries(IDENT)["1"].rejected_fingerprint == "sha256-at:abc"
+        store.record({"1": FetchRecord(sentinel="token expired")}, IDENT)
+        assert store.entries(IDENT)["1"].rejected_fingerprint == "sha256-at:abc"
+        store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
+        assert store.entries(IDENT)["1"].rejected_fingerprint is None
+
     def test_overlay_wins_decisions_but_not_display(self, store):
         store.record({"1": FetchRecord(usage=USAGE)}, IDENT)
         entry = with_sentinel(store.entries(IDENT)["1"], "token expired")


### PR DESCRIPTION
While a session-mode claude is live, cswap reads its account's usage with a credential it must never refresh: the profile's own copy, or the stored backup when the profile has nothing readable. Two shapes of that read were still being recorded as transient failures. A backup copy that had already expired was sent anyway, and a credential the server refused with a 401 was recorded as an error, which starts the failure backoff and, on the fourth probe, draws a usage-endpoint 429 that parks the slot for over an hour. Neither record can lead anywhere, because the only party allowed to refresh that family is the live claude, which does so on its own next call.

This change returns the existing token-expired sentinel in both cases, the same answer already given for an expired profile credential under a live session. An expired backup copy is not requested at all, and a 401 on either read-only credential becomes the sentinel rather than an error. Sentinels are re-derived every pass and never persisted, so nothing accumulates and the slot resumes normally once the session renews or exits. Every other outcome keeps its identity, a 429 above all, since that budget belongs to the account rather than the credential. The idle path is untouched: with nobody live, a 401 still goes through the consume gate and the store's retry and strike accounting, and the active login's path keeps surfacing a 401 as an error because it has a recovery of its own.

The three-way split in the fetch is now written out, since after the exited-session adoption the profile-credential branch only ever runs under a live session.