### PR TITLE
remove: the remaining accounts renumber 1…n after a remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ cswap list --token-status       # Add source-labelled OAuth token diagnostics
 cswap status                    # Show current account
 cswap add --slot 3              # Add account to a specific slot (prompts before overwrite)
 cswap add --alias dev           # Add account and give it a short alias
-cswap remove 2                  # Remove an account
+cswap remove 2                  # Remove an account (the rest renumber 1…n)
 cswap disable 2                 # Hold an account out of auto-rotation (keeps its login)
 cswap enable 2                  # Return a disabled account to rotation
 cswap alias 2 dev               # Give an account a short alias (usable anywhere NUM|EMAIL is)

--- a/src/claude_swap/switcher.py
+++ b/src/claude_swap/switcher.py
@@ -1466,8 +1466,9 @@ class ClaudeAccountSwitcher:
           like ``swap account <occupant>``; the displaced account takes the
           vacated slot, so nothing is ever lost.
 
-        Slot numbers may be sparse (``remove`` leaves gaps, ``add`` grows from
-        the max), so any positive number up to 99 — or the current highest
+        Slot numbers are normally 1…n (``remove`` renumbers the rest; a
+        renumber blocked by a live session leaves a gap), so any positive
+        number up to 99 — or the current highest
         slot, if a table already grew past that — is a legal target. The cap
         exists because ``add`` numbers from the max: a stray huge target would
         inflate every future account number.
@@ -4021,6 +4022,8 @@ class ClaudeAccountSwitcher:
         # Update sequence.json
         del data["accounts"][account_num]
         data["sequence"] = [n for n in data["sequence"] if n != int(account_num)]
+        if str(active_account) == account_num:
+            data["activeAccountNumber"] = None
         data["lastUpdated"] = get_timestamp()
 
         self._write_json(self.sequence_file, data)
@@ -4028,6 +4031,41 @@ class ClaudeAccountSwitcher:
         print(f"{accent('Removed')} Account-{account_num} ({email})")
 
         self._prune_mappings(email, account_info.get("organizationUuid", ""))
+        self._compact_slots()
+
+    def _compact_slots(self) -> list[tuple[str, str]]:
+        """Renumber the remaining accounts 1…n so slot numbers stay sequential
+        after a ``remove``. Each account relocates in ascending order into
+        the empty slot below it, carrying everything keyed by the number
+        (backups, session profile, alias, disabled flag, activeAccountNumber).
+        An account with a live session-mode Claude cannot move; the renumber
+        stops there so relative order holds, and says how to finish later.
+        Returns the ``(old, new)`` moves made.
+        """
+        moves: list[tuple[str, str]] = []
+        with FileLock(self.lock_file):
+            data = self._get_sequence_data() or {}
+            slots = sorted(data.get("accounts", {}), key=int)
+            for position, num in enumerate(slots, start=1):
+                target = str(position)
+                if num == target:
+                    continue
+                try:
+                    self._relocate_locked(num, target)
+                except SessionError as e:
+                    rest = slots[slots.index(num):]
+                    steps = " && ".join(
+                        f"cswap move {n} {i}" for i, n in enumerate(rest, start=position)
+                    )
+                    warning(
+                        f"Slots {', '.join(rest)} keep their numbers: {e} "
+                        f"Renumber later with: {steps}"
+                    )
+                    break
+                moves.append((num, target))
+        if moves:
+            print(f"{accent('Renumbered')} " + ", ".join(f"{a}→{b}" for a, b in moves))
+        return moves
 
     def _build_accounts_info(self) -> list[tuple[int, str, str, str, bool, str, str]]:
         """Build per-account (num, email, org_name, org_uuid, is_active, creds, alias).

--- a/tests/test_remove_compacts.py
+++ b/tests/test_remove_compacts.py
@@ -1,0 +1,101 @@
+"""``remove`` renumbers the remaining accounts 1…n (Infinitus #374)."""
+
+from unittest.mock import patch
+
+from claude_swap.exceptions import SessionError
+from claude_swap.models import Platform
+from claude_swap.switcher import ClaudeAccountSwitcher
+
+
+def _switcher(emails):
+    s = ClaudeAccountSwitcher()
+    s.platform = Platform.LINUX
+    s._setup_directories()
+    s._init_sequence_file()
+    for i, email in enumerate(emails, start=1):
+        s.add_account_from_token(f"sk-ant-oat01-{i}", email=email)
+    return s
+
+
+def _roster(s):
+    data = s._get_sequence_data()
+    return {num: acc["email"] for num, acc in data["accounts"].items()}, data
+
+
+class TestRemoveCompactsSlots:
+    def test_removing_the_middle_closes_the_gap(self, temp_home, capsys):
+        s = _switcher(["a@x.com", "b@x.com", "c@x.com"])
+        s.set_alias("3", "cee")
+        s.set_account_disabled("3", True)
+        capsys.readouterr()
+
+        s.remove_account("2", assume_yes=True)
+
+        roster, data = _roster(s)
+        assert roster == {"1": "a@x.com", "2": "c@x.com"}
+        assert data["sequence"] == [1, 2]
+        assert data["accounts"]["2"]["alias"] == "cee"
+        assert s.is_account_disabled("2") is True
+        assert s._read_backup_or_abort("2", "c@x.com")  # backup followed the account
+        assert "Renumbered 3→2" in capsys.readouterr().out
+
+    def test_an_old_gap_closes_too(self, temp_home):
+        s = _switcher(["a@x.com", "b@x.com", "c@x.com", "d@x.com"])
+        data = s._get_sequence_data()
+        data["accounts"]["5"] = data["accounts"].pop("4")
+        data["sequence"] = [1, 2, 3, 5]
+        s._write_json(s.sequence_file, data)
+        s._write_account_credentials("5", "d@x.com", "sk-ant-oat01-4")
+
+        s.remove_account("2", assume_yes=True)
+
+        roster, data = _roster(s)
+        assert roster == {"1": "a@x.com", "2": "c@x.com", "3": "d@x.com"}
+        assert data["sequence"] == [1, 2, 3]
+
+    def test_removing_the_last_moves_nothing(self, temp_home, capsys):
+        s = _switcher(["a@x.com", "b@x.com"])
+        capsys.readouterr()
+
+        s.remove_account("2", assume_yes=True)
+
+        assert _roster(s)[0] == {"1": "a@x.com"}
+        assert "Renumbered" not in capsys.readouterr().out
+
+    def test_removing_the_active_account_clears_active(self, temp_home):
+        s = _switcher(["a@x.com", "b@x.com", "c@x.com"])
+        data = s._get_sequence_data()
+        data["activeAccountNumber"] = 2
+        s._write_json(s.sequence_file, data)
+
+        s.remove_account("2", assume_yes=True)
+
+        assert s._get_sequence_data()["activeAccountNumber"] is None
+
+    def test_active_number_follows_its_account(self, temp_home):
+        s = _switcher(["a@x.com", "b@x.com", "c@x.com"])
+        data = s._get_sequence_data()
+        data["activeAccountNumber"] = 3
+        s._write_json(s.sequence_file, data)
+
+        s.remove_account("1", assume_yes=True)
+
+        roster, data = _roster(s)
+        assert roster == {"1": "b@x.com", "2": "c@x.com"}
+        assert data["activeAccountNumber"] == 2
+
+    def test_a_live_session_stops_the_renumber_and_says_how_to_finish(self, temp_home, capsys):
+        s = _switcher(["a@x.com", "b@x.com", "c@x.com", "d@x.com"])
+
+        def guard(num, email, action):
+            if num == "3":
+                raise SessionError(f"Account-{num} ({email}) has a live session.")
+
+        with patch.object(s, "_ensure_no_live_session", side_effect=guard):
+            s.remove_account("2", assume_yes=True)
+
+        roster, data = _roster(s)
+        assert roster == {"1": "a@x.com", "3": "c@x.com", "4": "d@x.com"}
+        out = capsys.readouterr().out
+        assert "Slots 3, 4 keep their numbers" in out
+        assert "cswap move 3 2 && cswap move 4 3" in out


### PR DESCRIPTION
## Why

Removing an account leaves a gap today (`remove 2` of three → slots 1 and 3; the next `add` takes 4). The numbers people learn — `switch 3`, `autoswitch.preferred` by number, a menu-bar app's rows — drift away from a compact 1…n over time. This makes slot numbers stay sequential after every remove.

## What

- `remove_account` now finishes by renumbering the remaining accounts 1…n in ascending order. Each relocation goes through the existing `_relocate_locked`, so backups, the session profile, alias, disabled flag and `activeAccountNumber` follow the account. Prints `Renumbered 3→2, 4→3`.
- An account with a live session-mode Claude cannot move (`_ensure_no_live_session`). The renumber stops at that account so relative order holds, and the warning prints the exact `cswap move …` steps to finish later.
- Removing the active account clears `activeAccountNumber` instead of leaving it pointing at whichever account slides into that number.
- Docstrings of `move_account` / `reorder_accounts`, the `reorder` help text and the README line for `remove` updated: a gap now only comes from a renumber blocked by a live session.

## Tests

`tests/test_remove_compacts.py`: middle removal closes the gap (alias, disabled flag and backup follow), an older gap closes too, removing the last moves nothing, removing the active account clears it, the active number follows its account, and a live session stops the renumber with the finish-up command. Full suite green except three tests that fail on `main` for me before this change (the two unreadable-enc move/swap tests and `test_real_store_guard` c0).

Note for anyone pinning by number: `autoswitch.preferred` entries are better as emails or aliases, as the README already says for `reorder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)