### PR TITLE
fix(switch): keep a slot whose stored login is newer than the live one

### DIFF
--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -6376,6 +6376,40 @@ class ClaudeAccountSwitcher:
             self._logger.debug(f"Profile resolution raised: {e!r}")
         return result
 
+    @staticmethod
+    def _slot_supersedes_live(backup: str | None, live: str) -> bool:
+        """Whether the slot's stored credential is a NEWER LOGIN than live.
+
+        ``refreshTokenExpiresAt`` is stamped when a login is issued and stays
+        constant across the refresh-token rotations inside that family, so a
+        strictly greater value on the slot means the slot holds a login issued
+        later than the live copy — an out-of-band re-login registered with
+        ``cswap add`` while a stale credential was still sitting in the live
+        file.
+
+        Re-syncing live over that (the own-rotated path, which is right when
+        live is the newer side) reverts the slot to the older family. Nothing
+        recovers it: the older family is still alive, so no poll ever 401s, and
+        the slot quietly expires on the old deadline while the user believes
+        they re-logged in. See #302.
+
+        False whenever the comparison cannot be made — an absent or
+        non-numeric stamp on either side leaves the pre-existing behaviour
+        exactly as it was, since this guard may only ever *skip* a write.
+        """
+        if not backup:
+            return False
+        slot_oauth = oauth.extract_oauth_data(backup)
+        live_oauth = oauth.extract_oauth_data(live)
+        if not isinstance(slot_oauth, dict) or not isinstance(live_oauth, dict):
+            return False
+        slot_exp = slot_oauth.get("refreshTokenExpiresAt")
+        live_exp = live_oauth.get("refreshTokenExpiresAt")
+        for value in (slot_exp, live_exp):
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return False
+        return slot_exp > live_exp
+
     def _classify_outgoing_credential(
         self,
         current_account: str,
@@ -6396,6 +6430,12 @@ class ClaudeAccountSwitcher:
           resolved the live token to this slot's identity; back up normally
           (the live→backup re-sync that keeps slots alive across Claude
           Code's routine refresh-token rotations).
+        - ``"own-superseded"`` — resolved to this slot's identity, but the
+          slot's stored backup is a NEWER login than the live credential
+          (``refreshTokenExpiresAt`` strictly greater). Backing live up would
+          revert an out-of-band re-login to the older family, which never
+          401s and so is never recovered (#302). Config backed up; the
+          credential write is skipped.
         - ``"foreign"``        — uuid-positively resolved to *another* managed
           slot (``foreign_slot``) holding a different lineage; backing it up
           here would destroy this slot's only refresh token (issue #117's
@@ -6471,6 +6511,8 @@ class ClaudeAccountSwitcher:
         if r_uuid and own_uuid and r_uuid == own_uuid and (
             not r_org or not own_org or r_org == own_org
         ):
+            if self._slot_supersedes_live(backup, original_creds):
+                return ("own-superseded", None)
             return ("own-rotated", None)
         slot = self._find_account_slot(data, r_email, r_org) if r_email else None
         if slot is not None and r_uuid:
@@ -6495,6 +6537,8 @@ class ClaudeAccountSwitcher:
                     slot = num
                     break
         if slot == current_account:
+            if self._slot_supersedes_live(backup, original_creds):
+                return ("own-superseded", None)
             return ("own-rotated", None)
         if slot is None:
             # A positive "alien" needs a structurally complete identity —
@@ -7082,6 +7126,24 @@ class ClaudeAccountSwitcher:
                         f"Backed up account {current_account} (lineage "
                         "differs from the stored backup and ownership could "
                         "not be verified — pre-fix backup)"
+                    )
+                elif kind == "own-superseded":
+                    # The slot holds a NEWER login than the live copy: an
+                    # out-of-band re-login was registered while a stale
+                    # credential still sat in the live file. Writing live over
+                    # it would revert that login to the older family, and
+                    # because the older family is still alive nothing ever
+                    # 401s to trigger recovery — the slot would just expire on
+                    # the old deadline (#302). Config backup only; the live
+                    # bytes are this account's own superseded family, so there
+                    # is nothing worth preserving.
+                    self._write_account_config(
+                        current_account, current_email, original_config
+                    )
+                    self._logger.info(
+                        f"Backed up account {current_account} (config only; "
+                        "the stored credential is a newer login than the live "
+                        "one and was kept)"
                     )
                 elif kind == "own-bytes":
                     # Untouched since cswap wrote it — the slot already holds

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -12301,3 +12301,124 @@ class TestSessionShellGuardCoversEveryMutator:
         s = self._switcher(sample_sequence_data, monkeypatch)
         with pytest.raises(SwitchError):
             s.unset_alias("2")
+
+
+class TestBackupPreservesNewerSlotLogin:
+    """#302: the backup step must not revert an out-of-band re-login.
+
+    ``refreshTokenExpiresAt`` is stamped at login and constant across the
+    rotations inside one family, so it is the only field that orders two
+    live-vs-slot credentials by generation rather than by recency of use.
+    """
+
+    _setup_two_accounts = TestProvenanceGuard._setup_two_accounts
+    _install_store_patches = staticmethod(
+        TestProvenanceGuard._install_store_patches
+    )
+    _run_switch = TestProvenanceGuard._run_switch
+
+    _RESOLVER = {
+        "uuid": "uuid-1",
+        "email": "test@example.com",
+        "organizationUuid": None,
+    }
+
+    @staticmethod
+    def _creds(refresh: str, expires: object) -> str:
+        blob: dict = {"accessToken": f"sk-{refresh}", "refreshToken": refresh}
+        if expires is not None:
+            blob["refreshTokenExpiresAt"] = expires
+        return json.dumps({"claudeAiOauth": blob})
+
+    def _switch_with(self, temp_home, sample_sequence_data, slot, live):
+        switcher, creds_store, configs_store = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        creds_store[("1", "test@example.com")] = slot
+        patches = self._install_store_patches(
+            switcher, creds_store, configs_store, {"creds": live},
+        )
+        try:
+            self._run_switch(switcher, resolver=self._RESOLVER)
+        finally:
+            for p in patches:
+                p.stop()
+        return creds_store[("1", "test@example.com")]
+
+    def test_newer_slot_login_survives_the_switch(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """The reported case: re-login registered ahead of the old family's
+        deadline. The old family is still alive, so nothing ever 401s and the
+        .prev cushion is never reached — the slot must simply be kept."""
+        after = self._switch_with(
+            temp_home, sample_sequence_data,
+            slot=self._creds("rt-new-login", 2_000_000_000_000),
+            live=self._creds("rt-old-family", 1_000_000_000_000),
+        )
+        assert json.loads(after)["claudeAiOauth"]["refreshToken"] == "rt-new-login"
+
+    def test_ordinary_rotation_still_resyncs(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Live newer than the slot is the case own-rotated exists for: the
+        slot holds a consumed token and must be refreshed."""
+        after = self._switch_with(
+            temp_home, sample_sequence_data,
+            slot=self._creds("rt-stored", 1_000_000_000_000),
+            live=self._creds("rt-rotated", 2_000_000_000_000),
+        )
+        assert json.loads(after)["claudeAiOauth"]["refreshToken"] == "rt-rotated"
+
+    def test_same_family_deadline_resyncs(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Equal stamps mean one family whose refresh token rotated — the
+        guard must not fire, or every routine rotation would stop being
+        captured."""
+        after = self._switch_with(
+            temp_home, sample_sequence_data,
+            slot=self._creds("rt-old", 1_500_000_000_000),
+            live=self._creds("rt-rotated", 1_500_000_000_000),
+        )
+        assert json.loads(after)["claudeAiOauth"]["refreshToken"] == "rt-rotated"
+
+    def test_absent_stamp_falls_back_to_the_previous_behaviour(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        """Nothing to compare → the guard may not invent an ordering. It can
+        only ever skip a write, so silence has to mean the old path."""
+        after = self._switch_with(
+            temp_home, sample_sequence_data,
+            slot=self._creds("rt-new-login", None),
+            live=self._creds("rt-old-family", 1_000_000_000_000),
+        )
+        assert json.loads(after)["claudeAiOauth"]["refreshToken"] == "rt-old-family"
+
+    def test_non_numeric_stamp_falls_back(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        after = self._switch_with(
+            temp_home, sample_sequence_data,
+            slot=self._creds("rt-new-login", "2035-01-01"),
+            live=self._creds("rt-old-family", 1_000_000_000_000),
+        )
+        assert json.loads(after)["claudeAiOauth"]["refreshToken"] == "rt-old-family"
+
+    def test_classifier_reports_the_new_kind(
+        self, temp_home, mock_claude_config, sample_sequence_data,
+    ):
+        switcher, _creds_store, _configs = self._setup_two_accounts(
+            temp_home, sample_sequence_data,
+        )
+        live = self._creds("rt-old-family", 1_000_000_000_000)
+        with patch.object(
+            switcher, "_read_account_credentials",
+            return_value=self._creds("rt-new-login", 2_000_000_000_000),
+        ):
+            kind, foreign = switcher._classify_outgoing_credential(
+                "1", "test@example.com", live,
+                {"live": live, "resolved": self._RESOLVER},
+                switcher._get_sequence_data(),
+            )
+        assert (kind, foreign) == ("own-superseded", None)


### PR DESCRIPTION
## Why

Closes #302.

The switch-time backup classifies a live credential that resolves to the outgoing slot's identity as `own-rotated` and re-syncs it into the slot. That is correct when live is the newer side — the slot would otherwise keep a consumed refresh token. It also fires when the **slot** is the newer side: an out-of-band re-login registered with `cswap add` while a stale credential was still sitting in the live file. The re-sync reverts that login to the older family.

Nothing recovers it. @lbagic's report is precise about why: renewing a login *ahead* of its ~30-day deadline leaves the old family alive, so no poll ever 401s and the `.prev` retention is never reached. The slot quietly expires on the old family's schedule while the user believes they just re-logged in.

I reproduced it on `main` before changing anything, through the existing `TestProvenanceGuard` harness — slot holding `rt-new-login`, live holding `rt-old-family`, plain cross-slot switch:

```
--- slot 1, after the switch ---
expected: rt-new-login
actual:   rt-old-family
log:      Backed up account 1
```

## What this adds

`refreshTokenExpiresAt` is stamped when a login is issued and stays constant across the refresh-token rotations inside that family, so it orders two credentials by **generation** rather than by recency of use — which is exactly the distinction the classifier was missing. It appears nowhere in the codebase today.

A strictly greater value on the slot classifies `own-superseded`: the config is backed up, the credential write is skipped, and the slot keeps the newer login. The live bytes are this account's own superseded family, so there is nothing worth preserving and nothing is stashed.

Three deliberate non-triggers, each a test:

- **Equal stamps** are one family whose refresh token rotated — still `own-rotated`, or every routine rotation would stop being captured.
- **Live strictly newer** is the case `own-rotated` exists for — unchanged.
- **Absent or non-numeric stamp on either side** falls back to the previous behaviour. The guard may only ever *skip* a write, so it must never invent an ordering from missing data.

## What I did not do

The issue's second suggestion (`cswap add --no-activate`, so external re-login flows never need the `switch` that triggers this) is a separate change to `add`'s surface, and this fix removes the data loss without it. Worth its own issue if you want it.

## Validation

- `uv run pytest` — 2240 passed, 4 skipped, 0 failed.
- 6 new tests: the reported case, both non-triggering directions, both unreadable-stamp fallbacks, and the classifier returning the new kind directly.
- Negative controls: with the comparison forced to `False`, the two tests that depend on the guard fail; with `>` relaxed to `>=`, the same-family rotation test fails — so the strictness of the boundary is load-bearing rather than incidental.
- The 489 existing `test_switcher.py` tests pass unchanged, which is the part I cared about most: this touches the classifier every switch goes through.
