### PR TITLE
fix(oauth): keep the persist warning off stdout

### DIFF
--- a/src/claude_swap/oauth.py
+++ b/src/claude_swap/oauth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import sys
 import urllib.error
 import urllib.request
 from collections.abc import Callable, Sequence
@@ -764,7 +765,10 @@ def _persist(
             email,
             e,
         )
+        # stderr, not stdout: this runs inside ``cswap list --json`` and the
+        # other ``--json`` commands, whose stdout is one machine-readable object.
         print_warning(
             f"Warning: failed to save refreshed token for account {account_num} ({email}). "
-            f"If the next refresh fails, re-run `cswap --add-account` after logging in."
+            f"If the next refresh fails, re-run `cswap --add-account` after logging in.",
+            file=sys.stderr,
         )

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -845,7 +845,8 @@ class TestFetchUsageForAccount:
     def test_persist_failure_logs_warning_with_recovery_hint(self, caplog, capsys):
         """If the persist callback raises, _persist logs at WARNING level with
         a recovery hint (re-run `cswap --add-account`), not debug, AND prints
-        a user-visible warning to stdout.
+        a user-visible warning to stderr, so a ``--json`` payload on stdout
+        stays one parseable object.
         """
         import logging
 
@@ -866,10 +867,11 @@ class TestFetchUsageForAccount:
         assert "1" in msg
         assert "test@example.com" in msg
 
-        # Also verify the user-visible printed warning
-        output = capsys.readouterr().out
-        assert "failed to save refreshed token" in output
-        assert "cswap --add-account" in output
+        # Also verify the user-visible printed warning, and that stdout stays clean
+        captured = capsys.readouterr()
+        assert "failed to save refreshed token" in captured.err
+        assert "cswap --add-account" in captured.err
+        assert captured.out == ""
 
 
 class TestClassifyUsageError:


### PR DESCRIPTION
When a refreshed token cannot be saved back, `_persist` prints its warning to stdout. Inside `cswap list --json` that line lands in front of the JSON object and breaks whatever parses it, while `_build_list_payload`'s own comment states the contract: stdout stays a single machine-readable object. I hit this from a script that reads `cswap list --json` on a schedule.

Routing the warning to stderr keeps it visible in every mode and the payload parseable. The existing test now asserts the message on stderr and an empty stdout.
